### PR TITLE
release: exp.arolariu.ro microservice + CI fixes

### DIFF
--- a/.github/workflows/official-exp-trigger.yml
+++ b/.github/workflows/official-exp-trigger.yml
@@ -126,7 +126,7 @@ jobs:
         run: |
           echo "::group::🧪 Running Python Tests"
           START_TIME=$(date +%s)
-          python -m pytest tests/ -v --tb=short --cov=. --cov-report=term-missing --cov-fail-under=85
+          python -m pytest -v --tb=short --cov=. --cov-report=term-missing --cov-fail-under=85
           END_TIME=$(date +%s)
           DURATION=$((END_TIME - START_TIME))
           echo "::notice::✅ Tests completed in ${DURATION}s"


### PR DESCRIPTION
Supersedes #508. Adds two CI fixes on top:
- \ix(ci): exclude test files from bandit security scan\ — 206 false-positive B101 (assert_used) in test files
- \ix(ci): remove hardcoded tests/ path from pytest\ — exp uses co-located \*.test.py, not a tests/ directory

See #508 description for full changelog.