### PR TITLE
fix: playwright test step

### DIFF
--- a/.github/workflows/website-official-build.yml
+++ b/.github/workflows/website-official-build.yml
@@ -91,11 +91,13 @@ jobs:
 
       - name: 🧪 Running Playwright E2E Component tests...
         run: yarn test:playwright
-        env:
-          CI: "true"
+        env: # We will use local assets for the tests
+          USE_CDN: "false"
 
       - name: 🧪 Preparing UI tests (Building Storybook)...
         run: yarn storybook:build --quiet
+        env: # We will use local assets for the tests
+          USE_CDN: "false"
 
       - name: 🧪 Running Smoke & Integration tests (Playwright on Storybook)...
         run: |

--- a/sites/arolariu.ro/next.config.ts
+++ b/sites/arolariu.ro/next.config.ts
@@ -18,9 +18,6 @@ const cspHeader = `
     upgrade-insecure-requests;
 `;
 
-const weAreInCI = process.env["CI"] === "true"; // flag set for Playwright tests in CI.
-console.log(">>> We are in CI:", weAreInCI ? "✅" : "❌");
-
 const isCdnEnabled = process.env["USE_CDN"] === "true";
 console.log(">>> CDN enabled:", isCdnEnabled ? "✅" : "❌");
 
@@ -167,7 +164,7 @@ const nextConfig: NextConfig = {
   },
 
   pageExtensions: ["ts", "tsx"],
-  assetPrefix: isCdnEnabled && !weAreInCI ? "https://cdn.arolariu.ro" : undefined,
+  assetPrefix: isCdnEnabled ? "https://cdn.arolariu.ro" : undefined,
   compress: false, // We use AFD built-in compression for static assets.
   trailingSlash: true,
 };


### PR DESCRIPTION
This pull request updates the testing and configuration setup for the project, focusing on the use of local assets during tests and simplifying the handling of environment variables. The most important changes involve replacing the `CI` environment variable with `USE_CDN` for determining asset usage and removing redundant code related to the CI environment.

### Testing setup updates:
* [`.github/workflows/website-official-build.yml`](diffhunk://#diff-2030e47f22d6642af1f6115798fc92a6be52ad7db4402ef474ac259fb016398dL94-R100): Updated the environment variables for Playwright E2E Component tests and Storybook build tasks to use `USE_CDN: "false"`, ensuring local assets are used during tests instead of CDN-hosted ones.

### Configuration simplification:
* [`sites/arolariu.ro/next.config.ts`](diffhunk://#diff-786e74e87451c424874368cd9761e3bb79712e12d1d2910b830ab855d1cfa833L21-L23): Removed the `weAreInCI` variable and its associated logic, simplifying the configuration by relying solely on the `USE_CDN` variable to determine asset usage.
* [`sites/arolariu.ro/next.config.ts`](diffhunk://#diff-786e74e87451c424874368cd9761e3bb79712e12d1d2910b830ab855d1cfa833L170-R167): Updated the `assetPrefix` logic to depend only on `isCdnEnabled`, removing the `weAreInCI` check. This ensures consistent handling of assets based on the `USE_CDN` environment variable.