### PR TITLE
release: CI fixes for exp.arolariu.ro deployment

### DIFF
--- a/sites/exp.arolariu.ro/telemetry/settings.test.py
+++ b/sites/exp.arolariu.ro/telemetry/settings.test.py
@@ -11,6 +11,8 @@ class TestTelemetrySettings:
     def test_resolves_local_defaults(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("INFRA", "local")
         monkeypatch.delenv("APPLICATIONINSIGHTS_CONNECTION_STRING", raising=False)
+        monkeypatch.delenv("COMMIT_SHA", raising=False)
+        monkeypatch.delenv("EXP_SERVICE_VERSION", raising=False)
 
         settings = get_telemetry_settings()
 


### PR DESCRIPTION
Fixes three CI issues blocking exp.arolariu.ro deployment:

- \ix(ci): exclude test files from bandit security scan\ — 206 false-positive B101 assertions
- \ix(ci): remove hardcoded tests/ path from pytest\ — exp uses co-located \*.test.py files
- \ix(exp): unset COMMIT_SHA in telemetry settings test\ — CI env var overrides pyproject version

Also includes post-merge improvements from preview:
- OTel Activity tracing on API ConfigProxyClient + ConfigRefreshHostedService
- OTel withSpan/logWithTrace on website configProxy.ts
- Structured error logging with startup retry (3 attempts, exponential backoff)
- All 1189 website tests passing (96.72% coverage)
- All 80 exp tests passing (89% coverage)