### PR TITLE
feat: explicitly instruct github copilot agent to follow monorepo instructions

### DIFF
--- a/.github/instructions/README.md
+++ b/.github/instructions/README.md
@@ -1,0 +1,112 @@
+# Copilot Instructions Directory
+
+This directory contains specialized instruction files that provide context-specific guidance for different parts of the arolariu.ro monorepo. GitHub Copilot automatically applies these instructions when you work on files matching the specified patterns.
+
+## How It Works
+
+Each instruction file includes YAML frontmatter with an `applyTo` field that specifies which files the instructions apply to. When you edit a file matching that pattern, Copilot loads the corresponding instruction file to provide relevant best practices, coding standards, and architectural guidance.
+
+## Available Instruction Files
+
+### Workflow Instructions
+- **File**: `workflows.instructions.md`
+- **Applies To**: `.github/workflows/*.yml`
+- **Description**: Comprehensive guide for GitHub Actions CI/CD pipelines including workflow structure, jobs, steps, caching, and deployment strategies for the monorepo
+
+### TypeScript Instructions
+- **File**: `typescript.instructions.md`
+- **Applies To**: `**/*.ts`
+- **Description**: TypeScript development guidelines with strict typing standards, domain-driven design patterns, and type safety best practices
+
+### React Instructions
+- **File**: `react.instructions.md`
+- **Applies To**: `**/*.jsx, **/*.tsx, **/*.js, **/*.ts, **/*.css, **/*.scss`
+- **Description**: ReactJS development standards including functional components, hooks, state management, and testing practices
+
+### Frontend Instructions
+- **File**: `frontend.instructions.md`
+- **Applies To**: `sites/arolariu.ro/**/*.tsx, sites/arolariu.ro/**/*.ts, sites/arolariu.ro/**/*.jsx, sites/arolariu.ro/**/*.js, sites/arolariu.ro/**/*.css`
+- **Description**: Next.js frontend development with React Server Components, App Router patterns, performance optimization, and observability
+
+### Backend Instructions
+- **File**: `backend.instructions.md`
+- **Applies To**: `**/*.cs, **/*.csproj, **/Program.cs, **/appsettings.json`
+- **Description**: .NET backend development with domain-driven design, SOLID principles, modular monolith architecture, and 85%+ test coverage standards
+
+### Bicep Instructions
+- **File**: `bicep.instructions.md`
+- **Applies To**: `**/*.bicep`
+- **Description**: Azure Bicep infrastructure as code with naming conventions, security best practices, cost optimization, and resource management
+
+### Code Review Instructions
+- **File**: `code-review.instructions.md`
+- **Applies To**: `**` (all files)
+- **Description**: General code review guidelines and quality standards inspired by Gilfoyle's technical supremacy
+
+## Main Instructions
+
+For general repository guidelines, monorepo architecture, technology stack, and cross-cutting concerns, refer to:
+- **`.github/copilot-instructions.md`** - Comprehensive monorepo guidelines covering:
+  - Monorepo architecture (Nx-based)
+  - Documentation & Architecture RFCs
+  - Technology stack for all projects
+  - Code quality standards (ESLint, TypeScript, Prettier)
+  - Frontend development (Next.js, React)
+  - Backend development (.NET, DDD)
+  - Shared components library
+  - Type safety & TypeScript
+  - State management
+  - Testing practices
+  - Infrastructure & deployment
+  - Naming conventions
+  - Performance considerations
+  - Security guidelines
+
+## Architecture Documentation
+
+For detailed architectural decisions and patterns, consult:
+- **`docs/rfc/`** - Request for Comments documenting architectural decisions:
+  - **RFC 1000-1999**: Frontend architecture (OpenTelemetry, metadata system, documentation standards)
+  - **RFC 2000-2999**: Backend architecture (Domain-Driven Design, modular monolith)
+- **`docs/frontend/README.md`** - Frontend-specific implementation details
+- **`docs/backend/README.md`** - Backend-specific implementation details
+
+## Adding New Instructions
+
+To add new instruction files:
+
+1. **Create a new instruction file** in this directory with `.instructions.md` suffix
+2. **Add YAML frontmatter** at the top of the file:
+   ```yaml
+   ---
+   applyTo: 'pattern/**/*.ext'
+   description: 'Brief description of what this instruction covers'
+   ---
+   ```
+3. **Write comprehensive guidelines** for the specific domain
+4. **Update this README** to document the new instruction file
+5. **Test the instructions** by editing files matching the pattern
+
+## File Naming Convention
+
+All instruction files follow the pattern: `<topic>.instructions.md`
+
+Examples:
+- `workflows.instructions.md`
+- `typescript.instructions.md`
+- `backend.instructions.md`
+
+## Best Practices
+
+When writing instruction files:
+- **Be specific**: Focus on patterns and practices unique to that domain
+- **Cross-reference**: Link to main instructions and RFCs for broader context
+- **Include examples**: Provide code samples showing correct patterns
+- **Document rationale**: Explain why certain approaches are preferred
+- **Keep updated**: Maintain instructions as the codebase evolves
+
+## Resources
+
+- [GitHub Copilot Instructions Documentation](https://docs.github.com/en/copilot/customizing-copilot/adding-custom-instructions-for-github-copilot)
+- [Best Practices for Copilot Coding Agent](https://gh.io/copilot-coding-agent-tips)
+- Main repository guidelines: `.github/copilot-instructions.md`

--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@
     - [🌐 Website Pipelines](#-website-pipelines)
     - [⚙️ API Pipelines](#️-api-pipelines)
     - [🎯 Pipeline Features](#-pipeline-features)
+  - [🤖 GitHub Copilot Integration](#-github-copilot-integration)
+    - [📚 Comprehensive Documentation](#-comprehensive-documentation)
+    - [🎯 Context-Aware Assistance](#-context-aware-assistance)
+    - [📖 Architecture Documentation](#-architecture-documentation)
+    - [🚀 Getting Started with Copilot](#-getting-started-with-copilot)
   - [📊 Repository Statistics](#-repository-statistics)
     - [Activity Metrics](#activity-metrics)
       - [📅 Commit Timeline](#-commit-timeline)
@@ -320,6 +325,49 @@ npx nx run api:dev
 - ✅ **Blue-Green Deployments** - Zero-downtime releases
 - ✅ **Automatic Rollbacks** - Health check failures trigger rollback
 - ✅ **Environment Promotion** - Preview → Production workflow
+
+---
+
+## 🤖 GitHub Copilot Integration
+
+This repository is fully configured with **GitHub Copilot instructions** to provide context-aware AI assistance during development.
+
+### 📚 Comprehensive Documentation
+
+- **Main Instructions**: `.github/copilot-instructions.md` - Monorepo architecture, tech stack, and cross-cutting concerns
+- **Specialized Instructions**: `.github/instructions/` - Domain-specific guidelines for different file types
+
+### 🎯 Context-Aware Assistance
+
+Copilot automatically applies specialized instructions based on the files you're editing:
+
+| File Type | Instructions Applied | Key Topics |
+|-----------|---------------------|------------|
+| `.github/workflows/*.yml` | GitHub Actions CI/CD | Workflow structure, caching, monorepo patterns |
+| `**/*.ts` | TypeScript Development | Strict typing, DDD patterns, type safety |
+| `**/*.jsx, **/*.tsx` | React Development | Functional components, hooks, RSC patterns |
+| `sites/arolariu.ro/**/*` | Next.js Frontend | App Router, Server Components, performance |
+| `**/*.cs` | .NET Backend | DDD architecture, SOLID principles, testing |
+| `**/*.bicep` | Azure Infrastructure | IaC best practices, security, cost optimization |
+
+### 📖 Architecture Documentation
+
+For detailed architectural decisions and patterns:
+- **Frontend RFCs** (1000-1999): `docs/rfc/` - OpenTelemetry, metadata, documentation standards
+- **Backend RFCs** (2000-2999): `docs/rfc/` - Domain-Driven Design, modular monolith
+- **Domain Docs**: `docs/frontend/` and `docs/backend/` - Implementation details
+
+### 🚀 Getting Started with Copilot
+
+1. **Open any file** in the repository
+2. Copilot loads relevant instructions automatically
+3. Get context-aware suggestions based on:
+   - Project architecture and patterns
+   - Technology-specific best practices
+   - Code quality standards
+   - Security guidelines
+
+Learn more: [GitHub Copilot Documentation](https://docs.github.com/en/copilot) | [Instructions Setup](.github/instructions/README.md)
 
 ---
 


### PR DESCRIPTION
This pull request introduces comprehensive documentation and onboarding for GitHub Copilot integration in the repository. The main changes focus on providing detailed instructions for context-aware AI assistance, organizing specialized guidelines for different domains, and improving discoverability for Copilot features.

**GitHub Copilot Integration & Documentation:**

* Added a new `.github/instructions/README.md` file that explains the structure, purpose, and usage of Copilot instruction files, including file patterns, available instruction topics, and best practices for writing new instructions.
* Updated the main `README.md` to include a dedicated "GitHub Copilot Integration" section, outlining how Copilot is configured, what documentation is available, and how context-aware assistance works for different file types.
* Enhanced the table of contents in `README.md` to reference the new Copilot integration and documentation sections for easier navigation.