### PR TITLE
Disable hourly cron job in test workflow

### DIFF
--- a/.github/workflows/test-official-e2e.yml
+++ b/.github/workflows/test-official-e2e.yml
@@ -5,8 +5,8 @@ permissions:
   contents: read
 
 on:
-  schedule:
-    - cron: "0 * * * *" # Every hour UTC
+#  schedule:
+#   - cron: "0 * * * *" # Every hour UTC
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This pull request makes a small change to the GitHub Actions workflow configuration. The scheduled trigger for the workflow has been commented out, so the workflow will no longer run automatically on a schedule and can only be triggered manually.