### PR TITLE
Fixed merchant GET not returning correct response

### DIFF
--- a/backend/src/Domain/Invoices/Models/Invoice.Structs.cs
+++ b/backend/src/Domain/Invoices/Models/Invoice.Structs.cs
@@ -56,8 +56,8 @@ public record struct InvoiceMerchantInformation(
     internal static bool CheckInvoiceMerchantInformationStructIsNull(InvoiceMerchantInformation merchantInformation)
     {
         return
-            string.IsNullOrEmpty(merchantInformation.MerchantName) ||
-            string.IsNullOrEmpty(merchantInformation.MerchantAddress) ||
+            string.IsNullOrEmpty(merchantInformation.MerchantName) &&
+            string.IsNullOrEmpty(merchantInformation.MerchantAddress) &&
             string.IsNullOrEmpty(merchantInformation.MerchantPhoneNumber);
     }
 }


### PR DESCRIPTION
The GET /api/invoices/{id}/merchant request was returning a 404 even though the merchant information existed.

This resumed to be a problem on the merchant structs null checker method.