### PR TITLE
[Fix] fix website-official-release.yml to allow manual trigger execution

### DIFF
--- a/.github/workflows/website-official-release.yml
+++ b/.github/workflows/website-official-release.yml
@@ -32,7 +32,7 @@ jobs:
   release:
     name: 🚀 Release phase (1/1)
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     environment:
       name: ${{ inputs.environment || 'development'}}
       url: ${{ steps.deploy-to-webapp.outputs.webapp-url }}


### PR DESCRIPTION
This pull request includes a change to the GitHub Actions workflow to improve the conditions under which the release phase is triggered.

Workflow condition improvement:

* [`.github/workflows/website-official-release.yml`](diffhunk://#diff-c08f8c7e36e709032b3b4405ac58be55d380cf04892759806f0ef9d5ba10cb84L35-R35): Modified the `if` condition to trigger the release phase not only when the previous workflow run concludes successfully but also when the workflow is manually dispatched.