### PR TITLE
fix(ci): deploy step working-directory + label endpoints

### DIFF
--- a/.github/workflows/official-exp-trigger.yml
+++ b/.github/workflows/official-exp-trigger.yml
@@ -262,6 +262,7 @@ jobs:
           images: "${{ secrets.AZURE_CONTAINER_REGISTRY_ADDRESS }}/${{env.CONTAINER_NAME}}:${{env.CONTAINER_TAG}}"
 
       - name: 🏷️ Set COMMIT_SHA app setting
+        working-directory: .
         run: |
           az webapp config appsettings set \
             --name exp-arolariu-ro \


### PR DESCRIPTION
- Fix \working-directory\ on COMMIT_SHA deploy step (deploy job doesn't checkout repo)
- Label-aware \/build-time\ and \/run-time\ endpoints
- \generate.env.ts\ passes label from SITE_ENV
- Entra ID cheatsheet in README