### PR TITLE
feat: initial e2e ci pipeline

### DIFF
--- a/.github/templates/e2e-test-template.md
+++ b/.github/templates/e2e-test-template.md
@@ -1,0 +1,40 @@
+## 🚨 Live Test Failure Report
+
+**Workflow:** `${{ github.workflow }}`
+**Run ID:** [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+**Run Number:** `${{ github.run_number }}`
+**Triggered By:** `${{ github.event_name }}`
+**Execution Time (UTC):** `${{ steps.date.outputs.datetime }}`
+
+---
+
+### 🛠️ Job Status
+| Job Name   | Status   | Duration |
+|------------|----------|----------|
+| Frontend   | `${{ needs.frontend.result }}` | `${{ needs.frontend.outputs.duration }}` |
+| Backend    | `${{ needs.backend.result }}`  | `${{ needs.backend.outputs.duration }}`  |
+
+---
+
+### 🌡️ Backend Health Snapshot
+Below is the `/health` endpoint response at the time of testing:
+
+\`\`\`json
+${{ steps.health.outputs.json }}
+\`\`\`
+
+---
+
+### 📄 Logs & Artifacts
+- [View Full Workflow Logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+- Download attached artifacts for detailed logs.
+
+---
+
+### 🔍 Suggested Next Steps
+1. If the backend health check shows `"status": "Unhealthy"`, investigate failing dependencies first.
+2. Review the **log tail** below for immediate clues.
+3. Check full logs for stack traces or assertion errors.
+4. Re‑run the workflow manually to confirm reproducibility.
+
+---

--- a/.github/workflows/test-official-e2e.yml
+++ b/.github/workflows/test-official-e2e.yml
@@ -1,0 +1,126 @@
+name: "live-test-official"
+
+permissions:
+  id-token: write
+  contents: read
+
+on:
+  schedule:
+    - cron: "0 * * * *" # Every hour UTC
+  workflow_dispatch:
+
+jobs:
+  frontend:
+    name: '[Frontend] End-to-End Testing (🧪)'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🛫 Checking out the branch inside the runner environment...
+        uses: actions/checkout@v5
+
+      - name: 📦 Installing Node.js...
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+
+      - name: 📦 Installing dependencies...
+        run: |
+          npm install
+          npm install -g newman
+
+      - name: 🚀 Running end-to-end tests...
+        run: |
+          start=$(date +%s)
+          npm run e2e:frontend 2>&1 | tee frontend-tests.log
+          end=$(date +%s)
+          echo "time=$((end-start))s" >> $GITHUB_OUTPUT
+
+      - name: 📊 Upload frontend logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-test-logs
+          path: frontend-tests.log
+
+  backend:
+    name: '[Backend] End-to-End Testing (🧪)'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🛫 Checking out the branch inside the runner environment...
+        uses: actions/checkout@v5
+
+      - name: 📦 Installing Node.js...
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+
+      - name: 📦 Installing dependencies...
+        run: |
+          npm install
+          npm install -g newman
+
+      - name: 🌡️ Check dependencies health
+        run: |
+          echo "Fetching backend health status..."
+          curl -s https://api.arolariu.ro/health -o backend-health.json
+          cat backend-health.json
+
+      - name: 🚀 Running end-to-end tests...
+        run: |
+          start=$(date +%s)
+          npm run e2e:backend 2>&1 | tee backend-tests.log
+          end=$(date +%s)
+          echo "time=$((end-start))s" >> $GITHUB_OUTPUT
+
+      - name: 📊 Upload backend logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-test-logs
+          path: |
+            backend-tests.log
+            backend-health.json
+
+  raise-issue-on-failure:
+    name: 'Raise Issue on Failure'
+    needs: [frontend, backend]
+    runs-on: ubuntu-latest
+    if: ${{ needs.frontend.result == 'failure' || needs.backend.result == 'failure' }}
+    env:
+      TZ: Europe/Bucharest
+    steps:
+      - uses: actions/checkout@v5
+      - name: 📅 Get current date
+        id: date
+        run: echo "today=$(date +'%d-%m-%Y')" >> $GITHUB_OUTPUT
+
+      - name: Download all logs
+        uses: actions/download-artifact@v5
+        with:
+          path: logs
+
+      - id: health
+        run: |
+          if [ -f logs/backend-test-logs/backend-health.json ]; then
+            echo 'json<<EOF' >> $GITHUB_OUTPUT
+            cat logs/backend-test-logs/backend-health.json >> $GITHUB_OUTPUT
+            echo 'EOF' >> $GITHUB_OUTPUT
+          else
+            echo "json=No health data available" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Prepare log tail
+        run: |
+          echo "## 🔥 Log Tail from Failed Jobs" > log-tail.md
+          for file in logs/*/*.log; do
+            echo -e "\n### $(basename "$file")" >> log-tail.md
+            tail -n 50 "$file" >> log-tail.md
+          done
+
+      - run: cat .github/templates/live-test-template.md log-tail.md > final-issue.md
+
+      - uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: "[${{ steps.date.outputs.datetime }}] Hourly Live Test Failed 🚨"
+          content-filepath: final-issue.md
+          labels: bug, automated-test-failure
+          assignees: arolariu


### PR DESCRIPTION
This pull request introduces an automated, hourly end-to-end (E2E) testing workflow for both the frontend and backend, with robust failure reporting. The workflow runs on a schedule or can be triggered manually, and will automatically raise a detailed GitHub issue if any tests fail, including logs, backend health checks, and suggested next steps for debugging.

**Key changes:**

### New E2E Testing Workflow
* Added `.github/workflows/test-official-e2e.yml` to run scheduled and manual E2E tests for both frontend and backend, including installing dependencies, running tests, and uploading logs on failure.

### Automated Failure Reporting
* Implemented a job to automatically raise a GitHub issue if either frontend or backend E2E tests fail, attaching logs, backend health status, and a log tail for rapid diagnosis.
* Uses the `peter-evans/create-issue-from-file` action to create failure reports with relevant metadata and assigns them for triage.

### Issue Template for Failures
* Added `.github/templates/e2e-test-template.md` to standardize the failure report, including workflow details, job statuses, backend health snapshot, links to logs/artifacts, and actionable next steps.