### PR TITLE
fix: fix docs workflow and playwright test step in CI.

### DIFF
--- a/.github/workflows/docs-official-trigger.yml
+++ b/.github/workflows/docs-official-trigger.yml
@@ -28,7 +28,7 @@ jobs:
       - name: "[API::1/3] 🏗️ Installing the API dependencies..."
         run: |
           dotnet workload restore
-          dotnet restore
+          dotnet restore ./arolariu.slnx
 
       - name: "[API::2/3] ⚙️ Starting setup for the DocFX documentation platform..."
         run: |

--- a/sites/arolariu.ro/next.config.ts
+++ b/sites/arolariu.ro/next.config.ts
@@ -18,6 +18,12 @@ const cspHeader = `
     upgrade-insecure-requests;
 `;
 
+const weAreInCI = process.env["CI"] === "true"; // flag set for Playwright tests in CI.
+console.log(">>> We are in CI:", weAreInCI ? "✅" : "❌");
+
+const isCdnEnabled = process.env["USE_CDN"] === "true";
+console.log(">>> CDN enabled:", isCdnEnabled ? "✅" : "❌");
+
 const isDevBuild = process.env.NODE_ENV === "development";
 console.log(">>> isDevBuild", isDevBuild ? "✅" : "❌");
 console.log(">>> NODE_ENV", process.env.NODE_ENV);
@@ -161,7 +167,7 @@ const nextConfig: NextConfig = {
   },
 
   pageExtensions: ["ts", "tsx"],
-  assetPrefix: process.env["USE_CDN"] === "true" ? "https://cdn.arolariu.ro" : undefined,
+  assetPrefix: isCdnEnabled && !weAreInCI ? "https://cdn.arolariu.ro" : undefined,
   compress: false, // We use AFD built-in compression for static assets.
   trailingSlash: true,
 };


### PR DESCRIPTION
This pull request includes updates to CI workflows and environment-based configuration in the `next.config.ts` file for improved flexibility and debugging. The most important changes involve refining the `.github/workflows/docs-official-trigger.yml` file for targeted solution restoration and enhancing environment flag handling in `sites/arolariu.ro/next.config.ts`.

### CI Workflow Updates:
* [`.github/workflows/docs-official-trigger.yml`](diffhunk://#diff-2a269b09d5bbcdd908968f42307f927866ea18486ef6d484ec2a9621edfad8aeL31-R31): Modified the `dotnet restore` command to specify the solution file (`arolariu.slnx`) for better accuracy in dependency restoration.

### Environment-Based Configuration Enhancements:
* [`sites/arolariu.ro/next.config.ts`](diffhunk://#diff-786e74e87451c424874368cd9761e3bb79712e12d1d2910b830ab855d1cfa833R21-R26): Added `weAreInCI` and `isCdnEnabled` flags to improve debugging and configuration flexibility based on environment variables. Debugging logs were added to indicate the status of these flags.
* [`sites/arolariu.ro/next.config.ts`](diffhunk://#diff-786e74e87451c424874368cd9761e3bb79712e12d1d2910b830ab855d1cfa833L164-R170): Updated the `assetPrefix` configuration to conditionally enable the CDN only when `USE_CDN` is true and the build is not running in CI, ensuring appropriate asset handling in different environments.