### PR TITLE
[Feat] Added initial on-prem local development workflow using docker containers.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Alexandru-Razvan Olariu
+Copyright (c) 2023-2024 Alexandru-Razvan Olariu
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/infra/Local/Management/docker-compose.yml
+++ b/infra/Local/Management/docker-compose.yml
@@ -1,0 +1,31 @@
+# This docker compose will spin up the following management containers:
+# - Traefik (Reverse Proxy);
+# - Network for external use (by other docker-compose files);
+
+name: "arolariu-management"
+
+networks:
+  default:
+    name: "arolariu-network"
+    driver: "bridge"
+
+services:
+  traefik:
+    image: "traefik:v3.1.4"
+    container_name: "traefik"
+    command:
+      - "--api.insecure=true" # Enable the Traefik API over HTTP
+      - "--providers.docker=true" # Enable Docker as a container provider
+    ports:
+      - "80:80" # HTTP traffic entrypoint
+      - "8080:8080" # Traefik API Dashboard
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    labels:
+      - "traefik.http.routers.api.rule=Host(`traefik.arolariu.ro.localhost`)"
+
+  whoami:
+    image: traefik/whoami
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.whoami.rule=Host(`whoami.arolariu.ro.localhost`)"

--- a/infra/Local/Storage/docker-compose.yml
+++ b/infra/Local/Storage/docker-compose.yml
@@ -1,0 +1,54 @@
+# This docker-compose will spin up the following data storage containers:
+# - Microsoft SQL Server (MSSQL);
+# - Microsoft NoSQL Server (CosmosDB);
+
+name: "arolariu-storage"
+
+volumes:
+  storage:
+
+networks: # 2 networks: default (internal) and arolariu-network (external)
+  default:
+  external:
+    name: "arolariu-network"
+    external: true
+
+services:
+  mssql:
+    image: "mcr.microsoft.com/mssql/server:2022-latest"
+    container_name: "mssql"
+    environment:
+      MSSQL_SA_PASSWORD: "Pa$$w0rd1234!"
+      ACCEPT_EULA: "Y"
+    ports:
+      - "1433:1433" # MSSQL default port
+    networks:
+      - default
+      - external
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.mssql.rule=Host(`sql.arolariu.ro.localhost`)"
+      - "traefik.http.services.mssql.loadbalancer.server.port=1433"
+
+  cosmosdb:
+    image: "mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:latest"
+    container_name: "cosmosdb"
+    ports:
+      - "8081:8081" # CosmosDB default port
+      # the following ports are used for the data explorer
+      - "10250:10250"
+      - "10251:10251"
+      - "10252:10252"
+      - "10253:10253"
+      - "10254:10254"
+      - "10255:10255"
+    volumes:
+      - "storage:/var/opt/cosmosdb"
+      - "storage:/var/opt/cosmosdb/data"
+      - "storage:/var/opt/cosmosdb/logs"
+    networks:
+      - default
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.cosmosdb.rule=Host(`nosql.arolariu.ro.localhost`)"
+      - "traefik.http.services.cosmosdb.loadbalancer.server.port=8081"

--- a/infra/Local/selfhost-start.sh
+++ b/infra/Local/selfhost-start.sh
@@ -1,0 +1,9 @@
+# This script will start the docker containers that are needed for the selfhost project.
+
+# Start the Management container
+echo "📦 Preparing to start the management container..."
+docker-compose -f Management/docker-compose.yml up -d
+
+# Start the Storage container
+echo "📦 Preparing to start the storage container..."
+docker-compose -f Storage/docker-compose.yml up -d

--- a/infra/Local/selfhost-stop.sh
+++ b/infra/Local/selfhost-stop.sh
@@ -1,0 +1,9 @@
+# This script will stop the docker containers that were started by the selfhost-start.sh script.
+
+# Stop the Storage container
+echo "📦 Preparing to stop the storage container..."
+docker-compose -f Storage/docker-compose.yml down
+
+# Stop the Management container
+echo "📦 Preparing to stop the management container..."
+docker-compose -f Management/docker-compose.yml down


### PR DESCRIPTION
This pull request includes several changes to the infrastructure setup, particularly focusing on Docker configurations for local development and licensing updates. Below is a summary of the most important changes:

### Infrastructure Setup

* **Management Containers:**
  * Added a `docker-compose.yml` file to spin up Traefik and a network for external use. (`infra/Local/Management/docker-compose.yml`)

* **Storage Containers:**
  * Added a `docker-compose.yml` file to spin up Microsoft SQL Server and CosmosDB containers. (`infra/Local/Storage/docker-compose.yml`)

* **Self-Host Scripts:**
  * Added a script to start the management and storage containers. (`infra/Local/selfhost-start.sh`)
  * Added a script to stop the management and storage containers. (`infra/Local/selfhost-stop.sh`)

### Licensing

* **License Update:**
  * Updated the copyright year in the `LICENSE` file. (`LICENSE`)

These changes enhance the local development environment by setting up essential infrastructure components and updating the licensing information.