### PR TITLE
[Fix] Fixed bug with the GET /invoices endpoint

### DIFF
--- a/sites/api.arolariu.ro/src/Invoices/Brokers/DatabaseBroker/InvoiceNoSqlBroker.cs
+++ b/sites/api.arolariu.ro/src/Invoices/Brokers/DatabaseBroker/InvoiceNoSqlBroker.cs
@@ -20,8 +20,6 @@ public sealed partial class InvoiceNoSqlBroker : DbContext, IInvoiceNoSqlBroker
 {
 	private CosmosClient CosmosClient { get; }
 
-	private DbSet<Invoice> InvoicesContext => Set<Invoice>();
-
 	/// <summary>
 	/// Entity Framework Invoice NoSQL broker constructor.
 	/// </summary>

--- a/sites/arolariu.ro/data/mocks/invoices.ts
+++ b/sites/arolariu.ro/data/mocks/invoices.ts
@@ -48,13 +48,11 @@ const generateFakeInvoice = (): Invoice => {
           duration: `${fake.number.int({min: 5, max: 120})} minutes`,
         }) satisfies Recipe,
     ),
-    additionalMetadata: Array.from(
-      {length: fake.number.int({min: 0, max: 2})},
-      () =>
-        ({
-          [fake.lorem.word(4)]: fake.lorem.sentence(5),
-        }) as unknown as Record<string, string>,
-    ),
+    additionalMetadata: {
+      isComplete: fake.string.nanoid(),
+      isEdited: fake.string.nanoid(),
+      isSoftDeleted: fake.string.nanoid(),
+    },
   } satisfies Invoice;
 };
 

--- a/sites/arolariu.ro/src/app/api/user/route.ts
+++ b/sites/arolariu.ro/src/app/api/user/route.ts
@@ -16,8 +16,8 @@ export const dynamic = "force-dynamic";
 export async function GET() {
   const user = await currentUser();
   let userId = user?.id ?? "00000000-0000-0000-0000-000000000000";
-
   const isGuestUser = userId === "00000000-0000-0000-0000-000000000000";
+
   const idHash = isGuestUser ? null : await crypto.subtle.digest("SHA-256", new TextEncoder().encode(userId));
   const userIdentifier = idHash ? generateGuid(idHash) : "00000000-0000-0000-0000-000000000000";
 
@@ -28,11 +28,11 @@ export async function GET() {
     aud: "https://api.arolariu.ro",
     iat: Math.floor(Date.now() / 1000),
     nbf: Math.floor(Date.now() / 1000),
-    exp: Math.floor(Date.now() / 1000) + 180,
+    exp: Math.floor(Date.now() / 1000) + 5 * 60,
     sub: user?.id ?? "guest",
     userIdentifier: userIdentifier,
   } satisfies jose.JWTPayload;
-  const userJwt = await new jose.SignJWT(payload).setProtectedHeader(header).sign(secret);
 
+  const userJwt = await new jose.SignJWT(payload).setProtectedHeader(header).sign(secret);
   return NextResponse.json({user, userIdentifier, userJwt} satisfies UserInformation, {status: 200});
 }

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/InvoiceInformation.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/InvoiceInformation.tsx
@@ -21,12 +21,12 @@ export const InvoiceInformation = ({invoice}: Readonly<{invoice: Invoice}>) => {
         <span>User Identifier</span>
         <span className='ml-auto dark:text-gray-300'>{userIdentifier}</span>
       </div>
-      {additionalMetadata.map((kvPair, index) => (
+      {Object.entries(additionalMetadata).map(([key, value], index) => (
         <div
           key={index}
           className='flex border-b border-gray-200 py-2'>
-          <span>{String(kvPair["key"])}</span>
-          <span className='ml-auto dark:text-gray-300'>{String(kvPair["value"])}</span>
+          <span>{key}</span>
+          <span className='ml-auto dark:text-gray-300'>{value}</span>
         </div>
       ))}
       <div>

--- a/sites/arolariu.ro/src/lib/actions/invoices/uploadInvoice.ts
+++ b/sites/arolariu.ro/src/lib/actions/invoices/uploadInvoice.ts
@@ -22,12 +22,16 @@ export default async function uploadInvoice(blobInformation: BlobStorageResponse
       userIdentifier: userInformation.userIdentifier,
       photoIdentifier: blobInformation.blobIdentifier,
       photoLocation: blobInformation.blobUrl,
-      photoMetadata: [{key: "dateOfUploadToServer", value: new Date().toISOString()}],
+      photoMetadata: {} as Record<string, string>,
     } satisfies InvoicePayload;
 
+    const photoMetadata = {dateOfUploadToServer: new Date().toISOString()} as Record<string, string>;
     for (const metadataKey in blobInformation.blobMetadata) {
-      invoicePayload.photoMetadata.push({key: metadataKey, value: blobInformation.blobMetadata[metadataKey]!});
+      const metadataValue = blobInformation.blobMetadata[metadataKey] as string;
+      photoMetadata[metadataKey] = metadataValue;
     }
+
+    invoicePayload.photoMetadata = photoMetadata;
 
     const invoiceHttpHeaders = {
       "Content-Type": "application/json",

--- a/sites/arolariu.ro/src/types/invoices/Invoice.ts
+++ b/sites/arolariu.ro/src/types/invoices/Invoice.ts
@@ -39,12 +39,12 @@ export default interface Invoice extends NamedEntity<string> {
   merchant: Merchant | null;
   items: Product[];
   possibleRecipes: Recipe[];
-  additionalMetadata: Record<string, string>[];
+  additionalMetadata: Record<string, string>;
 }
 
 export interface InvoicePayload {
   userIdentifier: string;
   photoIdentifier: string;
   photoLocation: string;
-  photoMetadata: Record<string, string>[];
+  photoMetadata: Record<string, string>;
 }


### PR DESCRIPTION
This pull request includes several changes to improve the handling of invoices in both the backend and frontend. The most important changes involve switching from Entity Framework to Cosmos DB for querying invoices, updating JWT token expiration time, and refactoring metadata handling for invoices.

### Backend Changes:

* [`sites/api.arolariu.ro/src/Invoices/Brokers/DatabaseBroker/InvoiceNoSqlBroker.Invoices.cs`](diffhunk://#diff-7e1e5c624de72d15265019b09239d5a0d8a8f90b0e0879abd1e4dae13204c91cL54-R68): Replaced Entity Framework with Cosmos DB for querying invoices to improve performance and scalability.
* [`sites/api.arolariu.ro/src/Invoices/Brokers/DatabaseBroker/InvoiceNoSqlBroker.cs`](diffhunk://#diff-04e8e340219a25e55bdaf70e3cb017dedf498305b03d69ab5c91a95a6299efa3L23-L24): Removed the `DbSet<Invoice>` property as it is no longer needed after switching to Cosmos DB.

### Frontend Changes:

* [`sites/arolariu.ro/src/app/api/user/route.ts`](diffhunk://#diff-51def3eca794734ce7dc7f26b79d2cd3505b2714beb8f34d0752e907d19a9979L31-R36): Updated JWT token expiration time from 3 minutes to 5 minutes to allow users more time for session activities.
* [`sites/arolariu.ro/src/lib/actions/invoices/uploadInvoice.ts`](diffhunk://#diff-4d5056c5bfaf0bf73144da369d5b11234c5cd85c1b20c287fe43712dbbbe4d9cL25-R35): Refactored the handling of `photoMetadata` to use a single `Record<string, string>` instead of an array of key-value pairs for better consistency and easier manipulation.
* [`sites/arolariu.ro/src/types/invoices/Invoice.ts`](diffhunk://#diff-d95a28895391040f3369ce9f8285d20b6ead0ad8225d7f607bffd3b650a0a289L42-R49): Updated the `Invoice` and `InvoicePayload` interfaces to use `Record<string, string>` for `additionalMetadata` and `photoMetadata` properties.