### PR TITLE
refactor(i18n): restructure Invoices namespace into IMS-- keys to fix TS type explosion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ sites/arolariu.ro/next-env.d.ts
 **/e2e-storage-state.json
 
 temp/
+
+# Backup files
+*.bak

--- a/sites/arolariu.ro/messages/en.json
+++ b/sites/arolariu.ro/messages/en.json
@@ -1191,2845 +1191,6 @@
       }
     }
   },
-  "Invoices": {
-    "metadata": {
-      "description": "Manage receipts, create invoices, and gain insights into your spending habits.",
-      "title": "Invoice Management System"
-    },
-    "Homepage": {
-      "metadata": {
-        "description": "The main landing page for the Invoice Management System domain service.",
-        "title": "Invoice Management System - Home"
-      },
-      "hero": {
-        "title": "Manage Your",
-        "titleHighlight": "Invoices",
-        "titleSuffix": "with Ease",
-        "description": "Upload your receipts and bills, organize them into invoices, and gain insights into your spending habits. Our AI-powered system extracts data automatically.",
-        "getStarted": "Get Started",
-        "viewMyInvoices": "View My Invoices",
-        "imageAlt": "Invoice management illustration"
-      },
-      "workflow": {
-        "title": "How It Works",
-        "description": "Three simple steps to digitize and organize your financial documents",
-        "step1": {
-          "title": "Upload Scans",
-          "description": "Drag and drop your receipts, invoices, or bills. We support JPG, PNG, and PDF files up to 10MB each.",
-          "button": "Upload Now"
-        },
-        "step2": {
-          "title": "View & Organize",
-          "description": "Review your uploaded scans, select the ones you want, and create invoices from them individually or in batches.",
-          "button": "View Scans"
-        },
-        "step3": {
-          "title": "Manage Invoices",
-          "description": "View your invoices, analyze spending patterns, and get AI-powered insights into your financial habits.",
-          "button": "View Invoices"
-        }
-      },
-      "features": {
-        "title": "Powerful Features",
-        "description": "Everything you need to manage your invoices efficiently",
-        "ocr": {
-          "title": "Smart OCR Extraction",
-          "description": "Our AI automatically extracts merchant names, dates, amounts, and line items from your scans."
-        },
-        "analytics": {
-          "title": "Spending Analytics",
-          "description": "Get detailed insights into your spending patterns with charts and reports."
-        },
-        "batch": {
-          "title": "Batch Processing",
-          "description": "Process multiple scans at once - create individual invoices or combine them into one."
-        },
-        "signInPrompt": "Sign in to save your invoices permanently and access them from any device.",
-        "imageAlt": "Invoice features illustration",
-        "signIn": "Sign in"
-      },
-      "bento": {
-        "title": "Everything You Need",
-        "description": "Powerful features designed to make invoice management effortless",
-        "ai": {
-          "title": "AI-Powered",
-          "description": "GPT-4 extraction"
-        },
-        "analyticsCard": {
-          "title": "Analytics",
-          "description": "Spending insights"
-        },
-        "cloud": {
-          "title": "Cloud Sync",
-          "description": "Access anywhere"
-        },
-        "ocr": {
-          "title": "Smart OCR",
-          "description": "Auto data capture"
-        },
-        "secure": {
-          "title": "Secure",
-          "description": "Bank-grade encryption"
-        },
-        "share": {
-          "title": "Share",
-          "description": "Collaborate easily"
-        },
-        "mobile": "Works beautifully on mobile devices"
-      },
-      "cta": {
-        "title": "Ready to Get Started?",
-        "description": "Upload your first scan and experience the magic of AI-powered invoice management.",
-        "uploadButton": "Upload Your First Scan",
-        "learnMore": "Learn More",
-        "badges": {
-          "secure": "Secure & Private",
-          "cloud": "Cloud Synced",
-          "ai": "AI-Powered"
-        }
-      }
-    },
-    "UploadScans": {
-      "metadata": {
-        "description": "Upload receipt scans to your account for later processing into invoices.",
-        "title": "Invoice Management System - Upload Scans"
-      },
-      "title": "Upload Scans",
-      "subtitle": "Upload receipt images or PDFs. Create invoices from them later.",
-      "breadcrumb": "Back to Invoices",
-      "header": {
-        "title": "Upload Scans",
-        "description": "Upload receipt images or PDFs. Create invoices from them later.",
-        "tooltip": "Upload your receipts, invoices, or bills here. You can select multiple files and organize them into invoices later from the View Scans page."
-      },
-      "buttons": {
-        "viewScans": "View Your Scans",
-        "myInvoices": "My Invoices",
-        "uploadFirst": "Upload Your First Scan"
-      },
-      "stats": {
-        "added": "Added",
-        "pending": "Pending",
-        "uploading": "Uploading",
-        "completed": "Completed",
-        "failed": "Failed"
-      },
-      "sidebar": {
-        "formats": {
-          "title": "Supported Formats",
-          "images": "Images",
-          "imageExtensions": ".jpg, .jpeg, .png",
-          "documents": "Documents",
-          "documentExtensions": ".pdf",
-          "maxSize": "Maximum file size: 10MB per file"
-        },
-        "tips": {
-          "title": "Tips for Best Results",
-          "tip1": "Use good lighting when photographing receipts",
-          "tip2": "Ensure text is clear and readable",
-          "tip3": "Avoid shadows and glare",
-          "tip4": "Capture the entire receipt in frame",
-          "tip5": "PDFs work best for digital receipts"
-        },
-        "security": {
-          "title": "Secure Storage",
-          "description": "Your scans are encrypted and stored securely. Only you can access them."
-        },
-        "nextSteps": {
-          "title": "All uploads complete!",
-          "description": "Your scans are ready. Head to View Scans to organize them into invoices.",
-          "button": "Continue to View Scans"
-        }
-      },
-      "upload": {
-        "dropzone": "Drag and drop your receipt images or PDFs here",
-        "browse": "Browse files",
-        "or": "or"
-      },
-      "errors": {
-        "unsupportedType": "Unsupported file type: {type}",
-        "tooLarge": "File too large: {name} (max 10MB)"
-      },
-      "uploadArea": {
-        "aria": {
-          "uploadFiles": "Upload files"
-        },
-        "empty": {
-          "title": "Drag and drop your files here",
-          "dropActive": "Drop files to upload",
-          "dropInactive": "Click or drag files to upload",
-          "formats": "Supported formats: JPG, PNG, PDF (max 10MB each)",
-          "note": "You can select multiple files.",
-          "chooseFiles": "Choose Files"
-        },
-        "compact": {
-          "dropActive": "Drop files to add them",
-          "dropInactive": "Drag files here or click to browse",
-          "subtitle": "JPG, PNG, PDF up to 10MB"
-        },
-        "actions": {
-          "clearAll": "Clear All",
-          "uploading": "Uploading...",
-          "uploadScans": "Upload Scans"
-        },
-        "tooltips": {
-          "clearAll": "Remove all pending uploads",
-          "uploadScans": "Start uploading all pending scans"
-        }
-      },
-      "preview": {
-        "title": "Pending uploads ({count})",
-        "status": {
-          "pending": "Pending",
-          "uploading": "Uploading",
-          "retrying": "Retrying",
-          "completed": "Completed",
-          "failed": "Failed"
-        },
-        "removeTooltip": "Remove this file",
-        "retryAttempt": "Retry attempt {attempt}",
-        "pendingTooltip": "This scan will not be persisted until you click Upload",
-        "pagination": {
-          "previous": "Previous",
-          "next": "Next",
-          "pageInfo": "{current} / {total} ({count} scans)"
-        }
-      },
-      "postUpload": {
-        "title": "Upload Complete!",
-        "subtitle": "Do these scans represent a single purchase?",
-        "createInvoice": "Yes, create invoice",
-        "viewScans": "No, I'll combine later",
-        "dismiss": "Dismiss"
-      }
-    },
-    "ViewScans": {
-      "metadata": {
-        "description": "View and manage your uploaded scans. Create invoices from selected scans.",
-        "title": "Invoice Management System - View Scans"
-      },
-      "title": "Your Scans",
-      "subtitle": "Select scans to create invoices from them.",
-      "breadcrumb": "Back to Invoices",
-      "header": {
-        "title": "Your Scans",
-        "titleWithCount": "Your Scans ({count})",
-        "subtitle": "Select scans to create invoices from them",
-        "lastSynced": "Last synced: {time}",
-        "tooltip": "Select scans to create invoices from them. You can create one invoice per scan or combine multiple scans into a single invoice.",
-        "uploadMore": "Upload More",
-        "upload": "Upload",
-        "uploadTooltip": "Upload more scans to your account",
-        "myInvoices": "My Invoices",
-        "invoices": "Invoices",
-        "myInvoicesTooltip": "View your created invoices",
-        "sync": "Sync",
-        "syncing": "Syncing...",
-        "syncTooltip": "Refresh scans from server"
-      },
-      "stats": {
-        "totalScans": "Total Scans",
-        "ready": "Ready",
-        "selected": "Selected",
-        "selectHint": "Click on scans to select them for invoice creation",
-        "tapHint": "Tap to select"
-      },
-      "sidebar": {
-        "howTo": {
-          "title": "How to Create Invoices",
-          "step1Title": "Select Scans",
-          "step1Description": "Click on scans to select them",
-          "step2Title": "Choose Mode",
-          "step2Description": "One invoice per scan or combine multiple",
-          "step3Title": "Create Invoice",
-          "step3Description": "AI extracts data automatically"
-        },
-        "selectionStatus": {
-          "singular": "scan selected",
-          "plural": "scans selected",
-          "readySingular": "Ready to create an invoice",
-          "readyPlural": "Create multiple invoices or combine into one"
-        },
-        "quickUpload": {
-          "title": "Need more scans?",
-          "description": "Upload additional receipts",
-          "button": "Upload"
-        }
-      },
-      "emptyState": {
-        "title": "No scans yet",
-        "description": "Start by uploading your receipts and invoices. Here's how it works:",
-        "step1Title": "Upload your scans",
-        "step1Description": "Take photos of receipts or upload PDFs of digital invoices",
-        "step2Title": "Select and organize",
-        "step2Description": "Choose which scans to convert into invoices",
-        "step3Title": "Create invoices",
-        "step3Description": "Our AI automatically extracts all the data for you",
-        "uploadButton": "Upload Your First Scan",
-        "learnMoreButton": "Learn More"
-      },
-      "toolbar": {
-        "selected": "selected",
-        "clearSelection": "Clear",
-        "createInvoice": "Create Invoice",
-        "createInvoices": "Create Invoices",
-        "delete": {
-          "button": "Delete ({count})",
-          "confirmTitle": "Delete selected scans?",
-          "confirmDescription": "This will permanently delete {count} scan(s) from storage. This action cannot be undone.",
-          "cancel": "Cancel",
-          "confirm": "Delete",
-          "success": "{count} scan(s) deleted successfully",
-          "partial": "{success} deleted, {failed} failed",
-          "failed": "Failed to delete scans",
-          "error": "An error occurred while deleting scans"
-        }
-      },
-      "scanCard": {
-        "loading": "Loading...",
-        "delete": "Delete scan",
-        "linked": "Linked",
-        "deleteDialog": {
-          "title": "Delete scan?",
-          "description": "Are you sure you want to delete \"{name}\"? This action cannot be undone and the scan will be permanently removed from storage.",
-          "linkedWarning": "This scan is linked to an invoice.",
-          "linkedDescription": "Deleting it will remove the scan from storage, but the invoice will retain a copy of the image. This action cannot be undone.",
-          "cancel": "Cancel",
-          "delete": "Delete",
-          "deleting": "Deleting...",
-          "success": "Scan deleted successfully",
-          "error": "Failed to delete scan"
-        },
-        "rename": "Rename scan",
-        "renamePlaceholder": "Enter new name",
-        "preview": "Preview scan",
-        "previewTitle": "Scan Preview",
-        "actions": {
-          "rename": "Rename scan",
-          "delete": "Delete scan",
-          "rotateCW": "Rotate 90° Clockwise",
-          "rotateCCW": "Rotate 90° Counter-clockwise",
-          "rotating": "Rotating...",
-          "rotateSuccess": "Image rotated successfully",
-          "rotateError": "Failed to rotate image",
-          "rotateUnsupported": "Cannot rotate PDF files"
-        }
-      },
-      "createInvoiceDialog": {
-        "title": "Create Invoice",
-        "titlePlural": "Create Invoices",
-        "description": "Transform your scans into structured invoice data with AI-powered extraction.",
-        "selectedScans": "Selected Scans",
-        "totalSize": "total",
-        "chooseMode": "Choose Creation Mode",
-        "singleMode": {
-          "title": "One invoice per scan",
-          "description": "Creates {count} separate invoices. Best when each scan is a different receipt."
-        },
-        "batchMode": {
-          "title": "Combine into one invoice",
-          "description": "Creates 1 invoice with all {count} scans attached. Best for multi-page receipts."
-        },
-        "singleScanInfo": {
-          "title": "What happens next?",
-          "description": "Our AI will analyze your scan and automatically extract merchant details, items, prices, and totals. You can review and edit the results afterward."
-        },
-        "buttons": {
-          "cancel": "Cancel",
-          "createSingle": "Create Invoice",
-          "createMultiple": "Create {count} Invoices",
-          "close": "Close"
-        },
-        "creating": {
-          "title": "Creating Your Invoice",
-          "titlePlural": "Creating Your Invoices",
-          "processing": "Processing {count} scan...",
-          "processingPlural": "Processing {count} scans...",
-          "step1Title": "Uploading scans",
-          "step1Description": "Sending your scans to our servers",
-          "step2Title": "Creating invoice records",
-          "step2Description": "Setting up invoice data structures",
-          "step3Title": "Finalizing",
-          "step3Description": "Preparing invoices for viewing"
-        },
-        "complete": {
-          "title": "{count} Invoice Created!",
-          "titlePlural": "{count} Invoices Created!",
-          "description": "Your invoice is ready for viewing and editing.",
-          "descriptionPlural": "Your invoices are ready for viewing and editing.",
-          "nextSteps": "Next steps:",
-          "nextStepsDescription": "Review your invoice, verify the extracted data, and make any necessary edits. You can also request AI analysis for spending insights.",
-          "nextStepsDescriptionPlural": "Review your invoices, verify the extracted data, and make any necessary edits. You can also request AI analysis for spending insights.",
-          "viewButton": "View Invoice",
-          "viewButtonPlural": "View Invoices",
-          "failureTitle": "Creation Failed",
-          "failureDescription": "We couldn't create any invoices. Please review the errors below and try again.",
-          "partialTitle": "{created} of {total} Invoices Created",
-          "partialDescription": "Some scans couldn't be processed. Successfully created invoices are ready for viewing.",
-          "errorsLabel": "Failed Scans:",
-          "retryButton": "Try Again"
-        },
-        "errors": {
-          "partialFail": "Failed to create {count} invoice(s)",
-          "createFailed": "Failed to create invoices: {message}",
-          "unknown": "Unknown error"
-        }
-      },
-      "createFromAll": {
-        "button": "Create from All Scans",
-        "title": "All scans are ready!",
-        "description": "Create invoices from all {count} scans at once"
-      },
-      "groupBanner": {
-        "title": "These {count} scans were uploaded together",
-        "subtitle": "Create an invoice from these scans?",
-        "createInvoice": "Create Invoice",
-        "dismiss": "Dismiss"
-      },
-      "pagination": {
-        "previous": "Previous",
-        "next": "Next",
-        "pageInfo": "{current} / {total} ({count} scans)"
-      }
-    },
-    "ViewInvoices": {
-      "metadata": {
-        "description": "List all invoices from the invoice management system.",
-        "title": "Invoice Management System - List Invoices"
-      },
-      "subtitle": "This is your digital receipts inventory. <br></br> Here you can find the receipts that you've uploaded so far. <br></br> By clicking on a receipt, you will be redirected to that specific receipt's page.",
-      "title": "Welcome, {name}!",
-      "viewInvoicesPage": {
-        "guestName": "dear guest"
-      },
-      "viewInvoicesIsland": {
-        "tabs": {
-          "invoices": "Invoices",
-          "statistics": "Statistics",
-          "liveAnalysis": "Live analysis"
-        }
-      },
-      "invoicesHeader": {
-        "title": "Invoice management",
-        "description": "Manage your receipts and track your spending habits",
-        "actions": {
-          "import": "Import",
-          "export": "Export",
-          "print": "Print",
-          "newInvoice": "New invoice"
-        },
-        "tooltips": {
-          "import": "Import invoices from files",
-          "export": "Export all invoices",
-          "print": "Print invoices",
-          "newInvoice": "Create a new invoice"
-        }
-      },
-      "invoicesView": {
-        "searchPlaceholder": "Search invoices...",
-        "filters": {
-          "category": "Category",
-          "timeOfDay": "Time of day",
-          "categories": "Categories",
-          "paymentTypes": "Payment Types",
-          "dateRange": "Date Range",
-          "dateFrom": "From date",
-          "dateTo": "To date",
-          "amountRange": "Amount Range",
-          "amountMin": "Min amount",
-          "amountMax": "Max amount",
-          "sortBy": "Sort By",
-          "sortOptions": {
-            "dateNewest": "Date (newest first)",
-            "dateOldest": "Date (oldest first)",
-            "amountHighToLow": "Amount (high to low)",
-            "amountLowToHigh": "Amount (low to high)",
-            "nameAZ": "Name (A-Z)",
-            "nameZA": "Name (Z-A)",
-            "none": "No sorting (default order)"
-          },
-          "title": "Filters",
-          "button": "Filters",
-          "clear": "Clear all",
-          "activeCount": "{count} active"
-        },
-        "categories": {
-          "all": "All categories",
-          "groceries": "Groceries",
-          "dining": "Dining",
-          "utilities": "Utilities",
-          "entertainment": "Entertainment",
-          "travel": "Travel",
-          "other": "Other"
-        },
-        "times": {
-          "all": "All times",
-          "day": "Daytime (6am-6pm)",
-          "night": "Nighttime (6pm-6am)"
-        },
-        "placeholderPanel": "More filter controls coming soon.",
-        "viewModes": {
-          "table": "Table view",
-          "grid": "Grid view"
-        }
-      },
-      "statisticsView": {
-        "title": "Invoice Statistics",
-        "subtitle": "Manage your receipts and track your spending habits",
-        "charts": {
-          "calendarHeatmap": {
-            "days": {
-              "wed": "Wed",
-              "thu": "Thu",
-              "fri": "Fri",
-              "sun": "Sun",
-              "mon": "Mon",
-              "sat": "Sat",
-              "tue": "Tue"
-            },
-            "tooltip": {
-              "noSpending": "No spending",
-              "amount": "Spent",
-              "invoices": "{count} invoices"
-            },
-            "legend": {
-              "less": "Less",
-              "more": "More"
-            },
-            "title": "Spending Calendar",
-            "description": "Daily spending intensity over time",
-            "navigation": {
-              "previous": "Previous month",
-              "next": "Next month"
-            },
-            "aria": {
-              "calendarGrid": "Daily spending calendar"
-            }
-          },
-          "spendingOverTime": {
-            "labels": {
-              "amount": "Amount"
-            },
-            "tooltip": {
-              "invoiceCount": "{count} invoices",
-              "andMore": "and {count} more..."
-            },
-            "title": "Spending Over Time",
-            "description": "Track your spending trends"
-          },
-          "categoryBreakdown": {
-            "title": "Spending by Category",
-            "description": "Distribution across categories",
-            "totalLabel": "Total Spending",
-            "tooltip": {
-              "invoiceCount": "{count} invoices"
-            }
-          },
-          "currencyDistribution": {
-            "title": "Currency Distribution",
-            "description": "Spending breakdown by currency with RON conversion",
-            "toggleLabel": "Toggle currency view",
-            "showOriginal": "Show Original",
-            "showRON": "Show RON",
-            "singleCurrency": "All invoices in {currency} ({symbol})",
-            "invoiceCount": "{count} invoices",
-            "originalAmount": "Original",
-            "ronEquivalent": "RON equivalent",
-            "totalAmount": "Total Amount",
-            "totalCurrencies": "Total Currencies",
-            "totalSpending": "Total Spending"
-          },
-          "merchantLeaderboard": {
-            "title": "Top Merchants",
-            "description": "Where you spend most",
-            "labels": {
-              "totalSpent": "Total Spent"
-            },
-            "tooltip": {
-              "invoiceCount": "{count} invoices"
-            },
-            "empty": "No merchant data available yet"
-          },
-          "merchantTrends": {
-            "title": "Merchant Spending Trends",
-            "description": "Monthly spending patterns for top merchants",
-            "labels": {
-              "merchant": "Merchant",
-              "totalSpend": "Total Spend",
-              "trend": "Trend (Last 6 Months)"
-            },
-            "aria": {
-              "sparkline": "Spending trend for {merchant}"
-            },
-            "empty": "No merchant data available yet"
-          },
-          "merchantVisit": {
-            "title": "Merchant Visit Patterns",
-            "description": "Shopping frequency and basket insights",
-            "metrics": {
-              "totalVisits": "Total Visits",
-              "visitsPerMonth": "Visits/Month",
-              "basketSize": "Avg Basket",
-              "preferredDay": "Preferred Day",
-              "avgSpend": "Avg Spend/Visit"
-            },
-            "empty": "No visit data available yet"
-          },
-          "priceDistribution": {
-            "title": "Price Distribution",
-            "description": "Item price distribution",
-            "labels": {
-              "itemCount": "Item Count"
-            },
-            "tooltip": {
-              "itemCount": "{count} items"
-            }
-          },
-          "timeOfDay": {
-            "title": "Shopping Patterns",
-            "description": "When you shop",
-            "labels": {
-              "invoiceCount": "Invoice Count"
-            },
-            "tooltip": {
-              "invoiceCount": "{count} invoices"
-            }
-          },
-          "productCategory": {
-            "description": "Spending breakdown by product type",
-            "tooltip": {
-              "productCount": "{count} products"
-            },
-            "title": "Product Category Spending",
-            "empty": "No products to analyze yet"
-          },
-          "topProducts": {
-            "ariaLabel": "Top products leaderboard",
-            "description": "Most purchased items",
-            "headers": {
-              "rank": "#",
-              "avgPrice": "Avg Price",
-              "quantity": "Qty",
-              "purchases": "Purchases",
-              "product": "Product",
-              "totalSpent": "Total"
-            },
-            "title": "Top Products",
-            "empty": "No products purchased yet"
-          },
-          "allergenSummary": {
-            "ariaLabel": "Allergen frequency summary",
-            "description": "Allergen exposure across products",
-            "stats": {
-              "products": "products",
-              "ofTotal": "of total"
-            },
-            "title": "Allergen Summary",
-            "empty": "No allergens detected in your purchases"
-          }
-        },
-        "kpi": {
-          "totalSpending": "Total Spending",
-          "invoiceCount": "Invoice Count",
-          "topMerchant": "Top Merchant",
-          "averageItems": "Avg. Items",
-          "vsLastMonth": "{delta}% vs last month",
-          "avgPerInvoice": "avg {amount} per invoice",
-          "visits": "{count} visits",
-          "acrossInvoices": "across {count} invoices",
-          "noneYet": "No data yet"
-        },
-        "comparison": {
-          "title": "Month-over-Month",
-          "description": "Comparison with previous month",
-          "spendingDelta": "Spending Change",
-          "invoiceCount": "Invoice Count",
-          "newMerchants": "New Merchants",
-          "discovered": "discovered",
-          "none": "none",
-          "increase": "increase",
-          "decrease": "decrease"
-        },
-        "empty": {
-          "title": "No Statistics Yet",
-          "subtitle": "Upload receipts to see analytics",
-          "cta": "Upload Receipt"
-        },
-        "productAnalytics": {
-          "title": "Product-Level Analytics",
-          "subtitle": "Insights into your purchased items"
-        }
-      },
-      "messageList": {
-        "aiAssistant": "AI Assistant",
-        "you": "You"
-      },
-      "generativeView": {
-        "welcomeMessage": "Hello! I'm your invoice analysis assistant. How can I help you today? Try commands like /find to search invoices.",
-        "title": "Live analysis",
-        "subtitle": "Chat with AI to analyze your invoices and get insights",
-        "help": "Help",
-        "tabs": {
-          "chat": "Chat",
-          "settings": "Settings"
-        },
-        "chatDescription": "Chat with AI to analyze your invoices and get insights. Try commands like /find to search invoices.",
-        "settings": {
-          "title": "Chat settings",
-          "description": "Configure your AI assistant preferences",
-          "historyLabel": "Chat history",
-          "retentionPlaceholder": "Select retention period",
-          "retention": {
-            "30": "Keep for 30 days",
-            "60": "Keep for 60 days",
-            "90": "Keep for 90 days",
-            "none": "Don't save history"
-          },
-          "dataAccessTitle": "Data access",
-          "allowInvoiceData": "Allow access to invoice data",
-          "allowMerchantData": "Allow access to merchant data",
-          "notificationPreferences": "Notification preferences",
-          "notifyInsights": "Notify me about new insights",
-          "save": "Save settings"
-        }
-      },
-      "tableView": {
-        "empty": {
-          "title": "No Invoices Yet",
-          "description": "Start by uploading your receipts to create your first invoice",
-          "uploadCta": "Upload Your First Receipt"
-        },
-        "columns": {
-          "invoice": "Invoice",
-          "category": "Category",
-          "date": "Date",
-          "amount": "Amount",
-          "actions": "Actions"
-        },
-        "aria": {
-          "selectAllInvoices": "Select all invoices",
-          "selectInvoice": "Select invoice {name}",
-          "rowsPerPage": "Rows per page",
-          "sortByDate": "Sort by date",
-          "sortByAmount": "Sort by amount"
-        },
-        "viewInvoice": "View Invoice",
-        "rowsPerPage": "Rows per page:",
-        "pageOf": "Page {current} of {total}",
-        "previousPage": "Previous Page",
-        "nextPage": "Next Page",
-        "tooltips": {
-          "notAnalyzed": "This invoice has not been analyzed yet"
-        }
-      },
-      "gridView": {
-        "tooltips": {
-          "viewDetails": "View Details"
-        },
-        "itemCount": "{count, plural, one {# item} other {# items}}"
-      },
-      "tableViewActions": {
-        "actions": {
-          "edit": "Edit",
-          "share": "Share",
-          "delete": "Delete"
-        },
-        "tooltips": {
-          "moreActions": "More actions",
-          "edit": "Edit invoice details",
-          "share": "Share invoice via link or email",
-          "delete": "Permanently delete this invoice"
-        }
-      },
-      "exportDialog": {
-        "title": "Export Invoices",
-        "description": "Export {count} invoices in your preferred format.",
-        "format": {
-          "title": "Export Format",
-          "labels": {
-            "csv": "CSV",
-            "json": "JSON",
-            "pdf": "PDF"
-          },
-          "descriptions": {
-            "json": "Structured data format",
-            "csv": "Spreadsheet format, compatible with Excel",
-            "pdf": "Printable document format"
-          }
-        },
-        "options": {
-          "title": "Options",
-          "includeMetadata": "Include metadata",
-          "includeProducts": "Include products",
-          "includeMerchant": "Include merchant",
-          "csv": {
-            "includeHeaders": "Include CSV Headers",
-            "delimiterLabel": "CSV Delimiter Override (optional):",
-            "delimiterPlaceholder": ","
-          },
-          "json": {
-            "prettyPrint": "Pretty Print (2 spaces)"
-          }
-        },
-        "buttons": {
-          "cancel": "Cancel",
-          "export": "Export",
-          "copy": "Copy to Clipboard",
-          "copied": "Copied!"
-        },
-        "filename": {
-          "hint": "The file will be saved with the extension based on format",
-          "label": "Filename"
-        },
-        "estimate": {
-          "label": "Estimated file size:"
-        }
-      },
-      "importDialog": {
-        "title": "Import Invoices",
-        "description": "Upload your invoice files to import them into the system.",
-        "tabs": {
-          "csv": "CSV",
-          "pdf": "PDF",
-          "xlsx": "Excel"
-        },
-        "dropzone": {
-          "dropHere": "Drop files here...",
-          "dragAndDrop": "Drag & drop files here",
-          "orClickBrowse": "or click to browse files",
-          "acceptsCsv": "Accepts .csv files (max 10MB)",
-          "acceptsPdf": "Accepts .pdf files (max 10MB)",
-          "acceptsXlsx": "Accepts .xlsx and .xls files (max 10MB)"
-        },
-        "selectedFiles": "Selected Files",
-        "remove": "Remove",
-        "status": {
-          "success": "Files imported successfully!",
-          "error": "Error importing files. Please try again."
-        },
-        "buttons": {
-          "cancel": "Cancel",
-          "import": "Import",
-          "importWithCount": "Import ({count})"
-        }
-      },
-      "bulkActions": {
-        "selected": "{count, plural, one {# invoice selected} other {# invoices selected}}",
-        "clearSelection": "Clear selection",
-        "export": "Export",
-        "delete": "Delete",
-        "changeCategory": "Change Category",
-        "deleteConfirm": {
-          "title": "Delete Invoices",
-          "description": "{count, plural, one {Are you sure you want to delete this invoice? This action cannot be undone.} other {Are you sure you want to delete these # invoices? This action cannot be undone.}}",
-          "confirm": "Delete",
-          "cancel": "Cancel"
-        },
-        "deleteSuccess": "{count, plural, one {Invoice deleted successfully} other {# invoices deleted successfully}}",
-        "deleteError": "Failed to delete invoices. Please try again.",
-        "deletePartialSuccess": "{success} invoice(s) deleted, {failed} failed",
-        "categoryChanged": "{count, plural, one {Invoice category updated successfully} other {# invoice categories updated successfully}}",
-        "categoryChangeError": "Failed to update invoice categories. Please try again.",
-        "categoryPartialSuccess": "{success} invoice(s) updated, {failed} failed",
-        "categories": {
-          "notDefined": "Not Defined",
-          "grocery": "Groceries",
-          "fastFood": "Fast Food",
-          "homeCleaning": "Home Cleaning",
-          "carAuto": "Car & Auto",
-          "other": "Other"
-        }
-      }
-    },
-    "ViewInvoice": {
-      "metadata": {
-        "description": "View your invoice details, items, and associated merchant information.",
-        "title": "Invoice Management System - View Invoice"
-      },
-      "invoiceAnalytics": {
-        "title": "Analytics & Insights",
-        "tabs": {
-          "current": "This Invoice",
-          "compare": "Comparison"
-        },
-        "emptyState": {
-          "title": "Not Enough Data for Comparisons",
-          "description": "Add more invoices to see spending trends, merchant breakdowns, and category comparisons."
-        }
-      },
-      "invoiceTimeline": {
-        "title": "Invoice Timeline",
-        "subtitle": "Complete history of actions and changes",
-        "eventCount": "{count, plural, one {# event} other {# events}}"
-      },
-      "invoiceTabs": {
-        "tabs": {
-          "possibleRecipes": "Possible Recipes",
-          "additionalInfo": "Additional Info"
-        },
-        "recipe": {
-          "duration": "{minutes} min",
-          "prepCook": "Prep: {prep}m • Cook: {cook}m",
-          "viewRecipe": "View Recipe",
-          "ingredients": "Ingredients",
-          "instructions": "Instructions"
-        },
-        "actions": {
-          "regenerate": "Regenerate Recipes",
-          "regenerateTooltip": "Re-analyze the invoice to generate new recipe suggestions",
-          "generate": "Generate Recipes"
-        },
-        "empty": {
-          "recipes": "No recipe suggestions available",
-          "additionalInfo": "No additional information available"
-        }
-      },
-      "timelineItem": {
-        "aria": {
-          "moreInfo": "More info about {title}"
-        },
-        "confidence": "Confidence: {value}%",
-        "events": {
-          "created": {
-            "title": "Invoice Created",
-            "description": "Scanned and digitized from receipt"
-          },
-          "aiAnalysis": {
-            "title": "AI Analysis Complete",
-            "description": "{count, plural, one {# item detected and categorized} other {# items detected and categorized}}"
-          },
-          "recipesGenerated": {
-            "title": "Recipes Generated",
-            "description": "{count, plural, one {# recipe suggested} other {# recipes suggested}}"
-          },
-          "shared": {
-            "title": "Shared with Others",
-            "description": "Shared with {count, plural, one {# person} other {# people}}"
-          },
-          "edited": {
-            "title": "Invoice Updated"
-          },
-          "exported": {
-            "title": "Invoice Exported"
-          },
-          "markedImportant": {
-            "title": "Marked as Important",
-            "description": "Flagged for priority tracking"
-          },
-          "categorized": {
-            "title": "Category Assigned",
-            "description": "Auto-categorized based on items"
-          }
-        },
-        "tooltips": {
-          "created": "Invoice was scanned and digitized using {method}.",
-          "aiAnalysis": "AI processed this invoice in {duration} and analyzed {count, plural, one {# item} other {# items}}.",
-          "recipesGenerated": "Based on purchased ingredients, {count, plural, one {# recipe was generated} other {# recipes were generated}}.",
-          "shared": "Invoice was shared with {count, plural, one {# user} other {# users}}.",
-          "edited": "Manual changes were made to the invoice.",
-          "exported": "Invoice was exported in {format} format.",
-          "markedImportant": "Invoice was flagged as important for quick access.",
-          "categorized": "Invoice was assigned a category for better organization.",
-          "unavailable": "Event details unavailable"
-        },
-        "relativeTime": {
-          "now": "Just now"
-        },
-        "fallbacks": {
-          "ocr": "OCR",
-          "pdf": "PDF"
-        }
-      },
-      "timelineSharedWithList": {
-        "header": {
-          "title": "Shared With",
-          "publicBadge": "Public"
-        },
-        "publicAccess": {
-          "title": "Public Access Enabled",
-          "description": "This invoice is publicly accessible. Anyone with the link can view it, including guests without an account."
-        },
-        "aria": {
-          "sendEmail": "Send email to {user}"
-        },
-        "actions": {
-          "sendEmail": "Send email",
-          "manageSharing": "Manage Sharing"
-        }
-      },
-      "budgetImpactCard": {
-        "title": "{month} Budget Impact",
-        "monthlyBudget": "Monthly Budget",
-        "spent": "{amount} spent",
-        "invoiceUsed": "This invoice used",
-        "ofMonthlyBudget": "of your monthly budget",
-        "remaining": "Remaining",
-        "overBudget": "Over budget",
-        "daysLeft": "Days Left",
-        "inMonth": "in {month}",
-        "dailyAllowance": "Daily Allowance",
-        "dailyAllowanceValue": "{amount}/day"
-      },
-      "comparisonStatsCard": {
-        "title": "How You Compare",
-        "subtitle": "Against your last {count} invoices",
-        "vsAverage": "vs Average",
-        "avgValue": "Avg: {amount} {currency}",
-        "thisValue": "This: {amount} {currency}",
-        "minValue": "Min: {amount}",
-        "maxValue": "Max: {amount}",
-        "positionInRange": "Your position in spending range",
-        "itemCount": "Item Count",
-        "itemCountComparison": "{current} vs avg {average}",
-        "sameStore": "Same Store",
-        "sameStoreComparison": "vs avg {average} {currency}"
-      },
-      "invoiceDetailsCard": {
-        "title": "Invoice Details",
-        "labels": {
-          "dateUtc": "Date (UTC)",
-          "category": "Category",
-          "payment": "Payment",
-          "totalAmount": "Total Amount",
-          "receiptType": "Receipt Type",
-          "countryRegion": "Country/Region",
-          "subtotal": "Subtotal",
-          "tip": "Tip",
-          "ronEquivalent": "RON Equivalent"
-        },
-        "tooltips": {
-          "exchangeRate": "1 {fromCurrency} = {rate} RON (avg. {year})"
-        },
-        "sections": {
-          "paymentMethods": "Payment Methods",
-          "taxBreakdown": "Tax Breakdown"
-        },
-        "taxLabels": {
-          "net": "Net",
-          "tax": "Tax"
-        },
-        "itemsTitle": "Items ({count})",
-        "table": {
-          "item": "Item",
-          "qty": "Qty",
-          "unit": "Unit",
-          "price": "Price",
-          "total": "Total",
-          "grandTotal": "Grand Total"
-        },
-        "pagination": {
-          "pageOf": "Page {current} of {total}",
-          "previous": "Previous",
-          "next": "Next"
-        }
-      },
-      "merchantInfoCard": {
-        "title": "Merchant Information",
-        "noMerchantLinked": "No merchant linked to this invoice",
-        "viewAllReceipts": "View All Receipts",
-        "viewAllInvoices": "View All Invoices",
-        "viewOnMap": "View on Map",
-        "spendingHistory": "Spending History",
-        "categoryDistribution": "Category Distribution",
-        "stats": {
-          "visits": "visits",
-          "avgSpend": "Avg Spend",
-          "daysAgo": "days ago"
-        }
-      },
-      "receiptScanCard": {
-        "title": "Receipt Scan",
-        "dialogTitle": "Receipt Image",
-        "scanAlt": "Receipt scan {index}",
-        "scanAltFullSize": "Receipt scan {index} - full size",
-        "buttons": {
-          "expand": "Expand Image",
-          "previousScan": "Previous Scan",
-          "nextScan": "Next Scan"
-        },
-        "tooltips": {
-          "expand": "View the receipt image in full size",
-          "previousScan": "View the previous receipt scan",
-          "nextScan": "View the next receipt scan"
-        },
-        "titleWithIndex": "Receipt Scan ({current}/{total})",
-        "dialogTitleWithIndex": "Receipt Image ({current}/{total})",
-        "controls": {
-          "zoomIn": "Zoom In",
-          "zoomOut": "Zoom Out",
-          "reset": "Reset Zoom",
-          "rotate": "Rotate",
-          "download": "Download",
-          "fullScreen": "Full Screen",
-          "toggleZoom": "Click to toggle zoom"
-        },
-        "navigation": {
-          "previous": "Previous",
-          "next": "Next",
-          "of": "of"
-        }
-      },
-      "seasonalInsightsCard": {
-        "title": "Seasonal Insight",
-        "month": {
-          "spendingSoFar": "{month} so far",
-          "vsAverage": "vs {month} avg: {amount}"
-        },
-        "insights": {
-          "spike": {
-            "title": "{category} Spike",
-            "description": "+{percent}% vs your average"
-          },
-          "holidaySeason": {
-            "title": "Holiday Season",
-            "description": "December spending is typically 35% higher"
-          },
-          "stockUpTip": {
-            "title": "Stock Up Tip",
-            "description": "Prices increase ~15% after Dec 15th"
-          },
-          "normalPattern": {
-            "title": "Normal Shopping Pattern",
-            "description": "Your spending is within typical range"
-          },
-          "insufficientData": {
-            "title": "Building Your Spending Profile",
-            "description": "Add more invoices to see seasonal insights and spending patterns"
-          }
-        }
-      },
-      "shoppingCalendarCard": {
-        "title": "Shopping Calendar",
-        "tooltip": {
-          "basedOnCachedInvoices": "Based on {count} cached invoices",
-          "currentInvoiceOnly": "Showing current invoice only",
-          "more": "+{count} more",
-          "vsAverage": "vs avg ({years}y data)",
-          "invoiceCount": "{count} invoice(s)",
-          "currentInvoice": "Current invoice"
-        },
-        "legend": {
-          "less": "Less",
-          "more": "More"
-        },
-        "stats": {
-          "monthTotal": "Month Total",
-          "shoppingDays": "Shopping Days"
-        },
-        "insights": {
-          "shopEveryPrefix": "You shop every",
-          "days": "{count} days",
-          "onAverage": "on average",
-          "spendingPrefix": ", spending",
-          "perTrip": " per trip",
-          "mostActiveOn": "Most active on",
-          "weekdayLabel": "{weekday}s"
-        }
-      },
-      "summaryStatsCard": {
-        "title": "Invoice Summary",
-        "description": "Key statistics at a glance",
-        "stats": {
-          "totalItems": {
-            "label": "Total Items",
-            "description": "Products purchased"
-          },
-          "categories": {
-            "label": "Categories",
-            "description": "Unique categories"
-          },
-          "averagePrice": {
-            "label": "Avg. Price",
-            "description": "{currency} per item"
-          },
-          "taxRate": {
-            "label": "Tax Rate",
-            "description": "{amount} {currency}"
-          }
-        },
-        "extremes": {
-          "highest": "Highest",
-          "lowest": "Lowest"
-        }
-      },
-      "invoiceGuestBanner": {
-        "title": "Guest View",
-        "description": "You are not currently the owner of this invoice. The view is limited to what the owner has specified in the share settings."
-      },
-      "categoryComparisonChart": {
-        "title": "Category Comparison",
-        "description": "This invoice vs your average",
-        "labels": {
-          "current": "Current",
-          "average": "Average"
-        }
-      },
-      "itemsBreakdownChart": {
-        "title": "Top Items by Cost",
-        "description": "Highest spending items",
-        "labels": {
-          "price": "Price",
-          "quantity": "Qty"
-        }
-      },
-      "merchantBreakdownChart": {
-        "title": "Spending by Store",
-        "description": "All-time totals across merchants",
-        "labels": {
-          "totalSpent": "Total Spent",
-          "total": "Total",
-          "visits": "Visits",
-          "averagePerVisit": "Avg/visit"
-        },
-        "unknownMerchant": "Unknown Merchant"
-      },
-      "priceDistributionChart": {
-        "title": "Price Distribution",
-        "description": "Items by price range ({currency})",
-        "labels": {
-          "items": "Items"
-        },
-        "tooltip": {
-          "itemCount": "{count, plural, one {# item} other {# items}}"
-        }
-      },
-      "spendingByCategoryChart": {
-        "title": "Spending by Category",
-        "description": "Distribution of expenses",
-        "totalLabel": "Total Spending",
-        "tooltip": {
-          "itemCount": "{count, plural, one {# item} other {# items}}"
-        }
-      },
-      "spendingTrendChart": {
-        "title": "Spending Over Time",
-        "description": "Your invoice history trend",
-        "labels": {
-          "amount": "Amount"
-        },
-        "tooltip": {
-          "currentInvoice": "Current Invoice",
-          "andMore": "and {count} more..."
-        }
-      },
-      "shareAnalyticsDialog": {
-        "title": "Share Analytics",
-        "description": "Share your spending analytics for {merchant} with others.",
-        "tabs": {
-          "image": "Image",
-          "email": "Email"
-        },
-        "image": {
-          "description": "Download or copy the analytics graph as a PNG image that you can share or save.",
-          "previewPlaceholder": "Analytics Preview",
-          "download": "Download graph",
-          "copyToClipboard": "Copy graph to clipboard"
-        },
-        "email": {
-          "description": "Send the analytics to an email address.",
-          "label": "Email address",
-          "placeholder": "name@example.com",
-          "send": "Send Email"
-        },
-        "toasts": {
-          "imageCopied": {
-            "title": "Image copied!",
-            "description": "The analytics image has been copied to your clipboard"
-          },
-          "emailSent": {
-            "title": "Email sent!",
-            "description": "Analytics report sent to {email}"
-          },
-          "imageSaved": {
-            "title": "Image saved!",
-            "description": "Spending analytics for {merchant} has been downloaded as PNG"
-          }
-        }
-      },
-      "categorySuggestionCard": {
-        "title": "Help Us Categorize This Invoice",
-        "description": "We couldn't automatically categorize this invoice. Select the right category to unlock insights:",
-        "moreCategories": "More categories:",
-        "gamification": "Categorize {goal} invoices to unlock detailed insights!"
-      },
-      "diningCard": {
-        "title": "Dining Insights",
-        "sodium": {
-          "high": "High",
-          "medium": "Medium",
-          "low": "Low"
-        },
-        "estimatedNutrition": {
-          "title": "Estimated Nutrition",
-          "calories": "Calories",
-          "caloriesValue": "~{value} kcal",
-          "protein": "Protein",
-          "proteinValue": "~{value}g",
-          "sodium": "Sodium",
-          "carbs": "Carbs",
-          "carbsValue": "~{value}g"
-        },
-        "habits": {
-          "title": "Your Fast Food Habits",
-          "frequency": "Frequency",
-          "frequencyValue": "{count}x/month",
-          "frequencyDiff": "+1 vs avg",
-          "avgSpend": "Avg Spend",
-          "favorite": "Favorite",
-          "visits": "{count} visits"
-        },
-        "swaps": {
-          "title": "Healthier Swaps",
-          "grilled": "Grilled instead of fried",
-          "water": "Water instead of soda",
-          "salad": "Side salad instead of fries",
-          "caloriesSaved": "-{count} cal",
-          "moneySaved": ", saves {amount}"
-        },
-        "challenge": {
-          "title": "Weekly Challenge",
-          "descriptionPrefix": "Skip fast food for 7 days and save",
-          "descriptionSuffix": ""
-        }
-      },
-      "generalExpenseCard": {
-        "title": "Expense intelligence",
-        "detectedCategory": "Electronics / Technology",
-        "confidence": "Confidence: {value}%",
-        "sections": {
-          "autoDetectedCategory": "Auto-detected category",
-          "budgetImpact": "Budget impact",
-          "taxBusiness": "Tax & Business options",
-          "similarPurchases": "Similar past purchases"
-        },
-        "buttons": {
-          "correct": "Correct",
-          "change": "Change",
-          "organize": "Organize",
-          "export": "Export"
-        },
-        "aria": {
-          "confirmCategory": "Confirm category detection is correct",
-          "changeCategory": "Change detected category",
-          "organize": "Organize this expense into categories",
-          "export": "Export expense data"
-        },
-        "nearLimitAlert": "{name}: {percent}% used (10 days left in month)",
-        "options": {
-          "businessExpense": "Mark as business expense",
-          "trackWarranty": "Track warranty (24 months standard)",
-          "insuranceInventory": "Add to insurance inventory"
-        },
-        "vatReclaimable": "VAT reclaimable",
-        "budgetCategories": {
-          "electronics": "Electronics",
-          "entertainment": "Entertainment",
-          "shopping": "Shopping"
-        }
-      },
-      "homeInventoryCard": {
-        "title": "Home Inventory & Supplies",
-        "supplyNames": {
-          "laundryDetergent": "Laundry Detergent",
-          "dishSoap": "Dish Soap",
-          "paperProducts": "Paper Products",
-          "floorCleaner": "Floor Cleaner"
-        },
-        "stockLevels": {
-          "title": "Supply Stock Levels (estimated)",
-          "daysRemaining": "~{count} days"
-        },
-        "eco": {
-          "title": "Eco-Friendliness Score",
-          "productsWithEcoLabels": "{count} products with eco-labels",
-          "recyclablePackaging": "{count} product with recyclable packaging",
-          "tip": "Tip: Eco alternatives save 2kg plastic/year"
-        },
-        "bulk": {
-          "title": "Bulk Buying Savings",
-          "description": "5L detergent vs 2L saves 18% ({amount}/year)"
-        }
-      },
-      "nutritionCard": {
-        "title": "Nutrition Overview",
-        "score": {
-          "title": "Food Balance Score",
-          "excellent": "Excellent",
-          "good": "Good",
-          "fair": "Fair",
-          "needsWork": "Needs Work"
-        },
-        "composition": {
-          "title": "Your Basket Composition",
-          "wholeFoods": "Whole Foods",
-          "processed": "Processed",
-          "dairyOther": "Dairy/Other"
-        },
-        "foodGroups": {
-          "fruits": "Fruits",
-          "vegetables": "Vegetables",
-          "protein": "Protein",
-          "grains": "Grains",
-          "itemsCount": "{count} item(s)"
-        },
-        "allergens": {
-          "title": "Allergens Detected",
-          "foundInItems": "Found in {count} item(s)"
-        },
-        "suggestions": {
-          "addFruitsAndVegetables": "Add more fruits and vegetables to balance your basket",
-          "addVegetables": "Consider adding vegetables for a more balanced diet",
-          "addFruits": "Adding some fruits would improve nutritional balance",
-          "swapProcessed": "Try swapping some processed items for whole foods",
-          "greatBalance": "Great balanced shopping!"
-        }
-      },
-      "vehicleCard": {
-        "title": "Vehicle Expense Analysis",
-        "expenseType": "Expense Type: Fuel",
-        "details": {
-          "liters": "Liters",
-          "pricePerLiter": "Price/L",
-          "station": "Station",
-          "vehicle": "Vehicle",
-          "notSet": "Not set"
-        },
-        "chart": {
-          "title": "Monthly Fuel Spending",
-          "amount": "Amount"
-        },
-        "stats": {
-          "thisMonth": "This Month",
-          "fillUps": "{count} fill-ups",
-          "costPerKm": "Cost/km",
-          "estimated": "estimated",
-          "fuelPrice": "Fuel Price",
-          "thisMonthSuffix": "this month"
-        },
-        "maintenance": {
-          "title": "Maintenance Reminders"
-        },
-        "tip": {
-          "title": "Cheapest Nearby",
-          "perLiter": "L"
-        },
-        "buttons": {
-          "addVehicle": "Add Vehicle",
-          "fullReport": "Full Report"
-        },
-        "months": {
-          "sep": "Sep",
-          "oct": "Oct",
-          "nov": "Nov",
-          "dec": "Dec"
-        },
-        "reminders": {
-          "oilChange": "Oil change due in ~1,200 km",
-          "tireRotation": "Tire rotation recommended"
-        }
-      },
-      "print": {
-        "generatedOn": "Printed on {date}",
-        "page": "Page",
-        "labels": {
-          "date": "Date",
-          "merchant": "Merchant",
-          "total": "Total Amount",
-          "items": "Items"
-        }
-      },
-      "relatedInvoices": {
-        "noRelated": "No related invoices found",
-        "subtitle": "Similar invoices based on merchant, category, or amount",
-        "sameCategory": "Same Category",
-        "viewInvoice": "View",
-        "similarAmount": "Similar Amount",
-        "sameMerchant": "Same Merchant",
-        "title": "Related Invoices"
-      },
-      "shareCollaborate": {
-        "title": "Sharing & Collaboration",
-        "private": "Private",
-        "shared": "Shared",
-        "public": "Public",
-        "sharedWith": "Shared with",
-        "copyLink": "Copy Link",
-        "shareEmail": "Share via Email",
-        "manageSharing": "Manage Sharing",
-        "copied": "Link copied to clipboard!",
-        "activity": {
-          "title": "Activity",
-          "created": "Created {time}",
-          "modified": "Last modified {time}",
-          "daysAgo": "{count, plural, one {# day ago} other {# days ago}}",
-          "today": "today"
-        },
-        "publicAccess": "Public Access",
-        "publicAccessDescription": "Anyone with the link can view this invoice",
-        "madePublic": "Invoice is now public",
-        "madePrivate": "Invoice is now private",
-        "toggleError": "Failed to update sharing settings",
-        "qrCode": "QR Code",
-        "qrCopied": "Link copied! QR code generation coming soon.",
-        "copyError": "Failed to copy link"
-      },
-      "healthScore": {
-        "hideDetails": "Hide factor breakdown",
-        "title": "Invoice Health Score",
-        "status": {
-          "incomplete": "Incomplete",
-          "good": "Good",
-          "needsAttention": "Needs Attention",
-          "excellent": "Excellent"
-        },
-        "suggestions": {
-          "noRecipes": "No recipes generated — run AI analysis to discover meal ideas",
-          "title": "Suggested Improvements",
-          "incompletePayment": "Incomplete payment information — add transaction date, amount, and currency",
-          "fix": "Fix",
-          "noMerchant": "No merchant linked — add merchant details for better insights",
-          "noProducts": "No products found — upload a receipt or add items manually",
-          "lowOcrConfidence": "Low OCR confidence on <strong>{count}</strong> products — review manually for accuracy",
-          "uncategorizedProducts": "<strong>{count}</strong> products uncategorized — assign categories for spending analysis",
-          "incompleteProducts": "<strong>{count}</strong> products incomplete — review and complete missing fields"
-        },
-        "points": "points",
-        "factors": {
-          "merchantLinked": "Merchant linked",
-          "ocrConfidence": "OCR confidence",
-          "recipesGenerated": "Recipes generated",
-          "paymentInfo": "Payment information",
-          "productCompleteness": "Product completeness",
-          "productsPresent": "Products extracted",
-          "categoriesAssigned": "Categories assigned"
-        },
-        "cta": {
-          "edit": "Edit Invoice",
-          "analyze": "Run AI Analysis"
-        },
-        "showDetails": "Show factor breakdown",
-        "subtitle": "Comprehensive data quality assessment",
-        "seeReport": "See detailed report",
-        "dialogTitle": "Invoice Health Report"
-      },
-      "itemAnalytics": {
-        "title": "Items",
-        "searchPlaceholder": "Search items...",
-        "columns": {
-          "name": "Name",
-          "category": "Category",
-          "price": "Price",
-          "quantity": "Qty",
-          "total": "Total"
-        },
-        "confidence": {
-          "label": "OCR Confidence",
-          "lowWarning": "Low confidence — consider reviewing this item"
-        },
-        "summary": {
-          "title": "Summary",
-          "mostExpensive": "Most expensive",
-          "cheapest": "Cheapest",
-          "categories": "{count} categories",
-          "allergens": "{count} allergens detected"
-        },
-        "empty": {
-          "title": "No items",
-          "subtitle": "Run AI analysis to extract items from your receipt"
-        },
-        "totalLabel": "TOTAL"
-      },
-      "analysisPanel": {
-        "tooltips": {
-          "itemsOnly": "Re-categorize and analyze line items only",
-          "completeAnalysis": "Complete OCR extraction + AI processing of all invoice data",
-          "merchantOnly": "Re-identify merchant and location data",
-          "invoiceOnly": "Re-extract basic invoice information (date, total, payment)",
-          "reanalyze": "Trigger complete re-analysis with all AI features"
-        },
-        "title": "AI Analysis",
-        "options": {
-          "itemsOnly": "Items Only",
-          "completeAnalysis": "Full Analysis",
-          "merchantOnly": "Merchant Only",
-          "invoiceOnly": "Invoice Only"
-        },
-        "steps": {
-          "processing": "Processing items...",
-          "finalizing": "Finalizing results...",
-          "preparing": "Preparing document...",
-          "complete": "Analysis complete!",
-          "analyzing": "Analyzing with AI...",
-          "extracting": "Running OCR extraction..."
-        },
-        "analyzing": {
-          "progress": "{progress}% complete",
-          "title": "Analyzing..."
-        },
-        "labels": {
-          "lastAnalyzed": "Last Analyzed",
-          "updates": "{count, plural, one {# update} other {# updates}}",
-          "granularOptions": "Or choose specific analysis",
-          "analysisComplete": "Analysis Complete — All data has been extracted"
-        },
-        "toasts": {
-          "error": {
-            "description": "Unable to analyze invoice. Please try again later.",
-            "title": "Analysis Failed"
-          },
-          "success": {
-            "description": "Invoice has been successfully re-analyzed with updated data.",
-            "title": "Analysis Complete"
-          }
-        },
-        "description": "Re-analyze this invoice with AI to extract or update data",
-        "buttons": {
-          "reanalyze": "Re-Analyze Invoice"
-        },
-        "tip": "Quick Tip: Full analysis takes 30-60 seconds but provides the most accurate results."
-      },
-      "export": {
-        "printError": "Failed to open print dialog",
-        "printSuccess": "Print dialog opened",
-        "csv": {
-          "title": "Export as CSV",
-          "description": "Download items as spreadsheet"
-        },
-        "description": "Export your invoice data in various formats",
-        "print": {
-          "title": "Print",
-          "description": "Print invoice using browser"
-        },
-        "csvSuccess": "CSV file downloaded successfully",
-        "copyError": "Failed to copy summary",
-        "copySummary": {
-          "title": "Copy Summary",
-          "description": "Copy text summary to clipboard"
-        },
-        "copySuccess": "Summary copied to clipboard",
-        "json": {
-          "title": "Export as JSON",
-          "description": "Download complete invoice data"
-        },
-        "jsonSuccess": "JSON file downloaded successfully",
-        "jsonError": "Failed to export JSON",
-        "csvError": "Failed to export CSV",
-        "title": "Export Invoice",
-        "pdf": {
-          "title": "Export as PDF",
-          "description": "Download professional invoice document"
-        },
-        "pdfSuccess": "PDF file downloaded successfully",
-        "pdfError": "Failed to generate PDF",
-        "pdfGenerating": "Generating PDF..."
-      }
-    },
-    "EditInvoice": {
-      "metadata": {
-        "description": "View and edit your invoice details, items, recipes, and sharing settings.",
-        "title": "Invoice Management System - Edit Invoice"
-      },
-      "editInvoiceContext": {
-        "toasts": {
-          "noChanges": "No changes to save",
-          "updated": "Invoice updated successfully",
-          "saveFailed": "Failed to save changes"
-        },
-        "console": {
-          "saveFailed": "Failed to save invoice:"
-        }
-      },
-      "triviaTips": {
-        "title": "Savings Tips",
-        "completeness": "Invoice is {percentage}% complete",
-        "completeLabel": "Invoice is fully complete!",
-        "difficulty": {
-          "easy": "Easy",
-          "medium": "Medium"
-        },
-        "banner": {
-          "potentialSavingsLabel": "Potential Savings",
-          "hint": "Apply these tips to save on your next visit to {merchantName}"
-        },
-        "contextTips": {
-          "noItems": "Run AI analysis to extract items from your receipt",
-          "noDescription": "Add a description to help you remember this purchase",
-          "noCategory": "Set a category to track spending patterns",
-          "defaultCategory": "Change the category from 'Uncategorized' to track better",
-          "noRecipes": "AI can suggest recipes based on your grocery items"
-        },
-        "contextActions": {
-          "analyze": "Run Analysis",
-          "addDescription": "Add Description",
-          "setCategory": "Set Category"
-        },
-        "tips": {
-          "loyaltyProgram": {
-            "title": "Join Loyalty Program",
-            "description": "Sign up for {merchantName}'s loyalty program to earn points on every purchase."
-          },
-          "bulkPurchase": {
-            "title": "Buy in Bulk",
-            "description": "Purchase non-perishable items in bulk to save on per-unit costs."
-          },
-          "digitalCoupons": {
-            "title": "Use Digital Coupons",
-            "description": "Check {merchantName}'s app for digital coupons before shopping."
-          }
-        },
-        "tooltips": {
-          "estimatedSavings": "Estimated savings with this tip"
-        },
-        "buttons": {
-          "viewMoreSavingsTips": "View More Savings Tips"
-        },
-        "disclaimer": "Savings are estimates based on average prices and promotions"
-      },
-      "invoiceCard": {
-        "title": "Invoice details",
-        "importantBadge": "IMPORTANT",
-        "markImportant": "Mark as important",
-        "tooltips": {
-          "unmarkFavorite": "Click to unmark as favorite",
-          "markFavorite": "Click to mark as favorite"
-        },
-        "fromMerchant": "From {merchant}",
-        "descriptionPlaceholder": "Enter invoice description...",
-        "labels": {
-          "dateUtc": "Date (UTC)",
-          "hours": "Hours",
-          "minutes": "Minutes",
-          "utc": "UTC",
-          "category": "Category",
-          "paymentMethod": "Payment method",
-          "totalAmount": "Total amount"
-        },
-        "placeholders": {
-          "selectCategory": "Select category",
-          "selectPaymentType": "Select payment type"
-        }
-      },
-      "merchantCard": {
-        "title": "Merchant",
-        "noMerchantLinked": "No merchant linked to this invoice",
-        "addressLabel": "Address: {address}",
-        "buttons": {
-          "viewMerchantDetails": "View Merchant Details",
-          "viewAllReceipts": "View All Receipts"
-        },
-        "tooltips": {
-          "viewMerchantDetails": "See detailed information about this merchant",
-          "viewAllReceipts": "View all receipts from this merchant"
-        }
-      },
-      "imageCard": {
-        "title": "Receipt scan",
-        "dialogTitle": "Receipt image",
-        "scanAlt": "Receipt scan {index}",
-        "scanAltFullSize": "Receipt scan {index} - full size",
-        "buttons": {
-          "expand": "Expand image",
-          "previous": "Previous",
-          "next": "Next",
-          "addScan": "Add scan",
-          "remove": "Remove"
-        },
-        "tooltips": {
-          "expand": "View the receipt image in full size",
-          "previous": "View the previous receipt scan",
-          "next": "View the next receipt scan",
-          "addScan": "Upload and attach a new receipt scan",
-          "remove": "Remove the current receipt scan"
-        },
-        "aria": {
-          "expandImage": "Click to expand image"
-        },
-        "titleWithIndex": "Receipt scan ({current}/{total})",
-        "dialogTitleWithIndex": "Receipt image ({current}/{total})"
-      },
-      "recipeCard": {
-        "complexity": {
-          "unknown": "Unknown",
-          "easy": "Easy",
-          "normal": "Normal",
-          "hard": "Hard"
-        },
-        "dropdown": {
-          "view": "View",
-          "edit": "Edit",
-          "delete": "Delete",
-          "share": "Share",
-          "markAsFavorite": "Mark as Favorite"
-        },
-        "ingredients": {
-          "label": "Ingredients:",
-          "more": "+{count} more",
-          "additionalLabel": "Additional ingredients:"
-        },
-        "timing": {
-          "prepLabel": "Prep: {minutes}′",
-          "prepTooltip": "Preparation time is {minutes} minutes.",
-          "cookLabel": "Cook: {minutes}′",
-          "cookTooltip": "Cooking time is {minutes} minutes."
-        },
-        "buttons": {
-          "visitReference": "Visit Reference",
-          "viewRecipe": "View Recipe"
-        }
-      },
-      "sharingCard": {
-        "title": "Sharing",
-        "ownerAvatarAlt": "User",
-        "owner": "Owner",
-        "sharedWith": "Shared With",
-        "userWithId": "User {id}",
-        "publicInvoice": {
-          "title": "Public Invoice",
-          "description": "This invoice is publicly accessible. Anyone with the link can view it."
-        },
-        "emptyShared": {
-          "public": "No additional users have direct access",
-          "private": "Not shared with anyone"
-        },
-        "buttons": {
-          "manageSharing": "Manage Sharing",
-          "shareInvoice": "Share Invoice",
-          "revokingAccess": "Revoking Access...",
-          "markAsPrivate": "Mark as Private"
-        },
-        "tooltips": {
-          "manageSharing": "Manage sharing settings for this invoice",
-          "removeAccess": "Remove access",
-          "shareInvoice": "Share this invoice with other users",
-          "markAsPrivate": "Mark the invoice as private"
-        },
-        "toasts": {
-          "removeAccessComingSoon": {
-            "title": "Remove access feature coming soon",
-            "description": "This feature is currently under development."
-          },
-          "revoke": {
-            "loading": "Revoking public access...",
-            "success": "Invoice is now private. Existing links will no longer work.",
-            "error": "Failed to mark private: {message}"
-          }
-        }
-      },
-      "recipesTab": {
-        "header": {
-          "title": "Recipes You Can Make",
-          "description": "Based on items in this invoice"
-        },
-        "buttons": {
-          "generate": "Generate",
-          "addRecipe": "Add Recipe",
-          "createFirstRecipe": "Create Your First Recipe"
-        },
-        "tooltips": {
-          "generateRecipeUsingAi": "Generate a recipe using AI!",
-          "createRecipeWithIngredients": "Create a new recipe with these ingredients"
-        },
-        "emptyState": {
-          "noRecipesAvailable": "No recipes available yet"
-        },
-        "pagination": {
-          "previous": "Previous",
-          "next": "Next",
-          "pageOf": "Page {currentPage} of {totalPages}"
-        },
-        "toasts": {
-          "aiGenerationComingSoon": {
-            "title": "AI recipe generation coming soon",
-            "description": "This feature is currently under development."
-          }
-        }
-      },
-      "metadataTab": {
-        "header": {
-          "title": "Additional Information",
-          "description": "Metadata associated with this invoice"
-        },
-        "buttons": {
-          "addField": "Add Field",
-          "addFirstMetadataField": "Add Your First Metadata Field"
-        },
-        "tooltips": {
-          "addCustomMetadata": "Add custom metadata to this invoice"
-        },
-        "badges": {
-          "readonly": "Readonly"
-        },
-        "dropdown": {
-          "edit": "Edit",
-          "delete": "Delete"
-        },
-        "emptyState": {
-          "noMetadataFields": "No metadata fields added yet"
-        }
-      },
-      "analyzeDialog": {
-        "header": {
-          "title": "Analyze Invoice",
-          "description": "Configure AI-powered analysis for invoice"
-        },
-        "options": {
-          "completeAnalysis": {
-            "title": "Complete Analysis",
-            "description": "Full AI-powered analysis including all invoice data, items, and merchant information.",
-            "estimatedTime": "2-3 min",
-            "features": {
-              "ocrExtraction": "OCR extraction",
-              "itemCategorization": "Item categorization",
-              "merchantIdentification": "Merchant identification",
-              "priceAnalysis": "Price analysis",
-              "receiptValidation": "Receipt validation"
-            }
-          },
-          "invoiceOnly": {
-            "title": "Invoice Data Only",
-            "description": "Analyze basic invoice information like totals, dates, and payment details.",
-            "estimatedTime": "30-60 sec",
-            "features": {
-              "totalExtraction": "Total extraction",
-              "dateParsing": "Date parsing",
-              "paymentMethodDetection": "Payment method detection"
-            }
-          },
-          "itemsOnly": {
-            "title": "Items Analysis",
-            "description": "Focus on extracting and categorizing individual line items from the invoice.",
-            "estimatedTime": "1-2 min",
-            "features": {
-              "itemExtraction": "Item extraction",
-              "categoryAssignment": "Category assignment",
-              "pricePerItem": "Price per item",
-              "quantityDetection": "Quantity detection"
-            }
-          },
-          "merchantOnly": {
-            "title": "Merchant Analysis",
-            "description": "Identify and analyze merchant information including location and category.",
-            "estimatedTime": "30-45 sec",
-            "features": {
-              "merchantIdentification": "Merchant identification",
-              "locationExtraction": "Location extraction",
-              "businessCategory": "Business category",
-              "contactInfo": "Contact info"
-            }
-          }
-        },
-        "analysisSteps": {
-          "preparingDocument": "Preparing document...",
-          "runningOcrExtraction": "Running OCR extraction...",
-          "analyzingWithAi": "Analyzing with AI...",
-          "categorizingItems": "Categorizing items...",
-          "finalizingResults": "Finalizing results...",
-          "processing": "Processing..."
-        },
-        "analyzing": {
-          "title": "Analyzing Invoice",
-          "progressComplete": "{progress}% complete"
-        },
-        "sections": {
-          "analysisType": "Analysis Type",
-          "includedFeatures": "Included Features",
-          "enhancementsOptional": "Enhancements (Optional)"
-        },
-        "enhancements": {
-          "priceComparison": {
-            "label": "Price Comparison",
-            "description": "Compare prices with historical data"
-          },
-          "savingsTips": {
-            "label": "Savings Suggestions",
-            "description": "Get AI-powered saving recommendations"
-          },
-          "quickExtract": {
-            "label": "Quick Extract Mode",
-            "description": "Prioritize speed over accuracy"
-          }
-        },
-        "badges": {
-          "recommended": "Recommended"
-        },
-        "summary": {
-          "enhancementsSelected": "+ {count} enhancement(s)",
-          "noEnhancementsSelected": "No enhancements selected",
-          "estimatedTime": "Estimated time"
-        },
-        "buttons": {
-          "cancel": "Cancel",
-          "analyzing": "Analyzing...",
-          "startAnalysis": "Start Analysis"
-        },
-        "toasts": {
-          "analysisComplete": {
-            "title": "Analysis Complete",
-            "description": "Your invoice has been analyzed successfully."
-          },
-          "analysisFailed": {
-            "title": "Analysis Failed",
-            "description": "We couldn't analyze your invoice. Please try again."
-          }
-        }
-      },
-      "addScanDialog": {
-        "title": "Add new scan",
-        "description": "Upload a new receipt image or document to attach to this invoice.",
-        "dropzone": {
-          "dropHere": "Drop the file here...",
-          "dragAndDrop": "Drag & drop a file here",
-          "orClickBrowse": "or click to browse",
-          "formats": "JPEG, PNG, PDF (max 10MB)"
-        },
-        "scanType": {
-          "label": "Scan type",
-          "placeholder": "Select scan type",
-          "jpeg": "JPEG image",
-          "png": "PNG image",
-          "pdf": "PDF document",
-          "other": "Other"
-        },
-        "buttons": {
-          "cancel": "Cancel",
-          "uploading": "Uploading...",
-          "upload": "Upload scan"
-        },
-        "errors": {
-          "uploadStorageFailed": "Failed to upload scan to storage",
-          "unknown": "Unknown error occurred"
-        },
-        "toasts": {
-          "fileTooLargeTitle": "File too large",
-          "fileTooLargeDescription": "Maximum file size is 10MB",
-          "scanAddedTitle": "Scan added successfully",
-          "scanAddedDescription": "The scan has been attached to the invoice",
-          "scanFailedTitle": "Failed to add scan"
-        },
-        "console": {
-          "uploadError": "Error uploading scan:"
-        }
-      },
-      "imageDialog": {
-        "title": "Image ({image})",
-        "imageAlt": "Photo of receipt"
-      },
-      "itemsDialog": {
-        "title": "Edit invoice items",
-        "description": "Update quantities, prices, or add new items to this invoice",
-        "table": {
-          "item": "Item",
-          "quantity": "Quantity",
-          "unit": "Unit",
-          "price": "Price",
-          "total": "Total",
-          "actions": "Actions"
-        },
-        "footer": {
-          "itemsFound": "{total} items found (showing {shown})",
-          "page": "Page {current} of {total}",
-          "itemsTotal": "{count, plural, one {# item in total} other {# items in total}}"
-        },
-        "buttons": {
-          "previous": "Previous",
-          "next": "Next",
-          "addItem": "Add item",
-          "cancel": "Cancel",
-          "saveChanges": "Save changes"
-        },
-        "aria": {
-          "deleteItem": "Delete item: {name}",
-          "unnamedItem": "unnamed item",
-          "previousPage": "Go to previous page (page {page})",
-          "nextPage": "Go to next page (page {page})",
-          "addItem": "Add a new item to the invoice",
-          "cancel": "Cancel editing and close dialog",
-          "save": "Save changes to invoice items"
-        }
-      },
-      "merchantDialog": {
-        "title": "Merchant Details",
-        "noMerchantLinked": "No merchant linked to this invoice",
-        "description": "Information about {merchantName}",
-        "fields": {
-          "address": "Address",
-          "phone": "Phone",
-          "parentCompany": "Parent Company"
-        },
-        "buttons": {
-          "openInMaps": "Open in Maps"
-        }
-      },
-      "feedbackDialog": {
-        "title": "Provide Feedback",
-        "description": "Help us improve analytics for {merchant} by sharing your thoughts",
-        "sections": {
-          "rating": "How would you rate the analytics?",
-          "features": "Which features were most helpful? (Select all that apply)",
-          "comments": "Additional comments (optional)"
-        },
-        "features": {
-          "spendingTrends": "Spending Trends",
-          "priceComparisons": "Price Comparisons",
-          "savingsTips": "Savings Tips",
-          "merchantAnalysis": "Merchant Analysis",
-          "visualCharts": "Visual Charts",
-          "categoryBreakdown": "Category Breakdown"
-        },
-        "commentsPlaceholder": "Share your thoughts about the analytics...",
-        "buttons": {
-          "cancel": "Cancel",
-          "submit": "Submit Feedback"
-        },
-        "toasts": {
-          "sending": {
-            "title": "Sending feedback...",
-            "description": "Please wait while we submit your feedback."
-          },
-          "ratingRequired": {
-            "title": "Rating required",
-            "description": "Please provide a star rating before submitting"
-          },
-          "success": {
-            "title": "Feedback sent!",
-            "description": "Feedback sent successfully"
-          },
-          "error": {
-            "title": "An error occurred while submitting feedback",
-            "description": "Please try again later."
-          }
-        }
-      },
-      "metadataDialog": {
-        "add": {
-          "title": "Add metadata",
-          "description": "Add additional information to this invoice"
-        },
-        "edit": {
-          "title": "Edit metadata",
-          "description": "Update the value of this metadata field",
-          "fieldLabel": "Metadata field"
-        },
-        "delete": {
-          "title": "Delete metadata",
-          "description": "Are you sure you want to delete this metadata?"
-        },
-        "fields": {
-          "keyLabel": "Metadata key",
-          "valueLabel": "Metadata value",
-          "keyPlaceholder": "Enter key",
-          "valuePlaceholder": "Enter value"
-        },
-        "buttons": {
-          "cancel": "Cancel",
-          "save": "Save",
-          "delete": "Delete"
-        }
-      },
-      "recipeDialog": {
-        "create": {
-          "title": "Add new recipe",
-          "description": "Fill in the details to create a recipe.",
-          "success": "Recipe created successfully",
-          "error": "Failed to create recipe"
-        },
-        "read": {
-          "description": "Recipe details and cooking instructions",
-          "noDescription": "No description provided.",
-          "notSpecified": "Not specified"
-        },
-        "update": {
-          "title": "Update recipe",
-          "description": "Update recipe details."
-        },
-        "delete": {
-          "title": "Are you sure?",
-          "description": "This action cannot be undone. This will permanently delete the recipe <strong>{name}</strong> and all its associated data."
-        },
-        "fields": {
-          "recipeName": "Recipe name",
-          "description": "Description",
-          "ingredients": "Ingredients",
-          "difficulty": "Difficulty level",
-          "complexity": "Complexity level",
-          "instructions": "Instructions",
-          "prepTime": "Prep time",
-          "cookTime": "Cook time",
-          "totalDuration": "Total Duration"
-        },
-        "actions": {
-          "generateName": "Generate name",
-          "enhanceInstructions": "Enhance instructions"
-        },
-        "tooltips": {
-          "generateName": "Generate a recipe name based on your ingredients and difficulty level using AI",
-          "enhanceInstructions": "Use AI to enhance your instructions with more details"
-        },
-        "placeholders": {
-          "recipeName": "Enter recipe name",
-          "description": "Enter a brief description of the recipe",
-          "selectDifficulty": "Select difficulty",
-          "instructions": "Enter cooking instructions",
-          "prepTime": "e.g. 15 minutes",
-          "cookTime": "e.g. 30 minutes"
-        },
-        "difficulty": {
-          "easy": "Easy",
-          "medium": "Medium",
-          "hard": "Hard"
-        },
-        "buttons": {
-          "add": "Add",
-          "cancel": "Cancel",
-          "save": "Save",
-          "saving": "Saving...",
-          "close": "Close",
-          "delete": "Delete"
-        },
-        "minutes": "minutes"
-      },
-      "merchantReceiptsDialog": {
-        "title": "All receipts from {merchant}",
-        "description": "View and filter all your receipts from this merchant",
-        "searchPlaceholder": "Search receipts...",
-        "filters": {
-          "date": "Date",
-          "sort": "Sort"
-        },
-        "dateOptions": {
-          "allTime": "All time",
-          "last30Days": "Last 30 days",
-          "last90Days": "Last 90 days",
-          "thisYear": "This year"
-        },
-        "sortOptions": {
-          "newest": "Newest first",
-          "oldest": "Oldest first"
-        },
-        "table": {
-          "receipt": "Receipt",
-          "date": "Date",
-          "itemsCount": "Items #",
-          "actions": "Actions",
-          "view": "View"
-        },
-        "footer": {
-          "receiptsFound": "{count} receipts found (showing {showing})",
-          "page": "Page {current} of {total}"
-        },
-        "buttons": {
-          "previous": "Previous",
-          "next": "Next"
-        }
-      },
-      "removeScanDialog": {
-        "title": "Remove scan",
-        "description": "Are you sure you want to remove scan {current} of {total}?",
-        "descriptionLastScan": "This is the only scan attached to this invoice. You cannot remove it.",
-        "scanAlt": "Scan {index}",
-        "scanCaption": "Scan {index}",
-        "warning": {
-          "title": "Cannot remove last scan",
-          "description": "Every invoice must have at least one scan attached. Add another scan before removing this one."
-        },
-        "buttons": {
-          "cancel": "Cancel",
-          "removing": "Removing...",
-          "remove": "Remove scan"
-        },
-        "toasts": {
-          "cannotDeleteLastTitle": "Cannot delete last scan",
-          "cannotDeleteLastDescription": "An invoice must have at least one scan attached",
-          "removedTitle": "Scan removed successfully",
-          "removedDescription": "The scan has been removed from the invoice",
-          "removeFailedTitle": "Failed to remove scan"
-        },
-        "errors": {
-          "unknown": "Unknown error occurred"
-        },
-        "console": {
-          "deleteError": "Error deleting scan:"
-        }
-      },
-      "itemsTable": {
-        "title": "Items",
-        "buttons": {
-          "editItems": "Edit Items",
-          "addItem": "Add Item"
-        },
-        "tooltips": {
-          "editInvoiceItemsAndQuantities": "Edit invoice items and quantities"
-        },
-        "columns": {
-          "selectAll": "Select all items",
-          "selectRow": "Select {name}",
-          "name": "Name",
-          "quantity": "Quantity",
-          "price": "Price",
-          "unit": "Unit",
-          "total": "Total",
-          "actions": "Actions"
-        },
-        "tableHeaders": {
-          "item": "Item",
-          "quantity": "Qty",
-          "price": "Price",
-          "total": "Total"
-        },
-        "footer": {
-          "total": "Total"
-        },
-        "pagination": {
-          "totalItems": "{count, plural, one {# item in total} other {# items in total}}",
-          "previous": "Previous",
-          "next": "Next",
-          "pageOf": "Page {currentPage} of {totalPages}"
-        },
-        "search": {
-          "placeholder": "Search items..."
-        },
-        "bulkToolbar": {
-          "selectedCount": "{count, plural, one {# item selected} other {# items selected}}",
-          "deleteSelected": "Delete Selected",
-          "changeCategory": "Change Category",
-          "noSelection": "No products selected"
-        },
-        "editing": {
-          "saved": "Item updated successfully",
-          "cancel": "Edit canceled",
-          "fieldLabel": "Edit {field} for {name}"
-        },
-        "deleteConfirm": {
-          "title": "Delete Items",
-          "description": "{count, plural, one {Are you sure you want to delete this item?} other {Are you sure you want to delete # items?}}",
-          "confirm": "Delete",
-          "cancel": "Cancel",
-          "success": "{count, plural, one {# item deleted} other {# items deleted}}"
-        },
-        "newItem": {
-          "defaultName": "New Item",
-          "added": "New item added"
-        },
-        "indicators": {
-          "uncategorized": "Uncategorized",
-          "uncategorizedTooltip": "This product needs a category assigned for better spending tracking",
-          "missingName": "Missing name",
-          "missingNameTooltip": "Generic name translation is missing or identical to raw OCR text",
-          "lowConfidence": "Low confidence",
-          "lowConfidenceTooltip": "OCR confidence is {confidence}% - manual review recommended",
-          "edited": "Edited",
-          "editedTooltip": "This product has been manually modified",
-          "allergens": "{count, plural, one {# allergen} other {# allergens}}"
-        },
-        "actions": {
-          "remove": "Remove item",
-          "restore": "Restore item",
-          "editAllergens": "Edit allergens"
-        },
-        "softDelete": {
-          "success": "Item '{name}' removed",
-          "error": "Failed to remove item"
-        },
-        "restore": {
-          "success": "Item '{name}' restored",
-          "error": "Failed to restore item"
-        },
-        "bulkCategory": {
-          "noSelection": "Please select at least one product"
-        }
-      },
-      "guidedEdit": {
-        "banner": {
-          "title": "{count, plural, one {# product needs review} other {# products need review}}",
-          "summary": {
-            "uncategorized": "{count, plural, one {# uncategorized} other {# uncategorized}}",
-            "lowConfidence": "{count, plural, one {# low confidence} other {# low confidence}}",
-            "missingName": "{count, plural, one {# missing name} other {# missing name}}"
-          },
-          "actions": {
-            "reviewAll": "Review All",
-            "dismiss": "Dismiss"
-          },
-          "badges": {
-            "uncategorized": "{count, plural, one {# uncategorized} other {# uncategorized}}",
-            "lowConfidence": "{count, plural, one {# low confidence} other {# low confidence}}",
-            "missingName": "{count, plural, one {# missing name} other {# missing name}}"
-          }
-        }
-      },
-      "changeHistory": {
-        "unsavedChanges": "Unsaved changes",
-        "pending": "Pending",
-        "created": "Invoice created",
-        "title": "Change History",
-        "time": {
-          "justNow": "Just now",
-          "secondsAgo": "{seconds} seconds ago",
-          "hoursAgo": "{hours} hours ago",
-          "daysAgo": "{days} days ago",
-          "minutesAgo": "{minutes} minutes ago"
-        },
-        "modified": "Last modified",
-        "changes": {
-          "paymentTypeChanged": "Payment type changed",
-          "unmarkedImportant": "Unmarked as important",
-          "categoryUpdated": "Category updated",
-          "transactionDateChanged": "Transaction date changed",
-          "nameChanged": "Name changed",
-          "descriptionChanged": "Description changed",
-          "markedImportant": "Marked as important",
-          "importanceChanged": "Importance changed"
-        }
-      },
-      "allergenDialog": {
-        "labels": {
-          "currentAllergens": "Current Allergens",
-          "customAllergen": "Add Custom Allergen",
-          "quickAdd": "Quick Add Common Allergens"
-        },
-        "title": "Edit Allergens",
-        "success": {
-          "added": "Added allergen: {name}",
-          "saved": "Allergens updated successfully",
-          "removed": "Removed allergen: {name}"
-        },
-        "buttons": {
-          "save": "Save Changes",
-          "saving": "Saving...",
-          "cancel": "Cancel",
-          "add": "Add"
-        },
-        "defaultDescription": "Contains {name}",
-        "aria": {
-          "removeAllergen": "Remove {name} allergen"
-        },
-        "placeholders": {
-          "customAllergen": "Enter allergen name..."
-        },
-        "empty": {
-          "noAllergens": "No allergens detected"
-        },
-        "description": "Manage allergens for {productName}",
-        "errors": {
-          "emptyName": "Allergen name cannot be empty",
-          "duplicate": "Allergen '{name}' already added",
-          "missingData": "Missing product data",
-          "saveFailed": "Failed to save allergens"
-        }
-      },
-      "bulkCategoryDialog": {
-        "errors": {
-          "saveFailed": "Failed to update categories",
-          "missingData": "Missing data",
-          "noProducts": "No products selected"
-        },
-        "success": {
-          "saved": "{count, plural, one {Category updated for # product} other {Category updated for # products}}"
-        },
-        "description": "{count, plural, one {Change category for # product} other {Change category for # products}}",
-        "buttons": {
-          "save": "Apply to All",
-          "saving": "Saving...",
-          "cancel": "Cancel"
-        },
-        "labels": {
-          "andMore": "...and {count} more",
-          "newCategory": "New Category",
-          "selectedProducts": "Selected Products"
-        },
-        "placeholders": {
-          "selectCategory": "Select a category"
-        },
-        "title": "Change Category"
-      }
-    },
-    "Shared": {
-      "invoiceHeader": {
-        "tooltips": {
-          "importantInvoice": "Important Invoice",
-          "edit": "Edit this invoice",
-          "delete": "Delete this invoice permanently",
-          "print": "Print this invoice",
-          "saveAllPendingChanges": "Save all pending changes",
-          "discardAllPendingChanges": "Discard all pending changes",
-          "printInvoiceWithAllDetails": "Print this invoice with all details",
-          "analyzeSpendingPatterns": "Analyze spending patterns for this invoice",
-          "deleteInvoicePermanently": "Delete this invoice permanently",
-          "export": "Export invoice data in various formats"
-        },
-        "id": "ID: {id}",
-        "buttons": {
-          "edit": "Edit",
-          "delete": "Delete",
-          "print": "Print",
-          "save": "Save",
-          "saving": "Saving...",
-          "discard": "Discard",
-          "analyzeWithAi": "Analyze with AI",
-          "export": "Export"
-        }
-      },
-      "states": {
-        "notFound": {
-          "title": "Invoice Not Found",
-          "description": "The invoice with the identifier {invoiceIdentifier} was not found."
-        },
-        "loading": {
-          "title": "Loading Invoice",
-          "description": "Loading the invoice with the identifier {invoiceIdentifier}."
-        }
-      },
-      "loadingInvoices": {
-        "title": "Loading invoices",
-        "description": "Loading invoices..."
-      },
-      "invoicesNotFound": {
-        "title": "Something is missing here...",
-        "description": "It seems that you do not have any invoices associated with your account. Please upload some invoices and come back later.",
-        "cta": "Upload an invoice here."
-      },
-      "shareInvoiceDialog": {
-        "title": "Share invoice",
-        "selection": {
-          "description": "Choose how you want to share this invoice. Your choice affects who can access it.",
-          "publicTitle": "Public sharing",
-          "publicDescription": "Generate a link or QR code that <strong>anyone</strong> can use to view this invoice.",
-          "privateTitle": "Private sharing",
-          "privateDescription": "Send an email invitation to a <strong>specific person</strong>. Only they will have access.",
-          "privacyNoticeTitle": "Privacy notice",
-          "privacyNoticeDescription": "Public links can be accessed by anyone who has the URL. Private sharing restricts access to the specific recipient."
-        },
-        "dialogDescription": {
-          "currentlyPublic": "\"{invoiceName}\" is currently public",
-          "selection": "Choose how to share \"{invoiceName}\"",
-          "public": "Share \"{invoiceName}\" publicly",
-          "private": "Send \"{invoiceName}\" privately"
-        },
-        "toasts": {
-          "copyLink": {
-            "loadingPublic": "Copying link...",
-            "loadingMakePublic": "Making invoice public...",
-            "successPublic": "Link copied to clipboard!",
-            "successMadePublic": "Invoice is now public! Link copied to clipboard.",
-            "error": "Failed: {message}"
-          },
-          "copyQr": {
-            "loadingPublic": "Copying QR code...",
-            "loadingMakePublic": "Making invoice public...",
-            "successPublic": "QR code copied to clipboard!",
-            "successMadePublic": "Invoice is now public! QR code copied to clipboard.",
-            "error": "Failed: {message}"
-          },
-          "sendEmail": {
-            "loading": "Sending invitation to {email}...",
-            "success": "Invitation sent to {email}!",
-            "error": "Failed: {message}",
-            "comingSoon": "Email sharing is coming soon"
-          },
-          "revoke": {
-            "loading": "Sending revoke request to backend...",
-            "success": "Invoice is now private. Existing links will no longer work.",
-            "error": "Failed to revoke access: {message}"
-          }
-        },
-        "errors": {
-          "qrNotFound": "QR code element not found"
-        }
-      },
-      "shareInvoiceDialogPublic": {
-        "tabs": {
-          "directLink": "Direct link",
-          "qrCode": "QR code"
-        },
-        "hints": {
-          "link": "Copy this link and share it. Anyone who receives it will be able to view the invoice.",
-          "qr": "Anyone who scans this QR code will be directed to view the invoice."
-        },
-        "copyQrImage": "Copy QR code as image",
-        "alreadyPublic": {
-          "title": "This invoice is currently public",
-          "description": "This invoice is publicly accessible. <strong>Anyone with the link can view it</strong>, including all invoice details, items, and amounts. You can revoke public access at any time to make it private again.",
-          "revoke": "Revoke public access",
-          "revoking": "Revoking access...",
-          "revokeHint": "This will make the invoice private. Existing links will stop working."
-        },
-        "backToOptions": "Back to options",
-        "warning": {
-          "title": "Public access warning",
-          "description": "By sharing this invoice publicly, <strong>anyone with the link will be able to view it</strong>. This includes all invoice details, items, and amounts. Only proceed if you intend to make this invoice accessible to the public."
-        }
-      },
-      "shareInvoiceDialogPrivate": {
-        "backToOptions": "Back to options",
-        "title": "Private sharing",
-        "description": "The invitation will be sent directly to the email address you specify. Only this recipient will receive access to view the invoice.",
-        "emailLabel": "Recipient's email address",
-        "emailPlaceholder": "name@example.com",
-        "emailHint": "An email invitation will be sent to this address with a private link to view the invoice.",
-        "sendInvitation": "Send private invitation",
-        "sending": "Sending invitation...",
-        "comingSoonTooltip": "Email sharing feature is coming soon"
-      },
-      "deleteInvoiceDialog": {
-        "title": "Delete invoice",
-        "description": "This action cannot be undone. Please review carefully before proceeding.",
-        "deleting": {
-          "title": "Deleting invoice...",
-          "description": "Please wait while we remove all associated data."
-        },
-        "impact": {
-          "title": "Permanent deletion",
-          "intro": "The following data will be permanently deleted:",
-          "invoiceRecord": "Invoice record and metadata",
-          "uploadedScans": "{count} uploaded scan(s)",
-          "lineItems": "{count} line item(s)",
-          "sharedAccess": "Shared access for {count} user(s)"
-        },
-        "confirmation": {
-          "typeToConfirm": "Type <highlight>{name}</highlight> to confirm:",
-          "understoodLabel": "I understand this action is permanent",
-          "understoodDescription": "This invoice and all its data will be permanently deleted and cannot be recovered."
-        },
-        "buttons": {
-          "cancel": "Cancel",
-          "deleting": "Deleting...",
-          "deletePermanently": "Delete permanently"
-        },
-        "toasts": {
-          "deletedTitle": "Invoice deleted",
-          "deletedDescription": "The invoice was deleted successfully.",
-          "deleteFailedTitle": "Delete failed",
-          "deleteFailedDescription": "We couldn't delete this invoice. Please try again."
-        },
-        "console": {
-          "deleteError": "Error deleting invoice:"
-        }
-      },
-      "shortcuts": {
-        "title": "Keyboard Shortcuts",
-        "description": "Quick access to common actions using your keyboard",
-        "openSearch": "Open search",
-        "newInvoice": "New invoice",
-        "uploadScan": "Upload scan",
-        "showHelp": "Show this help",
-        "closeDialog": "Close dialog",
-        "close": "Close"
-      },
-      "commandPalette": {
-        "placeholder": "Search invoices, merchants, items...",
-        "noResults": "No results found",
-        "groups": {
-          "quickActions": "Quick Actions",
-          "recentInvoices": "Recent Invoices",
-          "searchResults": "Search Results"
-        },
-        "actions": {
-          "uploadScans": "Upload Scans",
-          "createInvoice": "Create Invoice",
-          "viewStatistics": "View Statistics",
-          "viewAll": "View All Invoices"
-        }
-      },
-      "onboarding": {
-        "steps": {
-          "upload": {
-            "description": "Take a photo or upload a PDF of your receipt. Our system supports multiple formats and can process batches of receipts at once.",
-            "title": "Upload Your Receipts"
-          },
-          "analyze": {
-            "description": "Our AI-powered system automatically extracts merchant names, dates, amounts, and line items from your receipts with high accuracy.",
-            "title": "AI Extracts the Details"
-          },
-          "track": {
-            "description": "View detailed analytics and insights into your spending patterns. Understand where your money goes with interactive charts and reports.",
-            "title": "Track Your Spending"
-          }
-        },
-        "getStarted": "Get Started",
-        "stepOf": "Step {current} of {total}",
-        "next": "Next",
-        "skip": "Skip",
-        "back": "Back",
-        "dontShowAgain": "Don't show this again"
-      },
-      "notifications": {
-        "timeAgo": {
-          "hours": "{count, plural, one {# hour ago} other {# hours ago}}",
-          "minutes": "{count, plural, one {# minute ago} other {# minutes ago}}",
-          "days": "{count, plural, one {# day ago} other {# days ago}}",
-          "now": "Just now"
-        },
-        "types": {
-          "invoiceCreated": "Invoice created",
-          "analysisComplete": "AI analysis complete",
-          "monthlyReport": "Monthly report ready"
-        },
-        "title": "Notifications",
-        "noNotifications": "No notifications yet",
-        "markAllRead": "Mark all as read"
-      },
-      "preferences": {
-        "title": "Invoice Preferences",
-        "defaultView": "Default View",
-        "sortBy": "Sort By",
-        "pageSize": "Items per Page",
-        "currency": "Currency",
-        "showStats": "Show statistics on home",
-        "save": "Save Preferences",
-        "saved": "Preferences saved successfully",
-        "views": {
-          "table": "Table View",
-          "grid": "Grid View"
-        },
-        "sortOptions": {
-          "dateDesc": "Date (Newest First)",
-          "dateAsc": "Date (Oldest First)",
-          "amountDesc": "Amount (High to Low)",
-          "amountAsc": "Amount (Low to High)",
-          "nameAsc": "Name (A to Z)"
-        }
-      },
-      "mobileNav": {
-        "profile": "Profile",
-        "ariaLabel": "Mobile navigation",
-        "home": "Home",
-        "scan": "Scan",
-        "invoices": "Invoices"
-      },
-      "workflowProgress": {
-        "upload": "Upload",
-        "review": "Review",
-        "create": "Create"
-      },
-      "unknownMerchant": "Unknown Merchant"
-    },
-    "CreateInvoice": {
-      "metadata": {
-        "title": "Invoice Management System - Create Invoice",
-        "description": "Create a new invoice from your uploaded scans."
-      },
-      "navigation": {
-        "back": "Back",
-        "next": "Next"
-      },
-      "emptyState": {
-        "title": "No Scans Available",
-        "description": "Upload some receipt scans first to create an invoice.",
-        "uploadButton": "Upload Scans",
-        "viewScansButton": "View Scans"
-      },
-      "header": {
-        "backToInvoices": "Back to Invoices",
-        "title": "Create Invoice",
-        "subtitle": "Follow the steps below to create a new invoice from your scans"
-      },
-      "steps": {
-        "selectScans": "Select Scans",
-        "details": "Invoice Details",
-        "review": "Review & Create",
-        "selectScansDesc": "Choose receipt scans",
-        "detailsDesc": "Fill in invoice info",
-        "reviewDesc": "Confirm and create"
-      },
-      "scanSelector": {
-        "title": "Select Scans",
-        "subtitle": "Choose the scans that belong to this invoice",
-        "selectedCount": "{count} selected",
-        "clearAll": "Clear",
-        "selectAll": "Select All",
-        "noScans": "No scans available",
-        "previous": "Previous",
-        "next": "Next",
-        "scansCount": "scans"
-      },
-      "detailsForm": {
-        "title": "Invoice Details",
-        "subtitle": "Provide the details for your new invoice",
-        "scanPreview": {
-          "title": "Scan Preview"
-        },
-        "fields": {
-          "name": {
-            "label": "Invoice Name",
-            "placeholder": "e.g., Weekly Groceries",
-            "hint": "Give your invoice a descriptive name"
-          },
-          "category": {
-            "label": "Category",
-            "placeholder": "Select a category",
-            "options": {
-              "notDefined": "Uncategorized",
-              "grocery": "Grocery",
-              "fastFood": "Dining",
-              "homeCleaning": "Home & Cleaning",
-              "carAuto": "Auto & Vehicle",
-              "other": "Other"
-            }
-          },
-          "paymentType": {
-            "label": "Payment Method",
-            "placeholder": "Select payment method",
-            "options": {
-              "unknown": "Unknown",
-              "cash": "Cash",
-              "card": "Card",
-              "transfer": "Bank Transfer",
-              "mobilePayment": "Mobile Payment",
-              "voucher": "Voucher",
-              "other": "Other"
-            }
-          },
-          "transactionDate": {
-            "label": "Transaction Date"
-          },
-          "description": {
-            "label": "Description",
-            "placeholder": "Add any notes about this invoice (optional)",
-            "hint": "Optional notes about this purchase"
-          }
-        }
-      },
-      "reviewStep": {
-        "title": "Review & Create",
-        "subtitle": "Review your invoice details before creating",
-        "categories": {
-          "notDefined": "Uncategorized",
-          "grocery": "Grocery",
-          "fastFood": "Dining",
-          "homeCleaning": "Home & Cleaning",
-          "carAuto": "Auto & Vehicle",
-          "other": "Other"
-        },
-        "paymentTypes": {
-          "unknown": "Unknown",
-          "cash": "Cash",
-          "card": "Card",
-          "transfer": "Bank Transfer",
-          "mobilePayment": "Mobile Payment",
-          "voucher": "Voucher",
-          "other": "Other"
-        },
-        "sections": {
-          "scans": {
-            "title": "Scans"
-          },
-          "details": {
-            "title": "Invoice Details",
-            "name": "Name",
-            "category": "Category",
-            "paymentType": "Payment Method",
-            "transactionDate": "Transaction Date",
-            "description": "Description"
-          }
-        },
-        "actions": {
-          "creating": "Creating invoice...",
-          "create": "Create Invoice",
-          "hint": "This will create the invoice and upload the selected scans."
-        }
-      }
-    }
-  },
   "Profile": {
     "metadata": {
       "title": "My Profile",
@@ -4675,5 +1836,2846 @@
       }
     },
     "title": "Acknowledgements"
+  },
+  "IMS--Cards": {
+    "budgetImpactCard": {
+      "title": "{month} Budget Impact",
+      "monthlyBudget": "Monthly Budget",
+      "spent": "{amount} spent",
+      "invoiceUsed": "This invoice used",
+      "ofMonthlyBudget": "of your monthly budget",
+      "remaining": "Remaining",
+      "overBudget": "Over budget",
+      "daysLeft": "Days Left",
+      "inMonth": "in {month}",
+      "dailyAllowance": "Daily Allowance",
+      "dailyAllowanceValue": "{amount}/day"
+    },
+    "comparisonStatsCard": {
+      "title": "How You Compare",
+      "subtitle": "Against your last {count} invoices",
+      "vsAverage": "vs Average",
+      "avgValue": "Avg: {amount} {currency}",
+      "thisValue": "This: {amount} {currency}",
+      "minValue": "Min: {amount}",
+      "maxValue": "Max: {amount}",
+      "positionInRange": "Your position in spending range",
+      "itemCount": "Item Count",
+      "itemCountComparison": "{current} vs avg {average}",
+      "sameStore": "Same Store",
+      "sameStoreComparison": "vs avg {average} {currency}"
+    },
+    "invoiceDetailsCard": {
+      "title": "Invoice Details",
+      "labels": {
+        "dateUtc": "Date (UTC)",
+        "category": "Category",
+        "payment": "Payment",
+        "totalAmount": "Total Amount",
+        "receiptType": "Receipt Type",
+        "countryRegion": "Country/Region",
+        "subtotal": "Subtotal",
+        "tip": "Tip",
+        "ronEquivalent": "RON Equivalent"
+      },
+      "tooltips": {
+        "exchangeRate": "1 {fromCurrency} = {rate} RON (avg. {year})"
+      },
+      "sections": {
+        "paymentMethods": "Payment Methods",
+        "taxBreakdown": "Tax Breakdown"
+      },
+      "taxLabels": {
+        "net": "Net",
+        "tax": "Tax"
+      },
+      "itemsTitle": "Items ({count})",
+      "table": {
+        "item": "Item",
+        "qty": "Qty",
+        "unit": "Unit",
+        "price": "Price",
+        "total": "Total",
+        "grandTotal": "Grand Total"
+      },
+      "pagination": {
+        "pageOf": "Page {current} of {total}",
+        "previous": "Previous",
+        "next": "Next"
+      }
+    },
+    "merchantInfoCard": {
+      "title": "Merchant Information",
+      "noMerchantLinked": "No merchant linked to this invoice",
+      "viewAllReceipts": "View All Receipts",
+      "viewAllInvoices": "View All Invoices",
+      "viewOnMap": "View on Map",
+      "spendingHistory": "Spending History",
+      "categoryDistribution": "Category Distribution",
+      "stats": {
+        "visits": "visits",
+        "avgSpend": "Avg Spend",
+        "daysAgo": "days ago"
+      }
+    },
+    "receiptScanCard": {
+      "title": "Receipt Scan",
+      "dialogTitle": "Receipt Image",
+      "scanAlt": "Receipt scan {index}",
+      "scanAltFullSize": "Receipt scan {index} - full size",
+      "buttons": {
+        "expand": "Expand Image",
+        "previousScan": "Previous Scan",
+        "nextScan": "Next Scan"
+      },
+      "tooltips": {
+        "expand": "View the receipt image in full size",
+        "previousScan": "View the previous receipt scan",
+        "nextScan": "View the next receipt scan"
+      },
+      "titleWithIndex": "Receipt Scan ({current}/{total})",
+      "dialogTitleWithIndex": "Receipt Image ({current}/{total})",
+      "controls": {
+        "zoomIn": "Zoom In",
+        "zoomOut": "Zoom Out",
+        "reset": "Reset Zoom",
+        "rotate": "Rotate",
+        "download": "Download",
+        "fullScreen": "Full Screen",
+        "toggleZoom": "Click to toggle zoom"
+      },
+      "navigation": {
+        "previous": "Previous",
+        "next": "Next",
+        "of": "of"
+      }
+    },
+    "seasonalInsightsCard": {
+      "title": "Seasonal Insight",
+      "month": {
+        "spendingSoFar": "{month} so far",
+        "vsAverage": "vs {month} avg: {amount}"
+      },
+      "insights": {
+        "spike": {
+          "title": "{category} Spike",
+          "description": "+{percent}% vs your average"
+        },
+        "holidaySeason": {
+          "title": "Holiday Season",
+          "description": "December spending is typically 35% higher"
+        },
+        "stockUpTip": {
+          "title": "Stock Up Tip",
+          "description": "Prices increase ~15% after Dec 15th"
+        },
+        "normalPattern": {
+          "title": "Normal Shopping Pattern",
+          "description": "Your spending is within typical range"
+        },
+        "insufficientData": {
+          "title": "Building Your Spending Profile",
+          "description": "Add more invoices to see seasonal insights and spending patterns"
+        }
+      }
+    },
+    "shoppingCalendarCard": {
+      "title": "Shopping Calendar",
+      "tooltip": {
+        "basedOnCachedInvoices": "Based on {count} cached invoices",
+        "currentInvoiceOnly": "Showing current invoice only",
+        "more": "+{count} more",
+        "vsAverage": "vs avg ({years}y data)",
+        "invoiceCount": "{count} invoice(s)",
+        "currentInvoice": "Current invoice"
+      },
+      "legend": {
+        "less": "Less",
+        "more": "More"
+      },
+      "stats": {
+        "monthTotal": "Month Total",
+        "shoppingDays": "Shopping Days"
+      },
+      "insights": {
+        "shopEveryPrefix": "You shop every",
+        "days": "{count} days",
+        "onAverage": "on average",
+        "spendingPrefix": ", spending",
+        "perTrip": " per trip",
+        "mostActiveOn": "Most active on",
+        "weekdayLabel": "{weekday}s"
+      }
+    },
+    "summaryStatsCard": {
+      "title": "Invoice Summary",
+      "description": "Key statistics at a glance",
+      "stats": {
+        "totalItems": {
+          "label": "Total Items",
+          "description": "Products purchased"
+        },
+        "categories": {
+          "label": "Categories",
+          "description": "Unique categories"
+        },
+        "averagePrice": {
+          "label": "Avg. Price",
+          "description": "{currency} per item"
+        },
+        "taxRate": {
+          "label": "Tax Rate",
+          "description": "{amount} {currency}"
+        }
+      },
+      "extremes": {
+        "highest": "Highest",
+        "lowest": "Lowest"
+      }
+    },
+    "categorySuggestionCard": {
+      "title": "Help Us Categorize This Invoice",
+      "description": "We couldn't automatically categorize this invoice. Select the right category to unlock insights:",
+      "moreCategories": "More categories:",
+      "gamification": "Categorize {goal} invoices to unlock detailed insights!"
+    },
+    "diningCard": {
+      "title": "Dining Insights",
+      "sodium": {
+        "high": "High",
+        "medium": "Medium",
+        "low": "Low"
+      },
+      "estimatedNutrition": {
+        "title": "Estimated Nutrition",
+        "calories": "Calories",
+        "caloriesValue": "~{value} kcal",
+        "protein": "Protein",
+        "proteinValue": "~{value}g",
+        "sodium": "Sodium",
+        "carbs": "Carbs",
+        "carbsValue": "~{value}g"
+      },
+      "habits": {
+        "title": "Your Fast Food Habits",
+        "frequency": "Frequency",
+        "frequencyValue": "{count}x/month",
+        "frequencyDiff": "+1 vs avg",
+        "avgSpend": "Avg Spend",
+        "favorite": "Favorite",
+        "visits": "{count} visits"
+      },
+      "swaps": {
+        "title": "Healthier Swaps",
+        "grilled": "Grilled instead of fried",
+        "water": "Water instead of soda",
+        "salad": "Side salad instead of fries",
+        "caloriesSaved": "-{count} cal",
+        "moneySaved": ", saves {amount}"
+      },
+      "challenge": {
+        "title": "Weekly Challenge",
+        "descriptionPrefix": "Skip fast food for 7 days and save",
+        "descriptionSuffix": ""
+      }
+    },
+    "generalExpenseCard": {
+      "title": "Expense intelligence",
+      "detectedCategory": "Electronics / Technology",
+      "confidence": "Confidence: {value}%",
+      "sections": {
+        "autoDetectedCategory": "Auto-detected category",
+        "budgetImpact": "Budget impact",
+        "taxBusiness": "Tax & Business options",
+        "similarPurchases": "Similar past purchases"
+      },
+      "buttons": {
+        "correct": "Correct",
+        "change": "Change",
+        "organize": "Organize",
+        "export": "Export"
+      },
+      "aria": {
+        "confirmCategory": "Confirm category detection is correct",
+        "changeCategory": "Change detected category",
+        "organize": "Organize this expense into categories",
+        "export": "Export expense data"
+      },
+      "nearLimitAlert": "{name}: {percent}% used (10 days left in month)",
+      "options": {
+        "businessExpense": "Mark as business expense",
+        "trackWarranty": "Track warranty (24 months standard)",
+        "insuranceInventory": "Add to insurance inventory"
+      },
+      "vatReclaimable": "VAT reclaimable",
+      "budgetCategories": {
+        "electronics": "Electronics",
+        "entertainment": "Entertainment",
+        "shopping": "Shopping"
+      }
+    },
+    "homeInventoryCard": {
+      "title": "Home Inventory & Supplies",
+      "supplyNames": {
+        "laundryDetergent": "Laundry Detergent",
+        "dishSoap": "Dish Soap",
+        "paperProducts": "Paper Products",
+        "floorCleaner": "Floor Cleaner"
+      },
+      "stockLevels": {
+        "title": "Supply Stock Levels (estimated)",
+        "daysRemaining": "~{count} days"
+      },
+      "eco": {
+        "title": "Eco-Friendliness Score",
+        "productsWithEcoLabels": "{count} products with eco-labels",
+        "recyclablePackaging": "{count} product with recyclable packaging",
+        "tip": "Tip: Eco alternatives save 2kg plastic/year"
+      },
+      "bulk": {
+        "title": "Bulk Buying Savings",
+        "description": "5L detergent vs 2L saves 18% ({amount}/year)"
+      }
+    },
+    "nutritionCard": {
+      "title": "Nutrition Overview",
+      "score": {
+        "title": "Food Balance Score",
+        "excellent": "Excellent",
+        "good": "Good",
+        "fair": "Fair",
+        "needsWork": "Needs Work"
+      },
+      "composition": {
+        "title": "Your Basket Composition",
+        "wholeFoods": "Whole Foods",
+        "processed": "Processed",
+        "dairyOther": "Dairy/Other"
+      },
+      "foodGroups": {
+        "fruits": "Fruits",
+        "vegetables": "Vegetables",
+        "protein": "Protein",
+        "grains": "Grains",
+        "itemsCount": "{count} item(s)"
+      },
+      "allergens": {
+        "title": "Allergens Detected",
+        "foundInItems": "Found in {count} item(s)"
+      },
+      "suggestions": {
+        "addFruitsAndVegetables": "Add more fruits and vegetables to balance your basket",
+        "addVegetables": "Consider adding vegetables for a more balanced diet",
+        "addFruits": "Adding some fruits would improve nutritional balance",
+        "swapProcessed": "Try swapping some processed items for whole foods",
+        "greatBalance": "Great balanced shopping!"
+      }
+    },
+    "vehicleCard": {
+      "title": "Vehicle Expense Analysis",
+      "expenseType": "Expense Type: Fuel",
+      "details": {
+        "liters": "Liters",
+        "pricePerLiter": "Price/L",
+        "station": "Station",
+        "vehicle": "Vehicle",
+        "notSet": "Not set"
+      },
+      "chart": {
+        "title": "Monthly Fuel Spending",
+        "amount": "Amount"
+      },
+      "stats": {
+        "thisMonth": "This Month",
+        "fillUps": "{count} fill-ups",
+        "costPerKm": "Cost/km",
+        "estimated": "estimated",
+        "fuelPrice": "Fuel Price",
+        "thisMonthSuffix": "this month"
+      },
+      "maintenance": {
+        "title": "Maintenance Reminders"
+      },
+      "tip": {
+        "title": "Cheapest Nearby",
+        "perLiter": "L"
+      },
+      "buttons": {
+        "addVehicle": "Add Vehicle",
+        "fullReport": "Full Report"
+      },
+      "months": {
+        "sep": "Sep",
+        "oct": "Oct",
+        "nov": "Nov",
+        "dec": "Dec"
+      },
+      "reminders": {
+        "oilChange": "Oil change due in ~1,200 km",
+        "tireRotation": "Tire rotation recommended"
+      }
+    },
+    "invoiceCard": {
+      "title": "Invoice details",
+      "importantBadge": "IMPORTANT",
+      "markImportant": "Mark as important",
+      "tooltips": {
+        "unmarkFavorite": "Click to unmark as favorite",
+        "markFavorite": "Click to mark as favorite"
+      },
+      "fromMerchant": "From {merchant}",
+      "descriptionPlaceholder": "Enter invoice description...",
+      "labels": {
+        "dateUtc": "Date (UTC)",
+        "hours": "Hours",
+        "minutes": "Minutes",
+        "utc": "UTC",
+        "category": "Category",
+        "paymentMethod": "Payment method",
+        "totalAmount": "Total amount"
+      },
+      "placeholders": {
+        "selectCategory": "Select category",
+        "selectPaymentType": "Select payment type"
+      }
+    },
+    "merchantCard": {
+      "title": "Merchant",
+      "noMerchantLinked": "No merchant linked to this invoice",
+      "addressLabel": "Address: {address}",
+      "buttons": {
+        "viewMerchantDetails": "View Merchant Details",
+        "viewAllReceipts": "View All Receipts"
+      },
+      "tooltips": {
+        "viewMerchantDetails": "See detailed information about this merchant",
+        "viewAllReceipts": "View all receipts from this merchant"
+      }
+    },
+    "imageCard": {
+      "title": "Receipt scan",
+      "dialogTitle": "Receipt image",
+      "scanAlt": "Receipt scan {index}",
+      "scanAltFullSize": "Receipt scan {index} - full size",
+      "buttons": {
+        "expand": "Expand image",
+        "previous": "Previous",
+        "next": "Next",
+        "addScan": "Add scan",
+        "remove": "Remove"
+      },
+      "tooltips": {
+        "expand": "View the receipt image in full size",
+        "previous": "View the previous receipt scan",
+        "next": "View the next receipt scan",
+        "addScan": "Upload and attach a new receipt scan",
+        "remove": "Remove the current receipt scan"
+      },
+      "aria": {
+        "expandImage": "Click to expand image"
+      },
+      "titleWithIndex": "Receipt scan ({current}/{total})",
+      "dialogTitleWithIndex": "Receipt image ({current}/{total})"
+    },
+    "recipeCard": {
+      "complexity": {
+        "unknown": "Unknown",
+        "easy": "Easy",
+        "normal": "Normal",
+        "hard": "Hard"
+      },
+      "dropdown": {
+        "view": "View",
+        "edit": "Edit",
+        "delete": "Delete",
+        "share": "Share",
+        "markAsFavorite": "Mark as Favorite"
+      },
+      "ingredients": {
+        "label": "Ingredients:",
+        "more": "+{count} more",
+        "additionalLabel": "Additional ingredients:"
+      },
+      "timing": {
+        "prepLabel": "Prep: {minutes}′",
+        "prepTooltip": "Preparation time is {minutes} minutes.",
+        "cookLabel": "Cook: {minutes}′",
+        "cookTooltip": "Cooking time is {minutes} minutes."
+      },
+      "buttons": {
+        "visitReference": "Visit Reference",
+        "viewRecipe": "View Recipe"
+      }
+    },
+    "sharingCard": {
+      "title": "Sharing",
+      "ownerAvatarAlt": "User",
+      "owner": "Owner",
+      "sharedWith": "Shared With",
+      "userWithId": "User {id}",
+      "publicInvoice": {
+        "title": "Public Invoice",
+        "description": "This invoice is publicly accessible. Anyone with the link can view it."
+      },
+      "emptyShared": {
+        "public": "No additional users have direct access",
+        "private": "Not shared with anyone"
+      },
+      "buttons": {
+        "manageSharing": "Manage Sharing",
+        "shareInvoice": "Share Invoice",
+        "revokingAccess": "Revoking Access...",
+        "markAsPrivate": "Mark as Private"
+      },
+      "tooltips": {
+        "manageSharing": "Manage sharing settings for this invoice",
+        "removeAccess": "Remove access",
+        "shareInvoice": "Share this invoice with other users",
+        "markAsPrivate": "Mark the invoice as private"
+      },
+      "toasts": {
+        "removeAccessComingSoon": {
+          "title": "Remove access feature coming soon",
+          "description": "This feature is currently under development."
+        },
+        "revoke": {
+          "loading": "Revoking public access...",
+          "success": "Invoice is now private. Existing links will no longer work.",
+          "error": "Failed to mark private: {message}"
+        }
+      }
+    }
+  },
+  "IMS--Common": {
+    "invoiceHeader": {
+      "tooltips": {
+        "importantInvoice": "Important Invoice",
+        "edit": "Edit this invoice",
+        "delete": "Delete this invoice permanently",
+        "print": "Print this invoice",
+        "saveAllPendingChanges": "Save all pending changes",
+        "discardAllPendingChanges": "Discard all pending changes",
+        "printInvoiceWithAllDetails": "Print this invoice with all details",
+        "analyzeSpendingPatterns": "Analyze spending patterns for this invoice",
+        "deleteInvoicePermanently": "Delete this invoice permanently",
+        "export": "Export invoice data in various formats"
+      },
+      "id": "ID: {id}",
+      "buttons": {
+        "edit": "Edit",
+        "delete": "Delete",
+        "print": "Print",
+        "save": "Save",
+        "saving": "Saving...",
+        "discard": "Discard",
+        "analyzeWithAi": "Analyze with AI",
+        "export": "Export"
+      }
+    },
+    "statesNotFound": {
+      "title": "Invoice Not Found",
+      "description": "The invoice with the identifier {invoiceIdentifier} was not found."
+    },
+    "statesLoading": {
+      "title": "Loading Invoice",
+      "description": "Loading the invoice with the identifier {invoiceIdentifier}."
+    },
+    "loadingInvoices": {
+      "title": "Loading invoices",
+      "description": "Loading invoices..."
+    },
+    "invoicesNotFound": {
+      "title": "Something is missing here...",
+      "description": "It seems that you do not have any invoices associated with your account. Please upload some invoices and come back later.",
+      "cta": "Upload an invoice here."
+    },
+    "shortcuts": {
+      "title": "Keyboard Shortcuts",
+      "description": "Quick access to common actions using your keyboard",
+      "openSearch": "Open search",
+      "newInvoice": "New invoice",
+      "uploadScan": "Upload scan",
+      "showHelp": "Show this help",
+      "closeDialog": "Close dialog",
+      "close": "Close"
+    },
+    "commandPalette": {
+      "placeholder": "Search invoices, merchants, items...",
+      "noResults": "No results found",
+      "groups": {
+        "quickActions": "Quick Actions",
+        "recentInvoices": "Recent Invoices",
+        "searchResults": "Search Results"
+      },
+      "actions": {
+        "uploadScans": "Upload Scans",
+        "createInvoice": "Create Invoice",
+        "viewStatistics": "View Statistics",
+        "viewAll": "View All Invoices"
+      }
+    },
+    "onboarding": {
+      "steps": {
+        "upload": {
+          "description": "Take a photo or upload a PDF of your receipt. Our system supports multiple formats and can process batches of receipts at once.",
+          "title": "Upload Your Receipts"
+        },
+        "analyze": {
+          "description": "Our AI-powered system automatically extracts merchant names, dates, amounts, and line items from your receipts with high accuracy.",
+          "title": "AI Extracts the Details"
+        },
+        "track": {
+          "description": "View detailed analytics and insights into your spending patterns. Understand where your money goes with interactive charts and reports.",
+          "title": "Track Your Spending"
+        }
+      },
+      "getStarted": "Get Started",
+      "stepOf": "Step {current} of {total}",
+      "next": "Next",
+      "skip": "Skip",
+      "back": "Back",
+      "dontShowAgain": "Don't show this again"
+    },
+    "notifications": {
+      "timeAgo": {
+        "hours": "{count, plural, one {# hour ago} other {# hours ago}}",
+        "minutes": "{count, plural, one {# minute ago} other {# minutes ago}}",
+        "days": "{count, plural, one {# day ago} other {# days ago}}",
+        "now": "Just now"
+      },
+      "types": {
+        "invoiceCreated": "Invoice created",
+        "analysisComplete": "AI analysis complete",
+        "monthlyReport": "Monthly report ready"
+      },
+      "title": "Notifications",
+      "noNotifications": "No notifications yet",
+      "markAllRead": "Mark all as read"
+    },
+    "preferences": {
+      "title": "Invoice Preferences",
+      "defaultView": "Default View",
+      "sortBy": "Sort By",
+      "pageSize": "Items per Page",
+      "currency": "Currency",
+      "showStats": "Show statistics on home",
+      "save": "Save Preferences",
+      "saved": "Preferences saved successfully",
+      "views": {
+        "table": "Table View",
+        "grid": "Grid View"
+      },
+      "sortOptions": {
+        "dateDesc": "Date (Newest First)",
+        "dateAsc": "Date (Oldest First)",
+        "amountDesc": "Amount (High to Low)",
+        "amountAsc": "Amount (Low to High)",
+        "nameAsc": "Name (A to Z)"
+      }
+    },
+    "mobileNav": {
+      "profile": "Profile",
+      "ariaLabel": "Mobile navigation",
+      "home": "Home",
+      "scan": "Scan",
+      "invoices": "Invoices"
+    },
+    "workflowProgress": {
+      "upload": "Upload",
+      "review": "Review",
+      "create": "Create"
+    },
+    "unknownMerchant": "Unknown Merchant"
+  },
+  "IMS--Create": {
+    "metadata": {
+      "title": "Invoice Management System - Create Invoice",
+      "description": "Create a new invoice from your uploaded scans."
+    },
+    "navigation": {
+      "back": "Back",
+      "next": "Next"
+    },
+    "emptyState": {
+      "title": "No Scans Available",
+      "description": "Upload some receipt scans first to create an invoice.",
+      "uploadButton": "Upload Scans",
+      "viewScansButton": "View Scans"
+    },
+    "header": {
+      "backToInvoices": "Back to Invoices",
+      "title": "Create Invoice",
+      "subtitle": "Follow the steps below to create a new invoice from your scans"
+    },
+    "steps": {
+      "selectScans": "Select Scans",
+      "details": "Invoice Details",
+      "review": "Review & Create",
+      "selectScansDesc": "Choose receipt scans",
+      "detailsDesc": "Fill in invoice info",
+      "reviewDesc": "Confirm and create"
+    },
+    "scanSelector": {
+      "title": "Select Scans",
+      "subtitle": "Choose the scans that belong to this invoice",
+      "selectedCount": "{count} selected",
+      "clearAll": "Clear",
+      "selectAll": "Select All",
+      "noScans": "No scans available",
+      "previous": "Previous",
+      "next": "Next",
+      "scansCount": "scans"
+    },
+    "detailsForm": {
+      "title": "Invoice Details",
+      "subtitle": "Provide the details for your new invoice",
+      "scanPreview": {
+        "title": "Scan Preview"
+      },
+      "fields": {
+        "name": {
+          "label": "Invoice Name",
+          "placeholder": "e.g., Weekly Groceries",
+          "hint": "Give your invoice a descriptive name"
+        },
+        "category": {
+          "label": "Category",
+          "placeholder": "Select a category",
+          "options": {
+            "notDefined": "Uncategorized",
+            "grocery": "Grocery",
+            "fastFood": "Dining",
+            "homeCleaning": "Home & Cleaning",
+            "carAuto": "Auto & Vehicle",
+            "other": "Other"
+          }
+        },
+        "paymentType": {
+          "label": "Payment Method",
+          "placeholder": "Select payment method",
+          "options": {
+            "unknown": "Unknown",
+            "cash": "Cash",
+            "card": "Card",
+            "transfer": "Bank Transfer",
+            "mobilePayment": "Mobile Payment",
+            "voucher": "Voucher",
+            "other": "Other"
+          }
+        },
+        "transactionDate": {
+          "label": "Transaction Date"
+        },
+        "description": {
+          "label": "Description",
+          "placeholder": "Add any notes about this invoice (optional)",
+          "hint": "Optional notes about this purchase"
+        }
+      }
+    },
+    "reviewStep": {
+      "title": "Review & Create",
+      "subtitle": "Review your invoice details before creating",
+      "categories": {
+        "notDefined": "Uncategorized",
+        "grocery": "Grocery",
+        "fastFood": "Dining",
+        "homeCleaning": "Home & Cleaning",
+        "carAuto": "Auto & Vehicle",
+        "other": "Other"
+      },
+      "paymentTypes": {
+        "unknown": "Unknown",
+        "cash": "Cash",
+        "card": "Card",
+        "transfer": "Bank Transfer",
+        "mobilePayment": "Mobile Payment",
+        "voucher": "Voucher",
+        "other": "Other"
+      },
+      "sections": {
+        "scans": {
+          "title": "Scans"
+        },
+        "details": {
+          "title": "Invoice Details",
+          "name": "Name",
+          "category": "Category",
+          "paymentType": "Payment Method",
+          "transactionDate": "Transaction Date",
+          "description": "Description"
+        }
+      },
+      "actions": {
+        "creating": "Creating invoice...",
+        "create": "Create Invoice",
+        "hint": "This will create the invoice and upload the selected scans."
+      }
+    }
+  },
+  "IMS--Dialogs": {
+    "shareAnalyticsDialog": {
+      "title": "Share Analytics",
+      "description": "Share your spending analytics for {merchant} with others.",
+      "tabs": {
+        "image": "Image",
+        "email": "Email"
+      },
+      "image": {
+        "description": "Download or copy the analytics graph as a PNG image that you can share or save.",
+        "previewPlaceholder": "Analytics Preview",
+        "download": "Download graph",
+        "copyToClipboard": "Copy graph to clipboard"
+      },
+      "email": {
+        "description": "Send the analytics to an email address.",
+        "label": "Email address",
+        "placeholder": "name@example.com",
+        "send": "Send Email"
+      },
+      "toasts": {
+        "imageCopied": {
+          "title": "Image copied!",
+          "description": "The analytics image has been copied to your clipboard"
+        },
+        "emailSent": {
+          "title": "Email sent!",
+          "description": "Analytics report sent to {email}"
+        },
+        "imageSaved": {
+          "title": "Image saved!",
+          "description": "Spending analytics for {merchant} has been downloaded as PNG"
+        }
+      }
+    },
+    "analyzeDialog": {
+      "header": {
+        "title": "Analyze Invoice",
+        "description": "Configure AI-powered analysis for invoice"
+      },
+      "options": {
+        "completeAnalysis": {
+          "title": "Complete Analysis",
+          "description": "Full AI-powered analysis including all invoice data, items, and merchant information.",
+          "estimatedTime": "2-3 min",
+          "features": {
+            "ocrExtraction": "OCR extraction",
+            "itemCategorization": "Item categorization",
+            "merchantIdentification": "Merchant identification",
+            "priceAnalysis": "Price analysis",
+            "receiptValidation": "Receipt validation"
+          }
+        },
+        "invoiceOnly": {
+          "title": "Invoice Data Only",
+          "description": "Analyze basic invoice information like totals, dates, and payment details.",
+          "estimatedTime": "30-60 sec",
+          "features": {
+            "totalExtraction": "Total extraction",
+            "dateParsing": "Date parsing",
+            "paymentMethodDetection": "Payment method detection"
+          }
+        },
+        "itemsOnly": {
+          "title": "Items Analysis",
+          "description": "Focus on extracting and categorizing individual line items from the invoice.",
+          "estimatedTime": "1-2 min",
+          "features": {
+            "itemExtraction": "Item extraction",
+            "categoryAssignment": "Category assignment",
+            "pricePerItem": "Price per item",
+            "quantityDetection": "Quantity detection"
+          }
+        },
+        "merchantOnly": {
+          "title": "Merchant Analysis",
+          "description": "Identify and analyze merchant information including location and category.",
+          "estimatedTime": "30-45 sec",
+          "features": {
+            "merchantIdentification": "Merchant identification",
+            "locationExtraction": "Location extraction",
+            "businessCategory": "Business category",
+            "contactInfo": "Contact info"
+          }
+        }
+      },
+      "analysisSteps": {
+        "preparingDocument": "Preparing document...",
+        "runningOcrExtraction": "Running OCR extraction...",
+        "analyzingWithAi": "Analyzing with AI...",
+        "categorizingItems": "Categorizing items...",
+        "finalizingResults": "Finalizing results...",
+        "processing": "Processing..."
+      },
+      "analyzing": {
+        "title": "Analyzing Invoice",
+        "progressComplete": "{progress}% complete"
+      },
+      "sections": {
+        "analysisType": "Analysis Type",
+        "includedFeatures": "Included Features",
+        "enhancementsOptional": "Enhancements (Optional)"
+      },
+      "enhancements": {
+        "priceComparison": {
+          "label": "Price Comparison",
+          "description": "Compare prices with historical data"
+        },
+        "savingsTips": {
+          "label": "Savings Suggestions",
+          "description": "Get AI-powered saving recommendations"
+        },
+        "quickExtract": {
+          "label": "Quick Extract Mode",
+          "description": "Prioritize speed over accuracy"
+        }
+      },
+      "badges": {
+        "recommended": "Recommended"
+      },
+      "summary": {
+        "enhancementsSelected": "+ {count} enhancement(s)",
+        "noEnhancementsSelected": "No enhancements selected",
+        "estimatedTime": "Estimated time"
+      },
+      "buttons": {
+        "cancel": "Cancel",
+        "analyzing": "Analyzing...",
+        "startAnalysis": "Start Analysis"
+      },
+      "toasts": {
+        "analysisComplete": {
+          "title": "Analysis Complete",
+          "description": "Your invoice has been analyzed successfully."
+        },
+        "analysisFailed": {
+          "title": "Analysis Failed",
+          "description": "We couldn't analyze your invoice. Please try again."
+        }
+      }
+    },
+    "addScanDialog": {
+      "title": "Add new scan",
+      "description": "Upload a new receipt image or document to attach to this invoice.",
+      "dropzone": {
+        "dropHere": "Drop the file here...",
+        "dragAndDrop": "Drag & drop a file here",
+        "orClickBrowse": "or click to browse",
+        "formats": "JPEG, PNG, PDF (max 10MB)"
+      },
+      "scanType": {
+        "label": "Scan type",
+        "placeholder": "Select scan type",
+        "jpeg": "JPEG image",
+        "png": "PNG image",
+        "pdf": "PDF document",
+        "other": "Other"
+      },
+      "buttons": {
+        "cancel": "Cancel",
+        "uploading": "Uploading...",
+        "upload": "Upload scan"
+      },
+      "errors": {
+        "uploadStorageFailed": "Failed to upload scan to storage",
+        "unknown": "Unknown error occurred"
+      },
+      "toasts": {
+        "fileTooLargeTitle": "File too large",
+        "fileTooLargeDescription": "Maximum file size is 10MB",
+        "scanAddedTitle": "Scan added successfully",
+        "scanAddedDescription": "The scan has been attached to the invoice",
+        "scanFailedTitle": "Failed to add scan"
+      },
+      "console": {
+        "uploadError": "Error uploading scan:"
+      }
+    },
+    "imageDialog": {
+      "title": "Image ({image})",
+      "imageAlt": "Photo of receipt"
+    },
+    "itemsDialog": {
+      "title": "Edit invoice items",
+      "description": "Update quantities, prices, or add new items to this invoice",
+      "table": {
+        "item": "Item",
+        "quantity": "Quantity",
+        "unit": "Unit",
+        "price": "Price",
+        "total": "Total",
+        "actions": "Actions"
+      },
+      "footer": {
+        "itemsFound": "{total} items found (showing {shown})",
+        "page": "Page {current} of {total}",
+        "itemsTotal": "{count, plural, one {# item in total} other {# items in total}}"
+      },
+      "buttons": {
+        "previous": "Previous",
+        "next": "Next",
+        "addItem": "Add item",
+        "cancel": "Cancel",
+        "saveChanges": "Save changes"
+      },
+      "aria": {
+        "deleteItem": "Delete item: {name}",
+        "unnamedItem": "unnamed item",
+        "previousPage": "Go to previous page (page {page})",
+        "nextPage": "Go to next page (page {page})",
+        "addItem": "Add a new item to the invoice",
+        "cancel": "Cancel editing and close dialog",
+        "save": "Save changes to invoice items"
+      }
+    },
+    "merchantDialog": {
+      "title": "Merchant Details",
+      "noMerchantLinked": "No merchant linked to this invoice",
+      "description": "Information about {merchantName}",
+      "fields": {
+        "address": "Address",
+        "phone": "Phone",
+        "parentCompany": "Parent Company"
+      },
+      "buttons": {
+        "openInMaps": "Open in Maps"
+      }
+    },
+    "feedbackDialog": {
+      "title": "Provide Feedback",
+      "description": "Help us improve analytics for {merchant} by sharing your thoughts",
+      "sections": {
+        "rating": "How would you rate the analytics?",
+        "features": "Which features were most helpful? (Select all that apply)",
+        "comments": "Additional comments (optional)"
+      },
+      "features": {
+        "spendingTrends": "Spending Trends",
+        "priceComparisons": "Price Comparisons",
+        "savingsTips": "Savings Tips",
+        "merchantAnalysis": "Merchant Analysis",
+        "visualCharts": "Visual Charts",
+        "categoryBreakdown": "Category Breakdown"
+      },
+      "commentsPlaceholder": "Share your thoughts about the analytics...",
+      "buttons": {
+        "cancel": "Cancel",
+        "submit": "Submit Feedback"
+      },
+      "toasts": {
+        "sending": {
+          "title": "Sending feedback...",
+          "description": "Please wait while we submit your feedback."
+        },
+        "ratingRequired": {
+          "title": "Rating required",
+          "description": "Please provide a star rating before submitting"
+        },
+        "success": {
+          "title": "Feedback sent!",
+          "description": "Feedback sent successfully"
+        },
+        "error": {
+          "title": "An error occurred while submitting feedback",
+          "description": "Please try again later."
+        }
+      }
+    },
+    "metadataDialog": {
+      "add": {
+        "title": "Add metadata",
+        "description": "Add additional information to this invoice"
+      },
+      "edit": {
+        "title": "Edit metadata",
+        "description": "Update the value of this metadata field",
+        "fieldLabel": "Metadata field"
+      },
+      "delete": {
+        "title": "Delete metadata",
+        "description": "Are you sure you want to delete this metadata?"
+      },
+      "fields": {
+        "keyLabel": "Metadata key",
+        "valueLabel": "Metadata value",
+        "keyPlaceholder": "Enter key",
+        "valuePlaceholder": "Enter value"
+      },
+      "buttons": {
+        "cancel": "Cancel",
+        "save": "Save",
+        "delete": "Delete"
+      }
+    },
+    "recipeDialog": {
+      "create": {
+        "title": "Add new recipe",
+        "description": "Fill in the details to create a recipe.",
+        "success": "Recipe created successfully",
+        "error": "Failed to create recipe"
+      },
+      "read": {
+        "description": "Recipe details and cooking instructions",
+        "noDescription": "No description provided.",
+        "notSpecified": "Not specified"
+      },
+      "update": {
+        "title": "Update recipe",
+        "description": "Update recipe details."
+      },
+      "delete": {
+        "title": "Are you sure?",
+        "description": "This action cannot be undone. This will permanently delete the recipe <strong>{name}</strong> and all its associated data."
+      },
+      "fields": {
+        "recipeName": "Recipe name",
+        "description": "Description",
+        "ingredients": "Ingredients",
+        "difficulty": "Difficulty level",
+        "complexity": "Complexity level",
+        "instructions": "Instructions",
+        "prepTime": "Prep time",
+        "cookTime": "Cook time",
+        "totalDuration": "Total Duration"
+      },
+      "actions": {
+        "generateName": "Generate name",
+        "enhanceInstructions": "Enhance instructions"
+      },
+      "tooltips": {
+        "generateName": "Generate a recipe name based on your ingredients and difficulty level using AI",
+        "enhanceInstructions": "Use AI to enhance your instructions with more details"
+      },
+      "placeholders": {
+        "recipeName": "Enter recipe name",
+        "description": "Enter a brief description of the recipe",
+        "selectDifficulty": "Select difficulty",
+        "instructions": "Enter cooking instructions",
+        "prepTime": "e.g. 15 minutes",
+        "cookTime": "e.g. 30 minutes"
+      },
+      "difficulty": {
+        "easy": "Easy",
+        "medium": "Medium",
+        "hard": "Hard"
+      },
+      "buttons": {
+        "add": "Add",
+        "cancel": "Cancel",
+        "save": "Save",
+        "saving": "Saving...",
+        "close": "Close",
+        "delete": "Delete"
+      },
+      "minutes": "minutes"
+    },
+    "merchantReceiptsDialog": {
+      "title": "All receipts from {merchant}",
+      "description": "View and filter all your receipts from this merchant",
+      "searchPlaceholder": "Search receipts...",
+      "filters": {
+        "date": "Date",
+        "sort": "Sort"
+      },
+      "dateOptions": {
+        "allTime": "All time",
+        "last30Days": "Last 30 days",
+        "last90Days": "Last 90 days",
+        "thisYear": "This year"
+      },
+      "sortOptions": {
+        "newest": "Newest first",
+        "oldest": "Oldest first"
+      },
+      "table": {
+        "receipt": "Receipt",
+        "date": "Date",
+        "itemsCount": "Items #",
+        "actions": "Actions",
+        "view": "View"
+      },
+      "footer": {
+        "receiptsFound": "{count} receipts found (showing {showing})",
+        "page": "Page {current} of {total}"
+      },
+      "buttons": {
+        "previous": "Previous",
+        "next": "Next"
+      }
+    },
+    "removeScanDialog": {
+      "title": "Remove scan",
+      "description": "Are you sure you want to remove scan {current} of {total}?",
+      "descriptionLastScan": "This is the only scan attached to this invoice. You cannot remove it.",
+      "scanAlt": "Scan {index}",
+      "scanCaption": "Scan {index}",
+      "warning": {
+        "title": "Cannot remove last scan",
+        "description": "Every invoice must have at least one scan attached. Add another scan before removing this one."
+      },
+      "buttons": {
+        "cancel": "Cancel",
+        "removing": "Removing...",
+        "remove": "Remove scan"
+      },
+      "toasts": {
+        "cannotDeleteLastTitle": "Cannot delete last scan",
+        "cannotDeleteLastDescription": "An invoice must have at least one scan attached",
+        "removedTitle": "Scan removed successfully",
+        "removedDescription": "The scan has been removed from the invoice",
+        "removeFailedTitle": "Failed to remove scan"
+      },
+      "errors": {
+        "unknown": "Unknown error occurred"
+      },
+      "console": {
+        "deleteError": "Error deleting scan:"
+      }
+    },
+    "allergenDialog": {
+      "labels": {
+        "currentAllergens": "Current Allergens",
+        "customAllergen": "Add Custom Allergen",
+        "quickAdd": "Quick Add Common Allergens"
+      },
+      "title": "Edit Allergens",
+      "success": {
+        "added": "Added allergen: {name}",
+        "saved": "Allergens updated successfully",
+        "removed": "Removed allergen: {name}"
+      },
+      "buttons": {
+        "save": "Save Changes",
+        "saving": "Saving...",
+        "cancel": "Cancel",
+        "add": "Add"
+      },
+      "defaultDescription": "Contains {name}",
+      "aria": {
+        "removeAllergen": "Remove {name} allergen"
+      },
+      "placeholders": {
+        "customAllergen": "Enter allergen name..."
+      },
+      "empty": {
+        "noAllergens": "No allergens detected"
+      },
+      "description": "Manage allergens for {productName}",
+      "errors": {
+        "emptyName": "Allergen name cannot be empty",
+        "duplicate": "Allergen '{name}' already added",
+        "missingData": "Missing product data",
+        "saveFailed": "Failed to save allergens"
+      }
+    },
+    "bulkCategoryDialog": {
+      "errors": {
+        "saveFailed": "Failed to update categories",
+        "missingData": "Missing data",
+        "noProducts": "No products selected",
+        "allFailed": "All products failed to update"
+      },
+      "success": {
+        "saved": "{count, plural, one {Category updated for # product} other {Category updated for # products}}",
+        "partialSuccess": "Updated {success} products, {failed} failed"
+      },
+      "description": "{count, plural, one {Change category for # product} other {Change category for # products}}",
+      "buttons": {
+        "save": "Apply to All",
+        "saving": "Saving...",
+        "cancel": "Cancel"
+      },
+      "labels": {
+        "andMore": "...and {count} more",
+        "newCategory": "New Category",
+        "selectedProducts": "Selected Products",
+        "progress": "Progress"
+      },
+      "placeholders": {
+        "selectCategory": "Select a category"
+      },
+      "title": "Change Category",
+      "progress": {
+        "updating": "Updating {current} of {total}..."
+      }
+    },
+    "exportDialog": {
+      "title": "Export Invoices",
+      "description": "Export {count} invoices in your preferred format.",
+      "format": {
+        "title": "Export Format",
+        "labels": {
+          "csv": "CSV",
+          "json": "JSON",
+          "pdf": "PDF"
+        },
+        "descriptions": {
+          "json": "Structured data format",
+          "csv": "Spreadsheet format, compatible with Excel",
+          "pdf": "Printable document format"
+        }
+      },
+      "options": {
+        "title": "Options",
+        "includeMetadata": "Include metadata",
+        "includeProducts": "Include products",
+        "includeMerchant": "Include merchant",
+        "csv": {
+          "includeHeaders": "Include CSV Headers",
+          "delimiterLabel": "CSV Delimiter Override (optional):",
+          "delimiterPlaceholder": ","
+        },
+        "json": {
+          "prettyPrint": "Pretty Print (2 spaces)"
+        }
+      },
+      "buttons": {
+        "cancel": "Cancel",
+        "export": "Export",
+        "copy": "Copy to Clipboard",
+        "copied": "Copied!"
+      },
+      "filename": {
+        "hint": "The file will be saved with the extension based on format",
+        "label": "Filename"
+      },
+      "estimate": {
+        "label": "Estimated file size:"
+      }
+    },
+    "importDialog": {
+      "title": "Import Invoices",
+      "description": "Upload your invoice files to import them into the system.",
+      "tabs": {
+        "csv": "CSV",
+        "pdf": "PDF",
+        "xlsx": "Excel"
+      },
+      "dropzone": {
+        "dropHere": "Drop files here...",
+        "dragAndDrop": "Drag & drop files here",
+        "orClickBrowse": "or click to browse files",
+        "acceptsCsv": "Accepts .csv files (max 10MB)",
+        "acceptsPdf": "Accepts .pdf files (max 10MB)",
+        "acceptsXlsx": "Accepts .xlsx and .xls files (max 10MB)"
+      },
+      "selectedFiles": "Selected Files",
+      "remove": "Remove",
+      "status": {
+        "success": "Files imported successfully!",
+        "error": "Error importing files. Please try again."
+      },
+      "buttons": {
+        "cancel": "Cancel",
+        "import": "Import",
+        "importWithCount": "Import ({count})"
+      }
+    },
+    "shareInvoiceDialog": {
+      "title": "Share invoice",
+      "selection": {
+        "description": "Choose how you want to share this invoice. Your choice affects who can access it.",
+        "publicTitle": "Public sharing",
+        "publicDescription": "Generate a link or QR code that <strong>anyone</strong> can use to view this invoice.",
+        "privateTitle": "Private sharing",
+        "privateDescription": "Send an email invitation to a <strong>specific person</strong>. Only they will have access.",
+        "privacyNoticeTitle": "Privacy notice",
+        "privacyNoticeDescription": "Public links can be accessed by anyone who has the URL. Private sharing restricts access to the specific recipient."
+      },
+      "dialogDescription": {
+        "currentlyPublic": "\"{invoiceName}\" is currently public",
+        "selection": "Choose how to share \"{invoiceName}\"",
+        "public": "Share \"{invoiceName}\" publicly",
+        "private": "Send \"{invoiceName}\" privately"
+      },
+      "toasts": {
+        "copyLink": {
+          "loadingPublic": "Copying link...",
+          "loadingMakePublic": "Making invoice public...",
+          "successPublic": "Link copied to clipboard!",
+          "successMadePublic": "Invoice is now public! Link copied to clipboard.",
+          "error": "Failed: {message}"
+        },
+        "copyQr": {
+          "loadingPublic": "Copying QR code...",
+          "loadingMakePublic": "Making invoice public...",
+          "successPublic": "QR code copied to clipboard!",
+          "successMadePublic": "Invoice is now public! QR code copied to clipboard.",
+          "error": "Failed: {message}"
+        },
+        "sendEmail": {
+          "loading": "Sending invitation to {email}...",
+          "success": "Invitation sent to {email}!",
+          "error": "Failed: {message}",
+          "comingSoon": "Email sharing is coming soon"
+        },
+        "revoke": {
+          "loading": "Sending revoke request to backend...",
+          "success": "Invoice is now private. Existing links will no longer work.",
+          "error": "Failed to revoke access: {message}"
+        }
+      },
+      "errors": {
+        "qrNotFound": "QR code element not found"
+      }
+    },
+    "shareInvoiceDialogPublic": {
+      "tabs": {
+        "directLink": "Direct link",
+        "qrCode": "QR code"
+      },
+      "hints": {
+        "link": "Copy this link and share it. Anyone who receives it will be able to view the invoice.",
+        "qr": "Anyone who scans this QR code will be directed to view the invoice."
+      },
+      "copyQrImage": "Copy QR code as image",
+      "alreadyPublic": {
+        "title": "This invoice is currently public",
+        "description": "This invoice is publicly accessible. <strong>Anyone with the link can view it</strong>, including all invoice details, items, and amounts. You can revoke public access at any time to make it private again.",
+        "revoke": "Revoke public access",
+        "revoking": "Revoking access...",
+        "revokeHint": "This will make the invoice private. Existing links will stop working."
+      },
+      "backToOptions": "Back to options",
+      "warning": {
+        "title": "Public access warning",
+        "description": "By sharing this invoice publicly, <strong>anyone with the link will be able to view it</strong>. This includes all invoice details, items, and amounts. Only proceed if you intend to make this invoice accessible to the public."
+      }
+    },
+    "shareInvoiceDialogPrivate": {
+      "backToOptions": "Back to options",
+      "title": "Private sharing",
+      "description": "The invitation will be sent directly to the email address you specify. Only this recipient will receive access to view the invoice.",
+      "emailLabel": "Recipient's email address",
+      "emailPlaceholder": "name@example.com",
+      "emailHint": "An email invitation will be sent to this address with a private link to view the invoice.",
+      "sendInvitation": "Send private invitation",
+      "sending": "Sending invitation...",
+      "comingSoonTooltip": "Email sharing feature is coming soon"
+    },
+    "deleteInvoiceDialog": {
+      "title": "Delete invoice",
+      "description": "This action cannot be undone. Please review carefully before proceeding.",
+      "deleting": {
+        "title": "Deleting invoice...",
+        "description": "Please wait while we remove all associated data."
+      },
+      "impact": {
+        "title": "Permanent deletion",
+        "intro": "The following data will be permanently deleted:",
+        "invoiceRecord": "Invoice record and metadata",
+        "uploadedScans": "{count} uploaded scan(s)",
+        "lineItems": "{count} line item(s)",
+        "sharedAccess": "Shared access for {count} user(s)"
+      },
+      "confirmation": {
+        "typeToConfirm": "Type <highlight>{name}</highlight> to confirm:",
+        "understoodLabel": "I understand this action is permanent",
+        "understoodDescription": "This invoice and all its data will be permanently deleted and cannot be recovered."
+      },
+      "buttons": {
+        "cancel": "Cancel",
+        "deleting": "Deleting...",
+        "deletePermanently": "Delete permanently"
+      },
+      "toasts": {
+        "deletedTitle": "Invoice deleted",
+        "deletedDescription": "The invoice was deleted successfully.",
+        "deleteFailedTitle": "Delete failed",
+        "deleteFailedDescription": "We couldn't delete this invoice. Please try again."
+      },
+      "console": {
+        "deleteError": "Error deleting invoice:"
+      }
+    },
+    "createInvoiceDialog": {
+      "title": "Create Invoice",
+      "titlePlural": "Create Invoices",
+      "description": "Transform your scans into structured invoice data with AI-powered extraction.",
+      "selectedScans": "Selected Scans",
+      "totalSize": "total",
+      "chooseMode": "Choose Creation Mode",
+      "singleMode": {
+        "title": "One invoice per scan",
+        "description": "Creates {count} separate invoices. Best when each scan is a different receipt."
+      },
+      "batchMode": {
+        "title": "Combine into one invoice",
+        "description": "Creates 1 invoice with all {count} scans attached. Best for multi-page receipts."
+      },
+      "singleScanInfo": {
+        "title": "What happens next?",
+        "description": "Our AI will analyze your scan and automatically extract merchant details, items, prices, and totals. You can review and edit the results afterward."
+      },
+      "buttons": {
+        "cancel": "Cancel",
+        "createSingle": "Create Invoice",
+        "createMultiple": "Create {count} Invoices",
+        "close": "Close"
+      },
+      "creating": {
+        "title": "Creating Your Invoice",
+        "titlePlural": "Creating Your Invoices",
+        "processing": "Processing {count} scan...",
+        "processingPlural": "Processing {count} scans...",
+        "step1Title": "Uploading scans",
+        "step1Description": "Sending your scans to our servers",
+        "step2Title": "Creating invoice records",
+        "step2Description": "Setting up invoice data structures",
+        "step3Title": "Finalizing",
+        "step3Description": "Preparing invoices for viewing"
+      },
+      "complete": {
+        "title": "{count} Invoice Created!",
+        "titlePlural": "{count} Invoices Created!",
+        "description": "Your invoice is ready for viewing and editing.",
+        "descriptionPlural": "Your invoices are ready for viewing and editing.",
+        "nextSteps": "Next steps:",
+        "nextStepsDescription": "Review your invoice, verify the extracted data, and make any necessary edits. You can also request AI analysis for spending insights.",
+        "nextStepsDescriptionPlural": "Review your invoices, verify the extracted data, and make any necessary edits. You can also request AI analysis for spending insights.",
+        "viewButton": "View Invoice",
+        "viewButtonPlural": "View Invoices",
+        "failureTitle": "Creation Failed",
+        "failureDescription": "We couldn't create any invoices. Please review the errors below and try again.",
+        "partialTitle": "{created} of {total} Invoices Created",
+        "partialDescription": "Some scans couldn't be processed. Successfully created invoices are ready for viewing.",
+        "errorsLabel": "Failed Scans:",
+        "retryButton": "Try Again"
+      },
+      "errors": {
+        "partialFail": "Failed to create {count} invoice(s)",
+        "createFailed": "Failed to create invoices: {message}",
+        "unknown": "Unknown error"
+      }
+    }
+  },
+  "IMS--Edit": {
+    "metadata": {
+      "description": "View and edit your invoice details, items, recipes, and sharing settings.",
+      "title": "Invoice Management System - Edit Invoice"
+    },
+    "editInvoiceContext": {
+      "toasts": {
+        "noChanges": "No changes to save",
+        "updated": "Invoice updated successfully",
+        "saveFailed": "Failed to save changes"
+      },
+      "console": {
+        "saveFailed": "Failed to save invoice:"
+      }
+    },
+    "triviaTips": {
+      "title": "Savings Tips",
+      "completeness": "Invoice is {percentage}% complete",
+      "completeLabel": "Invoice is fully complete!",
+      "difficulty": {
+        "easy": "Easy",
+        "medium": "Medium"
+      },
+      "banner": {
+        "potentialSavingsLabel": "Potential Savings",
+        "hint": "Apply these tips to save on your next visit to {merchantName}"
+      },
+      "contextTips": {
+        "noItems": "Run AI analysis to extract items from your receipt",
+        "noDescription": "Add a description to help you remember this purchase",
+        "noCategory": "Set a category to track spending patterns",
+        "defaultCategory": "Change the category from 'Uncategorized' to track better",
+        "noRecipes": "AI can suggest recipes based on your grocery items"
+      },
+      "contextActions": {
+        "analyze": "Run Analysis",
+        "addDescription": "Add Description",
+        "setCategory": "Set Category"
+      },
+      "tips": {
+        "loyaltyProgram": {
+          "title": "Join Loyalty Program",
+          "description": "Sign up for {merchantName}'s loyalty program to earn points on every purchase."
+        },
+        "bulkPurchase": {
+          "title": "Buy in Bulk",
+          "description": "Purchase non-perishable items in bulk to save on per-unit costs."
+        },
+        "digitalCoupons": {
+          "title": "Use Digital Coupons",
+          "description": "Check {merchantName}'s app for digital coupons before shopping."
+        }
+      },
+      "tooltips": {
+        "estimatedSavings": "Estimated savings with this tip"
+      },
+      "buttons": {
+        "viewMoreSavingsTips": "View More Savings Tips"
+      },
+      "disclaimer": "Savings are estimates based on average prices and promotions"
+    },
+    "recipesTab": {
+      "header": {
+        "title": "Recipes You Can Make",
+        "description": "Based on items in this invoice"
+      },
+      "buttons": {
+        "generate": "Generate",
+        "addRecipe": "Add Recipe",
+        "createFirstRecipe": "Create Your First Recipe"
+      },
+      "tooltips": {
+        "generateRecipeUsingAi": "Generate a recipe using AI!",
+        "createRecipeWithIngredients": "Create a new recipe with these ingredients"
+      },
+      "emptyState": {
+        "noRecipesAvailable": "No recipes available yet"
+      },
+      "pagination": {
+        "previous": "Previous",
+        "next": "Next",
+        "pageOf": "Page {currentPage} of {totalPages}"
+      },
+      "toasts": {
+        "aiGenerationComingSoon": {
+          "title": "AI recipe generation coming soon",
+          "description": "This feature is currently under development."
+        }
+      }
+    },
+    "metadataTab": {
+      "header": {
+        "title": "Additional Information",
+        "description": "Metadata associated with this invoice"
+      },
+      "buttons": {
+        "addField": "Add Field",
+        "addFirstMetadataField": "Add Your First Metadata Field"
+      },
+      "tooltips": {
+        "addCustomMetadata": "Add custom metadata to this invoice"
+      },
+      "badges": {
+        "readonly": "Readonly"
+      },
+      "dropdown": {
+        "edit": "Edit",
+        "delete": "Delete"
+      },
+      "emptyState": {
+        "noMetadataFields": "No metadata fields added yet"
+      }
+    },
+    "itemsTable": {
+      "title": "Items",
+      "buttons": {
+        "editItems": "Edit Items",
+        "addItem": "Add Item"
+      },
+      "tooltips": {
+        "editInvoiceItemsAndQuantities": "Edit invoice items and quantities"
+      },
+      "columns": {
+        "selectAll": "Select all items",
+        "selectRow": "Select {name}",
+        "name": "Name",
+        "quantity": "Quantity",
+        "price": "Price",
+        "unit": "Unit",
+        "total": "Total",
+        "actions": "Actions"
+      },
+      "tableHeaders": {
+        "item": "Item",
+        "quantity": "Qty",
+        "price": "Price",
+        "total": "Total"
+      },
+      "footer": {
+        "total": "Total"
+      },
+      "pagination": {
+        "totalItems": "{count, plural, one {# item in total} other {# items in total}}",
+        "previous": "Previous",
+        "next": "Next",
+        "pageOf": "Page {currentPage} of {totalPages}"
+      },
+      "search": {
+        "placeholder": "Search items..."
+      },
+      "bulkToolbar": {
+        "selectedCount": "{count, plural, one {# item selected} other {# items selected}}",
+        "deleteSelected": "Delete Selected",
+        "changeCategory": "Change Category",
+        "noSelection": "No products selected"
+      },
+      "editing": {
+        "saved": "Item updated successfully",
+        "cancel": "Edit canceled",
+        "fieldLabel": "Edit {field} for {name}"
+      },
+      "deleteConfirm": {
+        "title": "Delete Items",
+        "description": "{count, plural, one {Are you sure you want to delete this item?} other {Are you sure you want to delete # items?}}",
+        "confirm": "Delete",
+        "cancel": "Cancel",
+        "success": "{count, plural, one {# item deleted} other {# items deleted}}"
+      },
+      "newItem": {
+        "defaultName": "New Item",
+        "added": "New item added"
+      },
+      "indicators": {
+        "uncategorized": "Uncategorized",
+        "uncategorizedTooltip": "This product needs a category assigned for better spending tracking",
+        "missingName": "Missing name",
+        "missingNameTooltip": "Generic name translation is missing or identical to raw OCR text",
+        "lowConfidence": "Low confidence",
+        "lowConfidenceTooltip": "OCR confidence is {confidence}% - manual review recommended",
+        "edited": "Edited",
+        "editedTooltip": "This product has been manually modified",
+        "allergens": "{count, plural, one {# allergen} other {# allergens}}"
+      },
+      "actions": {
+        "remove": "Remove item",
+        "restore": "Restore item",
+        "editAllergens": "Edit allergens"
+      },
+      "softDelete": {
+        "success": "Item '{name}' removed",
+        "error": "Failed to remove item"
+      },
+      "restore": {
+        "success": "Item '{name}' restored",
+        "error": "Failed to restore item"
+      },
+      "bulkCategory": {
+        "noSelection": "Please select at least one product"
+      }
+    },
+    "changeHistory": {
+      "unsavedChanges": "Unsaved changes",
+      "pending": "Pending",
+      "created": "Invoice created",
+      "title": "Change History",
+      "time": {
+        "justNow": "Just now",
+        "secondsAgo": "{seconds} seconds ago",
+        "hoursAgo": "{hours} hours ago",
+        "daysAgo": "{days} days ago",
+        "minutesAgo": "{minutes} minutes ago"
+      },
+      "modified": "Last modified",
+      "changes": {
+        "paymentTypeChanged": "Payment type changed",
+        "unmarkedImportant": "Unmarked as important",
+        "categoryUpdated": "Category updated",
+        "transactionDateChanged": "Transaction date changed",
+        "nameChanged": "Name changed",
+        "descriptionChanged": "Description changed",
+        "markedImportant": "Marked as important",
+        "importanceChanged": "Importance changed"
+      }
+    },
+    "guidedEditBanner": {
+      "title": "{count, plural, one {# product needs review} other {# products need review}}",
+      "summary": {
+        "uncategorized": "{count, plural, one {# uncategorized} other {# uncategorized}}",
+        "lowConfidence": "{count, plural, one {# low confidence} other {# low confidence}}",
+        "missingName": "{count, plural, one {# missing name} other {# missing name}}"
+      },
+      "actions": {
+        "reviewAll": "Review All",
+        "dismiss": "Dismiss"
+      },
+      "badges": {
+        "uncategorized": "{count, plural, one {# uncategorized} other {# uncategorized}}",
+        "lowConfidence": "{count, plural, one {# low confidence} other {# low confidence}}",
+        "missingName": "{count, plural, one {# missing name} other {# missing name}}"
+      }
+    }
+  },
+  "IMS--Landing": {
+    "metadata": {
+      "description": "Manage receipts, create invoices, and gain insights into your spending habits.",
+      "title": "Invoice Management System"
+    },
+    "hero": {
+      "title": "Manage Your",
+      "titleHighlight": "Invoices",
+      "titleSuffix": "with Ease",
+      "description": "Upload your receipts and bills, organize them into invoices, and gain insights into your spending habits. Our AI-powered system extracts data automatically.",
+      "getStarted": "Get Started",
+      "viewMyInvoices": "View My Invoices",
+      "imageAlt": "Invoice management illustration"
+    },
+    "workflow": {
+      "title": "How It Works",
+      "description": "Three simple steps to digitize and organize your financial documents",
+      "step1": {
+        "title": "Upload Scans",
+        "description": "Drag and drop your receipts, invoices, or bills. We support JPG, PNG, and PDF files up to 10MB each.",
+        "button": "Upload Now"
+      },
+      "step2": {
+        "title": "View & Organize",
+        "description": "Review your uploaded scans, select the ones you want, and create invoices from them individually or in batches.",
+        "button": "View Scans"
+      },
+      "step3": {
+        "title": "Manage Invoices",
+        "description": "View your invoices, analyze spending patterns, and get AI-powered insights into your financial habits.",
+        "button": "View Invoices"
+      }
+    },
+    "features": {
+      "title": "Powerful Features",
+      "description": "Everything you need to manage your invoices efficiently",
+      "ocr": {
+        "title": "Smart OCR Extraction",
+        "description": "Our AI automatically extracts merchant names, dates, amounts, and line items from your scans."
+      },
+      "analytics": {
+        "title": "Spending Analytics",
+        "description": "Get detailed insights into your spending patterns with charts and reports."
+      },
+      "batch": {
+        "title": "Batch Processing",
+        "description": "Process multiple scans at once - create individual invoices or combine them into one."
+      },
+      "signInPrompt": "Sign in to save your invoices permanently and access them from any device.",
+      "imageAlt": "Invoice features illustration",
+      "signIn": "Sign in"
+    },
+    "bento": {
+      "title": "Everything You Need",
+      "description": "Powerful features designed to make invoice management effortless",
+      "ai": {
+        "title": "AI-Powered",
+        "description": "GPT-4 extraction"
+      },
+      "analyticsCard": {
+        "title": "Analytics",
+        "description": "Spending insights"
+      },
+      "cloud": {
+        "title": "Cloud Sync",
+        "description": "Access anywhere"
+      },
+      "ocr": {
+        "title": "Smart OCR",
+        "description": "Auto data capture"
+      },
+      "secure": {
+        "title": "Secure",
+        "description": "Bank-grade encryption"
+      },
+      "share": {
+        "title": "Share",
+        "description": "Collaborate easily"
+      },
+      "mobile": "Works beautifully on mobile devices"
+    },
+    "cta": {
+      "title": "Ready to Get Started?",
+      "description": "Upload your first scan and experience the magic of AI-powered invoice management.",
+      "uploadButton": "Upload Your First Scan",
+      "learnMore": "Learn More",
+      "badges": {
+        "secure": "Secure & Private",
+        "cloud": "Cloud Synced",
+        "ai": "AI-Powered"
+      }
+    }
+  },
+  "IMS--List": {
+    "metadata": {
+      "description": "List all invoices from the invoice management system.",
+      "title": "Invoice Management System - List Invoices"
+    },
+    "subtitle": "This is your digital receipts inventory. <br></br> Here you can find the receipts that you've uploaded so far. <br></br> By clicking on a receipt, you will be redirected to that specific receipt's page.",
+    "title": "Welcome, {name}!",
+    "viewInvoicesPage": {
+      "guestName": "dear guest"
+    },
+    "viewInvoicesIsland": {
+      "tabs": {
+        "invoices": "Invoices",
+        "statistics": "Statistics",
+        "liveAnalysis": "Live analysis"
+      }
+    },
+    "invoicesHeader": {
+      "title": "Invoice management",
+      "description": "Manage your receipts and track your spending habits",
+      "actions": {
+        "import": "Import",
+        "export": "Export",
+        "print": "Print",
+        "newInvoice": "New invoice"
+      },
+      "tooltips": {
+        "import": "Import invoices from files",
+        "export": "Export all invoices",
+        "print": "Print invoices",
+        "newInvoice": "Create a new invoice"
+      }
+    },
+    "invoicesView": {
+      "searchPlaceholder": "Search invoices...",
+      "filters": {
+        "category": "Category",
+        "timeOfDay": "Time of day",
+        "categories": "Categories",
+        "paymentTypes": "Payment Types",
+        "dateRange": "Date Range",
+        "dateFrom": "From date",
+        "dateTo": "To date",
+        "amountRange": "Amount Range",
+        "amountMin": "Min amount",
+        "amountMax": "Max amount",
+        "sortBy": "Sort By",
+        "sortOptions": {
+          "dateNewest": "Date (newest first)",
+          "dateOldest": "Date (oldest first)",
+          "amountHighToLow": "Amount (high to low)",
+          "amountLowToHigh": "Amount (low to high)",
+          "nameAZ": "Name (A-Z)",
+          "nameZA": "Name (Z-A)",
+          "none": "No sorting (default order)"
+        },
+        "title": "Filters",
+        "button": "Filters",
+        "clear": "Clear all",
+        "activeCount": "{count} active"
+      },
+      "categories": {
+        "all": "All categories",
+        "groceries": "Groceries",
+        "dining": "Dining",
+        "utilities": "Utilities",
+        "entertainment": "Entertainment",
+        "travel": "Travel",
+        "other": "Other"
+      },
+      "times": {
+        "all": "All times",
+        "day": "Daytime (6am-6pm)",
+        "night": "Nighttime (6pm-6am)"
+      },
+      "placeholderPanel": "More filter controls coming soon.",
+      "viewModes": {
+        "table": "Table view",
+        "grid": "Grid view"
+      }
+    },
+    "messageList": {
+      "aiAssistant": "AI Assistant",
+      "you": "You"
+    },
+    "generativeView": {
+      "welcomeMessage": "Hello! I'm your invoice analysis assistant. How can I help you today? Try commands like /find to search invoices.",
+      "title": "Live analysis",
+      "subtitle": "Chat with AI to analyze your invoices and get insights",
+      "help": "Help",
+      "tabs": {
+        "chat": "Chat",
+        "settings": "Settings"
+      },
+      "chatDescription": "Chat with AI to analyze your invoices and get insights. Try commands like /find to search invoices.",
+      "settings": {
+        "title": "Chat settings",
+        "description": "Configure your AI assistant preferences",
+        "historyLabel": "Chat history",
+        "retentionPlaceholder": "Select retention period",
+        "retention": {
+          "30": "Keep for 30 days",
+          "60": "Keep for 60 days",
+          "90": "Keep for 90 days",
+          "none": "Don't save history"
+        },
+        "dataAccessTitle": "Data access",
+        "allowInvoiceData": "Allow access to invoice data",
+        "allowMerchantData": "Allow access to merchant data",
+        "notificationPreferences": "Notification preferences",
+        "notifyInsights": "Notify me about new insights",
+        "save": "Save settings"
+      }
+    },
+    "tableView": {
+      "empty": {
+        "title": "No Invoices Yet",
+        "description": "Start by uploading your receipts to create your first invoice",
+        "uploadCta": "Upload Your First Receipt"
+      },
+      "columns": {
+        "invoice": "Invoice",
+        "category": "Category",
+        "date": "Date",
+        "amount": "Amount",
+        "actions": "Actions"
+      },
+      "aria": {
+        "selectAllInvoices": "Select all invoices",
+        "selectInvoice": "Select invoice {name}",
+        "rowsPerPage": "Rows per page",
+        "sortByDate": "Sort by date",
+        "sortByAmount": "Sort by amount"
+      },
+      "viewInvoice": "View Invoice",
+      "rowsPerPage": "Rows per page:",
+      "pageOf": "Page {current} of {total}",
+      "previousPage": "Previous Page",
+      "nextPage": "Next Page",
+      "tooltips": {
+        "notAnalyzed": "This invoice has not been analyzed yet"
+      }
+    },
+    "gridView": {
+      "tooltips": {
+        "viewDetails": "View Details"
+      },
+      "itemCount": "{count, plural, one {# item} other {# items}}"
+    },
+    "tableViewActions": {
+      "actions": {
+        "edit": "Edit",
+        "share": "Share",
+        "delete": "Delete"
+      },
+      "tooltips": {
+        "moreActions": "More actions",
+        "edit": "Edit invoice details",
+        "share": "Share invoice via link or email",
+        "delete": "Permanently delete this invoice"
+      }
+    },
+    "bulkActions": {
+      "selected": "{count, plural, one {# invoice selected} other {# invoices selected}}",
+      "clearSelection": "Clear selection",
+      "export": "Export",
+      "delete": "Delete",
+      "changeCategory": "Change Category",
+      "deleteConfirm": {
+        "title": "Delete Invoices",
+        "description": "{count, plural, one {Are you sure you want to delete this invoice? This action cannot be undone.} other {Are you sure you want to delete these # invoices? This action cannot be undone.}}",
+        "confirm": "Delete",
+        "cancel": "Cancel"
+      },
+      "deleteSuccess": "{count, plural, one {Invoice deleted successfully} other {# invoices deleted successfully}}",
+      "deleteError": "Failed to delete invoices. Please try again.",
+      "deletePartialSuccess": "{success} invoice(s) deleted, {failed} failed",
+      "categoryChanged": "{count, plural, one {Invoice category updated successfully} other {# invoice categories updated successfully}}",
+      "categoryChangeError": "Failed to update invoice categories. Please try again.",
+      "categoryPartialSuccess": "{success} invoice(s) updated, {failed} failed",
+      "categories": {
+        "notDefined": "Not Defined",
+        "grocery": "Groceries",
+        "fastFood": "Fast Food",
+        "homeCleaning": "Home Cleaning",
+        "carAuto": "Car & Auto",
+        "other": "Other"
+      }
+    }
+  },
+  "IMS--Stats": {
+    "title": "Invoice Statistics",
+    "subtitle": "Manage your receipts and track your spending habits",
+    "calendarHeatmap": {
+      "days": {
+        "wed": "Wed",
+        "thu": "Thu",
+        "fri": "Fri",
+        "sun": "Sun",
+        "mon": "Mon",
+        "sat": "Sat",
+        "tue": "Tue"
+      },
+      "tooltip": {
+        "noSpending": "No spending",
+        "amount": "Spent",
+        "invoices": "{count} invoices"
+      },
+      "legend": {
+        "less": "Less",
+        "more": "More"
+      },
+      "title": "Spending Calendar",
+      "description": "Daily spending intensity over time",
+      "navigation": {
+        "previous": "Previous month",
+        "next": "Next month"
+      },
+      "aria": {
+        "calendarGrid": "Daily spending calendar"
+      }
+    },
+    "spendingOverTime": {
+      "labels": {
+        "amount": "Amount"
+      },
+      "tooltip": {
+        "invoiceCount": "{count} invoices",
+        "andMore": "and {count} more..."
+      },
+      "title": "Spending Over Time",
+      "description": "Track your spending trends"
+    },
+    "categoryBreakdown": {
+      "title": "Spending by Category",
+      "description": "Distribution across categories",
+      "totalLabel": "Total Spending",
+      "tooltip": {
+        "invoiceCount": "{count} invoices"
+      }
+    },
+    "currencyDistribution": {
+      "title": "Currency Distribution",
+      "description": "Spending breakdown by currency with RON conversion",
+      "toggleLabel": "Toggle currency view",
+      "showOriginal": "Show Original",
+      "showRON": "Show RON",
+      "singleCurrency": "All invoices in {currency} ({symbol})",
+      "invoiceCount": "{count} invoices",
+      "originalAmount": "Original",
+      "ronEquivalent": "RON equivalent",
+      "totalAmount": "Total Amount",
+      "totalCurrencies": "Total Currencies",
+      "totalSpending": "Total Spending"
+    },
+    "merchantLeaderboard": {
+      "title": "Top Merchants",
+      "description": "Where you spend most",
+      "labels": {
+        "totalSpent": "Total Spent"
+      },
+      "tooltip": {
+        "invoiceCount": "{count} invoices"
+      },
+      "empty": "No merchant data available yet"
+    },
+    "merchantTrends": {
+      "title": "Merchant Spending Trends",
+      "description": "Monthly spending patterns for top merchants",
+      "labels": {
+        "merchant": "Merchant",
+        "totalSpend": "Total Spend",
+        "trend": "Trend (Last 6 Months)"
+      },
+      "aria": {
+        "sparkline": "Spending trend for {merchant}"
+      },
+      "empty": "No merchant data available yet"
+    },
+    "merchantVisit": {
+      "title": "Merchant Visit Patterns",
+      "description": "Shopping frequency and basket insights",
+      "metrics": {
+        "totalVisits": "Total Visits",
+        "visitsPerMonth": "Visits/Month",
+        "basketSize": "Avg Basket",
+        "preferredDay": "Preferred Day",
+        "avgSpend": "Avg Spend/Visit"
+      },
+      "empty": "No visit data available yet"
+    },
+    "priceDistribution": {
+      "title": "Price Distribution",
+      "description": "Item price distribution",
+      "labels": {
+        "itemCount": "Item Count"
+      },
+      "tooltip": {
+        "itemCount": "{count} items"
+      }
+    },
+    "timeOfDay": {
+      "title": "Shopping Patterns",
+      "description": "When you shop",
+      "labels": {
+        "invoiceCount": "Invoice Count"
+      },
+      "tooltip": {
+        "invoiceCount": "{count} invoices"
+      }
+    },
+    "productCategory": {
+      "description": "Spending breakdown by product type",
+      "tooltip": {
+        "productCount": "{count} products"
+      },
+      "title": "Product Category Spending",
+      "empty": "No products to analyze yet"
+    },
+    "topProducts": {
+      "ariaLabel": "Top products leaderboard",
+      "description": "Most purchased items",
+      "headers": {
+        "rank": "#",
+        "avgPrice": "Avg Price",
+        "quantity": "Qty",
+        "purchases": "Purchases",
+        "product": "Product",
+        "totalSpent": "Total"
+      },
+      "title": "Top Products",
+      "empty": "No products purchased yet"
+    },
+    "allergenSummary": {
+      "ariaLabel": "Allergen frequency summary",
+      "description": "Allergen exposure across products",
+      "stats": {
+        "products": "products",
+        "ofTotal": "of total"
+      },
+      "title": "Allergen Summary",
+      "empty": "No allergens detected in your purchases"
+    },
+    "kpi": {
+      "totalSpending": "Total Spending",
+      "invoiceCount": "Invoice Count",
+      "topMerchant": "Top Merchant",
+      "averageItems": "Avg. Items",
+      "vsLastMonth": "{delta}% vs last month",
+      "avgPerInvoice": "avg {amount} per invoice",
+      "visits": "{count} visits",
+      "acrossInvoices": "across {count} invoices",
+      "noneYet": "No data yet"
+    },
+    "comparison": {
+      "title": "Month-over-Month",
+      "description": "Comparison with previous month",
+      "spendingDelta": "Spending Change",
+      "invoiceCount": "Invoice Count",
+      "newMerchants": "New Merchants",
+      "discovered": "discovered",
+      "none": "none",
+      "increase": "increase",
+      "decrease": "decrease"
+    },
+    "empty": {
+      "title": "No Statistics Yet",
+      "subtitle": "Upload receipts to see analytics",
+      "cta": "Upload Receipt"
+    },
+    "productAnalytics": {
+      "title": "Product-Level Analytics",
+      "subtitle": "Insights into your purchased items"
+    }
+  },
+  "IMS--UploadScans": {
+    "metadata": {
+      "description": "Upload receipt scans to your account for later processing into invoices.",
+      "title": "Invoice Management System - Upload Scans"
+    },
+    "title": "Upload Scans",
+    "subtitle": "Upload receipt images or PDFs. Create invoices from them later.",
+    "breadcrumb": "Back to Invoices",
+    "header": {
+      "title": "Upload Scans",
+      "description": "Upload receipt images or PDFs. Create invoices from them later.",
+      "tooltip": "Upload your receipts, invoices, or bills here. You can select multiple files and organize them into invoices later from the View Scans page."
+    },
+    "buttons": {
+      "viewScans": "View Your Scans",
+      "myInvoices": "My Invoices",
+      "uploadFirst": "Upload Your First Scan"
+    },
+    "stats": {
+      "added": "Added",
+      "pending": "Pending",
+      "uploading": "Uploading",
+      "completed": "Completed",
+      "failed": "Failed"
+    },
+    "sidebar": {
+      "formats": {
+        "title": "Supported Formats",
+        "images": "Images",
+        "imageExtensions": ".jpg, .jpeg, .png",
+        "documents": "Documents",
+        "documentExtensions": ".pdf",
+        "maxSize": "Maximum file size: 10MB per file"
+      },
+      "tips": {
+        "title": "Tips for Best Results",
+        "tip1": "Use good lighting when photographing receipts",
+        "tip2": "Ensure text is clear and readable",
+        "tip3": "Avoid shadows and glare",
+        "tip4": "Capture the entire receipt in frame",
+        "tip5": "PDFs work best for digital receipts"
+      },
+      "security": {
+        "title": "Secure Storage",
+        "description": "Your scans are encrypted and stored securely. Only you can access them."
+      },
+      "nextSteps": {
+        "title": "All uploads complete!",
+        "description": "Your scans are ready. Head to View Scans to organize them into invoices.",
+        "button": "Continue to View Scans"
+      }
+    },
+    "upload": {
+      "dropzone": "Drag and drop your receipt images or PDFs here",
+      "browse": "Browse files",
+      "or": "or"
+    },
+    "errors": {
+      "unsupportedType": "Unsupported file type: {type}",
+      "tooLarge": "File too large: {name} (max 10MB)"
+    },
+    "uploadArea": {
+      "aria": {
+        "uploadFiles": "Upload files"
+      },
+      "empty": {
+        "title": "Drag and drop your files here",
+        "dropActive": "Drop files to upload",
+        "dropInactive": "Click or drag files to upload",
+        "formats": "Supported formats: JPG, PNG, PDF (max 10MB each)",
+        "note": "You can select multiple files.",
+        "chooseFiles": "Choose Files"
+      },
+      "compact": {
+        "dropActive": "Drop files to add them",
+        "dropInactive": "Drag files here or click to browse",
+        "subtitle": "JPG, PNG, PDF up to 10MB"
+      },
+      "actions": {
+        "clearAll": "Clear All",
+        "uploading": "Uploading...",
+        "uploadScans": "Upload Scans"
+      },
+      "tooltips": {
+        "clearAll": "Remove all pending uploads",
+        "uploadScans": "Start uploading all pending scans"
+      }
+    },
+    "preview": {
+      "title": "Pending uploads ({count})",
+      "status": {
+        "pending": "Pending",
+        "uploading": "Uploading",
+        "retrying": "Retrying",
+        "completed": "Completed",
+        "failed": "Failed"
+      },
+      "removeTooltip": "Remove this file",
+      "retryAttempt": "Retry attempt {attempt}",
+      "pendingTooltip": "This scan will not be persisted until you click Upload",
+      "pagination": {
+        "previous": "Previous",
+        "next": "Next",
+        "pageInfo": "{current} / {total} ({count} scans)"
+      }
+    },
+    "postUpload": {
+      "title": "Upload Complete!",
+      "subtitle": "Do these scans represent a single purchase?",
+      "createInvoice": "Yes, create invoice",
+      "viewScans": "No, I'll combine later",
+      "dismiss": "Dismiss"
+    }
+  },
+  "IMS--View": {
+    "metadata": {
+      "description": "View your invoice details, items, and associated merchant information.",
+      "title": "Invoice Management System - View Invoice"
+    },
+    "invoiceAnalytics": {
+      "title": "Analytics & Insights",
+      "tabs": {
+        "current": "This Invoice",
+        "compare": "Comparison"
+      },
+      "emptyState": {
+        "title": "Not Enough Data for Comparisons",
+        "description": "Add more invoices to see spending trends, merchant breakdowns, and category comparisons."
+      }
+    },
+    "invoiceTimeline": {
+      "title": "Invoice Timeline",
+      "subtitle": "Complete history of actions and changes",
+      "eventCount": "{count, plural, one {# event} other {# events}}"
+    },
+    "invoiceTabs": {
+      "tabs": {
+        "possibleRecipes": "Possible Recipes",
+        "additionalInfo": "Additional Info"
+      },
+      "recipe": {
+        "duration": "{minutes} min",
+        "prepCook": "Prep: {prep}m • Cook: {cook}m",
+        "viewRecipe": "View Recipe",
+        "ingredients": "Ingredients",
+        "instructions": "Instructions"
+      },
+      "actions": {
+        "regenerate": "Regenerate Recipes",
+        "regenerateTooltip": "Re-analyze the invoice to generate new recipe suggestions",
+        "generate": "Generate Recipes"
+      },
+      "empty": {
+        "recipes": "No recipe suggestions available",
+        "additionalInfo": "No additional information available"
+      }
+    },
+    "timelineItem": {
+      "aria": {
+        "moreInfo": "More info about {title}"
+      },
+      "confidence": "Confidence: {value}%",
+      "events": {
+        "created": {
+          "title": "Invoice Created",
+          "description": "Scanned and digitized from receipt"
+        },
+        "aiAnalysis": {
+          "title": "AI Analysis Complete",
+          "description": "{count, plural, one {# item detected and categorized} other {# items detected and categorized}}"
+        },
+        "recipesGenerated": {
+          "title": "Recipes Generated",
+          "description": "{count, plural, one {# recipe suggested} other {# recipes suggested}}"
+        },
+        "shared": {
+          "title": "Shared with Others",
+          "description": "Shared with {count, plural, one {# person} other {# people}}"
+        },
+        "edited": {
+          "title": "Invoice Updated"
+        },
+        "exported": {
+          "title": "Invoice Exported"
+        },
+        "markedImportant": {
+          "title": "Marked as Important",
+          "description": "Flagged for priority tracking"
+        },
+        "categorized": {
+          "title": "Category Assigned",
+          "description": "Auto-categorized based on items"
+        }
+      },
+      "tooltips": {
+        "created": "Invoice was scanned and digitized using {method}.",
+        "aiAnalysis": "AI processed this invoice in {duration} and analyzed {count, plural, one {# item} other {# items}}.",
+        "recipesGenerated": "Based on purchased ingredients, {count, plural, one {# recipe was generated} other {# recipes were generated}}.",
+        "shared": "Invoice was shared with {count, plural, one {# user} other {# users}}.",
+        "edited": "Manual changes were made to the invoice.",
+        "exported": "Invoice was exported in {format} format.",
+        "markedImportant": "Invoice was flagged as important for quick access.",
+        "categorized": "Invoice was assigned a category for better organization.",
+        "unavailable": "Event details unavailable"
+      },
+      "relativeTime": {
+        "now": "Just now"
+      },
+      "fallbacks": {
+        "ocr": "OCR",
+        "pdf": "PDF"
+      }
+    },
+    "timelineSharedWithList": {
+      "header": {
+        "title": "Shared With",
+        "publicBadge": "Public"
+      },
+      "publicAccess": {
+        "title": "Public Access Enabled",
+        "description": "This invoice is publicly accessible. Anyone with the link can view it, including guests without an account."
+      },
+      "aria": {
+        "sendEmail": "Send email to {user}"
+      },
+      "actions": {
+        "sendEmail": "Send email",
+        "manageSharing": "Manage Sharing"
+      }
+    },
+    "invoiceGuestBanner": {
+      "title": "Guest View",
+      "description": "You are not currently the owner of this invoice. The view is limited to what the owner has specified in the share settings."
+    },
+    "categoryComparisonChart": {
+      "title": "Category Comparison",
+      "description": "This invoice vs your average",
+      "labels": {
+        "current": "Current",
+        "average": "Average"
+      }
+    },
+    "itemsBreakdownChart": {
+      "title": "Top Items by Cost",
+      "description": "Highest spending items",
+      "labels": {
+        "price": "Price",
+        "quantity": "Qty"
+      }
+    },
+    "merchantBreakdownChart": {
+      "title": "Spending by Store",
+      "description": "All-time totals across merchants",
+      "labels": {
+        "totalSpent": "Total Spent",
+        "total": "Total",
+        "visits": "Visits",
+        "averagePerVisit": "Avg/visit"
+      },
+      "unknownMerchant": "Unknown Merchant"
+    },
+    "priceDistributionChart": {
+      "title": "Price Distribution",
+      "description": "Items by price range ({currency})",
+      "labels": {
+        "items": "Items"
+      },
+      "tooltip": {
+        "itemCount": "{count, plural, one {# item} other {# items}}"
+      }
+    },
+    "spendingByCategoryChart": {
+      "title": "Spending by Category",
+      "description": "Distribution of expenses",
+      "totalLabel": "Total Spending",
+      "tooltip": {
+        "itemCount": "{count, plural, one {# item} other {# items}}"
+      }
+    },
+    "spendingTrendChart": {
+      "title": "Spending Over Time",
+      "description": "Your invoice history trend",
+      "labels": {
+        "amount": "Amount"
+      },
+      "tooltip": {
+        "currentInvoice": "Current Invoice",
+        "andMore": "and {count} more..."
+      }
+    },
+    "print": {
+      "generatedOn": "Printed on {date}",
+      "page": "Page",
+      "labels": {
+        "date": "Date",
+        "merchant": "Merchant",
+        "total": "Total Amount",
+        "items": "Items"
+      }
+    },
+    "relatedInvoices": {
+      "noRelated": "No related invoices found",
+      "subtitle": "Similar invoices based on merchant, category, or amount",
+      "sameCategory": "Same Category",
+      "viewInvoice": "View",
+      "similarAmount": "Similar Amount",
+      "sameMerchant": "Same Merchant",
+      "title": "Related Invoices"
+    },
+    "shareCollaborate": {
+      "title": "Sharing & Collaboration",
+      "private": "Private",
+      "shared": "Shared",
+      "public": "Public",
+      "sharedWith": "Shared with",
+      "copyLink": "Copy Link",
+      "shareEmail": "Share via Email",
+      "manageSharing": "Manage Sharing",
+      "copied": "Link copied to clipboard!",
+      "activity": {
+        "title": "Activity",
+        "created": "Created {time}",
+        "modified": "Last modified {time}",
+        "daysAgo": "{count, plural, one {# day ago} other {# days ago}}",
+        "today": "today"
+      },
+      "publicAccess": "Public Access",
+      "publicAccessDescription": "Anyone with the link can view this invoice",
+      "madePublic": "Invoice is now public",
+      "madePrivate": "Invoice is now private",
+      "toggleError": "Failed to update sharing settings",
+      "qrCode": "QR Code",
+      "qrCopied": "Link copied! QR code generation coming soon.",
+      "copyError": "Failed to copy link"
+    },
+    "healthScore": {
+      "hideDetails": "Hide factor breakdown",
+      "title": "Invoice Health Score",
+      "status": {
+        "incomplete": "Incomplete",
+        "good": "Good",
+        "needsAttention": "Needs Attention",
+        "excellent": "Excellent"
+      },
+      "suggestions": {
+        "noRecipes": "No recipes generated — run AI analysis to discover meal ideas",
+        "title": "Suggested Improvements",
+        "incompletePayment": "Incomplete payment information — add transaction date, amount, and currency",
+        "fix": "Fix",
+        "noMerchant": "No merchant linked — add merchant details for better insights",
+        "noProducts": "No products found — upload a receipt or add items manually",
+        "lowOcrConfidence": "Low OCR confidence on <strong>{count}</strong> products — review manually for accuracy",
+        "uncategorizedProducts": "<strong>{count}</strong> products uncategorized — assign categories for spending analysis",
+        "incompleteProducts": "<strong>{count}</strong> products incomplete — review and complete missing fields"
+      },
+      "points": "points",
+      "factors": {
+        "merchantLinked": "Merchant linked",
+        "ocrConfidence": "OCR confidence",
+        "recipesGenerated": "Recipes generated",
+        "paymentInfo": "Payment information",
+        "productCompleteness": "Product completeness",
+        "productsPresent": "Products extracted",
+        "categoriesAssigned": "Categories assigned"
+      },
+      "cta": {
+        "edit": "Edit Invoice",
+        "analyze": "Run AI Analysis"
+      },
+      "showDetails": "Show factor breakdown",
+      "subtitle": "Comprehensive data quality assessment",
+      "seeReport": "See detailed report",
+      "dialogTitle": "Invoice Health Report"
+    },
+    "itemAnalytics": {
+      "title": "Items",
+      "searchPlaceholder": "Search items...",
+      "columns": {
+        "name": "Name",
+        "category": "Category",
+        "price": "Price",
+        "quantity": "Qty",
+        "total": "Total"
+      },
+      "confidence": {
+        "label": "OCR Confidence",
+        "lowWarning": "Low confidence — consider reviewing this item",
+        "ariaLabel": "{level} confidence: {percent}%",
+        "high": "High",
+        "medium": "Medium",
+        "low": "Low"
+      },
+      "summary": {
+        "title": "Summary",
+        "mostExpensive": "Most expensive",
+        "cheapest": "Cheapest",
+        "categories": "{count} categories",
+        "allergens": "{count} allergens detected"
+      },
+      "empty": {
+        "title": "No items",
+        "subtitle": "Run AI analysis to extract items from your receipt"
+      },
+      "totalLabel": "TOTAL"
+    },
+    "analysisPanel": {
+      "tooltips": {
+        "itemsOnly": "Re-categorize and analyze line items only",
+        "completeAnalysis": "Complete OCR extraction + AI processing of all invoice data",
+        "merchantOnly": "Re-identify merchant and location data",
+        "invoiceOnly": "Re-extract basic invoice information (date, total, payment)",
+        "reanalyze": "Trigger complete re-analysis with all AI features"
+      },
+      "title": "AI Analysis",
+      "options": {
+        "itemsOnly": "Items Only",
+        "completeAnalysis": "Full Analysis",
+        "merchantOnly": "Merchant Only",
+        "invoiceOnly": "Invoice Only"
+      },
+      "steps": {
+        "processing": "Processing items...",
+        "finalizing": "Finalizing results...",
+        "preparing": "Preparing document...",
+        "complete": "Analysis complete!",
+        "analyzing": "Analyzing with AI...",
+        "extracting": "Running OCR extraction..."
+      },
+      "analyzing": {
+        "progress": "{progress}% complete",
+        "title": "Analyzing..."
+      },
+      "labels": {
+        "lastAnalyzed": "Last Analyzed",
+        "updates": "{count, plural, one {# update} other {# updates}}",
+        "granularOptions": "Or choose specific analysis",
+        "analysisComplete": "Analysis Complete — All data has been extracted"
+      },
+      "toasts": {
+        "error": {
+          "description": "Unable to analyze invoice. Please try again later.",
+          "title": "Analysis Failed"
+        },
+        "success": {
+          "description": "Invoice has been successfully re-analyzed with updated data.",
+          "title": "Analysis Complete"
+        }
+      },
+      "description": "Re-analyze this invoice with AI to extract or update data",
+      "buttons": {
+        "reanalyze": "Re-Analyze Invoice"
+      },
+      "tip": "Quick Tip: Full analysis takes 30-60 seconds but provides the most accurate results."
+    },
+    "export": {
+      "printError": "Failed to open print dialog",
+      "printSuccess": "Print dialog opened",
+      "csv": {
+        "title": "Export as CSV",
+        "description": "Download items as spreadsheet"
+      },
+      "description": "Export your invoice data in various formats",
+      "print": {
+        "title": "Print",
+        "description": "Print invoice using browser"
+      },
+      "csvSuccess": "CSV file downloaded successfully",
+      "copyError": "Failed to copy summary",
+      "copySummary": {
+        "title": "Copy Summary",
+        "description": "Copy text summary to clipboard"
+      },
+      "copySuccess": "Summary copied to clipboard",
+      "json": {
+        "title": "Export as JSON",
+        "description": "Download complete invoice data"
+      },
+      "jsonSuccess": "JSON file downloaded successfully",
+      "jsonError": "Failed to export JSON",
+      "csvError": "Failed to export CSV",
+      "title": "Export Invoice",
+      "pdf": {
+        "title": "Export as PDF",
+        "description": "Download professional invoice document"
+      },
+      "pdfSuccess": "PDF file downloaded successfully",
+      "pdfError": "Failed to generate PDF",
+      "pdfGenerating": "Generating PDF..."
+    }
+  },
+  "IMS--ViewScans": {
+    "metadata": {
+      "description": "View and manage your uploaded scans. Create invoices from selected scans.",
+      "title": "Invoice Management System - View Scans"
+    },
+    "title": "Your Scans",
+    "subtitle": "Select scans to create invoices from them.",
+    "breadcrumb": "Back to Invoices",
+    "header": {
+      "title": "Your Scans",
+      "titleWithCount": "Your Scans ({count})",
+      "subtitle": "Select scans to create invoices from them",
+      "lastSynced": "Last synced: {time}",
+      "tooltip": "Select scans to create invoices from them. You can create one invoice per scan or combine multiple scans into a single invoice.",
+      "uploadMore": "Upload More",
+      "upload": "Upload",
+      "uploadTooltip": "Upload more scans to your account",
+      "myInvoices": "My Invoices",
+      "invoices": "Invoices",
+      "myInvoicesTooltip": "View your created invoices",
+      "sync": "Sync",
+      "syncing": "Syncing...",
+      "syncTooltip": "Refresh scans from server"
+    },
+    "stats": {
+      "totalScans": "Total Scans",
+      "ready": "Ready",
+      "selected": "Selected",
+      "selectHint": "Click on scans to select them for invoice creation",
+      "tapHint": "Tap to select"
+    },
+    "sidebar": {
+      "howTo": {
+        "title": "How to Create Invoices",
+        "step1Title": "Select Scans",
+        "step1Description": "Click on scans to select them",
+        "step2Title": "Choose Mode",
+        "step2Description": "One invoice per scan or combine multiple",
+        "step3Title": "Create Invoice",
+        "step3Description": "AI extracts data automatically"
+      },
+      "selectionStatus": {
+        "singular": "scan selected",
+        "plural": "scans selected",
+        "readySingular": "Ready to create an invoice",
+        "readyPlural": "Create multiple invoices or combine into one"
+      },
+      "quickUpload": {
+        "title": "Need more scans?",
+        "description": "Upload additional receipts",
+        "button": "Upload"
+      }
+    },
+    "emptyState": {
+      "title": "No scans yet",
+      "description": "Start by uploading your receipts and invoices. Here's how it works:",
+      "step1Title": "Upload your scans",
+      "step1Description": "Take photos of receipts or upload PDFs of digital invoices",
+      "step2Title": "Select and organize",
+      "step2Description": "Choose which scans to convert into invoices",
+      "step3Title": "Create invoices",
+      "step3Description": "Our AI automatically extracts all the data for you",
+      "uploadButton": "Upload Your First Scan",
+      "learnMoreButton": "Learn More"
+    },
+    "toolbar": {
+      "selected": "selected",
+      "clearSelection": "Clear",
+      "createInvoice": "Create Invoice",
+      "createInvoices": "Create Invoices",
+      "delete": {
+        "button": "Delete ({count})",
+        "confirmTitle": "Delete selected scans?",
+        "confirmDescription": "This will permanently delete {count} scan(s) from storage. This action cannot be undone.",
+        "cancel": "Cancel",
+        "confirm": "Delete",
+        "success": "{count} scan(s) deleted successfully",
+        "partial": "{success} deleted, {failed} failed",
+        "failed": "Failed to delete scans",
+        "error": "An error occurred while deleting scans"
+      }
+    },
+    "scanCard": {
+      "loading": "Loading...",
+      "delete": "Delete scan",
+      "linked": "Linked",
+      "deleteDialog": {
+        "title": "Delete scan?",
+        "description": "Are you sure you want to delete \"{name}\"? This action cannot be undone and the scan will be permanently removed from storage.",
+        "linkedWarning": "This scan is linked to an invoice.",
+        "linkedDescription": "Deleting it will remove the scan from storage, but the invoice will retain a copy of the image. This action cannot be undone.",
+        "cancel": "Cancel",
+        "delete": "Delete",
+        "deleting": "Deleting...",
+        "success": "Scan deleted successfully",
+        "error": "Failed to delete scan"
+      },
+      "rename": "Rename scan",
+      "renamePlaceholder": "Enter new name",
+      "preview": "Preview scan",
+      "previewTitle": "Scan Preview",
+      "actions": {
+        "rename": "Rename scan",
+        "delete": "Delete scan",
+        "rotateCW": "Rotate 90° Clockwise",
+        "rotateCCW": "Rotate 90° Counter-clockwise",
+        "rotating": "Rotating...",
+        "rotateSuccess": "Image rotated successfully",
+        "rotateError": "Failed to rotate image",
+        "rotateUnsupported": "Cannot rotate PDF files"
+      }
+    },
+    "createFromAll": {
+      "button": "Create from All Scans",
+      "title": "All scans are ready!",
+      "description": "Create invoices from all {count} scans at once"
+    },
+    "groupBanner": {
+      "title": "These {count} scans were uploaded together",
+      "subtitle": "Create an invoice from these scans?",
+      "createInvoice": "Create Invoice",
+      "dismiss": "Dismiss"
+    },
+    "pagination": {
+      "previous": "Previous",
+      "next": "Next",
+      "pageInfo": "{current} / {total} ({count} scans)"
+    }
   }
 }

--- a/sites/arolariu.ro/messages/fr.json
+++ b/sites/arolariu.ro/messages/fr.json
@@ -1191,2829 +1191,6 @@
       }
     }
   },
-  "Invoices": {
-    "metadata": {
-      "description": "Gérez vos reçus, créez des factures et obtenez des informations sur vos habitudes de dépenses.",
-      "title": "Système de Gestion des Factures"
-    },
-    "Homepage": {
-      "metadata": {
-        "description": "La page d'accueil principale du service de domaine Système de Gestion des Factures.",
-        "title": "Système de Gestion des Factures - Accueil"
-      },
-      "hero": {
-        "title": "Gérez Vos",
-        "titleHighlight": "Factures",
-        "titleSuffix": "Facilement",
-        "description": "Téléchargez vos reçus et factures, organisez-les et obtenez des informations sur vos habitudes de dépenses. Notre système alimenté par l'IA extrait les données automatiquement.",
-        "getStarted": "Commencer",
-        "viewMyInvoices": "Voir Mes Factures",
-        "imageAlt": "Illustration de gestion des factures"
-      },
-      "workflow": {
-        "title": "Comment Ça Marche",
-        "description": "Trois étapes simples pour numériser et organiser vos documents financiers",
-        "step1": {
-          "title": "Télécharger des Scans",
-          "description": "Glissez-déposez vos reçus, factures ou notes. Nous acceptons les fichiers JPG, PNG et PDF jusqu'à 10 Mo chacun.",
-          "button": "Télécharger"
-        },
-        "step2": {
-          "title": "Voir et Organiser",
-          "description": "Examinez vos scans téléchargés, sélectionnez ceux que vous voulez et créez des factures individuellement ou par lots.",
-          "button": "Voir les Scans"
-        },
-        "step3": {
-          "title": "Gérer les Factures",
-          "description": "Consultez vos factures, analysez les habitudes de dépenses et obtenez des informations alimentées par l'IA sur vos habitudes financières.",
-          "button": "Voir les Factures"
-        }
-      },
-      "features": {
-        "title": "Fonctionnalités Puissantes",
-        "description": "Tout ce dont vous avez besoin pour gérer vos factures efficacement",
-        "ocr": {
-          "title": "Extraction OCR Intelligente",
-          "description": "Notre IA extrait automatiquement les noms des commerçants, dates, montants et articles de vos scans."
-        },
-        "analytics": {
-          "title": "Analyse des Dépenses",
-          "description": "Obtenez des informations détaillées sur vos habitudes de dépenses avec des graphiques et rapports."
-        },
-        "batch": {
-          "title": "Traitement par Lots",
-          "description": "Traitez plusieurs scans à la fois - créez des factures individuelles ou combinez-les en une seule."
-        },
-        "signInPrompt": "Connectez-vous pour sauvegarder vos factures de façon permanente et y accéder depuis n'importe quel appareil.",
-        "imageAlt": "Illustration des fonctionnalités des factures",
-        "signIn": "Connectez-vous"
-      },
-      "bento": {
-        "title": "Tout Ce Dont Vous Avez Besoin",
-        "description": "Des fonctionnalités puissantes conçues pour rendre la gestion des factures sans effort",
-        "ai": {
-          "title": "Alimenté par l'IA",
-          "description": "Extraction GPT-4"
-        },
-        "analyticsCard": {
-          "title": "Analyse",
-          "description": "Aperçu des dépenses"
-        },
-        "cloud": {
-          "title": "Sync Cloud",
-          "description": "Accès partout"
-        },
-        "ocr": {
-          "title": "OCR Intelligent",
-          "description": "Capture auto des données"
-        },
-        "secure": {
-          "title": "Sécurisé",
-          "description": "Chiffrement bancaire"
-        },
-        "share": {
-          "title": "Partager",
-          "description": "Collaboration facile"
-        },
-        "mobile": "Fonctionne parfaitement sur mobile"
-      },
-      "cta": {
-        "title": "Prêt à Commencer?",
-        "description": "Téléchargez votre premier scan et découvrez la magie de la gestion des factures alimentée par l'IA.",
-        "uploadButton": "Télécharger Votre Premier Scan",
-        "learnMore": "En Savoir Plus",
-        "badges": {
-          "secure": "Sécurisé et Privé",
-          "cloud": "Synchronisé dans le Cloud",
-          "ai": "Alimenté par l'IA"
-        }
-      }
-    },
-    "UploadScans": {
-      "metadata": {
-        "description": "Téléchargez des scans de reçus sur votre compte pour un traitement ultérieur en factures.",
-        "title": "Système de Gestion des Factures - Télécharger des Scans"
-      },
-      "title": "Télécharger des Scans",
-      "subtitle": "Téléchargez des images de reçus ou des PDF. Créez des factures à partir de ceux-ci plus tard.",
-      "breadcrumb": "Retour aux Factures",
-      "header": {
-        "title": "Télécharger des Scans",
-        "description": "Téléchargez des images de reçus ou des PDF. Créez des factures à partir de ceux-ci plus tard.",
-        "tooltip": "Téléchargez vos reçus, factures ou notes ici. Vous pouvez sélectionner plusieurs fichiers et les organiser en factures plus tard depuis la page Voir les Scans."
-      },
-      "buttons": {
-        "viewScans": "Voir Vos Scans",
-        "myInvoices": "Mes Factures",
-        "uploadFirst": "Télécharger Votre Premier Scan"
-      },
-      "stats": {
-        "added": "Ajouté",
-        "pending": "En attente",
-        "uploading": "Téléchargement",
-        "completed": "Terminé",
-        "failed": "Échoué"
-      },
-      "sidebar": {
-        "formats": {
-          "title": "Formats Pris en Charge",
-          "images": "Images",
-          "imageExtensions": ".jpg, .jpeg, .png",
-          "documents": "Documents",
-          "documentExtensions": ".pdf",
-          "maxSize": "Taille maximale du fichier : 10 Mo par fichier"
-        },
-        "tips": {
-          "title": "Conseils pour de Meilleurs Résultats",
-          "tip1": "Utilisez un bon éclairage lors de la photographie des reçus",
-          "tip2": "Assurez-vous que le texte est clair et lisible",
-          "tip3": "Évitez les ombres et les reflets",
-          "tip4": "Capturez tout le reçu dans le cadre",
-          "tip5": "Les PDF fonctionnent mieux pour les reçus numériques"
-        },
-        "security": {
-          "title": "Stockage Sécurisé",
-          "description": "Vos scans sont chiffrés et stockés en toute sécurité. Vous seul pouvez y accéder."
-        },
-        "nextSteps": {
-          "title": "Tous les téléchargements terminés !",
-          "description": "Vos scans sont prêts. Allez sur Voir les Scans pour les organiser en factures.",
-          "button": "Continuer vers Voir les Scans"
-        }
-      },
-      "upload": {
-        "dropzone": "Glissez et déposez vos images de reçus ou PDF ici",
-        "browse": "Parcourir les fichiers",
-        "or": "ou"
-      },
-      "errors": {
-        "unsupportedType": "Type de fichier non pris en charge : {type}",
-        "tooLarge": "Fichier trop volumineux : {name} (max 10 Mo)"
-      },
-      "uploadArea": {
-        "aria": {
-          "uploadFiles": "Téléverser des fichiers"
-        },
-        "empty": {
-          "title": "Glissez-déposez vos fichiers ici",
-          "dropActive": "Déposez les fichiers pour les téléverser",
-          "dropInactive": "Cliquez ou glissez des fichiers pour les téléverser",
-          "formats": "Formats pris en charge : JPG, PNG, PDF (10 Mo max chacun)",
-          "note": "Vous pouvez sélectionner plusieurs fichiers.",
-          "chooseFiles": "Choisir des fichiers"
-        },
-        "compact": {
-          "dropActive": "Déposez les fichiers pour les ajouter",
-          "dropInactive": "Glissez des fichiers ici ou cliquez pour parcourir",
-          "subtitle": "JPG, PNG, PDF jusqu'à 10 Mo"
-        },
-        "actions": {
-          "clearAll": "Tout effacer",
-          "uploading": "Téléversement...",
-          "uploadScans": "Téléverser les scans"
-        },
-        "tooltips": {
-          "clearAll": "Supprimer tous les téléversements en attente",
-          "uploadScans": "Démarrer le téléversement de tous les scans en attente"
-        }
-      },
-      "preview": {
-        "title": "Téléversements en attente ({count})",
-        "status": {
-          "pending": "En attente",
-          "uploading": "Téléversement",
-          "retrying": "Nouvelle tentative",
-          "completed": "Terminé",
-          "failed": "Échoué"
-        },
-        "removeTooltip": "Supprimer ce fichier",
-        "retryAttempt": "Nouvelle tentative {attempt}",
-        "pendingTooltip": "Ce scan ne sera pas enregistré tant que vous n'aurez pas cliqué sur Télécharger",
-        "pagination": {
-          "previous": "Précédent",
-          "next": "Suivant",
-          "pageInfo": "{current} / {total} ({count} scans)"
-        }
-      },
-      "postUpload": {
-        "title": "Téléchargement terminé !",
-        "subtitle": "Ces numérisations représentent-elles un seul achat ?",
-        "createInvoice": "Oui, créer une facture",
-        "viewScans": "Non, je les combinerai plus tard",
-        "dismiss": "Fermer"
-      }
-    },
-    "ViewScans": {
-      "metadata": {
-        "description": "Consultez et gérez vos scans téléchargés. Créez des factures à partir des scans sélectionnés.",
-        "title": "Système de Gestion des Factures - Voir les Scans"
-      },
-      "title": "Vos Scans",
-      "subtitle": "Sélectionnez des scans pour créer des factures à partir de ceux-ci.",
-      "breadcrumb": "Retour aux Factures",
-      "header": {
-        "title": "Vos Scans",
-        "titleWithCount": "Vos Scans ({count})",
-        "subtitle": "Sélectionnez des scans pour créer des factures à partir de ceux-ci",
-        "lastSynced": "Dernière synchronisation : {time}",
-        "tooltip": "Sélectionnez des scans pour créer des factures. Vous pouvez créer une facture par scan ou combiner plusieurs scans en une seule facture.",
-        "uploadMore": "Télécharger Plus",
-        "upload": "Télécharger",
-        "uploadTooltip": "Téléchargez plus de scans sur votre compte",
-        "myInvoices": "Mes Factures",
-        "invoices": "Factures",
-        "myInvoicesTooltip": "Voir vos factures créées",
-        "sync": "Synchroniser",
-        "syncing": "Synchronisation...",
-        "syncTooltip": "Actualiser les scans depuis le serveur"
-      },
-      "stats": {
-        "totalScans": "Total des Scans",
-        "ready": "Prêt",
-        "selected": "Sélectionné",
-        "selectHint": "Cliquez sur les scans pour les sélectionner pour la création de factures",
-        "tapHint": "Appuyez pour sélectionner"
-      },
-      "sidebar": {
-        "howTo": {
-          "title": "Comment Créer des Factures",
-          "step1Title": "Sélectionner des Scans",
-          "step1Description": "Cliquez sur les scans pour les sélectionner",
-          "step2Title": "Choisir le Mode",
-          "step2Description": "Une facture par scan ou combiner plusieurs",
-          "step3Title": "Créer la Facture",
-          "step3Description": "L'IA extrait les données automatiquement"
-        },
-        "selectionStatus": {
-          "singular": "scan sélectionné",
-          "plural": "scans sélectionnés",
-          "readySingular": "Prêt à créer une facture",
-          "readyPlural": "Créez plusieurs factures ou combinez en une seule"
-        },
-        "quickUpload": {
-          "title": "Besoin de plus de scans ?",
-          "description": "Téléchargez des reçus supplémentaires",
-          "button": "Télécharger"
-        }
-      },
-      "emptyState": {
-        "title": "Pas encore de scans",
-        "description": "Commencez par télécharger vos reçus et factures. Voici comment cela fonctionne :",
-        "step1Title": "Téléchargez vos scans",
-        "step1Description": "Prenez des photos de reçus ou téléchargez des PDF de factures numériques",
-        "step2Title": "Sélectionnez et organisez",
-        "step2Description": "Choisissez quels scans convertir en factures",
-        "step3Title": "Créez des factures",
-        "step3Description": "Notre IA extrait automatiquement toutes les données pour vous",
-        "uploadButton": "Télécharger Votre Premier Scan",
-        "learnMoreButton": "En Savoir Plus"
-      },
-      "toolbar": {
-        "selected": "sélectionné",
-        "clearSelection": "Effacer",
-        "createInvoice": "Créer une Facture",
-        "createInvoices": "Créer des Factures",
-        "delete": {
-          "button": "Supprimer ({count})",
-          "confirmTitle": "Supprimer les scans sélectionnés ?",
-          "confirmDescription": "Cela supprimera définitivement {count} scan(s) du stockage. Cette action est irréversible.",
-          "cancel": "Annuler",
-          "confirm": "Supprimer",
-          "success": "{count} scan(s) supprimé(s) avec succès",
-          "partial": "{success} supprimé(s), {failed} échoué(s)",
-          "failed": "Échec de la suppression des scans",
-          "error": "Une erreur est survenue lors de la suppression des scans"
-        }
-      },
-      "scanCard": {
-        "loading": "Chargement...",
-        "delete": "Supprimer le scan",
-        "linked": "Lié",
-        "deleteDialog": {
-          "title": "Supprimer le scan ?",
-          "description": "Êtes-vous sûr de vouloir supprimer \"{name}\" ? Cette action ne peut pas être annulée et le scan sera définitivement supprimé du stockage.",
-          "linkedWarning": "Ce scan est lié à une facture.",
-          "linkedDescription": "Le supprimer retirera le scan du stockage, mais la facture conservera une copie de l'image. Cette action ne peut pas être annulée.",
-          "cancel": "Annuler",
-          "delete": "Supprimer",
-          "deleting": "Suppression...",
-          "success": "Scan supprimé avec succès",
-          "error": "Échec de la suppression du scan"
-        },
-        "rename": "Renommer le scan",
-        "renamePlaceholder": "Entrez le nouveau nom",
-        "preview": "Aperçu du scan",
-        "previewTitle": "Aperçu du scan",
-        "actions": {
-          "rename": "Renommer le scan",
-          "delete": "Supprimer le scan",
-          "rotateCW": "Pivoter de 90° dans le sens horaire",
-          "rotateCCW": "Pivoter de 90° dans le sens antihoraire",
-          "rotating": "Rotation en cours...",
-          "rotateSuccess": "Image pivotée avec succès",
-          "rotateError": "Échec de la rotation de l'image",
-          "rotateUnsupported": "Impossible de pivoter les fichiers PDF"
-        }
-      },
-      "createInvoiceDialog": {
-        "title": "Créer une Facture",
-        "titlePlural": "Créer des Factures",
-        "description": "Transformez vos scans en données de facture structurées grâce à l'extraction alimentée par l'IA.",
-        "selectedScans": "Scans Sélectionnés",
-        "totalSize": "total",
-        "chooseMode": "Choisir le Mode de Création",
-        "singleMode": {
-          "title": "Une facture par scan",
-          "description": "Crée {count} factures séparées. Idéal lorsque chaque scan est un reçu différent."
-        },
-        "batchMode": {
-          "title": "Combiner en une seule facture",
-          "description": "Crée 1 facture avec les {count} scans attachés. Idéal pour les reçus multi-pages."
-        },
-        "singleScanInfo": {
-          "title": "Que se passe-t-il ensuite ?",
-          "description": "Notre IA analysera votre scan et extraira automatiquement les détails du commerçant, les articles, les prix et les totaux. Vous pourrez examiner et modifier les résultats par la suite."
-        },
-        "buttons": {
-          "cancel": "Annuler",
-          "createSingle": "Créer une Facture",
-          "createMultiple": "Créer {count} Factures",
-          "close": "Fermer"
-        },
-        "creating": {
-          "title": "Création de Votre Facture",
-          "titlePlural": "Création de Vos Factures",
-          "processing": "Traitement de {count} scan...",
-          "processingPlural": "Traitement de {count} scans...",
-          "step1Title": "Téléchargement des scans",
-          "step1Description": "Envoi de vos scans vers nos serveurs",
-          "step2Title": "Création des enregistrements de factures",
-          "step2Description": "Configuration des structures de données de factures",
-          "step3Title": "Finalisation",
-          "step3Description": "Préparation des factures pour la visualisation"
-        },
-        "complete": {
-          "title": "{count} Facture Créée !",
-          "titlePlural": "{count} Factures Créées !",
-          "description": "Votre facture est prête à être consultée et modifiée.",
-          "descriptionPlural": "Vos factures sont prêtes à être consultées et modifiées.",
-          "nextSteps": "Prochaines étapes :",
-          "nextStepsDescription": "Examinez votre facture, vérifiez les données extraites et effectuez les modifications nécessaires. Vous pouvez également demander une analyse IA pour des informations sur vos dépenses.",
-          "nextStepsDescriptionPlural": "Examinez vos factures, vérifiez les données extraites et effectuez les modifications nécessaires. Vous pouvez également demander une analyse IA pour des informations sur vos dépenses.",
-          "viewButton": "Voir la Facture",
-          "viewButtonPlural": "Voir les Factures",
-          "failureTitle": "Échec de la création",
-          "failureDescription": "Nous n'avons pas pu créer de factures. Veuillez vérifier les erreurs ci-dessous et réessayer.",
-          "partialTitle": "{created} factures créées sur {total}",
-          "partialDescription": "Certains scans n'ont pas pu être traités. Les factures créées avec succès sont prêtes à être consultées.",
-          "errorsLabel": "Scans échoués :",
-          "retryButton": "Réessayer"
-        },
-        "errors": {
-          "partialFail": "Échec de la création de {count} facture(s)",
-          "createFailed": "Échec de la création des factures : {message}",
-          "unknown": "Erreur inconnue"
-        }
-      },
-      "createFromAll": {
-        "button": "Créer à partir de toutes les numérisations",
-        "title": "Toutes les numérisations sont prêtes !",
-        "description": "Créer des factures à partir de l'ensemble des {count} numérisations"
-      },
-      "groupBanner": {
-        "title": "{count} scans uploaded together — combine?",
-        "subtitle": "Créer une facture à partir de ces numérisations ?",
-        "createInvoice": "Créer une facture",
-        "dismiss": "Fermer"
-      },
-      "pagination": {
-        "previous": "Précédent",
-        "next": "Suivant",
-        "pageInfo": "{current} / {total} ({count} scans)"
-      }
-    },
-    "ViewInvoices": {
-      "metadata": {
-        "description": "Lister toutes les factures du système de gestion des factures.",
-        "title": "Système de Gestion des Factures - Liste des Factures"
-      },
-      "subtitle": "Ceci est votre inventaire de reçus numériques. <br></br> Ici vous pouvez trouver les reçus que vous avez téléchargés jusqu'à présent. <br></br> En cliquant sur un reçu, vous serez redirigé vers la page de ce reçu spécifique.",
-      "title": "Bienvenue, {name} !",
-      "viewInvoicesPage": {
-        "guestName": "cher invité"
-      },
-      "viewInvoicesIsland": {
-        "tabs": {
-          "invoices": "Factures",
-          "statistics": "Statistiques",
-          "liveAnalysis": "Analyse en direct"
-        }
-      },
-      "invoicesHeader": {
-        "title": "Gestion des factures",
-        "description": "Gérez vos reçus et suivez vos habitudes de dépenses",
-        "actions": {
-          "import": "Importer",
-          "export": "Exporter",
-          "print": "Imprimer",
-          "newInvoice": "Nouvelle facture"
-        },
-        "tooltips": {
-          "import": "Importer des factures depuis des fichiers",
-          "export": "Exporter toutes les factures",
-          "print": "Imprimer les factures",
-          "newInvoice": "Créer une nouvelle facture"
-        }
-      },
-      "invoicesView": {
-        "searchPlaceholder": "Rechercher des factures...",
-        "filters": {
-          "category": "Catégorie",
-          "timeOfDay": "Moment de la journée",
-          "categories": "Catégories",
-          "paymentTypes": "Types de paiement",
-          "dateRange": "Plage de dates",
-          "dateFrom": "Date de début",
-          "dateTo": "Date de fin",
-          "amountRange": "Plage de montants",
-          "amountMin": "Montant min.",
-          "amountMax": "Montant max.",
-          "sortBy": "Trier par",
-          "sortOptions": {
-            "dateNewest": "Date (plus récente)",
-            "dateOldest": "Date (plus ancienne)",
-            "amountHighToLow": "Montant (décroissant)",
-            "amountLowToHigh": "Montant (croissant)",
-            "nameAZ": "Nom (A-Z)",
-            "nameZA": "Nom (Z-A)"
-          },
-          "title": "Filtres",
-          "button": "Filtres",
-          "clear": "Tout effacer",
-          "activeCount": "{count} actifs"
-        },
-        "categories": {
-          "all": "Toutes les catégories",
-          "groceries": "Épicerie",
-          "dining": "Restauration",
-          "utilities": "Services",
-          "entertainment": "Divertissement",
-          "travel": "Voyage",
-          "other": "Autre"
-        },
-        "times": {
-          "all": "Tous les horaires",
-          "day": "Journée (6h-18h)",
-          "night": "Nuit (18h-6h)"
-        },
-        "placeholderPanel": "D’autres filtres seront bientôt disponibles.",
-        "viewModes": {
-          "table": "Table voir",
-          "grid": "Grid voir"
-        }
-      },
-      "statisticsView": {
-        "title": "Statistiques des factures",
-        "subtitle": "Gérez vos reçus et suivez vos habitudes de dépenses",
-        "charts": {
-          "calendarHeatmap": {
-            "days": {
-              "wed": "Mer",
-              "thu": "Jeu",
-              "fri": "Ven",
-              "sun": "Dim",
-              "mon": "Lun",
-              "sat": "Sam",
-              "tue": "Mar"
-            },
-            "tooltip": {
-              "noSpending": "Aucune dépense",
-              "amount": "Dépensé",
-              "invoices": "{count} factures"
-            },
-            "legend": {
-              "less": "Moins",
-              "more": "Plus"
-            },
-            "title": "Calendrier des dépenses",
-            "description": "Intensité des dépenses quotidiennes au fil du temps",
-            "navigation": {
-              "previous": "Mois précédent",
-              "next": "Mois suivant"
-            },
-            "aria": {
-              "calendarGrid": "Calendrier des dépenses quotidiennes"
-            }
-          },
-          "spendingOverTime": {
-            "labels": {
-              "amount": ""
-            },
-            "tooltip": {
-              "invoiceCount": "",
-              "andMore": "et {count} de plus..."
-            },
-            "title": "",
-            "description": ""
-          },
-          "categoryBreakdown": {
-            "title": "Dépenses par catégorie",
-            "description": "Répartition par catégories",
-            "totalLabel": "Dépenses totales",
-            "tooltip": {
-              "invoiceCount": "{count} factures"
-            }
-          },
-          "merchantLeaderboard": {
-            "title": "Principaux commerçants",
-            "description": "Où vous dépensez le plus",
-            "labels": {
-              "totalSpent": "Total dépensé"
-            },
-            "tooltip": {
-              "invoiceCount": "{count} factures"
-            },
-            "empty": "Aucune donnée de marchand disponible"
-          },
-          "priceDistribution": {
-            "title": "Distribution des prix",
-            "description": "Distribution des prix des articles",
-            "labels": {
-              "itemCount": "Nombre d'articles"
-            },
-            "tooltip": {
-              "itemCount": "{count} articles"
-            }
-          },
-          "timeOfDay": {
-            "title": "Habitudes d'achat",
-            "description": "Quand vous faites vos achats",
-            "labels": {
-              "invoiceCount": "Nombre de factures"
-            },
-            "tooltip": {
-              "invoiceCount": "{count} factures"
-            }
-          },
-          "currencyDistribution": {
-            "title": "Répartition par devise",
-            "description": "Répartition des dépenses par devise avec conversion en RON",
-            "toggleLabel": "Basculer la vue des devises",
-            "showOriginal": "Afficher l'original",
-            "showRON": "Afficher en RON",
-            "singleCurrency": "Toutes les factures en {currency} ({symbol})",
-            "invoiceCount": "{count} factures",
-            "originalAmount": "Original",
-            "ronEquivalent": "Équivalent RON",
-            "totalAmount": "Montant total",
-            "totalCurrencies": "Total des devises",
-            "totalSpending": "Dépenses totales"
-          },
-          "merchantTrends": {
-            "title": "Tendances de dépenses par commerçant",
-            "description": "Évolution mensuelle des dépenses chez les principaux commerçants",
-            "labels": {
-              "merchant": "Commerçant",
-              "totalSpend": "Total dépensé",
-              "trend": "Tendance (6 derniers mois)"
-            },
-            "aria": {
-              "sparkline": "Tendance des dépenses pour {merchant}"
-            },
-            "empty": "Aucune donnée de commerçant disponible"
-          },
-          "merchantVisit": {
-            "title": "Fréquentation des commerçants",
-            "description": "Fréquence d'achat et aperçu du panier",
-            "metrics": {
-              "totalVisits": "Visites totales",
-              "visitsPerMonth": "Visites/mois",
-              "basketSize": "Panier moyen",
-              "preferredDay": "Jour préféré",
-              "avgSpend": "Dépense moy./visite"
-            },
-            "empty": "Aucune donnée de visite disponible"
-          },
-          "productCategory": {
-            "description": "Répartition des dépenses par type de produit",
-            "tooltip": {
-              "productCount": "{count} produits"
-            },
-            "title": "Dépenses par catégorie de produit",
-            "empty": "Aucun produit à analyser pour le moment"
-          },
-          "topProducts": {
-            "ariaLabel": "Classement des produits les plus achetés",
-            "description": "Articles les plus achetés",
-            "headers": {
-              "rank": "#",
-              "avgPrice": "Prix moyen",
-              "quantity": "Qté",
-              "purchases": "Achats",
-              "product": "Produit",
-              "totalSpent": "Total"
-            },
-            "title": "Produits principaux",
-            "empty": "Aucun produit acheté pour le moment"
-          },
-          "allergenSummary": {
-            "ariaLabel": "Résumé de la fréquence des allergènes",
-            "description": "Exposition aux allergènes dans vos produits",
-            "stats": {
-              "products": "produits",
-              "ofTotal": "du total"
-            },
-            "title": "Résumé des allergènes",
-            "empty": "Aucun allergène détecté dans vos achats"
-          }
-        },
-        "kpi": {
-          "totalSpending": "Dépenses totales",
-          "invoiceCount": "Nombre de factures",
-          "topMerchant": "Commerçant principal",
-          "averageItems": "Articles moy.",
-          "vsLastMonth": "{delta}% par rapport au mois dernier",
-          "avgPerInvoice": "moy. {amount} par facture",
-          "visits": "{count} visites",
-          "acrossInvoices": "sur {count} factures",
-          "noneYet": "Pas encore de données"
-        },
-        "comparison": {
-          "title": "Mois par mois",
-          "description": "Comparaison avec le mois précédent",
-          "spendingDelta": "Variation des dépenses",
-          "invoiceCount": "Nombre de factures",
-          "newMerchants": "Nouveaux commerçants",
-          "discovered": "découverts",
-          "none": "aucun",
-          "increase": "augmentation",
-          "decrease": "diminution"
-        },
-        "empty": {
-          "title": "Pas encore de statistiques",
-          "subtitle": "Téléchargez des reçus pour voir les analyses",
-          "cta": "Télécharger un reçu"
-        },
-        "productAnalytics": {
-          "title": "Analyse des produits",
-          "subtitle": "Aperçu de vos articles achetés"
-        }
-      },
-      "messageList": {
-        "aiAssistant": "Assistant IA",
-        "you": "Vous"
-      },
-      "generativeView": {
-        "welcomeMessage": "Bonjour ! Je suis votre assistant d’analyse de factures. Comment puis-je vous aider aujourd’hui ? Essayez des commandes comme /find pour rechercher des factures.",
-        "title": "Analyse en direct",
-        "subtitle": "Discutez avec l’AI pour analyser vos factures et obtenir des analyses utiles",
-        "help": "Aide",
-        "tabs": {
-          "chat": "Discussion",
-          "settings": "Paramètres"
-        },
-        "chatDescription": "Discutez avec l’AI pour analyser vos factures et obtenir des analyses utiles. Essayez des commandes comme /find pour rechercher des factures.",
-        "settings": {
-          "title": "Chat paramètres",
-          "description": "Configurez les préférences de votre assistant AI",
-          "historyLabel": "Chat historique",
-          "retentionPlaceholder": "Sélectionnez la durée de conservation",
-          "retention": {
-            "30": "Conserver pendant 30 jours",
-            "60": "Conserver pendant 60 jours",
-            "90": "Conserver pendant 90 jours",
-            "none": "Don't enregistrer historique"
-          },
-          "dataAccessTitle": "Accès aux données",
-          "allowInvoiceData": "Autoriser l’accès aux données de la facture",
-          "allowMerchantData": "Autoriser l’accès aux données du commerçant",
-          "notificationPreferences": "Préférences de notification",
-          "notifyInsights": "Me notifier des nouvelles analyses",
-          "save": "Enregistrer paramètres"
-        }
-      },
-      "tableView": {
-        "empty": {
-          "title": "Aucune facture trouvée",
-          "description": "Commencez par télécharger vos reçus pour créer votre première facture",
-          "uploadCta": "Télécharger votre premier reçu"
-        },
-        "columns": {
-          "invoice": "Facture",
-          "category": "Catégorie",
-          "date": "Date",
-          "amount": "Montant",
-          "actions": "Opérations"
-        },
-        "aria": {
-          "selectAllInvoices": "Sélectionner toutes les factures",
-          "selectInvoice": "Sélectionner facture {name}",
-          "rowsPerPage": "Lignes par page",
-          "sortByDate": "Trier par date",
-          "sortByAmount": "Trier par montant"
-        },
-        "viewInvoice": "Voir Facture",
-        "rowsPerPage": "Lignes par page:",
-        "pageOf": "Page {current} sur {total}",
-        "previousPage": "Page précédente",
-        "nextPage": "Page suivante",
-        "tooltips": {
-          "notAnalyzed": "Cette facture n'a pas encore été analysée"
-        }
-      },
-      "gridView": {
-        "tooltips": {
-          "viewDetails": "Voir les détails"
-        },
-        "itemCount": "{count, plural, one {# article} other {# articles}}"
-      },
-      "tableViewActions": {
-        "actions": {
-          "edit": "Modifier",
-          "share": "Partager",
-          "delete": "Supprimer"
-        },
-        "tooltips": {
-          "moreActions": "Plus d'actions",
-          "edit": "Modifier les détails de la facture",
-          "share": "Partager facture via lien or e-mail",
-          "delete": "Supprimer définitivement cette facture"
-        }
-      },
-      "exportDialog": {
-        "title": "Exporter des factures",
-        "description": "Exporter {count} factures dans le format de votre choix.",
-        "format": {
-          "title": "Format d’export",
-          "labels": {
-            "csv": "CSV",
-            "json": "JSON",
-            "pdf": "PDF"
-          },
-          "descriptions": {
-            "json": "Format de données structurées",
-            "csv": "Format tableur, compatible avec Excel",
-            "pdf": "Format de document imprimable"
-          }
-        },
-        "options": {
-          "title": "Paramètres",
-          "includeMetadata": "Inclure les métadonnées",
-          "includeProducts": "Inclure les produits",
-          "includeMerchant": "Inclure le commerçant",
-          "csv": {
-            "includeHeaders": "Inclure les en-têtes CSV",
-            "delimiterLabel": "Séparateur CSV personnalisé (facultatif) :",
-            "delimiterPlaceholder": ","
-          },
-          "json": {
-            "prettyPrint": "Formatage lisible (2 espaces)"
-          }
-        },
-        "buttons": {
-          "cancel": "Annuler",
-          "export": "Exporter",
-          "copy": "Copier dans le presse-papiers",
-          "copied": "Copié !"
-        },
-        "filename": {
-          "hint": "Le fichier sera enregistré avec l'extension basée sur le format",
-          "label": "Nom du fichier"
-        },
-        "estimate": {
-          "label": "Taille estimée du fichier :"
-        }
-      },
-      "importDialog": {
-        "title": "Importer des factures",
-        "description": "Téléversez vos fichiers de factures pour les importer dans le système.",
-        "tabs": {
-          "csv": "CSV",
-          "pdf": "PDF",
-          "xlsx": "Excel"
-        },
-        "dropzone": {
-          "dropHere": "Déposez les fichiers ici...",
-          "dragAndDrop": "Glissez-déposez les fichiers ici",
-          "orClickBrowse": "ou cliquez pour parcourir les fichiers",
-          "acceptsCsv": "Accepte les fichiers .csv (max 10 Mo)",
-          "acceptsPdf": "Accepte les fichiers .pdf (max 10 Mo)",
-          "acceptsXlsx": "Accepte les fichiers .xlsx et .xls (max. 10 Mo)"
-        },
-        "selectedFiles": "Fichiers sélectionnés",
-        "remove": "Supprimer",
-        "status": {
-          "success": "Fichiers importés avec succès !",
-          "error": "Erreur lors de l’import des fichiers. Veuillez réessayer."
-        },
-        "buttons": {
-          "cancel": "Annuler",
-          "import": "Importer",
-          "importWithCount": "Importer ({count})"
-        }
-      },
-      "bulkActions": {
-        "selected": "{count, plural, one {# facture sélectionnée} other {# factures sélectionnées}}",
-        "clearSelection": "Effacer la sélection",
-        "export": "Exporter",
-        "delete": "Supprimer",
-        "changeCategory": "Changer de catégorie",
-        "deleteConfirm": {
-          "title": "Supprimer les factures",
-          "description": "{count, plural, one {Êtes-vous sûr de vouloir supprimer cette facture ? Cette action est irréversible.} other {Êtes-vous sûr de vouloir supprimer ces # factures ? Cette action est irréversible.}}",
-          "confirm": "Supprimer",
-          "cancel": "Annuler"
-        },
-        "deleteSuccess": "{count, plural, one {Facture supprimée avec succès} other {# factures supprimées avec succès}}",
-        "deleteError": "Échec de la suppression des factures. Veuillez réessayer.",
-        "deletePartialSuccess": "{success} facture(s) supprimée(s), {failed} en échec",
-        "categoryChanged": "{count, plural, one {Catégorie de la facture mise à jour avec succès} other {Catégories de # factures mises à jour avec succès}}",
-        "categoryChangeError": "Échec de la mise à jour des catégories de factures. Veuillez réessayer.",
-        "categoryPartialSuccess": "{success} facture(s) mise(s) à jour, {failed} en échec",
-        "categories": {
-          "notDefined": "Non défini",
-          "grocery": "Épicerie",
-          "fastFood": "Restauration rapide",
-          "homeCleaning": "Entretien ménager",
-          "carAuto": "Auto et véhicule",
-          "other": "Autre"
-        }
-      }
-    },
-    "ViewInvoice": {
-      "metadata": {
-        "description": "Consultez les détails de votre facture, les articles et les informations du commerçant associé.",
-        "title": "Système de Gestion des Factures - Voir la Facture"
-      },
-      "invoiceAnalytics": {
-        "title": "Analyses et insights",
-        "tabs": {
-          "current": "Cette facture",
-          "compare": "Comparaison"
-        }
-      },
-      "invoiceTimeline": {
-        "title": "Chronologie de la facture",
-        "subtitle": "Historique complet des actions et modifications",
-        "eventCount": "{count, plural, one {# événement} other {# événements}}"
-      },
-      "invoiceTabs": {
-        "tabs": {
-          "possibleRecipes": "Recettes possibles",
-          "additionalInfo": "Infos supplémentaires"
-        },
-        "recipe": {
-          "duration": "{minutes} min",
-          "prepCook": "Prépa : {prep}m • Cuisson : {cook}m",
-          "viewRecipe": "Voir Recipe",
-          "ingredients": "Ingrédients",
-          "instructions": "Instructions"
-        },
-        "empty": {
-          "recipes": "Aucune suggestion de recette disponible",
-          "additionalInfo": "Aucune information supplémentaire disponible"
-        },
-        "actions": {
-          "regenerate": "Régénérer les recettes",
-          "regenerateTooltip": "Réanalyser la facture pour générer de nouvelles suggestions de recettes",
-          "generate": "Générer des recettes"
-        }
-      },
-      "timelineItem": {
-        "aria": {
-          "moreInfo": "Plus d’infos sur {title}"
-        },
-        "confidence": "Confiance : {value}%",
-        "events": {
-          "created": {
-            "title": "Facture créée",
-            "description": "Scannée et numérisée depuis le reçu"
-          },
-          "aiAnalysis": {
-            "title": "Analyse IA terminée",
-            "description": "{count, plural, one {# article détecté et catégorisé} other {# articles détectés et catégorisés}}"
-          },
-          "recipesGenerated": {
-            "title": "Recettes générées",
-            "description": "{count, plural, one {# recette suggérée} other {# recettes suggérées}}"
-          },
-          "shared": {
-            "title": "Partagée avec d’autres",
-            "description": "Partagée avec {count, plural, one {# personne} other {# personnes}}"
-          },
-          "edited": {
-            "title": "Facture mise à jour"
-          },
-          "exported": {
-            "title": "Facture exportée"
-          },
-          "markedImportant": {
-            "title": "Marquée importante",
-            "description": "Signalée pour un suivi prioritaire"
-          },
-          "categorized": {
-            "title": "Catégorie attribuée",
-            "description": "Catégorisation automatique selon les articles"
-          }
-        },
-        "tooltips": {
-          "created": "La facture a été scannée et numérisée avec {method}.",
-          "aiAnalysis": "L’IA a traité cette facture en {duration} et analysé {count, plural, one {# article} other {# articles}}.",
-          "recipesGenerated": "D’après les ingrédients achetés, {count, plural, one {# recette a été générée} other {# recettes ont été générées}}.",
-          "shared": "La facture a été partagée avec {count, plural, one {# utilisateur} other {# utilisateurs}}.",
-          "edited": "Des modifications manuelles ont été apportées à la facture.",
-          "exported": "La facture a été exportée au format {format}.",
-          "markedImportant": "La facture a été marquée importante pour un accès rapide.",
-          "categorized": "La facture a reçu une catégorie pour une meilleure organisation.",
-          "unavailable": "Détails de l’événement indisponibles"
-        },
-        "relativeTime": {
-          "now": "À l’instant"
-        },
-        "fallbacks": {
-          "ocr": "OCR",
-          "pdf": "PDF"
-        }
-      },
-      "timelineSharedWithList": {
-        "header": {
-          "title": "Partagée avec",
-          "publicBadge": "Public"
-        },
-        "publicAccess": {
-          "title": "Accès public activé",
-          "description": "Cette facture est accessible publiquement. Toute personne disposant du lien peut la voir, y compris les invités sans compte."
-        },
-        "aria": {
-          "sendEmail": "Envoyer un e-mail à {user}"
-        },
-        "actions": {
-          "sendEmail": "Envoyer un e-mail",
-          "manageSharing": "Gérer le partage"
-        }
-      },
-      "budgetImpactCard": {
-        "title": "Impact budgétaire de {month}",
-        "monthlyBudget": "Budget mensuel",
-        "spent": "{amount} dépensés",
-        "invoiceUsed": "Cette facture a utilisé",
-        "ofMonthlyBudget": "de votre budget mensuel",
-        "remaining": "Restant",
-        "overBudget": "Dépassement de budget",
-        "daysLeft": "Jours restants",
-        "inMonth": "en {month}",
-        "dailyAllowance": "Budget quotidien",
-        "dailyAllowanceValue": "{amount} / jour"
-      },
-      "comparisonStatsCard": {
-        "title": "Comment vous vous situez",
-        "subtitle": "Par rapport à vos {count} dernières factures",
-        "vsAverage": "vs moyenne",
-        "avgValue": "Moy. : {amount} {currency}",
-        "thisValue": "Cette facture : {amount} {currency}",
-        "minValue": "Min. : {amount}",
-        "maxValue": "Max. : {amount}",
-        "positionInRange": "Votre position dans la plage de dépenses",
-        "itemCount": "Article Count",
-        "itemCountComparison": "{current} vs moy {average}",
-        "sameStore": "Même magasin",
-        "sameStoreComparison": "vs moy {average} {currency}"
-      },
-      "invoiceDetailsCard": {
-        "title": "Détails de la facture",
-        "labels": {
-          "dateUtc": "Date et heure (UTC)",
-          "category": "Catégorie",
-          "payment": "Paiement",
-          "totalAmount": "Montant total",
-          "receiptType": "Type de reçu",
-          "countryRegion": "Pays/Région",
-          "subtotal": "Sous-total",
-          "tip": "Pourboire",
-          "ronEquivalent": "Équivalent RON"
-        },
-        "itemsTitle": "Articles ({count})",
-        "table": {
-          "item": "Article",
-          "qty": "Qté",
-          "unit": "Unité",
-          "price": "Prix",
-          "total": "Somme",
-          "grandTotal": "Total général"
-        },
-        "pagination": {
-          "pageOf": "Page {current} sur {total}",
-          "previous": "Précédent",
-          "next": "Suivant"
-        },
-        "tooltips": {
-          "exchangeRate": "1 {fromCurrency} = {rate} RON (moy. {year})"
-        },
-        "sections": {
-          "paymentMethods": "Modes de paiement",
-          "taxBreakdown": "Détail des taxes"
-        },
-        "taxLabels": {
-          "net": "Net",
-          "tax": "Taxe"
-        }
-      },
-      "merchantInfoCard": {
-        "title": "Informations sur le commerçant",
-        "noMerchantLinked": "Aucun commerçant lié à cette facture",
-        "viewAllReceipts": "Voir tous les reçus",
-        "viewAllInvoices": "Voir toutes les factures",
-        "viewOnMap": "Voir sur la carte",
-        "spendingHistory": "Historique des dépenses",
-        "categoryDistribution": "Répartition par catégorie",
-        "stats": {
-          "visits": "visites",
-          "avgSpend": "Dépense moyenne",
-          "daysAgo": "il y a quelques jours"
-        }
-      },
-      "receiptScanCard": {
-        "title": "Scan du reçu",
-        "dialogTitle": "Image du reçu",
-        "scanAlt": "Scan du reçu {index}",
-        "scanAltFullSize": "Scan du reçu {index} - taille réelle",
-        "buttons": {
-          "expand": "Agrandir l’image",
-          "previousScan": "Scan précédent",
-          "nextScan": "Scan suivant"
-        },
-        "tooltips": {
-          "expand": "Voir l’image du reçu en taille réelle",
-          "previousScan": "Voir le scan précédent du reçu",
-          "nextScan": "Voir le scan suivant du reçu"
-        },
-        "titleWithIndex": "Scan du reçu ({current}/{total})",
-        "dialogTitleWithIndex": "Image du reçu ({current}/{total})",
-        "controls": {
-          "zoomIn": "Zoom avant",
-          "zoomOut": "Zoom arrière",
-          "reset": "Réinitialiser le zoom",
-          "rotate": "Pivoter",
-          "download": "Télécharger",
-          "fullScreen": "Plein écran",
-          "toggleZoom": "Basculer le zoom"
-        },
-        "navigation": {
-          "previous": "Précédent",
-          "next": "Suivant",
-          "of": "sur"
-        }
-      },
-      "seasonalInsightsCard": {
-        "title": "Insight saisonnier",
-        "month": {
-          "spendingSoFar": "{month} jusqu’à présent",
-          "vsAverage": "vs moyenne de {month} : {amount}"
-        },
-        "insights": {
-          "spike": {
-            "title": "Pic de {category}",
-            "description": "+{percent}% vs votre moyenne"
-          },
-          "holidaySeason": {
-            "title": "Saison des fêtes",
-            "description": "Les dépenses de décembre sont généralement 35% plus élevées"
-          },
-          "stockUpTip": {
-            "title": "Conseil de stock",
-            "description": "Les prix augmentent d’environ 15% après le 15 décembre"
-          },
-          "normalPattern": {
-            "title": "Habitude d’achat normale",
-            "description": "Vos dépenses sont dans la plage habituelle"
-          }
-        }
-      },
-      "shoppingCalendarCard": {
-        "title": "Calendrier d’achats",
-        "tooltip": {
-          "basedOnCachedInvoices": "Basé sur {count} factures en cache",
-          "currentInvoiceOnly": "Affichage de la facture actuelle uniquement",
-          "more": "+{count} de plus",
-          "vsAverage": "vs moy ({years} ans de données)",
-          "invoiceCount": "{count} facture(s)",
-          "currentInvoice": "Facture actuelle"
-        },
-        "legend": {
-          "less": "Moins",
-          "more": "Plus"
-        },
-        "stats": {
-          "monthTotal": "Total du mois",
-          "shoppingDays": "Jours d’achats"
-        },
-        "insights": {
-          "shopEveryPrefix": "Vous faites vos achats tous les",
-          "days": "{count} jours",
-          "onAverage": "en moyenne",
-          "spendingPrefix": ", dépensant",
-          "perTrip": " par achat",
-          "mostActiveOn": "Plus actif le",
-          "weekdayLabel": "{weekday}"
-        }
-      },
-      "summaryStatsCard": {
-        "title": "Résumé de la facture",
-        "description": "Statistiques clés en un coup d’œil",
-        "stats": {
-          "totalItems": {
-            "label": "Articles totaux",
-            "description": "Produits achetés"
-          },
-          "categories": {
-            "label": "Catégories",
-            "description": "Catégories uniques"
-          },
-          "averagePrice": {
-            "label": "Prix moyen",
-            "description": "{currency} par article"
-          },
-          "taxRate": {
-            "label": "Taux de taxe",
-            "description": "{amount} {currency}"
-          }
-        },
-        "extremes": {
-          "highest": "Le plus élevé",
-          "lowest": "Le plus bas"
-        }
-      },
-      "invoiceGuestBanner": {
-        "title": "Vue invité",
-        "description": "Vous n’êtes actuellement pas le propriétaire de cette facture. L’affichage est limité à ce que le propriétaire a défini dans les paramètres de partage."
-      },
-      "categoryComparisonChart": {
-        "title": "Comparaison des catégories",
-        "description": "Cette facture vs votre moyenne",
-        "labels": {
-          "current": "Actuel",
-          "average": "Moyenne"
-        }
-      },
-      "itemsBreakdownChart": {
-        "title": "Articles les plus coûteux",
-        "description": "Articles avec les plus fortes dépenses",
-        "labels": {
-          "price": "Prix",
-          "quantity": "Qté"
-        }
-      },
-      "merchantBreakdownChart": {
-        "title": "Dépenses par magasin",
-        "description": "Totaux cumulés sur tous les commerçants",
-        "labels": {
-          "totalSpent": "Total dépensé",
-          "total": "Total",
-          "visits": "Visites",
-          "averagePerVisit": "Moy./visite"
-        }
-      },
-      "priceDistributionChart": {
-        "title": "Répartition des prix",
-        "description": "Articles par tranche de prix ({currency})",
-        "labels": {
-          "items": "Articles"
-        },
-        "tooltip": {
-          "itemCount": "{count, plural, one {# article} other {# articles}}"
-        }
-      },
-      "spendingByCategoryChart": {
-        "title": "Dépenses par catégorie",
-        "description": "Répartition des dépenses",
-        "totalLabel": "Total des dépenses",
-        "tooltip": {
-          "itemCount": "{count, plural, one {# article} other {# articles}}"
-        }
-      },
-      "spendingTrendChart": {
-        "title": "Évolution des dépenses",
-        "description": "Tendance de votre historique de factures",
-        "labels": {
-          "amount": "Montant"
-        },
-        "tooltip": {
-          "currentInvoice": "Facture actuelle"
-        }
-      },
-      "shareAnalyticsDialog": {
-        "title": "Partager Analytics",
-        "description": "Partagez vos analyses de dépenses pour {merchant} avec d’autres personnes.",
-        "tabs": {
-          "image": "Aperçu image",
-          "email": "E-mail"
-        },
-        "image": {
-          "description": "Téléchargez ou copiez le graphique d’analyses en image PNG afin de le partager ou de l’enregistrer.",
-          "previewPlaceholder": "Aperçu des analyses",
-          "download": "Télécharger le graphique",
-          "copyToClipboard": "Copier le graphique dans le presse-papiers"
-        },
-        "email": {
-          "description": "Envoyez les analyses à une adresse e-mail.",
-          "label": "E-mail address",
-          "placeholder": "nom@exemple.com",
-          "send": "Envoyer E-mail"
-        },
-        "toasts": {
-          "imageCopied": {
-            "title": "Image copiée !",
-            "description": "L’image des analyses a été copiée dans votre presse-papiers"
-          },
-          "emailSent": {
-            "title": "E-mail envoyé !",
-            "description": "Rapport d’analyses envoyé à {email}"
-          },
-          "imageSaved": {
-            "title": "Image enregistrée !",
-            "description": "Les analyses de dépenses pour {merchant} ont été téléchargées au format PNG"
-          }
-        }
-      },
-      "categorySuggestionCard": {
-        "title": "Aidez-nous à catégoriser cette facture",
-        "description": "Nous n’avons pas pu catégoriser automatiquement cette facture. Sélectionnez la bonne catégorie pour débloquer des analyses :",
-        "moreCategories": "Plus de catégories :",
-        "gamification": "Catégorisez {goal} factures pour débloquer des analyses détaillées !"
-      },
-      "diningCard": {
-        "title": "Informations restauration",
-        "sodium": {
-          "high": "Élevé",
-          "medium": "Moyen",
-          "low": "Faible"
-        },
-        "estimatedNutrition": {
-          "title": "Valeurs nutritionnelles estimées",
-          "calories": "Énergie",
-          "caloriesValue": "~{value} kcal",
-          "protein": "Protéines",
-          "proteinValue": "~{value}g",
-          "sodium": "Sel (sodium)",
-          "carbs": "Glucides",
-          "carbsValue": "~{value}g"
-        },
-        "habits": {
-          "title": "Vos habitudes de restauration rapide",
-          "frequency": "Fréquence",
-          "frequencyValue": "{count}x/mois",
-          "frequencyDiff": "+1 vs moyenne",
-          "avgSpend": "Dépense moyenne",
-          "favorite": "Préféré",
-          "visits": "{count} visites"
-        },
-        "swaps": {
-          "title": "Alternatives plus saines",
-          "grilled": "Grillé au lieu de frit",
-          "water": "Eau au lieu de soda",
-          "salad": "Salade d’accompagnement au lieu de frites",
-          "caloriesSaved": "-{count} kcal",
-          "moneySaved": ", économise {amount}"
-        },
-        "challenge": {
-          "title": "Défi hebdomadaire",
-          "descriptionPrefix": "Évitez la restauration rapide pendant 7 jours et enregistrez",
-          "descriptionSuffix": ""
-        }
-      },
-      "generalExpenseCard": {
-        "title": "Analyse des dépenses",
-        "detectedCategory": "Électronique / Technologie",
-        "confidence": "Confiance : {value}%",
-        "sections": {
-          "autoDetectedCategory": "Auto-detected catégorie",
-          "budgetImpact": "Impact sur le budget",
-          "taxBusiness": "Options fiscales et professionnelles",
-          "similarPurchases": "Achats similaires passés"
-        },
-        "buttons": {
-          "correct": "Valider",
-          "change": "Modifier",
-          "organize": "Organiser",
-          "export": "Exporter"
-        },
-        "aria": {
-          "confirmCategory": "Confirmer que la catégorie détectée est correcte",
-          "changeCategory": "Change detected catégorie",
-          "organize": "Organiser cette dépense en catégories",
-          "export": "Exporter les données de dépense"
-        },
-        "nearLimitAlert": "{name} : {percent}% utilisé (10 jours restants ce mois)",
-        "options": {
-          "businessExpense": "Marquer comme dépense professionnelle",
-          "trackWarranty": "Suivre la garantie (24 mois standard)",
-          "insuranceInventory": "Ajouter à l’inventaire d’assurance"
-        },
-        "vatReclaimable": "TVA récupérable",
-        "budgetCategories": {
-          "electronics": "Électronique",
-          "entertainment": "Divertissement",
-          "shopping": "Achats"
-        }
-      },
-      "homeInventoryCard": {
-        "title": "Inventaire du domicile et fournitures",
-        "supplyNames": {
-          "laundryDetergent": "Lessive",
-          "dishSoap": "Liquide vaisselle",
-          "paperProducts": "Produits en papier",
-          "floorCleaner": "Nettoyant pour sols"
-        },
-        "stockLevels": {
-          "title": "Niveaux de stock des fournitures (estimés)",
-          "daysRemaining": "~{count} jours"
-        },
-        "eco": {
-          "title": "Score écoresponsable",
-          "productsWithEcoLabels": "{count} produits avec des écolabels",
-          "recyclablePackaging": "{count} produit avec emballage recyclable",
-          "tip": "Tip: Eco alternatives enregistrer 2kg plastic/year"
-        },
-        "bulk": {
-          "title": "Économies sur achats en gros",
-          "description": "Un bidon de 5L vs 2L permet d’économiser 18% ({amount}/an)"
-        }
-      },
-      "nutritionCard": {
-        "title": "Vue d’ensemble nutritionnelle",
-        "score": {
-          "title": "Score d’équilibre alimentaire",
-          "excellent": "Très bon",
-          "good": "Bon",
-          "fair": "Moyen",
-          "needsWork": "À améliorer"
-        },
-        "composition": {
-          "title": "Composition de votre panier",
-          "wholeFoods": "Aliments complets",
-          "processed": "Transformés",
-          "dairyOther": "Produits laitiers/Autre"
-        },
-        "foodGroups": {
-          "fruits": "Fruits frais",
-          "vegetables": "Légumes",
-          "protein": "Protéines",
-          "grains": "Céréales",
-          "itemsCount": "{count} article(s)"
-        },
-        "allergens": {
-          "title": "Allergènes détectés",
-          "foundInItems": "Trouvé dans {count} article(s)"
-        },
-        "suggestions": {
-          "addFruitsAndVegetables": "Ajoutez davantage de fruits et légumes pour équilibrer votre panier",
-          "addVegetables": "Pensez à ajouter des légumes pour une alimentation plus équilibrée",
-          "addFruits": "Ajouter des fruits améliorerait l’équilibre nutritionnel",
-          "swapProcessed": "Essayez de remplacer certains produits transformés par des aliments complets",
-          "greatBalance": "Excellent équilibre d’achats !"
-        }
-      },
-      "vehicleCard": {
-        "title": "Analyse des dépenses du véhicule",
-        "expenseType": "Type de dépense : Carburant",
-        "details": {
-          "liters": "Litres",
-          "pricePerLiter": "Prix/L",
-          "station": "Station-service",
-          "vehicle": "Véhicule",
-          "notSet": "Non défini"
-        },
-        "chart": {
-          "title": "Dépenses mensuelles en carburant",
-          "amount": "Montant"
-        },
-        "stats": {
-          "thisMonth": "Ce mois-ci",
-          "fillUps": "{count} pleins",
-          "costPerKm": "Coût/km",
-          "estimated": "estimé",
-          "fuelPrice": "Fuel Prix",
-          "thisMonthSuffix": "ce mois-ci"
-        },
-        "maintenance": {
-          "title": "Rappels d’entretien"
-        },
-        "tip": {
-          "title": "Le moins cher à proximité",
-          "perLiter": "L"
-        },
-        "buttons": {
-          "addVehicle": "Ajouter Véhicule",
-          "fullReport": "Rapport complet"
-        },
-        "months": {
-          "sep": "sept.",
-          "oct": "oct.",
-          "nov": "nov.",
-          "dec": "déc."
-        },
-        "reminders": {
-          "oilChange": "Vidange à prévoir dans ~1 200 km",
-          "tireRotation": "Rotation des pneus recommandée"
-        }
-      },
-      "print": {
-        "generatedOn": "Imprimé le {date}",
-        "page": "Page",
-        "labels": {
-          "date": "Date",
-          "merchant": "Commerçant",
-          "total": "Montant total",
-          "items": "Articles"
-        }
-      },
-      "relatedInvoices": {
-        "noRelated": "Aucune facture associée trouvée",
-        "subtitle": "Factures similaires par commerçant, catégorie ou montant",
-        "sameCategory": "Même catégorie",
-        "viewInvoice": "Afficher",
-        "similarAmount": "Montant similaire",
-        "sameMerchant": "Même commerçant",
-        "title": "Factures associées"
-      },
-      "shareCollaborate": {
-        "title": "Partage et collaboration",
-        "private": "Privé",
-        "shared": "Partagé",
-        "public": "Public",
-        "sharedWith": "Partagé avec",
-        "copyLink": "Copier le lien",
-        "shareEmail": "Partager par e-mail",
-        "manageSharing": "Gérer le partage",
-        "copied": "Lien copié dans le presse-papiers !",
-        "activity": {
-          "title": "Activité",
-          "created": "Créé {time}",
-          "modified": "Dernière modification {time}",
-          "daysAgo": "{count, plural, one {il y a # jour} other {il y a # jours}}",
-          "today": "aujourd'hui"
-        },
-        "publicAccess": "Accès public",
-        "publicAccessDescription": "Toute personne ayant le lien peut voir cette facture",
-        "madePublic": "La facture est maintenant publique",
-        "madePrivate": "La facture est maintenant privée",
-        "toggleError": "Échec de la mise à jour des paramètres de partage",
-        "qrCode": "Code QR",
-        "qrCopied": "Lien copié ! Génération du code QR bientôt disponible.",
-        "copyError": "Échec de la copie du lien"
-      },
-      "healthScore": {
-        "title": "Invoice Completeness",
-        "subtitle": "How complete is your invoice data",
-        "points": "points",
-        "showDetails": "Show details",
-        "hideDetails": "Hide details",
-        "factors": {
-          "merchantLinked": "Commerçant associé",
-          "ocrConfidence": "Confiance OCR",
-          "recipesGenerated": "Recettes générées",
-          "paymentInfo": "Informations de paiement",
-          "productCompleteness": "Complétude des produits",
-          "productsPresent": "Produits extraits",
-          "categoriesAssigned": "Catégories attribuées"
-        },
-        "cta": {
-          "analyze": "Lancer l'analyse IA",
-          "edit": "Modifier la facture"
-        },
-        "status": {
-          "incomplete": "Incomplet",
-          "good": "Bon",
-          "needsAttention": "Nécessite une attention",
-          "excellent": "Excellent"
-        },
-        "suggestions": {
-          "noRecipes": "Aucune recette générée — lancez l'analyse IA pour découvrir des idées de repas",
-          "title": "Améliorations suggérées",
-          "incompletePayment": "Informations de paiement incomplètes — ajoutez la date, le montant et la devise de la transaction",
-          "fix": "Corriger",
-          "noMerchant": "Aucun commerçant associé — ajoutez les détails du commerçant pour de meilleures analyses",
-          "noProducts": "Aucun produit trouvé — téléchargez un reçu ou ajoutez des articles manuellement",
-          "lowOcrConfidence": "Faible confiance OCR sur <strong>{count}</strong> produits — vérifiez manuellement pour plus de précision",
-          "uncategorizedProducts": "<strong>{count}</strong> produits non catégorisés — attribuez des catégories pour l'analyse des dépenses",
-          "incompleteProducts": "<strong>{count}</strong> produits incomplets — vérifiez et complétez les champs manquants"
-        },
-        "seeReport": "Voir le rapport détaillé",
-        "dialogTitle": "Rapport de santé de la facture"
-      },
-      "itemAnalytics": {
-        "title": "Articles",
-        "searchPlaceholder": "Rechercher des articles...",
-        "columns": {
-          "name": "Nom",
-          "category": "Catégorie",
-          "price": "Prix",
-          "quantity": "Qté",
-          "total": "Total"
-        },
-        "summary": {
-          "title": "Résumé",
-          "mostExpensive": "Le plus cher",
-          "cheapest": "Le moins cher",
-          "categories": "{count} catégories",
-          "allergens": "{count} allergènes détectés"
-        },
-        "empty": {
-          "title": "Aucun article",
-          "subtitle": "Lancez l'analyse IA pour extraire les articles de votre reçu"
-        },
-        "totalLabel": "TOTAL",
-        "confidence": {
-          "label": "Confiance OCR",
-          "lowWarning": "Faible confiance — vérifiez cet article"
-        }
-      },
-      "analysisPanel": {
-        "tooltips": {
-          "itemsOnly": "Recatégoriser et analyser uniquement les articles",
-          "completeAnalysis": "Extraction OCR complète + traitement IA de toutes les données de la facture",
-          "merchantOnly": "Réidentifier le commerçant et les données de localisation",
-          "invoiceOnly": "Réextraire les informations de base de la facture (date, total, paiement)",
-          "reanalyze": "Relancer l'analyse complète avec toutes les fonctionnalités IA"
-        },
-        "title": "Analyse IA",
-        "options": {
-          "itemsOnly": "Articles uniquement",
-          "completeAnalysis": "Analyse complète",
-          "merchantOnly": "Commerçant uniquement",
-          "invoiceOnly": "Facture uniquement"
-        },
-        "steps": {
-          "processing": "Traitement des articles...",
-          "finalizing": "Finalisation des résultats...",
-          "preparing": "Préparation du document...",
-          "complete": "Analyse terminée !",
-          "analyzing": "Analyse en cours avec l'IA...",
-          "extracting": "Extraction OCR en cours..."
-        },
-        "analyzing": {
-          "progress": "{progress}% terminé",
-          "title": "Analyse en cours..."
-        },
-        "labels": {
-          "lastAnalyzed": "Dernière analyse",
-          "updates": "{count, plural, one {# mise à jour} other {# mises à jour}}",
-          "granularOptions": "Ou choisissez une analyse spécifique",
-          "analysisComplete": "Analyse terminée — Toutes les données ont été extraites"
-        },
-        "toasts": {
-          "error": {
-            "description": "Impossible d'analyser la facture. Veuillez réessayer plus tard.",
-            "title": "Échec de l'analyse"
-          },
-          "success": {
-            "description": "La facture a été réanalysée avec succès avec des données mises à jour.",
-            "title": "Analyse terminée"
-          }
-        },
-        "description": "Réanalyser cette facture avec l'IA pour extraire ou mettre à jour les données",
-        "buttons": {
-          "reanalyze": "Réanalyser la facture"
-        },
-        "tip": "Astuce : L'analyse complète prend 30 à 60 secondes mais fournit les résultats les plus précis."
-      },
-      "export": {
-        "printError": "Échec de l'ouverture de la boîte de dialogue d'impression",
-        "printSuccess": "Boîte de dialogue d'impression ouverte",
-        "csv": {
-          "title": "Exporter en CSV",
-          "description": "Télécharger les articles sous forme de feuille de calcul"
-        },
-        "description": "Exportez vos données de facture dans différents formats",
-        "print": {
-          "title": "Imprimer",
-          "description": "Imprimer la facture via le navigateur"
-        },
-        "csvSuccess": "Fichier CSV téléchargé avec succès",
-        "copyError": "Échec de la copie du résumé",
-        "copySummary": {
-          "title": "Copier le résumé",
-          "description": "Copier le résumé texte dans le presse-papiers"
-        },
-        "copySuccess": "Résumé copié dans le presse-papiers",
-        "json": {
-          "title": "Exporter en JSON",
-          "description": "Télécharger les données complètes de la facture"
-        },
-        "jsonSuccess": "Fichier JSON téléchargé avec succès",
-        "jsonError": "Échec de l'export JSON",
-        "csvError": "Échec de l'export CSV",
-        "title": "Exporter la facture",
-        "pdf": {
-          "title": "Exporter en PDF",
-          "description": "Télécharger un document de facture professionnel"
-        },
-        "pdfSuccess": "Fichier PDF téléchargé avec succès",
-        "pdfError": "Échec de la génération du PDF",
-        "pdfGenerating": "Génération du PDF en cours..."
-      }
-    },
-    "EditInvoice": {
-      "metadata": {
-        "description": "Consultez et modifiez les détails de votre facture, les articles, les recettes et les paramètres de partage.",
-        "title": "Système de Gestion des Factures - Modifier la Facture"
-      },
-      "editInvoiceContext": {
-        "toasts": {
-          "noChanges": "Aucune modification à enregistrer",
-          "updated": "Facture mise à jour avec succès",
-          "saveFailed": "Échec de l’enregistrement des modifications"
-        },
-        "console": {
-          "saveFailed": "Échec de l’enregistrement de la facture :"
-        }
-      },
-      "triviaTips": {
-        "title": "Astuces économies",
-        "completeness": "La facture est complète à {percentage}%",
-        "completeLabel": "La facture est entièrement complète !",
-        "difficulty": {
-          "easy": "Facile",
-          "medium": "Moyen"
-        },
-        "banner": {
-          "potentialSavingsLabel": "Économies potentielles",
-          "hint": "Appliquez ces astuces pour économiser lors de votre prochaine visite chez {merchantName}"
-        },
-        "contextTips": {
-          "noItems": "Lancez l'analyse IA pour extraire les articles de votre reçu",
-          "noDescription": "Ajoutez une description pour vous souvenir de cet achat",
-          "noCategory": "Définissez une catégorie pour suivre vos habitudes de dépenses",
-          "defaultCategory": "Changez la catégorie de « Non catégorisé » pour un meilleur suivi",
-          "noRecipes": "L'IA peut suggérer des recettes basées sur vos articles d'épicerie"
-        },
-        "contextActions": {
-          "analyze": "Lancer l'analyse",
-          "addDescription": "Ajouter une description",
-          "setCategory": "Définir la catégorie"
-        },
-        "tips": {
-          "loyaltyProgram": {
-            "title": "Rejoindre le programme fidélité",
-            "description": "Inscrivez-vous au programme fidélité de {merchantName} pour gagner des points à chaque achat."
-          },
-          "bulkPurchase": {
-            "title": "Acheter en gros",
-            "description": "Achetez les produits non périssables en gros pour réduire le coût unitaire."
-          },
-          "digitalCoupons": {
-            "title": "Utiliser des coupons numériques",
-            "description": "Consultez l'application de {merchantName} pour des coupons numériques avant vos achats."
-          }
-        },
-        "tooltips": {
-          "estimatedSavings": "Économies estimées avec cette astuce"
-        },
-        "buttons": {
-          "viewMoreSavingsTips": "Voir plus d'astuces économies"
-        },
-        "disclaimer": "Les économies sont des estimations basées sur les prix et promotions moyens"
-      },
-      "invoiceCard": {
-        "title": "Détails de la facture",
-        "importantBadge": "IMPORTANT",
-        "markImportant": "Marquer comme important",
-        "tooltips": {
-          "unmarkFavorite": "Cliquer pour retirer des favoris",
-          "markFavorite": "Cliquer pour ajouter aux favoris"
-        },
-        "fromMerchant": "De {merchant}",
-        "descriptionPlaceholder": "Saisissez la description de la facture...",
-        "labels": {
-          "dateUtc": "Date et heure (UTC)",
-          "hours": "Heures",
-          "minutes": "Min",
-          "utc": "UTC",
-          "category": "Catégorie",
-          "paymentMethod": "Mode de paiement",
-          "totalAmount": "Montant total"
-        },
-        "placeholders": {
-          "selectCategory": "Sélectionner catégorie",
-          "selectPaymentType": "Sélectionner le type de paiement"
-        }
-      },
-      "merchantCard": {
-        "title": "Commerçant",
-        "noMerchantLinked": "Aucun commerçant lié à cette facture",
-        "addressLabel": "Adresse : {address}",
-        "buttons": {
-          "viewMerchantDetails": "Voir les détails du commerçant",
-          "viewAllReceipts": "Voir tous les reçus"
-        },
-        "tooltips": {
-          "viewMerchantDetails": "Voir des informations détaillées sur ce commerçant",
-          "viewAllReceipts": "Voir tous les reçus de ce commerçant"
-        }
-      },
-      "imageCard": {
-        "title": "Scan du reçu",
-        "dialogTitle": "Image du reçu",
-        "scanAlt": "Scan du reçu {index}",
-        "scanAltFullSize": "Scan du reçu {index} - taille réelle",
-        "buttons": {
-          "expand": "Agrandir l’image",
-          "previous": "Précédent",
-          "next": "Suivant",
-          "addScan": "Ajouter un scan",
-          "remove": "Supprimer"
-        },
-        "tooltips": {
-          "expand": "Voir l’image du reçu en taille réelle",
-          "previous": "Voir le scan précédent du reçu",
-          "next": "Voir le scan suivant du reçu",
-          "addScan": "Téléverser et joindre un nouveau scan du reçu",
-          "remove": "Supprimer le scan actuel du reçu"
-        },
-        "aria": {
-          "expandImage": "Cliquer pour agrandir l’image"
-        },
-        "titleWithIndex": "Scan du reçu ({current}/{total})",
-        "dialogTitleWithIndex": "Image du reçu ({current}/{total})"
-      },
-      "recipeCard": {
-        "complexity": {
-          "unknown": "Inconnu",
-          "easy": "Facile",
-          "normal": "Normal",
-          "hard": "Difficile"
-        },
-        "dropdown": {
-          "view": "Voir",
-          "edit": "Modifier",
-          "delete": "Supprimer",
-          "share": "Partager",
-          "markAsFavorite": "Marquer comme favori"
-        },
-        "ingredients": {
-          "label": "Ingrédients :",
-          "more": "+{count} de plus",
-          "additionalLabel": "Ingrédients supplémentaires :"
-        },
-        "timing": {
-          "prepLabel": "Prépa : {minutes}′",
-          "prepTooltip": "Le temps de préparation est de {minutes} minutes.",
-          "cookLabel": "Cuisson : {minutes}′",
-          "cookTooltip": "Le temps de cuisson est de {minutes} minutes."
-        },
-        "buttons": {
-          "visitReference": "Visiter la référence",
-          "viewRecipe": "Voir la recette"
-        }
-      },
-      "sharingCard": {
-        "title": "Partage",
-        "ownerAvatarAlt": "Utilisateur",
-        "owner": "Propriétaire",
-        "sharedWith": "Partagée avec",
-        "userWithId": "Utilisateur {id}",
-        "publicInvoice": {
-          "title": "Facture publique",
-          "description": "Cette facture est accessible publiquement. Toute personne disposant du lien peut la consulter."
-        },
-        "emptyShared": {
-          "public": "Aucun utilisateur supplémentaire n’a d’accès direct",
-          "private": "Non partagée"
-        },
-        "buttons": {
-          "manageSharing": "Gérer Partage",
-          "shareInvoice": "Partager Facture",
-          "revokingAccess": "Révocation de l’accès...",
-          "markAsPrivate": "Marquer comme privée"
-        },
-        "tooltips": {
-          "manageSharing": "Gérer les paramètres de partage de cette facture",
-          "removeAccess": "Supprimer l’accès",
-          "shareInvoice": "Partager cette facture avec d’autres utilisateurs",
-          "markAsPrivate": "Marquer la facture comme privée"
-        },
-        "toasts": {
-          "removeAccessComingSoon": {
-            "title": "La suppression d’accès sera bientôt disponible",
-            "description": "Cette fonctionnalité est en cours de développement."
-          },
-          "revoke": {
-            "loading": "Révocation de l’accès public...",
-            "success": "La facture est maintenant privée. Les liens existants ne fonctionneront plus.",
-            "error": "Échec du passage en privé : {message}"
-          }
-        }
-      },
-      "recipesTab": {
-        "header": {
-          "title": "Recettes que vous pouvez préparer",
-          "description": "Basé sur les articles de cette facture"
-        },
-        "buttons": {
-          "generate": "Générer",
-          "addRecipe": "Ajouter une recette",
-          "createFirstRecipe": "Créer votre première recette"
-        },
-        "tooltips": {
-          "generateRecipeUsingAi": "Générer une recette avec l'IA !",
-          "createRecipeWithIngredients": "Créer une nouvelle recette avec ces ingrédients"
-        },
-        "emptyState": {
-          "noRecipesAvailable": "Aucune recette disponible pour le moment"
-        },
-        "pagination": {
-          "previous": "Précédent",
-          "next": "Suivant",
-          "pageOf": "Page {currentPage} sur {totalPages}"
-        },
-        "toasts": {
-          "aiGenerationComingSoon": {
-            "title": "La génération de recettes par IA arrive bientôt",
-            "description": "Cette fonctionnalité est en cours de développement."
-          }
-        }
-      },
-      "metadataTab": {
-        "header": {
-          "title": "Informations supplémentaires",
-          "description": "Métadonnées associées à cette facture"
-        },
-        "buttons": {
-          "addField": "Ajouter un champ",
-          "addFirstMetadataField": "Ajouter votre premier champ de métadonnées"
-        },
-        "tooltips": {
-          "addCustomMetadata": "Ajouter des métadonnées personnalisées à cette facture"
-        },
-        "badges": {
-          "readonly": "Lecture seule"
-        },
-        "dropdown": {
-          "edit": "Modifier",
-          "delete": "Supprimer"
-        },
-        "emptyState": {
-          "noMetadataFields": "Aucun champ de métadonnées ajouté"
-        }
-      },
-      "analyzeDialog": {
-        "header": {
-          "title": "Analyser la facture",
-          "description": "Configurer une analyse alimentée par IA pour la facture"
-        },
-        "options": {
-          "completeAnalysis": {
-            "title": "Analyse complète",
-            "description": "Analyse IA complète incluant toutes les données de la facture, les articles et les informations du commerçant.",
-            "estimatedTime": "2-3 min",
-            "features": {
-              "ocrExtraction": "Extraction OCR",
-              "itemCategorization": "Catégorisation des articles",
-              "merchantIdentification": "Identification du commerçant",
-              "priceAnalysis": "Analyse des prix",
-              "receiptValidation": "Validation du reçu"
-            }
-          },
-          "invoiceOnly": {
-            "title": "Données de facture uniquement",
-            "description": "Analyser les informations de base de la facture comme les totaux, dates et détails de paiement.",
-            "estimatedTime": "30-60 s",
-            "features": {
-              "totalExtraction": "Extraction du total",
-              "dateParsing": "Analyse des dates",
-              "paymentMethodDetection": "Détection du mode de paiement"
-            }
-          },
-          "itemsOnly": {
-            "title": "Analyse des articles",
-            "description": "Se concentrer sur l'extraction et la catégorisation des lignes d'articles de la facture.",
-            "estimatedTime": "1-2 min",
-            "features": {
-              "itemExtraction": "Extraction des articles",
-              "categoryAssignment": "Attribution des catégories",
-              "pricePerItem": "Prix par article",
-              "quantityDetection": "Détection des quantités"
-            }
-          },
-          "merchantOnly": {
-            "title": "Analyse du commerçant",
-            "description": "Identifier et analyser les informations du commerçant, y compris localisation et catégorie.",
-            "estimatedTime": "30-45 s",
-            "features": {
-              "merchantIdentification": "Identification du commerçant",
-              "locationExtraction": "Extraction de la localisation",
-              "businessCategory": "Catégorie commerciale",
-              "contactInfo": "Coordonnées"
-            }
-          }
-        },
-        "analysisSteps": {
-          "preparingDocument": "Préparation du document...",
-          "runningOcrExtraction": "Exécution de l'extraction OCR...",
-          "analyzingWithAi": "Analyse avec l'IA...",
-          "categorizingItems": "Catégorisation des articles...",
-          "finalizingResults": "Finalisation des résultats...",
-          "processing": "Traitement..."
-        },
-        "analyzing": {
-          "title": "Analyse de la facture",
-          "progressComplete": "{progress}% terminé"
-        },
-        "sections": {
-          "analysisType": "Type d'analyse",
-          "includedFeatures": "Fonctionnalités incluses",
-          "enhancementsOptional": "Améliorations (optionnel)"
-        },
-        "enhancements": {
-          "priceComparison": {
-            "label": "Comparaison des prix",
-            "description": "Comparer les prix avec les données historiques"
-          },
-          "savingsTips": {
-            "label": "Suggestions d'économies",
-            "description": "Obtenir des recommandations d'économies par IA"
-          },
-          "quickExtract": {
-            "label": "Mode extraction rapide",
-            "description": "Prioriser la vitesse plutôt que la précision"
-          }
-        },
-        "badges": {
-          "recommended": "Recommandé"
-        },
-        "summary": {
-          "enhancementsSelected": "+ {count} amélioration(s)",
-          "noEnhancementsSelected": "Aucune amélioration sélectionnée",
-          "estimatedTime": "Durée estimée"
-        },
-        "buttons": {
-          "cancel": "Annuler",
-          "analyzing": "Analyse en cours...",
-          "startAnalysis": "Démarrer l'analyse"
-        },
-        "toasts": {
-          "analysisComplete": {
-            "title": "Analyse terminée",
-            "description": "Votre facture a été analysée avec succès."
-          },
-          "analysisFailed": {
-            "title": "Échec de l'analyse",
-            "description": "Nous n'avons pas pu analyser votre facture. Veuillez réessayer."
-          }
-        }
-      },
-      "addScanDialog": {
-        "title": "Ajouter un nouveau scan",
-        "description": "Téléversez une nouvelle image ou un nouveau document de reçu à joindre à cette facture.",
-        "dropzone": {
-          "dropHere": "Déposez le fichier ici...",
-          "dragAndDrop": "Glissez-déposez un fichier ici",
-          "orClickBrowse": "ou cliquez pour parcourir",
-          "formats": "JPEG, PNG, PDF (max 10 Mo)"
-        },
-        "scanType": {
-          "label": "Type de scan",
-          "placeholder": "Sélectionnez le type de scan",
-          "jpeg": "Image JPEG",
-          "png": "Image PNG",
-          "pdf": "Document PDF",
-          "other": "Autre"
-        },
-        "buttons": {
-          "cancel": "Annuler",
-          "uploading": "Téléversement...",
-          "upload": "Téléverser le scan"
-        },
-        "errors": {
-          "uploadStorageFailed": "Échec du téléversement du scan dans le stockage",
-          "unknown": "Une erreur inconnue est survenue"
-        },
-        "toasts": {
-          "fileTooLargeTitle": "Fichier trop volumineux",
-          "fileTooLargeDescription": "La taille maximale du fichier est de 10 Mo",
-          "scanAddedTitle": "Scan ajouté avec succès",
-          "scanAddedDescription": "Le scan a été joint à la facture",
-          "scanFailedTitle": "Échec de l’ajout du scan"
-        },
-        "console": {
-          "uploadError": "Erreur lors du téléversement du scan :"
-        }
-      },
-      "imageDialog": {
-        "title": "Aperçu ({image})",
-        "imageAlt": "Photo du reçu"
-      },
-      "itemsDialog": {
-        "title": "Modifier facture articles",
-        "description": "Mettez à jour les quantités, les prix ou ajoutez de nouveaux articles à cette facture",
-        "table": {
-          "item": "Article",
-          "quantity": "Quantité",
-          "unit": "Unité",
-          "price": "Prix",
-          "total": "Somme",
-          "actions": "Opérations"
-        },
-        "footer": {
-          "itemsFound": "{total} articles trouvés (affichage de {shown})",
-          "page": "Page {current} sur {total}",
-          "itemsTotal": "{count, plural, one {# article au total} other {# articles au total}}"
-        },
-        "buttons": {
-          "previous": "Précédent",
-          "next": "Suivant",
-          "addItem": "Ajouter article",
-          "cancel": "Annuler",
-          "saveChanges": "Enregistrer changes"
-        },
-        "aria": {
-          "deleteItem": "Supprimer article: {name}",
-          "unnamedItem": "unnamed article",
-          "previousPage": "Aller à la page précédente (page {page})",
-          "nextPage": "Aller à la page suivante (page {page})",
-          "addItem": "Ajouter un nouvel article à la facture",
-          "cancel": "Annuler la modification et fermer la boîte de dialogue",
-          "save": "Enregistrer les modifications des articles de la facture"
-        }
-      },
-      "merchantDialog": {
-        "title": "Détails du commerçant",
-        "noMerchantLinked": "Aucun commerçant lié à cette facture",
-        "description": "Informations sur {merchantName}",
-        "fields": {
-          "address": "Adresse",
-          "phone": "Téléphone",
-          "parentCompany": "Société mère"
-        },
-        "buttons": {
-          "openInMaps": "Ouvrir dans Maps"
-        }
-      },
-      "feedbackDialog": {
-        "title": "Donner un retour",
-        "description": "Aidez-nous à améliorer les analyses pour {merchant} en partageant votre avis",
-        "sections": {
-          "rating": "Comment évalueriez-vous les analyses ?",
-          "features": "Quelles fonctionnalités ont été les plus utiles ? (Sélectionnez toutes les réponses pertinentes)",
-          "comments": "Commentaires supplémentaires (facultatifs)"
-        },
-        "features": {
-          "spendingTrends": "Tendances de dépenses",
-          "priceComparisons": "Prix Comparisons",
-          "savingsTips": "Conseils d’économie",
-          "merchantAnalysis": "Merchant Analyse",
-          "visualCharts": "Graphiques visuels",
-          "categoryBreakdown": "Catégorie Breakdown"
-        },
-        "commentsPlaceholder": "Partagez vos impressions sur les analyses...",
-        "buttons": {
-          "cancel": "Annuler",
-          "submit": "Envoyer le retour"
-        },
-        "toasts": {
-          "sending": {
-            "title": "Envoi du retour...",
-            "description": "Veuillez patienter pendant l’envoi de votre retour."
-          },
-          "ratingRequired": {
-            "title": "Note requise",
-            "description": "Veuillez attribuer une note en étoiles avant l’envoi"
-          },
-          "success": {
-            "title": "Retour envoyé !",
-            "description": "Retour envoyé avec succès"
-          },
-          "error": {
-            "title": "Une erreur est survenue lors de l’envoi du retour",
-            "description": "Veuillez réessayer plus tard."
-          }
-        }
-      },
-      "metadataDialog": {
-        "add": {
-          "title": "Ajouter des métadonnées",
-          "description": "Ajouter des informations supplémentaires à cette facture"
-        },
-        "edit": {
-          "title": "Modifier les métadonnées",
-          "description": "Mettre à jour la valeur de ce champ de métadonnées",
-          "fieldLabel": "Champ de métadonnées"
-        },
-        "delete": {
-          "title": "Supprimer les métadonnées",
-          "description": "Êtes-vous sûr de vouloir supprimer ces métadonnées ?"
-        },
-        "fields": {
-          "keyLabel": "Clé de métadonnées",
-          "valueLabel": "Valeur de métadonnées",
-          "keyPlaceholder": "Saisir la clé",
-          "valuePlaceholder": "Saisir la valeur"
-        },
-        "buttons": {
-          "cancel": "Annuler",
-          "save": "Enregistrer",
-          "delete": "Supprimer"
-        }
-      },
-      "recipeDialog": {
-        "create": {
-          "title": "Ajouter une nouvelle recette",
-          "description": "Remplissez les détails pour créer une recette."
-        },
-        "read": {
-          "description": "Détails de la recette et instructions de préparation",
-          "noDescription": "Aucune description fournie.",
-          "notSpecified": "Non spécifié"
-        },
-        "update": {
-          "title": "Mettre à jour la recette",
-          "description": "Mettre à jour les détails de la recette."
-        },
-        "delete": {
-          "title": "Êtes-vous sûr ?",
-          "description": "Cette action est irréversible. Cela supprimera définitivement la recette <strong>{name}</strong> et toutes ses données associées."
-        },
-        "fields": {
-          "recipeName": "Nom de la recette",
-          "description": "Présentation",
-          "ingredients": "Ingrédients",
-          "difficulty": "Niveau de difficulté",
-          "complexity": "Niveau de complexité",
-          "instructions": "Étapes",
-          "prepTime": "Temps de préparation",
-          "cookTime": "Temps de cuisson"
-        },
-        "actions": {
-          "generateName": "Générer un nom",
-          "enhanceInstructions": "Améliorer les instructions"
-        },
-        "tooltips": {
-          "generateName": "Générer un nom de recette selon vos ingrédients et votre niveau de difficulté avec l’AI",
-          "enhanceInstructions": "Utiliser l’AI pour enrichir vos instructions avec davantage de détails"
-        },
-        "placeholders": {
-          "recipeName": "Saisir le nom de la recette",
-          "description": "Saisissez une brève description de la recette",
-          "selectDifficulty": "Sélectionner la difficulté",
-          "instructions": "Saisir les instructions de cuisson",
-          "prepTime": "ex. 15 minutes",
-          "cookTime": "ex. 30 minutes"
-        },
-        "difficulty": {
-          "easy": "Facile",
-          "medium": "Moyen",
-          "hard": "Difficile"
-        },
-        "buttons": {
-          "add": "Ajouter",
-          "cancel": "Annuler",
-          "save": "Enregistrer",
-          "close": "Fermer",
-          "delete": "Supprimer"
-        }
-      },
-      "merchantReceiptsDialog": {
-        "title": "Tous les reçus de {merchant}",
-        "description": "Voir et filtrer tous vos reçus de ce commerçant",
-        "searchPlaceholder": "Rechercher receipts...",
-        "filters": {
-          "date": "Date",
-          "sort": "Tri"
-        },
-        "dateOptions": {
-          "allTime": "Toute la période",
-          "last30Days": "30 derniers jours",
-          "last90Days": "90 derniers jours",
-          "thisYear": "Cette année"
-        },
-        "sortOptions": {
-          "newest": "Plus récents d’abord",
-          "oldest": "Plus anciens d’abord"
-        },
-        "table": {
-          "receipt": "Reçu",
-          "date": "Date",
-          "itemsCount": "Articles #",
-          "actions": "Opérations",
-          "view": "Voir"
-        },
-        "footer": {
-          "receiptsFound": "{count} reçus trouvés (affichage de {showing})",
-          "page": "Page {current} sur {total}"
-        },
-        "buttons": {
-          "previous": "Précédent",
-          "next": "Suivant"
-        }
-      },
-      "removeScanDialog": {
-        "title": "Supprimer scan",
-        "description": "Êtes-vous sûr de vouloir supprimer le scan {current} sur {total} ?",
-        "descriptionLastScan": "C’est le seul scan joint à cette facture. Vous ne pouvez pas le supprimer.",
-        "scanAlt": "Numérisation {index}",
-        "scanCaption": "Numérisation {index}",
-        "warning": {
-          "title": "Impossible de supprimer le dernier scan",
-          "description": "Chaque facture doit avoir au moins un scan joint. Ajoutez un autre scan avant de supprimer celui-ci."
-        },
-        "buttons": {
-          "cancel": "Annuler",
-          "removing": "Suppression...",
-          "remove": "Supprimer le scan"
-        },
-        "toasts": {
-          "cannotDeleteLastTitle": "Impossible de supprimer le dernier scan",
-          "cannotDeleteLastDescription": "Une facture doit avoir au moins un scan joint",
-          "removedTitle": "Scan supprimé avec succès",
-          "removedDescription": "Le scan a été retiré de la facture",
-          "removeFailedTitle": "Échec de la suppression du scan"
-        },
-        "errors": {
-          "unknown": "Une erreur inconnue est survenue"
-        },
-        "console": {
-          "deleteError": "Erreur suppression de scan:"
-        }
-      },
-      "itemsTable": {
-        "title": "Articles",
-        "buttons": {
-          "editItems": "Modifier les articles",
-          "addItem": "Ajouter un article"
-        },
-        "tooltips": {
-          "editInvoiceItemsAndQuantities": "Modifier les articles et les quantités de la facture"
-        },
-        "columns": {
-          "selectAll": "Tout sélectionner",
-          "selectRow": "Sélectionner {name}",
-          "name": "Nom",
-          "quantity": "Quantité",
-          "price": "Prix",
-          "unit": "Unité",
-          "total": "Total",
-          "actions": "Actions"
-        },
-        "tableHeaders": {
-          "item": "Article",
-          "quantity": "Qté",
-          "price": "Prix",
-          "total": "Total"
-        },
-        "footer": {
-          "total": "Total"
-        },
-        "pagination": {
-          "totalItems": "{count, plural, one {# article au total} other {# articles au total}}",
-          "previous": "Précédent",
-          "next": "Suivant",
-          "pageOf": "Page {currentPage} sur {totalPages}"
-        },
-        "search": {
-          "placeholder": "Rechercher des articles..."
-        },
-        "bulkToolbar": {
-          "selectedCount": "{count, plural, one {# article sélectionné} other {# articles sélectionnés}}",
-          "deleteSelected": "Supprimer la sélection",
-          "changeCategory": "Changer de catégorie",
-          "noSelection": "Aucun produit sélectionné"
-        },
-        "editing": {
-          "saved": "Article mis à jour avec succès",
-          "cancel": "Modification annulée",
-          "fieldLabel": "Modifier {field} pour {name}"
-        },
-        "deleteConfirm": {
-          "title": "Supprimer les articles",
-          "description": "{count, plural, one {Êtes-vous sûr de vouloir supprimer cet article ?} other {Êtes-vous sûr de vouloir supprimer # articles ?}}",
-          "confirm": "Supprimer",
-          "cancel": "Annuler",
-          "success": "{count, plural, one {# article supprimé} other {# articles supprimés}}"
-        },
-        "newItem": {
-          "defaultName": "Nouvel article",
-          "added": "Nouvel article ajouté"
-        },
-        "indicators": {
-          "uncategorized": "Non catégorisé",
-          "uncategorizedTooltip": "Ce produit nécessite une catégorie pour un meilleur suivi des dépenses",
-          "missingName": "Nom manquant",
-          "missingNameTooltip": "La traduction du nom générique est manquante ou identique au texte OCR brut",
-          "lowConfidence": "Faible confiance",
-          "lowConfidenceTooltip": "La confiance OCR est de {confidence}% - révision manuelle recommandée",
-          "edited": "Modifié",
-          "editedTooltip": "Ce produit a été modifié manuellement",
-          "allergens": "{count, plural, one {# allergène} other {# allergènes}}"
-        },
-        "actions": {
-          "remove": "Supprimer l'article",
-          "restore": "Restaurer l'article",
-          "editAllergens": "Modifier les allergènes"
-        },
-        "softDelete": {
-          "success": "Article « {name} » supprimé",
-          "error": "Échec de la suppression de l'article"
-        },
-        "restore": {
-          "success": "Article « {name} » restauré",
-          "error": "Échec de la restauration de l'article"
-        },
-        "bulkCategory": {
-          "noSelection": "Veuillez sélectionner au moins un produit"
-        }
-      },
-      "guidedEdit": {
-        "banner": {
-          "title": "{count, plural, one {# produit nécessite une révision} other {# produits nécessitent une révision}}",
-          "summary": {
-            "uncategorized": "{count, plural, one {# non catégorisé} other {# non catégorisés}}",
-            "lowConfidence": "{count, plural, one {# faible confiance} other {# faible confiance}}",
-            "missingName": "{count, plural, one {# nom manquant} other {# noms manquants}}"
-          },
-          "actions": {
-            "reviewAll": "Tout réviser",
-            "dismiss": "Fermer"
-          },
-          "badges": {
-            "uncategorized": "{count, plural, one {# non catégorisé} other {# non catégorisés}}",
-            "lowConfidence": "{count, plural, one {# faible confiance} other {# faible confiance}}",
-            "missingName": "{count, plural, one {# nom manquant} other {# noms manquants}}"
-          }
-        }
-      },
-      "changeHistory": {
-        "unsavedChanges": "Modifications non enregistrées",
-        "pending": "En attente",
-        "created": "Facture créée",
-        "title": "Historique des modifications",
-        "time": {
-          "justNow": "À l'instant",
-          "secondsAgo": "il y a {seconds} secondes",
-          "hoursAgo": "il y a {hours} heures",
-          "daysAgo": "il y a {days} jours",
-          "minutesAgo": "il y a {minutes} minutes"
-        },
-        "modified": "Dernière modification",
-        "changes": {
-          "paymentTypeChanged": "Type de paiement modifié",
-          "unmarkedImportant": "Retiré des favoris",
-          "categoryUpdated": "Catégorie mise à jour",
-          "transactionDateChanged": "Date de transaction modifiée",
-          "nameChanged": "Nom modifié",
-          "descriptionChanged": "Description modifiée",
-          "markedImportant": "Marqué comme important",
-          "importanceChanged": "Importance modifiée"
-        }
-      },
-      "allergenDialog": {
-        "labels": {
-          "currentAllergens": "Allergènes actuels",
-          "customAllergen": "Ajouter un allergène personnalisé",
-          "quickAdd": "Ajout rapide d'allergènes courants"
-        },
-        "title": "Modifier les allergènes",
-        "success": {
-          "added": "Allergène ajouté : {name}",
-          "saved": "Allergènes mis à jour avec succès",
-          "removed": "Allergène retiré : {name}"
-        },
-        "buttons": {
-          "save": "Enregistrer les modifications",
-          "saving": "Enregistrement...",
-          "cancel": "Annuler",
-          "add": "Ajouter"
-        },
-        "defaultDescription": "Contient {name}",
-        "aria": {
-          "removeAllergen": "Retirer l'allergène {name}"
-        },
-        "placeholders": {
-          "customAllergen": "Entrez le nom de l'allergène..."
-        },
-        "empty": {
-          "noAllergens": "Aucun allergène détecté"
-        },
-        "description": "Gérer les allergènes pour {productName}",
-        "errors": {
-          "emptyName": "Le nom de l'allergène ne peut pas être vide",
-          "duplicate": "L'allergène « {name} » a déjà été ajouté",
-          "missingData": "Données de produit manquantes",
-          "saveFailed": "Échec de l'enregistrement des allergènes"
-        }
-      },
-      "bulkCategoryDialog": {
-        "errors": {
-          "saveFailed": "Échec de la mise à jour des catégories",
-          "missingData": "Données manquantes",
-          "noProducts": "Aucun produit sélectionné"
-        },
-        "success": {
-          "saved": "{count, plural, one {Catégorie mise à jour pour # produit} other {Catégorie mise à jour pour # produits}}"
-        },
-        "description": "{count, plural, one {Changer la catégorie pour # produit} other {Changer la catégorie pour # produits}}",
-        "buttons": {
-          "save": "Appliquer à tous",
-          "saving": "Enregistrement...",
-          "cancel": "Annuler"
-        },
-        "labels": {
-          "andMore": "...et {count} de plus",
-          "newCategory": "Nouvelle catégorie",
-          "selectedProducts": "Produits sélectionnés"
-        },
-        "placeholders": {
-          "selectCategory": "Sélectionner une catégorie"
-        },
-        "title": "Changer de catégorie"
-      }
-    },
-    "Shared": {
-      "invoiceHeader": {
-        "tooltips": {
-          "importantInvoice": "Facture importante",
-          "edit": "Modifier cette facture",
-          "delete": "Supprimer définitivement cette facture",
-          "print": "Imprimer cette facture",
-          "saveAllPendingChanges": "Enregistrer toutes les modifications en attente",
-          "discardAllPendingChanges": "Annuler toutes les modifications en attente",
-          "printInvoiceWithAllDetails": "Imprimer cette facture avec tous les détails",
-          "analyzeSpendingPatterns": "Analyser les habitudes de dépenses de cette facture",
-          "deleteInvoicePermanently": "Supprimer cette facture définitivement",
-          "export": "Exporter les données de la facture dans différents formats"
-        },
-        "id": "ID : {id}",
-        "buttons": {
-          "edit": "Modifier",
-          "delete": "Supprimer",
-          "print": "Imprimer",
-          "save": "Enregistrer",
-          "saving": "Enregistrement...",
-          "discard": "Annuler",
-          "analyzeWithAi": "Analyser avec l'IA",
-          "export": "Exporter"
-        }
-      },
-      "states": {
-        "notFound": {
-          "title": "Facture Non Trouvée",
-          "description": "La facture avec l'identifiant {invoiceIdentifier} n'a pas été trouvée."
-        },
-        "loading": {
-          "title": "Chargement de la Facture",
-          "description": "Chargement de la facture avec l'identifiant {invoiceIdentifier}."
-        }
-      },
-      "loadingInvoices": {
-        "title": "Chargement factures",
-        "description": "Chargement factures..."
-      },
-      "invoicesNotFound": {
-        "title": "Il manque quelque chose ici...",
-        "description": "Il semble que vous n’ayez aucune facture associée à votre compte. Veuillez téléverser des factures puis revenir plus tard.",
-        "cta": "Téléverser une facture ici."
-      },
-      "shareInvoiceDialog": {
-        "title": "Partager facture",
-        "selection": {
-          "description": "Choisissez comment vous souhaitez partager cette facture. Votre choix détermine qui peut y accéder.",
-          "publicTitle": "Partage publique",
-          "publicDescription": "Générez un lien ou un code QR que <strong>n’importe qui</strong> peut utiliser pour voir cette facture.",
-          "privateTitle": "Privé sharing",
-          "privateDescription": "Envoyez une invitation par e-mail à une <strong>personne spécifique</strong>. Seule cette personne aura accès.",
-          "privacyNoticeTitle": "Avis de confidentialité",
-          "privacyNoticeDescription": "Les liens publics sont accessibles à toute personne disposant de l’URL. Le partage privé limite l’accès au destinataire spécifié."
-        },
-        "dialogDescription": {
-          "currentlyPublic": "\"{invoiceName}\" est actuellement publique",
-          "selection": "Choisissez comment partager « {invoiceName} »",
-          "public": "Partager \"{invoiceName}\" publiquement",
-          "private": "Envoyer \"{invoiceName}\" en privé"
-        },
-        "toasts": {
-          "copyLink": {
-            "loadingPublic": "Copie du lien...",
-            "loadingMakePublic": "La facture devient publique...",
-            "successPublic": "Lien copié dans le presse-papiers !",
-            "successMadePublic": "La facture est maintenant publique ! Lien copié dans le presse-papiers.",
-            "error": "Échoué: {message}"
-          },
-          "copyQr": {
-            "loadingPublic": "Copie du code QR...",
-            "loadingMakePublic": "La facture devient publique...",
-            "successPublic": "Code QR copié dans le presse-papiers !",
-            "successMadePublic": "La facture est maintenant publique ! Code QR copié dans le presse-papiers.",
-            "error": "Échoué: {message}"
-          },
-          "sendEmail": {
-            "loading": "Envoi de l’invitation à {email}...",
-            "success": "Invitation envoyée à {email} !",
-            "error": "Échoué: {message}",
-            "comingSoon": "Le partage par e-mail arrive bientôt"
-          },
-          "revoke": {
-            "loading": "Envoi de la demande de révocation au serveur...",
-            "success": "La facture est maintenant privée. Les liens existants ne fonctionneront plus.",
-            "error": "Échec de la révocation de l’accès : {message}"
-          }
-        },
-        "errors": {
-          "qrNotFound": "Élément de code QR introuvable"
-        }
-      },
-      "shareInvoiceDialogPublic": {
-        "tabs": {
-          "directLink": "Lien direct",
-          "qrCode": "Code QR"
-        },
-        "hints": {
-          "link": "Copiez ce lien et partagez-le. Toute personne qui le reçoit pourra consulter la facture.",
-          "qr": "Toute personne qui scanne ce QR code sera redirigée pour consulter la facture."
-        },
-        "copyQrImage": "Copier le code QR en tant qu’image",
-        "alreadyPublic": {
-          "title": "Cette facture est actuellement publique",
-          "description": "Cette facture est accessible publiquement. <strong>Toute personne disposant du lien peut la consulter</strong>, y compris tous les détails de la facture, les articles et les montants. Vous pouvez révoquer l’accès public à tout moment pour la rendre privée à nouveau.",
-          "revoke": "Révoquer l’accès public",
-          "revoking": "Révocation de l’accès...",
-          "revokeHint": "Cela rendra la facture privée. Les liens existants cesseront de fonctionner."
-        },
-        "backToOptions": "Retour aux options",
-        "warning": {
-          "title": "Avertissement d’accès public",
-          "description": "En partageant cette facture publiquement, <strong>toute personne disposant du lien pourra la consulter</strong>. Cela inclut tous les détails de la facture, les articles et les montants. Continuez uniquement si vous souhaitez rendre cette facture accessible au publique."
-        }
-      },
-      "shareInvoiceDialogPrivate": {
-        "backToOptions": "Retour aux options",
-        "title": "Privé sharing",
-        "description": "L’invitation sera envoyée directement à l’adresse e-mail que vous indiquez. Seul ce destinataire recevra l’accès pour consulter la facture.",
-        "emailLabel": "Recipient's e-mail address",
-        "emailPlaceholder": "nom@exemple.com",
-        "emailHint": "Une invitation par e-mail sera envoyée à cette adresse avec un lien privé pour consulter la facture.",
-        "sendInvitation": "Envoyer une invitation privée",
-        "sending": "Envoi de l'invitation...",
-        "comingSoonTooltip": "La fonction de partage par e-mail sera bientôt disponible"
-      },
-      "deleteInvoiceDialog": {
-        "title": "Supprimer facture",
-        "description": "Cette action est irréversible. Veuillez vérifier attentivement avant de continuer.",
-        "deleting": {
-          "title": "Suppression de facture...",
-          "description": "Veuillez patienter pendant que nous supprimons toutes les données associées."
-        },
-        "impact": {
-          "title": "Suppression définitive",
-          "intro": "Les données suivantes seront supprimées définitivement :",
-          "invoiceRecord": "Enregistrement de facture et métadonnées",
-          "uploadedScans": "{count} scan(s) téléversé(s)",
-          "lineItems": "{count} line article(s)",
-          "sharedAccess": "Accès partagé pour {count} utilisateur(s)"
-        },
-        "confirmation": {
-          "typeToConfirm": "Tapez <highlight>{name}</highlight> pour confirmer :",
-          "understoodLabel": "Je comprends que cette action est définitive",
-          "understoodDescription": "Cette facture et toutes ses données seront définitivement supprimées et ne pourront pas être récupérées."
-        },
-        "buttons": {
-          "cancel": "Annuler",
-          "deleting": "Suppression...",
-          "deletePermanently": "Supprimer définitivement"
-        },
-        "toasts": {
-          "deletedTitle": "Facture supprimée",
-          "deletedDescription": "La facture a été supprimée avec succès.",
-          "deleteFailedTitle": "Supprimer échoué",
-          "deleteFailedDescription": "Nous n’avons pas pu supprimer cette facture. Veuillez réessayer."
-        },
-        "console": {
-          "deleteError": "Erreur suppression de facture:"
-        }
-      },
-      "shortcuts": {
-        "title": "Raccourcis clavier",
-        "description": "Accès rapide aux actions courantes via votre clavier",
-        "openSearch": "Ouvrir la recherche",
-        "newInvoice": "Nouvelle facture",
-        "uploadScan": "Télécharger une numérisation",
-        "showHelp": "Afficher cette aide",
-        "closeDialog": "Fermer la boîte de dialogue",
-        "close": "Fermer"
-      },
-      "commandPalette": {
-        "placeholder": "Rechercher des factures, commerçants, articles...",
-        "noResults": "Aucun résultat trouvé",
-        "groups": {
-          "quickActions": "Actions rapides",
-          "recentInvoices": "Factures récentes",
-          "searchResults": "Résultats de recherche"
-        },
-        "actions": {
-          "uploadScans": "Télécharger des numérisations",
-          "createInvoice": "Créer une facture",
-          "viewStatistics": "Voir les statistiques",
-          "viewAll": "Voir toutes les factures"
-        }
-      },
-      "onboarding": {
-        "steps": {
-          "upload": {
-            "description": "Prenez une photo ou téléchargez un PDF de votre reçu. Notre système prend en charge plusieurs formats et peut traiter des lots de reçus en même temps.",
-            "title": "Téléchargez vos reçus"
-          },
-          "analyze": {
-            "description": "Notre système alimenté par l'IA extrait automatiquement les noms des commerçants, les dates, les montants et les articles de vos reçus avec une grande précision.",
-            "title": "L'IA extrait les détails"
-          },
-          "track": {
-            "description": "Consultez des analyses détaillées et des informations sur vos habitudes de dépenses. Comprenez où va votre argent grâce à des graphiques et rapports interactifs.",
-            "title": "Suivez vos dépenses"
-          }
-        },
-        "getStarted": "Commencer",
-        "stepOf": "Étape {current} sur {total}",
-        "next": "Suivant",
-        "skip": "Passer",
-        "back": "Retour",
-        "dontShowAgain": "Ne plus afficher"
-      },
-      "notifications": {
-        "timeAgo": {
-          "hours": "{count, plural, one {il y a # heure} other {il y a # heures}}",
-          "minutes": "{count, plural, one {il y a # minute} other {il y a # minutes}}",
-          "days": "{count, plural, one {il y a # jour} other {il y a # jours}}",
-          "now": "À l'instant"
-        },
-        "types": {
-          "invoiceCreated": "Facture créée",
-          "analysisComplete": "Analyse IA terminée",
-          "monthlyReport": "Rapport mensuel prêt"
-        },
-        "title": "Notifications",
-        "noNotifications": "Aucune notification pour le moment",
-        "markAllRead": "Tout marquer comme lu"
-      },
-      "preferences": {
-        "title": "Préférences de facturation",
-        "defaultView": "Vue par défaut",
-        "sortBy": "Trier par",
-        "pageSize": "Éléments par page",
-        "currency": "Devise",
-        "showStats": "Afficher les statistiques sur l'accueil",
-        "save": "Enregistrer les préférences",
-        "saved": "Préférences enregistrées avec succès",
-        "views": {
-          "table": "Vue tableau",
-          "grid": "Vue grille"
-        },
-        "sortOptions": {
-          "dateDesc": "Date (plus récente)",
-          "dateAsc": "Date (plus ancienne)",
-          "amountDesc": "Montant (décroissant)",
-          "amountAsc": "Montant (croissant)",
-          "nameAsc": "Nom (A à Z)"
-        }
-      },
-      "mobileNav": {
-        "profile": "Profil",
-        "ariaLabel": "Navigation mobile",
-        "home": "Accueil",
-        "scan": "Numériser",
-        "invoices": "Factures"
-      },
-      "workflowProgress": {
-        "upload": "Télécharger",
-        "review": "Vérifier",
-        "create": "Créer"
-      },
-      "unknownMerchant": "Commerçant inconnu"
-    },
-    "CreateInvoice": {
-      "metadata": {
-        "title": "Système de gestion des factures - Créer une facture",
-        "description": "Créez une nouvelle facture à partir de vos numérisations téléchargées."
-      },
-      "navigation": {
-        "back": "Retour",
-        "next": "Suivant"
-      },
-      "emptyState": {
-        "title": "Aucune numérisation disponible",
-        "description": "Téléchargez d'abord des numérisations de reçus pour créer une facture.",
-        "uploadButton": "Télécharger des numérisations",
-        "viewScansButton": "Voir les numérisations"
-      },
-      "header": {
-        "backToInvoices": "Retour aux factures",
-        "title": "Créer une facture",
-        "subtitle": "Suivez les étapes ci-dessous pour créer une nouvelle facture à partir de vos numérisations"
-      },
-      "steps": {
-        "selectScans": "Sélectionner les numérisations",
-        "details": "Détails de la facture",
-        "review": "Vérifier et créer",
-        "selectScansDesc": "Choisir les numérisations de reçus",
-        "detailsDesc": "Remplir les informations de la facture",
-        "reviewDesc": "Confirmer et créer"
-      },
-      "scanSelector": {
-        "title": "Sélectionner les numérisations",
-        "subtitle": "Choisissez les numérisations qui correspondent à cette facture",
-        "selectedCount": "{count} sélectionnée(s)",
-        "clearAll": "Effacer",
-        "selectAll": "Tout sélectionner",
-        "noScans": "Aucune numérisation disponible",
-        "previous": "Précédent",
-        "next": "Suivant",
-        "scansCount": "scans"
-      },
-      "detailsForm": {
-        "title": "Détails de la facture",
-        "subtitle": "Renseignez les détails de votre nouvelle facture",
-        "fields": {
-          "name": {
-            "label": "Nom de la facture",
-            "placeholder": "ex. Courses hebdomadaires",
-            "hint": "Donnez un nom descriptif à votre facture"
-          },
-          "category": {
-            "label": "Catégorie",
-            "placeholder": "Sélectionner une catégorie",
-            "options": {
-              "notDefined": "Non catégorisé",
-              "grocery": "Épicerie",
-              "fastFood": "Restauration",
-              "homeCleaning": "Maison et entretien",
-              "carAuto": "Auto et véhicule",
-              "other": "Autre"
-            }
-          },
-          "paymentType": {
-            "label": "Mode de paiement",
-            "placeholder": "Sélectionner un mode de paiement",
-            "options": {
-              "unknown": "Inconnu",
-              "cash": "Espèces",
-              "card": "Carte",
-              "transfer": "Virement bancaire",
-              "mobilePayment": "Paiement mobile",
-              "voucher": "Bon d'achat",
-              "other": "Autre"
-            }
-          },
-          "transactionDate": {
-            "label": "Date de transaction"
-          },
-          "description": {
-            "label": "Description",
-            "placeholder": "Ajoutez des notes sur cette facture (facultatif)",
-            "hint": "Notes facultatives sur cet achat"
-          }
-        },
-        "scanPreview": {
-          "title": "Aperçu de la numérisation"
-        }
-      },
-      "reviewStep": {
-        "title": "Vérifier et créer",
-        "subtitle": "Vérifiez les détails de votre facture avant de la créer",
-        "categories": {
-          "notDefined": "Non catégorisé",
-          "grocery": "Épicerie",
-          "fastFood": "Restauration",
-          "homeCleaning": "Maison et entretien",
-          "carAuto": "Auto et véhicule",
-          "other": "Autre"
-        },
-        "paymentTypes": {
-          "unknown": "Inconnu",
-          "cash": "Espèces",
-          "card": "Carte",
-          "transfer": "Virement bancaire",
-          "mobilePayment": "Paiement mobile",
-          "voucher": "Bon d'achat",
-          "other": "Autre"
-        },
-        "sections": {
-          "scans": {
-            "title": "Numérisations"
-          },
-          "details": {
-            "title": "Détails de la facture",
-            "name": "Nom",
-            "category": "Catégorie",
-            "paymentType": "Mode de paiement",
-            "transactionDate": "Date de transaction",
-            "description": "Description"
-          }
-        },
-        "actions": {
-          "creating": "Création de la facture...",
-          "create": "Créer la facture",
-          "hint": "Ceci créera la facture et téléchargera les numérisations sélectionnées."
-        }
-      }
-    }
-  },
   "Profile": {
     "metadata": {
       "title": "Mon Profil",
@@ -4659,5 +1836,2830 @@
       }
     },
     "title": "Remerciements"
+  },
+  "IMS--Cards": {
+    "budgetImpactCard": {
+      "title": "Impact budgétaire de {month}",
+      "monthlyBudget": "Budget mensuel",
+      "spent": "{amount} dépensés",
+      "invoiceUsed": "Cette facture a utilisé",
+      "ofMonthlyBudget": "de votre budget mensuel",
+      "remaining": "Restant",
+      "overBudget": "Dépassement de budget",
+      "daysLeft": "Jours restants",
+      "inMonth": "en {month}",
+      "dailyAllowance": "Budget quotidien",
+      "dailyAllowanceValue": "{amount} / jour"
+    },
+    "comparisonStatsCard": {
+      "title": "Comment vous vous situez",
+      "subtitle": "Par rapport à vos {count} dernières factures",
+      "vsAverage": "vs moyenne",
+      "avgValue": "Moy. : {amount} {currency}",
+      "thisValue": "Cette facture : {amount} {currency}",
+      "minValue": "Min. : {amount}",
+      "maxValue": "Max. : {amount}",
+      "positionInRange": "Votre position dans la plage de dépenses",
+      "itemCount": "Article Count",
+      "itemCountComparison": "{current} vs moy {average}",
+      "sameStore": "Même magasin",
+      "sameStoreComparison": "vs moy {average} {currency}"
+    },
+    "invoiceDetailsCard": {
+      "title": "Détails de la facture",
+      "labels": {
+        "dateUtc": "Date et heure (UTC)",
+        "category": "Catégorie",
+        "payment": "Paiement",
+        "totalAmount": "Montant total",
+        "receiptType": "Type de reçu",
+        "countryRegion": "Pays/Région",
+        "subtotal": "Sous-total",
+        "tip": "Pourboire",
+        "ronEquivalent": "Équivalent RON"
+      },
+      "itemsTitle": "Articles ({count})",
+      "table": {
+        "item": "Article",
+        "qty": "Qté",
+        "unit": "Unité",
+        "price": "Prix",
+        "total": "Somme",
+        "grandTotal": "Total général"
+      },
+      "pagination": {
+        "pageOf": "Page {current} sur {total}",
+        "previous": "Précédent",
+        "next": "Suivant"
+      },
+      "tooltips": {
+        "exchangeRate": "1 {fromCurrency} = {rate} RON (moy. {year})"
+      },
+      "sections": {
+        "paymentMethods": "Modes de paiement",
+        "taxBreakdown": "Détail des taxes"
+      },
+      "taxLabels": {
+        "net": "Net",
+        "tax": "Taxe"
+      }
+    },
+    "merchantInfoCard": {
+      "title": "Informations sur le commerçant",
+      "noMerchantLinked": "Aucun commerçant lié à cette facture",
+      "viewAllReceipts": "Voir tous les reçus",
+      "viewAllInvoices": "Voir toutes les factures",
+      "viewOnMap": "Voir sur la carte",
+      "spendingHistory": "Historique des dépenses",
+      "categoryDistribution": "Répartition par catégorie",
+      "stats": {
+        "visits": "visites",
+        "avgSpend": "Dépense moyenne",
+        "daysAgo": "il y a quelques jours"
+      }
+    },
+    "receiptScanCard": {
+      "title": "Scan du reçu",
+      "dialogTitle": "Image du reçu",
+      "scanAlt": "Scan du reçu {index}",
+      "scanAltFullSize": "Scan du reçu {index} - taille réelle",
+      "buttons": {
+        "expand": "Agrandir l’image",
+        "previousScan": "Scan précédent",
+        "nextScan": "Scan suivant"
+      },
+      "tooltips": {
+        "expand": "Voir l’image du reçu en taille réelle",
+        "previousScan": "Voir le scan précédent du reçu",
+        "nextScan": "Voir le scan suivant du reçu"
+      },
+      "titleWithIndex": "Scan du reçu ({current}/{total})",
+      "dialogTitleWithIndex": "Image du reçu ({current}/{total})",
+      "controls": {
+        "zoomIn": "Zoom avant",
+        "zoomOut": "Zoom arrière",
+        "reset": "Réinitialiser le zoom",
+        "rotate": "Pivoter",
+        "download": "Télécharger",
+        "fullScreen": "Plein écran",
+        "toggleZoom": "Basculer le zoom"
+      },
+      "navigation": {
+        "previous": "Précédent",
+        "next": "Suivant",
+        "of": "sur"
+      }
+    },
+    "seasonalInsightsCard": {
+      "title": "Insight saisonnier",
+      "month": {
+        "spendingSoFar": "{month} jusqu’à présent",
+        "vsAverage": "vs moyenne de {month} : {amount}"
+      },
+      "insights": {
+        "spike": {
+          "title": "Pic de {category}",
+          "description": "+{percent}% vs votre moyenne"
+        },
+        "holidaySeason": {
+          "title": "Saison des fêtes",
+          "description": "Les dépenses de décembre sont généralement 35% plus élevées"
+        },
+        "stockUpTip": {
+          "title": "Conseil de stock",
+          "description": "Les prix augmentent d’environ 15% après le 15 décembre"
+        },
+        "normalPattern": {
+          "title": "Habitude d’achat normale",
+          "description": "Vos dépenses sont dans la plage habituelle"
+        }
+      }
+    },
+    "shoppingCalendarCard": {
+      "title": "Calendrier d’achats",
+      "tooltip": {
+        "basedOnCachedInvoices": "Basé sur {count} factures en cache",
+        "currentInvoiceOnly": "Affichage de la facture actuelle uniquement",
+        "more": "+{count} de plus",
+        "vsAverage": "vs moy ({years} ans de données)",
+        "invoiceCount": "{count} facture(s)",
+        "currentInvoice": "Facture actuelle"
+      },
+      "legend": {
+        "less": "Moins",
+        "more": "Plus"
+      },
+      "stats": {
+        "monthTotal": "Total du mois",
+        "shoppingDays": "Jours d’achats"
+      },
+      "insights": {
+        "shopEveryPrefix": "Vous faites vos achats tous les",
+        "days": "{count} jours",
+        "onAverage": "en moyenne",
+        "spendingPrefix": ", dépensant",
+        "perTrip": " par achat",
+        "mostActiveOn": "Plus actif le",
+        "weekdayLabel": "{weekday}"
+      }
+    },
+    "summaryStatsCard": {
+      "title": "Résumé de la facture",
+      "description": "Statistiques clés en un coup d’œil",
+      "stats": {
+        "totalItems": {
+          "label": "Articles totaux",
+          "description": "Produits achetés"
+        },
+        "categories": {
+          "label": "Catégories",
+          "description": "Catégories uniques"
+        },
+        "averagePrice": {
+          "label": "Prix moyen",
+          "description": "{currency} par article"
+        },
+        "taxRate": {
+          "label": "Taux de taxe",
+          "description": "{amount} {currency}"
+        }
+      },
+      "extremes": {
+        "highest": "Le plus élevé",
+        "lowest": "Le plus bas"
+      }
+    },
+    "categorySuggestionCard": {
+      "title": "Aidez-nous à catégoriser cette facture",
+      "description": "Nous n’avons pas pu catégoriser automatiquement cette facture. Sélectionnez la bonne catégorie pour débloquer des analyses :",
+      "moreCategories": "Plus de catégories :",
+      "gamification": "Catégorisez {goal} factures pour débloquer des analyses détaillées !"
+    },
+    "diningCard": {
+      "title": "Informations restauration",
+      "sodium": {
+        "high": "Élevé",
+        "medium": "Moyen",
+        "low": "Faible"
+      },
+      "estimatedNutrition": {
+        "title": "Valeurs nutritionnelles estimées",
+        "calories": "Énergie",
+        "caloriesValue": "~{value} kcal",
+        "protein": "Protéines",
+        "proteinValue": "~{value}g",
+        "sodium": "Sel (sodium)",
+        "carbs": "Glucides",
+        "carbsValue": "~{value}g"
+      },
+      "habits": {
+        "title": "Vos habitudes de restauration rapide",
+        "frequency": "Fréquence",
+        "frequencyValue": "{count}x/mois",
+        "frequencyDiff": "+1 vs moyenne",
+        "avgSpend": "Dépense moyenne",
+        "favorite": "Préféré",
+        "visits": "{count} visites"
+      },
+      "swaps": {
+        "title": "Alternatives plus saines",
+        "grilled": "Grillé au lieu de frit",
+        "water": "Eau au lieu de soda",
+        "salad": "Salade d’accompagnement au lieu de frites",
+        "caloriesSaved": "-{count} kcal",
+        "moneySaved": ", économise {amount}"
+      },
+      "challenge": {
+        "title": "Défi hebdomadaire",
+        "descriptionPrefix": "Évitez la restauration rapide pendant 7 jours et enregistrez",
+        "descriptionSuffix": ""
+      }
+    },
+    "generalExpenseCard": {
+      "title": "Analyse des dépenses",
+      "detectedCategory": "Électronique / Technologie",
+      "confidence": "Confiance : {value}%",
+      "sections": {
+        "autoDetectedCategory": "Auto-detected catégorie",
+        "budgetImpact": "Impact sur le budget",
+        "taxBusiness": "Options fiscales et professionnelles",
+        "similarPurchases": "Achats similaires passés"
+      },
+      "buttons": {
+        "correct": "Valider",
+        "change": "Modifier",
+        "organize": "Organiser",
+        "export": "Exporter"
+      },
+      "aria": {
+        "confirmCategory": "Confirmer que la catégorie détectée est correcte",
+        "changeCategory": "Change detected catégorie",
+        "organize": "Organiser cette dépense en catégories",
+        "export": "Exporter les données de dépense"
+      },
+      "nearLimitAlert": "{name} : {percent}% utilisé (10 jours restants ce mois)",
+      "options": {
+        "businessExpense": "Marquer comme dépense professionnelle",
+        "trackWarranty": "Suivre la garantie (24 mois standard)",
+        "insuranceInventory": "Ajouter à l’inventaire d’assurance"
+      },
+      "vatReclaimable": "TVA récupérable",
+      "budgetCategories": {
+        "electronics": "Électronique",
+        "entertainment": "Divertissement",
+        "shopping": "Achats"
+      }
+    },
+    "homeInventoryCard": {
+      "title": "Inventaire du domicile et fournitures",
+      "supplyNames": {
+        "laundryDetergent": "Lessive",
+        "dishSoap": "Liquide vaisselle",
+        "paperProducts": "Produits en papier",
+        "floorCleaner": "Nettoyant pour sols"
+      },
+      "stockLevels": {
+        "title": "Niveaux de stock des fournitures (estimés)",
+        "daysRemaining": "~{count} jours"
+      },
+      "eco": {
+        "title": "Score écoresponsable",
+        "productsWithEcoLabels": "{count} produits avec des écolabels",
+        "recyclablePackaging": "{count} produit avec emballage recyclable",
+        "tip": "Tip: Eco alternatives enregistrer 2kg plastic/year"
+      },
+      "bulk": {
+        "title": "Économies sur achats en gros",
+        "description": "Un bidon de 5L vs 2L permet d’économiser 18% ({amount}/an)"
+      }
+    },
+    "nutritionCard": {
+      "title": "Vue d’ensemble nutritionnelle",
+      "score": {
+        "title": "Score d’équilibre alimentaire",
+        "excellent": "Très bon",
+        "good": "Bon",
+        "fair": "Moyen",
+        "needsWork": "À améliorer"
+      },
+      "composition": {
+        "title": "Composition de votre panier",
+        "wholeFoods": "Aliments complets",
+        "processed": "Transformés",
+        "dairyOther": "Produits laitiers/Autre"
+      },
+      "foodGroups": {
+        "fruits": "Fruits frais",
+        "vegetables": "Légumes",
+        "protein": "Protéines",
+        "grains": "Céréales",
+        "itemsCount": "{count} article(s)"
+      },
+      "allergens": {
+        "title": "Allergènes détectés",
+        "foundInItems": "Trouvé dans {count} article(s)"
+      },
+      "suggestions": {
+        "addFruitsAndVegetables": "Ajoutez davantage de fruits et légumes pour équilibrer votre panier",
+        "addVegetables": "Pensez à ajouter des légumes pour une alimentation plus équilibrée",
+        "addFruits": "Ajouter des fruits améliorerait l’équilibre nutritionnel",
+        "swapProcessed": "Essayez de remplacer certains produits transformés par des aliments complets",
+        "greatBalance": "Excellent équilibre d’achats !"
+      }
+    },
+    "vehicleCard": {
+      "title": "Analyse des dépenses du véhicule",
+      "expenseType": "Type de dépense : Carburant",
+      "details": {
+        "liters": "Litres",
+        "pricePerLiter": "Prix/L",
+        "station": "Station-service",
+        "vehicle": "Véhicule",
+        "notSet": "Non défini"
+      },
+      "chart": {
+        "title": "Dépenses mensuelles en carburant",
+        "amount": "Montant"
+      },
+      "stats": {
+        "thisMonth": "Ce mois-ci",
+        "fillUps": "{count} pleins",
+        "costPerKm": "Coût/km",
+        "estimated": "estimé",
+        "fuelPrice": "Fuel Prix",
+        "thisMonthSuffix": "ce mois-ci"
+      },
+      "maintenance": {
+        "title": "Rappels d’entretien"
+      },
+      "tip": {
+        "title": "Le moins cher à proximité",
+        "perLiter": "L"
+      },
+      "buttons": {
+        "addVehicle": "Ajouter Véhicule",
+        "fullReport": "Rapport complet"
+      },
+      "months": {
+        "sep": "sept.",
+        "oct": "oct.",
+        "nov": "nov.",
+        "dec": "déc."
+      },
+      "reminders": {
+        "oilChange": "Vidange à prévoir dans ~1 200 km",
+        "tireRotation": "Rotation des pneus recommandée"
+      }
+    },
+    "invoiceCard": {
+      "title": "Détails de la facture",
+      "importantBadge": "IMPORTANT",
+      "markImportant": "Marquer comme important",
+      "tooltips": {
+        "unmarkFavorite": "Cliquer pour retirer des favoris",
+        "markFavorite": "Cliquer pour ajouter aux favoris"
+      },
+      "fromMerchant": "De {merchant}",
+      "descriptionPlaceholder": "Saisissez la description de la facture...",
+      "labels": {
+        "dateUtc": "Date et heure (UTC)",
+        "hours": "Heures",
+        "minutes": "Min",
+        "utc": "UTC",
+        "category": "Catégorie",
+        "paymentMethod": "Mode de paiement",
+        "totalAmount": "Montant total"
+      },
+      "placeholders": {
+        "selectCategory": "Sélectionner catégorie",
+        "selectPaymentType": "Sélectionner le type de paiement"
+      }
+    },
+    "merchantCard": {
+      "title": "Commerçant",
+      "noMerchantLinked": "Aucun commerçant lié à cette facture",
+      "addressLabel": "Adresse : {address}",
+      "buttons": {
+        "viewMerchantDetails": "Voir les détails du commerçant",
+        "viewAllReceipts": "Voir tous les reçus"
+      },
+      "tooltips": {
+        "viewMerchantDetails": "Voir des informations détaillées sur ce commerçant",
+        "viewAllReceipts": "Voir tous les reçus de ce commerçant"
+      }
+    },
+    "imageCard": {
+      "title": "Scan du reçu",
+      "dialogTitle": "Image du reçu",
+      "scanAlt": "Scan du reçu {index}",
+      "scanAltFullSize": "Scan du reçu {index} - taille réelle",
+      "buttons": {
+        "expand": "Agrandir l’image",
+        "previous": "Précédent",
+        "next": "Suivant",
+        "addScan": "Ajouter un scan",
+        "remove": "Supprimer"
+      },
+      "tooltips": {
+        "expand": "Voir l’image du reçu en taille réelle",
+        "previous": "Voir le scan précédent du reçu",
+        "next": "Voir le scan suivant du reçu",
+        "addScan": "Téléverser et joindre un nouveau scan du reçu",
+        "remove": "Supprimer le scan actuel du reçu"
+      },
+      "aria": {
+        "expandImage": "Cliquer pour agrandir l’image"
+      },
+      "titleWithIndex": "Scan du reçu ({current}/{total})",
+      "dialogTitleWithIndex": "Image du reçu ({current}/{total})"
+    },
+    "recipeCard": {
+      "complexity": {
+        "unknown": "Inconnu",
+        "easy": "Facile",
+        "normal": "Normal",
+        "hard": "Difficile"
+      },
+      "dropdown": {
+        "view": "Voir",
+        "edit": "Modifier",
+        "delete": "Supprimer",
+        "share": "Partager",
+        "markAsFavorite": "Marquer comme favori"
+      },
+      "ingredients": {
+        "label": "Ingrédients :",
+        "more": "+{count} de plus",
+        "additionalLabel": "Ingrédients supplémentaires :"
+      },
+      "timing": {
+        "prepLabel": "Prépa : {minutes}′",
+        "prepTooltip": "Le temps de préparation est de {minutes} minutes.",
+        "cookLabel": "Cuisson : {minutes}′",
+        "cookTooltip": "Le temps de cuisson est de {minutes} minutes."
+      },
+      "buttons": {
+        "visitReference": "Visiter la référence",
+        "viewRecipe": "Voir la recette"
+      }
+    },
+    "sharingCard": {
+      "title": "Partage",
+      "ownerAvatarAlt": "Utilisateur",
+      "owner": "Propriétaire",
+      "sharedWith": "Partagée avec",
+      "userWithId": "Utilisateur {id}",
+      "publicInvoice": {
+        "title": "Facture publique",
+        "description": "Cette facture est accessible publiquement. Toute personne disposant du lien peut la consulter."
+      },
+      "emptyShared": {
+        "public": "Aucun utilisateur supplémentaire n’a d’accès direct",
+        "private": "Non partagée"
+      },
+      "buttons": {
+        "manageSharing": "Gérer Partage",
+        "shareInvoice": "Partager Facture",
+        "revokingAccess": "Révocation de l’accès...",
+        "markAsPrivate": "Marquer comme privée"
+      },
+      "tooltips": {
+        "manageSharing": "Gérer les paramètres de partage de cette facture",
+        "removeAccess": "Supprimer l’accès",
+        "shareInvoice": "Partager cette facture avec d’autres utilisateurs",
+        "markAsPrivate": "Marquer la facture comme privée"
+      },
+      "toasts": {
+        "removeAccessComingSoon": {
+          "title": "La suppression d’accès sera bientôt disponible",
+          "description": "Cette fonctionnalité est en cours de développement."
+        },
+        "revoke": {
+          "loading": "Révocation de l’accès public...",
+          "success": "La facture est maintenant privée. Les liens existants ne fonctionneront plus.",
+          "error": "Échec du passage en privé : {message}"
+        }
+      }
+    }
+  },
+  "IMS--Common": {
+    "invoiceHeader": {
+      "tooltips": {
+        "importantInvoice": "Facture importante",
+        "edit": "Modifier cette facture",
+        "delete": "Supprimer définitivement cette facture",
+        "print": "Imprimer cette facture",
+        "saveAllPendingChanges": "Enregistrer toutes les modifications en attente",
+        "discardAllPendingChanges": "Annuler toutes les modifications en attente",
+        "printInvoiceWithAllDetails": "Imprimer cette facture avec tous les détails",
+        "analyzeSpendingPatterns": "Analyser les habitudes de dépenses de cette facture",
+        "deleteInvoicePermanently": "Supprimer cette facture définitivement",
+        "export": "Exporter les données de la facture dans différents formats"
+      },
+      "id": "ID : {id}",
+      "buttons": {
+        "edit": "Modifier",
+        "delete": "Supprimer",
+        "print": "Imprimer",
+        "save": "Enregistrer",
+        "saving": "Enregistrement...",
+        "discard": "Annuler",
+        "analyzeWithAi": "Analyser avec l'IA",
+        "export": "Exporter"
+      }
+    },
+    "statesNotFound": {
+      "title": "Facture Non Trouvée",
+      "description": "La facture avec l'identifiant {invoiceIdentifier} n'a pas été trouvée."
+    },
+    "statesLoading": {
+      "title": "Chargement de la Facture",
+      "description": "Chargement de la facture avec l'identifiant {invoiceIdentifier}."
+    },
+    "loadingInvoices": {
+      "title": "Chargement factures",
+      "description": "Chargement factures..."
+    },
+    "invoicesNotFound": {
+      "title": "Il manque quelque chose ici...",
+      "description": "Il semble que vous n’ayez aucune facture associée à votre compte. Veuillez téléverser des factures puis revenir plus tard.",
+      "cta": "Téléverser une facture ici."
+    },
+    "shortcuts": {
+      "title": "Raccourcis clavier",
+      "description": "Accès rapide aux actions courantes via votre clavier",
+      "openSearch": "Ouvrir la recherche",
+      "newInvoice": "Nouvelle facture",
+      "uploadScan": "Télécharger une numérisation",
+      "showHelp": "Afficher cette aide",
+      "closeDialog": "Fermer la boîte de dialogue",
+      "close": "Fermer"
+    },
+    "commandPalette": {
+      "placeholder": "Rechercher des factures, commerçants, articles...",
+      "noResults": "Aucun résultat trouvé",
+      "groups": {
+        "quickActions": "Actions rapides",
+        "recentInvoices": "Factures récentes",
+        "searchResults": "Résultats de recherche"
+      },
+      "actions": {
+        "uploadScans": "Télécharger des numérisations",
+        "createInvoice": "Créer une facture",
+        "viewStatistics": "Voir les statistiques",
+        "viewAll": "Voir toutes les factures"
+      }
+    },
+    "onboarding": {
+      "steps": {
+        "upload": {
+          "description": "Prenez une photo ou téléchargez un PDF de votre reçu. Notre système prend en charge plusieurs formats et peut traiter des lots de reçus en même temps.",
+          "title": "Téléchargez vos reçus"
+        },
+        "analyze": {
+          "description": "Notre système alimenté par l'IA extrait automatiquement les noms des commerçants, les dates, les montants et les articles de vos reçus avec une grande précision.",
+          "title": "L'IA extrait les détails"
+        },
+        "track": {
+          "description": "Consultez des analyses détaillées et des informations sur vos habitudes de dépenses. Comprenez où va votre argent grâce à des graphiques et rapports interactifs.",
+          "title": "Suivez vos dépenses"
+        }
+      },
+      "getStarted": "Commencer",
+      "stepOf": "Étape {current} sur {total}",
+      "next": "Suivant",
+      "skip": "Passer",
+      "back": "Retour",
+      "dontShowAgain": "Ne plus afficher"
+    },
+    "notifications": {
+      "timeAgo": {
+        "hours": "{count, plural, one {il y a # heure} other {il y a # heures}}",
+        "minutes": "{count, plural, one {il y a # minute} other {il y a # minutes}}",
+        "days": "{count, plural, one {il y a # jour} other {il y a # jours}}",
+        "now": "À l'instant"
+      },
+      "types": {
+        "invoiceCreated": "Facture créée",
+        "analysisComplete": "Analyse IA terminée",
+        "monthlyReport": "Rapport mensuel prêt"
+      },
+      "title": "Notifications",
+      "noNotifications": "Aucune notification pour le moment",
+      "markAllRead": "Tout marquer comme lu"
+    },
+    "preferences": {
+      "title": "Préférences de facturation",
+      "defaultView": "Vue par défaut",
+      "sortBy": "Trier par",
+      "pageSize": "Éléments par page",
+      "currency": "Devise",
+      "showStats": "Afficher les statistiques sur l'accueil",
+      "save": "Enregistrer les préférences",
+      "saved": "Préférences enregistrées avec succès",
+      "views": {
+        "table": "Vue tableau",
+        "grid": "Vue grille"
+      },
+      "sortOptions": {
+        "dateDesc": "Date (plus récente)",
+        "dateAsc": "Date (plus ancienne)",
+        "amountDesc": "Montant (décroissant)",
+        "amountAsc": "Montant (croissant)",
+        "nameAsc": "Nom (A à Z)"
+      }
+    },
+    "mobileNav": {
+      "profile": "Profil",
+      "ariaLabel": "Navigation mobile",
+      "home": "Accueil",
+      "scan": "Numériser",
+      "invoices": "Factures"
+    },
+    "workflowProgress": {
+      "upload": "Télécharger",
+      "review": "Vérifier",
+      "create": "Créer"
+    },
+    "unknownMerchant": "Commerçant inconnu"
+  },
+  "IMS--Create": {
+    "metadata": {
+      "title": "Système de gestion des factures - Créer une facture",
+      "description": "Créez une nouvelle facture à partir de vos numérisations téléchargées."
+    },
+    "navigation": {
+      "back": "Retour",
+      "next": "Suivant"
+    },
+    "emptyState": {
+      "title": "Aucune numérisation disponible",
+      "description": "Téléchargez d'abord des numérisations de reçus pour créer une facture.",
+      "uploadButton": "Télécharger des numérisations",
+      "viewScansButton": "Voir les numérisations"
+    },
+    "header": {
+      "backToInvoices": "Retour aux factures",
+      "title": "Créer une facture",
+      "subtitle": "Suivez les étapes ci-dessous pour créer une nouvelle facture à partir de vos numérisations"
+    },
+    "steps": {
+      "selectScans": "Sélectionner les numérisations",
+      "details": "Détails de la facture",
+      "review": "Vérifier et créer",
+      "selectScansDesc": "Choisir les numérisations de reçus",
+      "detailsDesc": "Remplir les informations de la facture",
+      "reviewDesc": "Confirmer et créer"
+    },
+    "scanSelector": {
+      "title": "Sélectionner les numérisations",
+      "subtitle": "Choisissez les numérisations qui correspondent à cette facture",
+      "selectedCount": "{count} sélectionnée(s)",
+      "clearAll": "Effacer",
+      "selectAll": "Tout sélectionner",
+      "noScans": "Aucune numérisation disponible",
+      "previous": "Précédent",
+      "next": "Suivant",
+      "scansCount": "scans"
+    },
+    "detailsForm": {
+      "title": "Détails de la facture",
+      "subtitle": "Renseignez les détails de votre nouvelle facture",
+      "fields": {
+        "name": {
+          "label": "Nom de la facture",
+          "placeholder": "ex. Courses hebdomadaires",
+          "hint": "Donnez un nom descriptif à votre facture"
+        },
+        "category": {
+          "label": "Catégorie",
+          "placeholder": "Sélectionner une catégorie",
+          "options": {
+            "notDefined": "Non catégorisé",
+            "grocery": "Épicerie",
+            "fastFood": "Restauration",
+            "homeCleaning": "Maison et entretien",
+            "carAuto": "Auto et véhicule",
+            "other": "Autre"
+          }
+        },
+        "paymentType": {
+          "label": "Mode de paiement",
+          "placeholder": "Sélectionner un mode de paiement",
+          "options": {
+            "unknown": "Inconnu",
+            "cash": "Espèces",
+            "card": "Carte",
+            "transfer": "Virement bancaire",
+            "mobilePayment": "Paiement mobile",
+            "voucher": "Bon d'achat",
+            "other": "Autre"
+          }
+        },
+        "transactionDate": {
+          "label": "Date de transaction"
+        },
+        "description": {
+          "label": "Description",
+          "placeholder": "Ajoutez des notes sur cette facture (facultatif)",
+          "hint": "Notes facultatives sur cet achat"
+        }
+      },
+      "scanPreview": {
+        "title": "Aperçu de la numérisation"
+      }
+    },
+    "reviewStep": {
+      "title": "Vérifier et créer",
+      "subtitle": "Vérifiez les détails de votre facture avant de la créer",
+      "categories": {
+        "notDefined": "Non catégorisé",
+        "grocery": "Épicerie",
+        "fastFood": "Restauration",
+        "homeCleaning": "Maison et entretien",
+        "carAuto": "Auto et véhicule",
+        "other": "Autre"
+      },
+      "paymentTypes": {
+        "unknown": "Inconnu",
+        "cash": "Espèces",
+        "card": "Carte",
+        "transfer": "Virement bancaire",
+        "mobilePayment": "Paiement mobile",
+        "voucher": "Bon d'achat",
+        "other": "Autre"
+      },
+      "sections": {
+        "scans": {
+          "title": "Numérisations"
+        },
+        "details": {
+          "title": "Détails de la facture",
+          "name": "Nom",
+          "category": "Catégorie",
+          "paymentType": "Mode de paiement",
+          "transactionDate": "Date de transaction",
+          "description": "Description"
+        }
+      },
+      "actions": {
+        "creating": "Création de la facture...",
+        "create": "Créer la facture",
+        "hint": "Ceci créera la facture et téléchargera les numérisations sélectionnées."
+      }
+    }
+  },
+  "IMS--Dialogs": {
+    "shareAnalyticsDialog": {
+      "title": "Partager Analytics",
+      "description": "Partagez vos analyses de dépenses pour {merchant} avec d’autres personnes.",
+      "tabs": {
+        "image": "Aperçu image",
+        "email": "E-mail"
+      },
+      "image": {
+        "description": "Téléchargez ou copiez le graphique d’analyses en image PNG afin de le partager ou de l’enregistrer.",
+        "previewPlaceholder": "Aperçu des analyses",
+        "download": "Télécharger le graphique",
+        "copyToClipboard": "Copier le graphique dans le presse-papiers"
+      },
+      "email": {
+        "description": "Envoyez les analyses à une adresse e-mail.",
+        "label": "E-mail address",
+        "placeholder": "nom@exemple.com",
+        "send": "Envoyer E-mail"
+      },
+      "toasts": {
+        "imageCopied": {
+          "title": "Image copiée !",
+          "description": "L’image des analyses a été copiée dans votre presse-papiers"
+        },
+        "emailSent": {
+          "title": "E-mail envoyé !",
+          "description": "Rapport d’analyses envoyé à {email}"
+        },
+        "imageSaved": {
+          "title": "Image enregistrée !",
+          "description": "Les analyses de dépenses pour {merchant} ont été téléchargées au format PNG"
+        }
+      }
+    },
+    "analyzeDialog": {
+      "header": {
+        "title": "Analyser la facture",
+        "description": "Configurer une analyse alimentée par IA pour la facture"
+      },
+      "options": {
+        "completeAnalysis": {
+          "title": "Analyse complète",
+          "description": "Analyse IA complète incluant toutes les données de la facture, les articles et les informations du commerçant.",
+          "estimatedTime": "2-3 min",
+          "features": {
+            "ocrExtraction": "Extraction OCR",
+            "itemCategorization": "Catégorisation des articles",
+            "merchantIdentification": "Identification du commerçant",
+            "priceAnalysis": "Analyse des prix",
+            "receiptValidation": "Validation du reçu"
+          }
+        },
+        "invoiceOnly": {
+          "title": "Données de facture uniquement",
+          "description": "Analyser les informations de base de la facture comme les totaux, dates et détails de paiement.",
+          "estimatedTime": "30-60 s",
+          "features": {
+            "totalExtraction": "Extraction du total",
+            "dateParsing": "Analyse des dates",
+            "paymentMethodDetection": "Détection du mode de paiement"
+          }
+        },
+        "itemsOnly": {
+          "title": "Analyse des articles",
+          "description": "Se concentrer sur l'extraction et la catégorisation des lignes d'articles de la facture.",
+          "estimatedTime": "1-2 min",
+          "features": {
+            "itemExtraction": "Extraction des articles",
+            "categoryAssignment": "Attribution des catégories",
+            "pricePerItem": "Prix par article",
+            "quantityDetection": "Détection des quantités"
+          }
+        },
+        "merchantOnly": {
+          "title": "Analyse du commerçant",
+          "description": "Identifier et analyser les informations du commerçant, y compris localisation et catégorie.",
+          "estimatedTime": "30-45 s",
+          "features": {
+            "merchantIdentification": "Identification du commerçant",
+            "locationExtraction": "Extraction de la localisation",
+            "businessCategory": "Catégorie commerciale",
+            "contactInfo": "Coordonnées"
+          }
+        }
+      },
+      "analysisSteps": {
+        "preparingDocument": "Préparation du document...",
+        "runningOcrExtraction": "Exécution de l'extraction OCR...",
+        "analyzingWithAi": "Analyse avec l'IA...",
+        "categorizingItems": "Catégorisation des articles...",
+        "finalizingResults": "Finalisation des résultats...",
+        "processing": "Traitement..."
+      },
+      "analyzing": {
+        "title": "Analyse de la facture",
+        "progressComplete": "{progress}% terminé"
+      },
+      "sections": {
+        "analysisType": "Type d'analyse",
+        "includedFeatures": "Fonctionnalités incluses",
+        "enhancementsOptional": "Améliorations (optionnel)"
+      },
+      "enhancements": {
+        "priceComparison": {
+          "label": "Comparaison des prix",
+          "description": "Comparer les prix avec les données historiques"
+        },
+        "savingsTips": {
+          "label": "Suggestions d'économies",
+          "description": "Obtenir des recommandations d'économies par IA"
+        },
+        "quickExtract": {
+          "label": "Mode extraction rapide",
+          "description": "Prioriser la vitesse plutôt que la précision"
+        }
+      },
+      "badges": {
+        "recommended": "Recommandé"
+      },
+      "summary": {
+        "enhancementsSelected": "+ {count} amélioration(s)",
+        "noEnhancementsSelected": "Aucune amélioration sélectionnée",
+        "estimatedTime": "Durée estimée"
+      },
+      "buttons": {
+        "cancel": "Annuler",
+        "analyzing": "Analyse en cours...",
+        "startAnalysis": "Démarrer l'analyse"
+      },
+      "toasts": {
+        "analysisComplete": {
+          "title": "Analyse terminée",
+          "description": "Votre facture a été analysée avec succès."
+        },
+        "analysisFailed": {
+          "title": "Échec de l'analyse",
+          "description": "Nous n'avons pas pu analyser votre facture. Veuillez réessayer."
+        }
+      }
+    },
+    "addScanDialog": {
+      "title": "Ajouter un nouveau scan",
+      "description": "Téléversez une nouvelle image ou un nouveau document de reçu à joindre à cette facture.",
+      "dropzone": {
+        "dropHere": "Déposez le fichier ici...",
+        "dragAndDrop": "Glissez-déposez un fichier ici",
+        "orClickBrowse": "ou cliquez pour parcourir",
+        "formats": "JPEG, PNG, PDF (max 10 Mo)"
+      },
+      "scanType": {
+        "label": "Type de scan",
+        "placeholder": "Sélectionnez le type de scan",
+        "jpeg": "Image JPEG",
+        "png": "Image PNG",
+        "pdf": "Document PDF",
+        "other": "Autre"
+      },
+      "buttons": {
+        "cancel": "Annuler",
+        "uploading": "Téléversement...",
+        "upload": "Téléverser le scan"
+      },
+      "errors": {
+        "uploadStorageFailed": "Échec du téléversement du scan dans le stockage",
+        "unknown": "Une erreur inconnue est survenue"
+      },
+      "toasts": {
+        "fileTooLargeTitle": "Fichier trop volumineux",
+        "fileTooLargeDescription": "La taille maximale du fichier est de 10 Mo",
+        "scanAddedTitle": "Scan ajouté avec succès",
+        "scanAddedDescription": "Le scan a été joint à la facture",
+        "scanFailedTitle": "Échec de l’ajout du scan"
+      },
+      "console": {
+        "uploadError": "Erreur lors du téléversement du scan :"
+      }
+    },
+    "imageDialog": {
+      "title": "Aperçu ({image})",
+      "imageAlt": "Photo du reçu"
+    },
+    "itemsDialog": {
+      "title": "Modifier facture articles",
+      "description": "Mettez à jour les quantités, les prix ou ajoutez de nouveaux articles à cette facture",
+      "table": {
+        "item": "Article",
+        "quantity": "Quantité",
+        "unit": "Unité",
+        "price": "Prix",
+        "total": "Somme",
+        "actions": "Opérations"
+      },
+      "footer": {
+        "itemsFound": "{total} articles trouvés (affichage de {shown})",
+        "page": "Page {current} sur {total}",
+        "itemsTotal": "{count, plural, one {# article au total} other {# articles au total}}"
+      },
+      "buttons": {
+        "previous": "Précédent",
+        "next": "Suivant",
+        "addItem": "Ajouter article",
+        "cancel": "Annuler",
+        "saveChanges": "Enregistrer changes"
+      },
+      "aria": {
+        "deleteItem": "Supprimer article: {name}",
+        "unnamedItem": "unnamed article",
+        "previousPage": "Aller à la page précédente (page {page})",
+        "nextPage": "Aller à la page suivante (page {page})",
+        "addItem": "Ajouter un nouvel article à la facture",
+        "cancel": "Annuler la modification et fermer la boîte de dialogue",
+        "save": "Enregistrer les modifications des articles de la facture"
+      }
+    },
+    "merchantDialog": {
+      "title": "Détails du commerçant",
+      "noMerchantLinked": "Aucun commerçant lié à cette facture",
+      "description": "Informations sur {merchantName}",
+      "fields": {
+        "address": "Adresse",
+        "phone": "Téléphone",
+        "parentCompany": "Société mère"
+      },
+      "buttons": {
+        "openInMaps": "Ouvrir dans Maps"
+      }
+    },
+    "feedbackDialog": {
+      "title": "Donner un retour",
+      "description": "Aidez-nous à améliorer les analyses pour {merchant} en partageant votre avis",
+      "sections": {
+        "rating": "Comment évalueriez-vous les analyses ?",
+        "features": "Quelles fonctionnalités ont été les plus utiles ? (Sélectionnez toutes les réponses pertinentes)",
+        "comments": "Commentaires supplémentaires (facultatifs)"
+      },
+      "features": {
+        "spendingTrends": "Tendances de dépenses",
+        "priceComparisons": "Prix Comparisons",
+        "savingsTips": "Conseils d’économie",
+        "merchantAnalysis": "Merchant Analyse",
+        "visualCharts": "Graphiques visuels",
+        "categoryBreakdown": "Catégorie Breakdown"
+      },
+      "commentsPlaceholder": "Partagez vos impressions sur les analyses...",
+      "buttons": {
+        "cancel": "Annuler",
+        "submit": "Envoyer le retour"
+      },
+      "toasts": {
+        "sending": {
+          "title": "Envoi du retour...",
+          "description": "Veuillez patienter pendant l’envoi de votre retour."
+        },
+        "ratingRequired": {
+          "title": "Note requise",
+          "description": "Veuillez attribuer une note en étoiles avant l’envoi"
+        },
+        "success": {
+          "title": "Retour envoyé !",
+          "description": "Retour envoyé avec succès"
+        },
+        "error": {
+          "title": "Une erreur est survenue lors de l’envoi du retour",
+          "description": "Veuillez réessayer plus tard."
+        }
+      }
+    },
+    "metadataDialog": {
+      "add": {
+        "title": "Ajouter des métadonnées",
+        "description": "Ajouter des informations supplémentaires à cette facture"
+      },
+      "edit": {
+        "title": "Modifier les métadonnées",
+        "description": "Mettre à jour la valeur de ce champ de métadonnées",
+        "fieldLabel": "Champ de métadonnées"
+      },
+      "delete": {
+        "title": "Supprimer les métadonnées",
+        "description": "Êtes-vous sûr de vouloir supprimer ces métadonnées ?"
+      },
+      "fields": {
+        "keyLabel": "Clé de métadonnées",
+        "valueLabel": "Valeur de métadonnées",
+        "keyPlaceholder": "Saisir la clé",
+        "valuePlaceholder": "Saisir la valeur"
+      },
+      "buttons": {
+        "cancel": "Annuler",
+        "save": "Enregistrer",
+        "delete": "Supprimer"
+      }
+    },
+    "recipeDialog": {
+      "create": {
+        "title": "Ajouter une nouvelle recette",
+        "description": "Remplissez les détails pour créer une recette."
+      },
+      "read": {
+        "description": "Détails de la recette et instructions de préparation",
+        "noDescription": "Aucune description fournie.",
+        "notSpecified": "Non spécifié"
+      },
+      "update": {
+        "title": "Mettre à jour la recette",
+        "description": "Mettre à jour les détails de la recette."
+      },
+      "delete": {
+        "title": "Êtes-vous sûr ?",
+        "description": "Cette action est irréversible. Cela supprimera définitivement la recette <strong>{name}</strong> et toutes ses données associées."
+      },
+      "fields": {
+        "recipeName": "Nom de la recette",
+        "description": "Présentation",
+        "ingredients": "Ingrédients",
+        "difficulty": "Niveau de difficulté",
+        "complexity": "Niveau de complexité",
+        "instructions": "Étapes",
+        "prepTime": "Temps de préparation",
+        "cookTime": "Temps de cuisson"
+      },
+      "actions": {
+        "generateName": "Générer un nom",
+        "enhanceInstructions": "Améliorer les instructions"
+      },
+      "tooltips": {
+        "generateName": "Générer un nom de recette selon vos ingrédients et votre niveau de difficulté avec l’AI",
+        "enhanceInstructions": "Utiliser l’AI pour enrichir vos instructions avec davantage de détails"
+      },
+      "placeholders": {
+        "recipeName": "Saisir le nom de la recette",
+        "description": "Saisissez une brève description de la recette",
+        "selectDifficulty": "Sélectionner la difficulté",
+        "instructions": "Saisir les instructions de cuisson",
+        "prepTime": "ex. 15 minutes",
+        "cookTime": "ex. 30 minutes"
+      },
+      "difficulty": {
+        "easy": "Facile",
+        "medium": "Moyen",
+        "hard": "Difficile"
+      },
+      "buttons": {
+        "add": "Ajouter",
+        "cancel": "Annuler",
+        "save": "Enregistrer",
+        "close": "Fermer",
+        "delete": "Supprimer"
+      }
+    },
+    "merchantReceiptsDialog": {
+      "title": "Tous les reçus de {merchant}",
+      "description": "Voir et filtrer tous vos reçus de ce commerçant",
+      "searchPlaceholder": "Rechercher receipts...",
+      "filters": {
+        "date": "Date",
+        "sort": "Tri"
+      },
+      "dateOptions": {
+        "allTime": "Toute la période",
+        "last30Days": "30 derniers jours",
+        "last90Days": "90 derniers jours",
+        "thisYear": "Cette année"
+      },
+      "sortOptions": {
+        "newest": "Plus récents d’abord",
+        "oldest": "Plus anciens d’abord"
+      },
+      "table": {
+        "receipt": "Reçu",
+        "date": "Date",
+        "itemsCount": "Articles #",
+        "actions": "Opérations",
+        "view": "Voir"
+      },
+      "footer": {
+        "receiptsFound": "{count} reçus trouvés (affichage de {showing})",
+        "page": "Page {current} sur {total}"
+      },
+      "buttons": {
+        "previous": "Précédent",
+        "next": "Suivant"
+      }
+    },
+    "removeScanDialog": {
+      "title": "Supprimer scan",
+      "description": "Êtes-vous sûr de vouloir supprimer le scan {current} sur {total} ?",
+      "descriptionLastScan": "C’est le seul scan joint à cette facture. Vous ne pouvez pas le supprimer.",
+      "scanAlt": "Numérisation {index}",
+      "scanCaption": "Numérisation {index}",
+      "warning": {
+        "title": "Impossible de supprimer le dernier scan",
+        "description": "Chaque facture doit avoir au moins un scan joint. Ajoutez un autre scan avant de supprimer celui-ci."
+      },
+      "buttons": {
+        "cancel": "Annuler",
+        "removing": "Suppression...",
+        "remove": "Supprimer le scan"
+      },
+      "toasts": {
+        "cannotDeleteLastTitle": "Impossible de supprimer le dernier scan",
+        "cannotDeleteLastDescription": "Une facture doit avoir au moins un scan joint",
+        "removedTitle": "Scan supprimé avec succès",
+        "removedDescription": "Le scan a été retiré de la facture",
+        "removeFailedTitle": "Échec de la suppression du scan"
+      },
+      "errors": {
+        "unknown": "Une erreur inconnue est survenue"
+      },
+      "console": {
+        "deleteError": "Erreur suppression de scan:"
+      }
+    },
+    "allergenDialog": {
+      "labels": {
+        "currentAllergens": "Allergènes actuels",
+        "customAllergen": "Ajouter un allergène personnalisé",
+        "quickAdd": "Ajout rapide d'allergènes courants"
+      },
+      "title": "Modifier les allergènes",
+      "success": {
+        "added": "Allergène ajouté : {name}",
+        "saved": "Allergènes mis à jour avec succès",
+        "removed": "Allergène retiré : {name}"
+      },
+      "buttons": {
+        "save": "Enregistrer les modifications",
+        "saving": "Enregistrement...",
+        "cancel": "Annuler",
+        "add": "Ajouter"
+      },
+      "defaultDescription": "Contient {name}",
+      "aria": {
+        "removeAllergen": "Retirer l'allergène {name}"
+      },
+      "placeholders": {
+        "customAllergen": "Entrez le nom de l'allergène..."
+      },
+      "empty": {
+        "noAllergens": "Aucun allergène détecté"
+      },
+      "description": "Gérer les allergènes pour {productName}",
+      "errors": {
+        "emptyName": "Le nom de l'allergène ne peut pas être vide",
+        "duplicate": "L'allergène « {name} » a déjà été ajouté",
+        "missingData": "Données de produit manquantes",
+        "saveFailed": "Échec de l'enregistrement des allergènes"
+      }
+    },
+    "bulkCategoryDialog": {
+      "errors": {
+        "saveFailed": "Échec de la mise à jour des catégories",
+        "missingData": "Données manquantes",
+        "noProducts": "Aucun produit sélectionné",
+        "allFailed": "Echec de la mise a jour de tous les produits"
+      },
+      "success": {
+        "saved": "{count, plural, one {Catégorie mise à jour pour # produit} other {Catégorie mise à jour pour # produits}}",
+        "partialSuccess": "{success} produits mis a jour, {failed} echoues"
+      },
+      "description": "{count, plural, one {Changer la catégorie pour # produit} other {Changer la catégorie pour # produits}}",
+      "buttons": {
+        "save": "Appliquer à tous",
+        "saving": "Enregistrement...",
+        "cancel": "Annuler"
+      },
+      "labels": {
+        "andMore": "...et {count} de plus",
+        "newCategory": "Nouvelle catégorie",
+        "selectedProducts": "Produits sélectionnés",
+        "progress": "Progression"
+      },
+      "placeholders": {
+        "selectCategory": "Sélectionner une catégorie"
+      },
+      "title": "Changer de catégorie",
+      "progress": {
+        "updating": "Mise a jour {current} sur {total}..."
+      }
+    },
+    "exportDialog": {
+      "title": "Exporter des factures",
+      "description": "Exporter {count} factures dans le format de votre choix.",
+      "format": {
+        "title": "Format d’export",
+        "labels": {
+          "csv": "CSV",
+          "json": "JSON",
+          "pdf": "PDF"
+        },
+        "descriptions": {
+          "json": "Format de données structurées",
+          "csv": "Format tableur, compatible avec Excel",
+          "pdf": "Format de document imprimable"
+        }
+      },
+      "options": {
+        "title": "Paramètres",
+        "includeMetadata": "Inclure les métadonnées",
+        "includeProducts": "Inclure les produits",
+        "includeMerchant": "Inclure le commerçant",
+        "csv": {
+          "includeHeaders": "Inclure les en-têtes CSV",
+          "delimiterLabel": "Séparateur CSV personnalisé (facultatif) :",
+          "delimiterPlaceholder": ","
+        },
+        "json": {
+          "prettyPrint": "Formatage lisible (2 espaces)"
+        }
+      },
+      "buttons": {
+        "cancel": "Annuler",
+        "export": "Exporter",
+        "copy": "Copier dans le presse-papiers",
+        "copied": "Copié !"
+      },
+      "filename": {
+        "hint": "Le fichier sera enregistré avec l'extension basée sur le format",
+        "label": "Nom du fichier"
+      },
+      "estimate": {
+        "label": "Taille estimée du fichier :"
+      }
+    },
+    "importDialog": {
+      "title": "Importer des factures",
+      "description": "Téléversez vos fichiers de factures pour les importer dans le système.",
+      "tabs": {
+        "csv": "CSV",
+        "pdf": "PDF",
+        "xlsx": "Excel"
+      },
+      "dropzone": {
+        "dropHere": "Déposez les fichiers ici...",
+        "dragAndDrop": "Glissez-déposez les fichiers ici",
+        "orClickBrowse": "ou cliquez pour parcourir les fichiers",
+        "acceptsCsv": "Accepte les fichiers .csv (max 10 Mo)",
+        "acceptsPdf": "Accepte les fichiers .pdf (max 10 Mo)",
+        "acceptsXlsx": "Accepte les fichiers .xlsx et .xls (max. 10 Mo)"
+      },
+      "selectedFiles": "Fichiers sélectionnés",
+      "remove": "Supprimer",
+      "status": {
+        "success": "Fichiers importés avec succès !",
+        "error": "Erreur lors de l’import des fichiers. Veuillez réessayer."
+      },
+      "buttons": {
+        "cancel": "Annuler",
+        "import": "Importer",
+        "importWithCount": "Importer ({count})"
+      }
+    },
+    "shareInvoiceDialog": {
+      "title": "Partager facture",
+      "selection": {
+        "description": "Choisissez comment vous souhaitez partager cette facture. Votre choix détermine qui peut y accéder.",
+        "publicTitle": "Partage publique",
+        "publicDescription": "Générez un lien ou un code QR que <strong>n’importe qui</strong> peut utiliser pour voir cette facture.",
+        "privateTitle": "Privé sharing",
+        "privateDescription": "Envoyez une invitation par e-mail à une <strong>personne spécifique</strong>. Seule cette personne aura accès.",
+        "privacyNoticeTitle": "Avis de confidentialité",
+        "privacyNoticeDescription": "Les liens publics sont accessibles à toute personne disposant de l’URL. Le partage privé limite l’accès au destinataire spécifié."
+      },
+      "dialogDescription": {
+        "currentlyPublic": "\"{invoiceName}\" est actuellement publique",
+        "selection": "Choisissez comment partager « {invoiceName} »",
+        "public": "Partager \"{invoiceName}\" publiquement",
+        "private": "Envoyer \"{invoiceName}\" en privé"
+      },
+      "toasts": {
+        "copyLink": {
+          "loadingPublic": "Copie du lien...",
+          "loadingMakePublic": "La facture devient publique...",
+          "successPublic": "Lien copié dans le presse-papiers !",
+          "successMadePublic": "La facture est maintenant publique ! Lien copié dans le presse-papiers.",
+          "error": "Échoué: {message}"
+        },
+        "copyQr": {
+          "loadingPublic": "Copie du code QR...",
+          "loadingMakePublic": "La facture devient publique...",
+          "successPublic": "Code QR copié dans le presse-papiers !",
+          "successMadePublic": "La facture est maintenant publique ! Code QR copié dans le presse-papiers.",
+          "error": "Échoué: {message}"
+        },
+        "sendEmail": {
+          "loading": "Envoi de l’invitation à {email}...",
+          "success": "Invitation envoyée à {email} !",
+          "error": "Échoué: {message}",
+          "comingSoon": "Le partage par e-mail arrive bientôt"
+        },
+        "revoke": {
+          "loading": "Envoi de la demande de révocation au serveur...",
+          "success": "La facture est maintenant privée. Les liens existants ne fonctionneront plus.",
+          "error": "Échec de la révocation de l’accès : {message}"
+        }
+      },
+      "errors": {
+        "qrNotFound": "Élément de code QR introuvable"
+      }
+    },
+    "shareInvoiceDialogPublic": {
+      "tabs": {
+        "directLink": "Lien direct",
+        "qrCode": "Code QR"
+      },
+      "hints": {
+        "link": "Copiez ce lien et partagez-le. Toute personne qui le reçoit pourra consulter la facture.",
+        "qr": "Toute personne qui scanne ce QR code sera redirigée pour consulter la facture."
+      },
+      "copyQrImage": "Copier le code QR en tant qu’image",
+      "alreadyPublic": {
+        "title": "Cette facture est actuellement publique",
+        "description": "Cette facture est accessible publiquement. <strong>Toute personne disposant du lien peut la consulter</strong>, y compris tous les détails de la facture, les articles et les montants. Vous pouvez révoquer l’accès public à tout moment pour la rendre privée à nouveau.",
+        "revoke": "Révoquer l’accès public",
+        "revoking": "Révocation de l’accès...",
+        "revokeHint": "Cela rendra la facture privée. Les liens existants cesseront de fonctionner."
+      },
+      "backToOptions": "Retour aux options",
+      "warning": {
+        "title": "Avertissement d’accès public",
+        "description": "En partageant cette facture publiquement, <strong>toute personne disposant du lien pourra la consulter</strong>. Cela inclut tous les détails de la facture, les articles et les montants. Continuez uniquement si vous souhaitez rendre cette facture accessible au publique."
+      }
+    },
+    "shareInvoiceDialogPrivate": {
+      "backToOptions": "Retour aux options",
+      "title": "Privé sharing",
+      "description": "L’invitation sera envoyée directement à l’adresse e-mail que vous indiquez. Seul ce destinataire recevra l’accès pour consulter la facture.",
+      "emailLabel": "Recipient's e-mail address",
+      "emailPlaceholder": "nom@exemple.com",
+      "emailHint": "Une invitation par e-mail sera envoyée à cette adresse avec un lien privé pour consulter la facture.",
+      "sendInvitation": "Envoyer une invitation privée",
+      "sending": "Envoi de l'invitation...",
+      "comingSoonTooltip": "La fonction de partage par e-mail sera bientôt disponible"
+    },
+    "deleteInvoiceDialog": {
+      "title": "Supprimer facture",
+      "description": "Cette action est irréversible. Veuillez vérifier attentivement avant de continuer.",
+      "deleting": {
+        "title": "Suppression de facture...",
+        "description": "Veuillez patienter pendant que nous supprimons toutes les données associées."
+      },
+      "impact": {
+        "title": "Suppression définitive",
+        "intro": "Les données suivantes seront supprimées définitivement :",
+        "invoiceRecord": "Enregistrement de facture et métadonnées",
+        "uploadedScans": "{count} scan(s) téléversé(s)",
+        "lineItems": "{count} line article(s)",
+        "sharedAccess": "Accès partagé pour {count} utilisateur(s)"
+      },
+      "confirmation": {
+        "typeToConfirm": "Tapez <highlight>{name}</highlight> pour confirmer :",
+        "understoodLabel": "Je comprends que cette action est définitive",
+        "understoodDescription": "Cette facture et toutes ses données seront définitivement supprimées et ne pourront pas être récupérées."
+      },
+      "buttons": {
+        "cancel": "Annuler",
+        "deleting": "Suppression...",
+        "deletePermanently": "Supprimer définitivement"
+      },
+      "toasts": {
+        "deletedTitle": "Facture supprimée",
+        "deletedDescription": "La facture a été supprimée avec succès.",
+        "deleteFailedTitle": "Supprimer échoué",
+        "deleteFailedDescription": "Nous n’avons pas pu supprimer cette facture. Veuillez réessayer."
+      },
+      "console": {
+        "deleteError": "Erreur suppression de facture:"
+      }
+    },
+    "createInvoiceDialog": {
+      "title": "Créer une Facture",
+      "titlePlural": "Créer des Factures",
+      "description": "Transformez vos scans en données de facture structurées grâce à l'extraction alimentée par l'IA.",
+      "selectedScans": "Scans Sélectionnés",
+      "totalSize": "total",
+      "chooseMode": "Choisir le Mode de Création",
+      "singleMode": {
+        "title": "Une facture par scan",
+        "description": "Crée {count} factures séparées. Idéal lorsque chaque scan est un reçu différent."
+      },
+      "batchMode": {
+        "title": "Combiner en une seule facture",
+        "description": "Crée 1 facture avec les {count} scans attachés. Idéal pour les reçus multi-pages."
+      },
+      "singleScanInfo": {
+        "title": "Que se passe-t-il ensuite ?",
+        "description": "Notre IA analysera votre scan et extraira automatiquement les détails du commerçant, les articles, les prix et les totaux. Vous pourrez examiner et modifier les résultats par la suite."
+      },
+      "buttons": {
+        "cancel": "Annuler",
+        "createSingle": "Créer une Facture",
+        "createMultiple": "Créer {count} Factures",
+        "close": "Fermer"
+      },
+      "creating": {
+        "title": "Création de Votre Facture",
+        "titlePlural": "Création de Vos Factures",
+        "processing": "Traitement de {count} scan...",
+        "processingPlural": "Traitement de {count} scans...",
+        "step1Title": "Téléchargement des scans",
+        "step1Description": "Envoi de vos scans vers nos serveurs",
+        "step2Title": "Création des enregistrements de factures",
+        "step2Description": "Configuration des structures de données de factures",
+        "step3Title": "Finalisation",
+        "step3Description": "Préparation des factures pour la visualisation"
+      },
+      "complete": {
+        "title": "{count} Facture Créée !",
+        "titlePlural": "{count} Factures Créées !",
+        "description": "Votre facture est prête à être consultée et modifiée.",
+        "descriptionPlural": "Vos factures sont prêtes à être consultées et modifiées.",
+        "nextSteps": "Prochaines étapes :",
+        "nextStepsDescription": "Examinez votre facture, vérifiez les données extraites et effectuez les modifications nécessaires. Vous pouvez également demander une analyse IA pour des informations sur vos dépenses.",
+        "nextStepsDescriptionPlural": "Examinez vos factures, vérifiez les données extraites et effectuez les modifications nécessaires. Vous pouvez également demander une analyse IA pour des informations sur vos dépenses.",
+        "viewButton": "Voir la Facture",
+        "viewButtonPlural": "Voir les Factures",
+        "failureTitle": "Échec de la création",
+        "failureDescription": "Nous n'avons pas pu créer de factures. Veuillez vérifier les erreurs ci-dessous et réessayer.",
+        "partialTitle": "{created} factures créées sur {total}",
+        "partialDescription": "Certains scans n'ont pas pu être traités. Les factures créées avec succès sont prêtes à être consultées.",
+        "errorsLabel": "Scans échoués :",
+        "retryButton": "Réessayer"
+      },
+      "errors": {
+        "partialFail": "Échec de la création de {count} facture(s)",
+        "createFailed": "Échec de la création des factures : {message}",
+        "unknown": "Erreur inconnue"
+      }
+    }
+  },
+  "IMS--Edit": {
+    "metadata": {
+      "description": "Consultez et modifiez les détails de votre facture, les articles, les recettes et les paramètres de partage.",
+      "title": "Système de Gestion des Factures - Modifier la Facture"
+    },
+    "editInvoiceContext": {
+      "toasts": {
+        "noChanges": "Aucune modification à enregistrer",
+        "updated": "Facture mise à jour avec succès",
+        "saveFailed": "Échec de l’enregistrement des modifications"
+      },
+      "console": {
+        "saveFailed": "Échec de l’enregistrement de la facture :"
+      }
+    },
+    "triviaTips": {
+      "title": "Astuces économies",
+      "completeness": "La facture est complète à {percentage}%",
+      "completeLabel": "La facture est entièrement complète !",
+      "difficulty": {
+        "easy": "Facile",
+        "medium": "Moyen"
+      },
+      "banner": {
+        "potentialSavingsLabel": "Économies potentielles",
+        "hint": "Appliquez ces astuces pour économiser lors de votre prochaine visite chez {merchantName}"
+      },
+      "contextTips": {
+        "noItems": "Lancez l'analyse IA pour extraire les articles de votre reçu",
+        "noDescription": "Ajoutez une description pour vous souvenir de cet achat",
+        "noCategory": "Définissez une catégorie pour suivre vos habitudes de dépenses",
+        "defaultCategory": "Changez la catégorie de « Non catégorisé » pour un meilleur suivi",
+        "noRecipes": "L'IA peut suggérer des recettes basées sur vos articles d'épicerie"
+      },
+      "contextActions": {
+        "analyze": "Lancer l'analyse",
+        "addDescription": "Ajouter une description",
+        "setCategory": "Définir la catégorie"
+      },
+      "tips": {
+        "loyaltyProgram": {
+          "title": "Rejoindre le programme fidélité",
+          "description": "Inscrivez-vous au programme fidélité de {merchantName} pour gagner des points à chaque achat."
+        },
+        "bulkPurchase": {
+          "title": "Acheter en gros",
+          "description": "Achetez les produits non périssables en gros pour réduire le coût unitaire."
+        },
+        "digitalCoupons": {
+          "title": "Utiliser des coupons numériques",
+          "description": "Consultez l'application de {merchantName} pour des coupons numériques avant vos achats."
+        }
+      },
+      "tooltips": {
+        "estimatedSavings": "Économies estimées avec cette astuce"
+      },
+      "buttons": {
+        "viewMoreSavingsTips": "Voir plus d'astuces économies"
+      },
+      "disclaimer": "Les économies sont des estimations basées sur les prix et promotions moyens"
+    },
+    "recipesTab": {
+      "header": {
+        "title": "Recettes que vous pouvez préparer",
+        "description": "Basé sur les articles de cette facture"
+      },
+      "buttons": {
+        "generate": "Générer",
+        "addRecipe": "Ajouter une recette",
+        "createFirstRecipe": "Créer votre première recette"
+      },
+      "tooltips": {
+        "generateRecipeUsingAi": "Générer une recette avec l'IA !",
+        "createRecipeWithIngredients": "Créer une nouvelle recette avec ces ingrédients"
+      },
+      "emptyState": {
+        "noRecipesAvailable": "Aucune recette disponible pour le moment"
+      },
+      "pagination": {
+        "previous": "Précédent",
+        "next": "Suivant",
+        "pageOf": "Page {currentPage} sur {totalPages}"
+      },
+      "toasts": {
+        "aiGenerationComingSoon": {
+          "title": "La génération de recettes par IA arrive bientôt",
+          "description": "Cette fonctionnalité est en cours de développement."
+        }
+      }
+    },
+    "metadataTab": {
+      "header": {
+        "title": "Informations supplémentaires",
+        "description": "Métadonnées associées à cette facture"
+      },
+      "buttons": {
+        "addField": "Ajouter un champ",
+        "addFirstMetadataField": "Ajouter votre premier champ de métadonnées"
+      },
+      "tooltips": {
+        "addCustomMetadata": "Ajouter des métadonnées personnalisées à cette facture"
+      },
+      "badges": {
+        "readonly": "Lecture seule"
+      },
+      "dropdown": {
+        "edit": "Modifier",
+        "delete": "Supprimer"
+      },
+      "emptyState": {
+        "noMetadataFields": "Aucun champ de métadonnées ajouté"
+      }
+    },
+    "itemsTable": {
+      "title": "Articles",
+      "buttons": {
+        "editItems": "Modifier les articles",
+        "addItem": "Ajouter un article"
+      },
+      "tooltips": {
+        "editInvoiceItemsAndQuantities": "Modifier les articles et les quantités de la facture"
+      },
+      "columns": {
+        "selectAll": "Tout sélectionner",
+        "selectRow": "Sélectionner {name}",
+        "name": "Nom",
+        "quantity": "Quantité",
+        "price": "Prix",
+        "unit": "Unité",
+        "total": "Total",
+        "actions": "Actions"
+      },
+      "tableHeaders": {
+        "item": "Article",
+        "quantity": "Qté",
+        "price": "Prix",
+        "total": "Total"
+      },
+      "footer": {
+        "total": "Total"
+      },
+      "pagination": {
+        "totalItems": "{count, plural, one {# article au total} other {# articles au total}}",
+        "previous": "Précédent",
+        "next": "Suivant",
+        "pageOf": "Page {currentPage} sur {totalPages}"
+      },
+      "search": {
+        "placeholder": "Rechercher des articles..."
+      },
+      "bulkToolbar": {
+        "selectedCount": "{count, plural, one {# article sélectionné} other {# articles sélectionnés}}",
+        "deleteSelected": "Supprimer la sélection",
+        "changeCategory": "Changer de catégorie",
+        "noSelection": "Aucun produit sélectionné"
+      },
+      "editing": {
+        "saved": "Article mis à jour avec succès",
+        "cancel": "Modification annulée",
+        "fieldLabel": "Modifier {field} pour {name}"
+      },
+      "deleteConfirm": {
+        "title": "Supprimer les articles",
+        "description": "{count, plural, one {Êtes-vous sûr de vouloir supprimer cet article ?} other {Êtes-vous sûr de vouloir supprimer # articles ?}}",
+        "confirm": "Supprimer",
+        "cancel": "Annuler",
+        "success": "{count, plural, one {# article supprimé} other {# articles supprimés}}"
+      },
+      "newItem": {
+        "defaultName": "Nouvel article",
+        "added": "Nouvel article ajouté"
+      },
+      "indicators": {
+        "uncategorized": "Non catégorisé",
+        "uncategorizedTooltip": "Ce produit nécessite une catégorie pour un meilleur suivi des dépenses",
+        "missingName": "Nom manquant",
+        "missingNameTooltip": "La traduction du nom générique est manquante ou identique au texte OCR brut",
+        "lowConfidence": "Faible confiance",
+        "lowConfidenceTooltip": "La confiance OCR est de {confidence}% - révision manuelle recommandée",
+        "edited": "Modifié",
+        "editedTooltip": "Ce produit a été modifié manuellement",
+        "allergens": "{count, plural, one {# allergène} other {# allergènes}}"
+      },
+      "actions": {
+        "remove": "Supprimer l'article",
+        "restore": "Restaurer l'article",
+        "editAllergens": "Modifier les allergènes"
+      },
+      "softDelete": {
+        "success": "Article « {name} » supprimé",
+        "error": "Échec de la suppression de l'article"
+      },
+      "restore": {
+        "success": "Article « {name} » restauré",
+        "error": "Échec de la restauration de l'article"
+      },
+      "bulkCategory": {
+        "noSelection": "Veuillez sélectionner au moins un produit"
+      }
+    },
+    "changeHistory": {
+      "unsavedChanges": "Modifications non enregistrées",
+      "pending": "En attente",
+      "created": "Facture créée",
+      "title": "Historique des modifications",
+      "time": {
+        "justNow": "À l'instant",
+        "secondsAgo": "il y a {seconds} secondes",
+        "hoursAgo": "il y a {hours} heures",
+        "daysAgo": "il y a {days} jours",
+        "minutesAgo": "il y a {minutes} minutes"
+      },
+      "modified": "Dernière modification",
+      "changes": {
+        "paymentTypeChanged": "Type de paiement modifié",
+        "unmarkedImportant": "Retiré des favoris",
+        "categoryUpdated": "Catégorie mise à jour",
+        "transactionDateChanged": "Date de transaction modifiée",
+        "nameChanged": "Nom modifié",
+        "descriptionChanged": "Description modifiée",
+        "markedImportant": "Marqué comme important",
+        "importanceChanged": "Importance modifiée"
+      }
+    },
+    "guidedEditBanner": {
+      "title": "{count, plural, one {# produit nécessite une révision} other {# produits nécessitent une révision}}",
+      "summary": {
+        "uncategorized": "{count, plural, one {# non catégorisé} other {# non catégorisés}}",
+        "lowConfidence": "{count, plural, one {# faible confiance} other {# faible confiance}}",
+        "missingName": "{count, plural, one {# nom manquant} other {# noms manquants}}"
+      },
+      "actions": {
+        "reviewAll": "Tout réviser",
+        "dismiss": "Fermer"
+      },
+      "badges": {
+        "uncategorized": "{count, plural, one {# non catégorisé} other {# non catégorisés}}",
+        "lowConfidence": "{count, plural, one {# faible confiance} other {# faible confiance}}",
+        "missingName": "{count, plural, one {# nom manquant} other {# noms manquants}}"
+      }
+    }
+  },
+  "IMS--Landing": {
+    "metadata": {
+      "description": "Gérez vos reçus, créez des factures et obtenez des informations sur vos habitudes de dépenses.",
+      "title": "Système de Gestion des Factures"
+    },
+    "hero": {
+      "title": "Gérez Vos",
+      "titleHighlight": "Factures",
+      "titleSuffix": "Facilement",
+      "description": "Téléchargez vos reçus et factures, organisez-les et obtenez des informations sur vos habitudes de dépenses. Notre système alimenté par l'IA extrait les données automatiquement.",
+      "getStarted": "Commencer",
+      "viewMyInvoices": "Voir Mes Factures",
+      "imageAlt": "Illustration de gestion des factures"
+    },
+    "workflow": {
+      "title": "Comment Ça Marche",
+      "description": "Trois étapes simples pour numériser et organiser vos documents financiers",
+      "step1": {
+        "title": "Télécharger des Scans",
+        "description": "Glissez-déposez vos reçus, factures ou notes. Nous acceptons les fichiers JPG, PNG et PDF jusqu'à 10 Mo chacun.",
+        "button": "Télécharger"
+      },
+      "step2": {
+        "title": "Voir et Organiser",
+        "description": "Examinez vos scans téléchargés, sélectionnez ceux que vous voulez et créez des factures individuellement ou par lots.",
+        "button": "Voir les Scans"
+      },
+      "step3": {
+        "title": "Gérer les Factures",
+        "description": "Consultez vos factures, analysez les habitudes de dépenses et obtenez des informations alimentées par l'IA sur vos habitudes financières.",
+        "button": "Voir les Factures"
+      }
+    },
+    "features": {
+      "title": "Fonctionnalités Puissantes",
+      "description": "Tout ce dont vous avez besoin pour gérer vos factures efficacement",
+      "ocr": {
+        "title": "Extraction OCR Intelligente",
+        "description": "Notre IA extrait automatiquement les noms des commerçants, dates, montants et articles de vos scans."
+      },
+      "analytics": {
+        "title": "Analyse des Dépenses",
+        "description": "Obtenez des informations détaillées sur vos habitudes de dépenses avec des graphiques et rapports."
+      },
+      "batch": {
+        "title": "Traitement par Lots",
+        "description": "Traitez plusieurs scans à la fois - créez des factures individuelles ou combinez-les en une seule."
+      },
+      "signInPrompt": "Connectez-vous pour sauvegarder vos factures de façon permanente et y accéder depuis n'importe quel appareil.",
+      "imageAlt": "Illustration des fonctionnalités des factures",
+      "signIn": "Connectez-vous"
+    },
+    "bento": {
+      "title": "Tout Ce Dont Vous Avez Besoin",
+      "description": "Des fonctionnalités puissantes conçues pour rendre la gestion des factures sans effort",
+      "ai": {
+        "title": "Alimenté par l'IA",
+        "description": "Extraction GPT-4"
+      },
+      "analyticsCard": {
+        "title": "Analyse",
+        "description": "Aperçu des dépenses"
+      },
+      "cloud": {
+        "title": "Sync Cloud",
+        "description": "Accès partout"
+      },
+      "ocr": {
+        "title": "OCR Intelligent",
+        "description": "Capture auto des données"
+      },
+      "secure": {
+        "title": "Sécurisé",
+        "description": "Chiffrement bancaire"
+      },
+      "share": {
+        "title": "Partager",
+        "description": "Collaboration facile"
+      },
+      "mobile": "Fonctionne parfaitement sur mobile"
+    },
+    "cta": {
+      "title": "Prêt à Commencer?",
+      "description": "Téléchargez votre premier scan et découvrez la magie de la gestion des factures alimentée par l'IA.",
+      "uploadButton": "Télécharger Votre Premier Scan",
+      "learnMore": "En Savoir Plus",
+      "badges": {
+        "secure": "Sécurisé et Privé",
+        "cloud": "Synchronisé dans le Cloud",
+        "ai": "Alimenté par l'IA"
+      }
+    }
+  },
+  "IMS--List": {
+    "metadata": {
+      "description": "Lister toutes les factures du système de gestion des factures.",
+      "title": "Système de Gestion des Factures - Liste des Factures"
+    },
+    "subtitle": "Ceci est votre inventaire de reçus numériques. <br></br> Ici vous pouvez trouver les reçus que vous avez téléchargés jusqu'à présent. <br></br> En cliquant sur un reçu, vous serez redirigé vers la page de ce reçu spécifique.",
+    "title": "Bienvenue, {name} !",
+    "viewInvoicesPage": {
+      "guestName": "cher invité"
+    },
+    "viewInvoicesIsland": {
+      "tabs": {
+        "invoices": "Factures",
+        "statistics": "Statistiques",
+        "liveAnalysis": "Analyse en direct"
+      }
+    },
+    "invoicesHeader": {
+      "title": "Gestion des factures",
+      "description": "Gérez vos reçus et suivez vos habitudes de dépenses",
+      "actions": {
+        "import": "Importer",
+        "export": "Exporter",
+        "print": "Imprimer",
+        "newInvoice": "Nouvelle facture"
+      },
+      "tooltips": {
+        "import": "Importer des factures depuis des fichiers",
+        "export": "Exporter toutes les factures",
+        "print": "Imprimer les factures",
+        "newInvoice": "Créer une nouvelle facture"
+      }
+    },
+    "invoicesView": {
+      "searchPlaceholder": "Rechercher des factures...",
+      "filters": {
+        "category": "Catégorie",
+        "timeOfDay": "Moment de la journée",
+        "categories": "Catégories",
+        "paymentTypes": "Types de paiement",
+        "dateRange": "Plage de dates",
+        "dateFrom": "Date de début",
+        "dateTo": "Date de fin",
+        "amountRange": "Plage de montants",
+        "amountMin": "Montant min.",
+        "amountMax": "Montant max.",
+        "sortBy": "Trier par",
+        "sortOptions": {
+          "dateNewest": "Date (plus récente)",
+          "dateOldest": "Date (plus ancienne)",
+          "amountHighToLow": "Montant (décroissant)",
+          "amountLowToHigh": "Montant (croissant)",
+          "nameAZ": "Nom (A-Z)",
+          "nameZA": "Nom (Z-A)"
+        },
+        "title": "Filtres",
+        "button": "Filtres",
+        "clear": "Tout effacer",
+        "activeCount": "{count} actifs"
+      },
+      "categories": {
+        "all": "Toutes les catégories",
+        "groceries": "Épicerie",
+        "dining": "Restauration",
+        "utilities": "Services",
+        "entertainment": "Divertissement",
+        "travel": "Voyage",
+        "other": "Autre"
+      },
+      "times": {
+        "all": "Tous les horaires",
+        "day": "Journée (6h-18h)",
+        "night": "Nuit (18h-6h)"
+      },
+      "placeholderPanel": "D’autres filtres seront bientôt disponibles.",
+      "viewModes": {
+        "table": "Table voir",
+        "grid": "Grid voir"
+      }
+    },
+    "messageList": {
+      "aiAssistant": "Assistant IA",
+      "you": "Vous"
+    },
+    "generativeView": {
+      "welcomeMessage": "Bonjour ! Je suis votre assistant d’analyse de factures. Comment puis-je vous aider aujourd’hui ? Essayez des commandes comme /find pour rechercher des factures.",
+      "title": "Analyse en direct",
+      "subtitle": "Discutez avec l’AI pour analyser vos factures et obtenir des analyses utiles",
+      "help": "Aide",
+      "tabs": {
+        "chat": "Discussion",
+        "settings": "Paramètres"
+      },
+      "chatDescription": "Discutez avec l’AI pour analyser vos factures et obtenir des analyses utiles. Essayez des commandes comme /find pour rechercher des factures.",
+      "settings": {
+        "title": "Chat paramètres",
+        "description": "Configurez les préférences de votre assistant AI",
+        "historyLabel": "Chat historique",
+        "retentionPlaceholder": "Sélectionnez la durée de conservation",
+        "retention": {
+          "30": "Conserver pendant 30 jours",
+          "60": "Conserver pendant 60 jours",
+          "90": "Conserver pendant 90 jours",
+          "none": "Don't enregistrer historique"
+        },
+        "dataAccessTitle": "Accès aux données",
+        "allowInvoiceData": "Autoriser l’accès aux données de la facture",
+        "allowMerchantData": "Autoriser l’accès aux données du commerçant",
+        "notificationPreferences": "Préférences de notification",
+        "notifyInsights": "Me notifier des nouvelles analyses",
+        "save": "Enregistrer paramètres"
+      }
+    },
+    "tableView": {
+      "empty": {
+        "title": "Aucune facture trouvée",
+        "description": "Commencez par télécharger vos reçus pour créer votre première facture",
+        "uploadCta": "Télécharger votre premier reçu"
+      },
+      "columns": {
+        "invoice": "Facture",
+        "category": "Catégorie",
+        "date": "Date",
+        "amount": "Montant",
+        "actions": "Opérations"
+      },
+      "aria": {
+        "selectAllInvoices": "Sélectionner toutes les factures",
+        "selectInvoice": "Sélectionner facture {name}",
+        "rowsPerPage": "Lignes par page",
+        "sortByDate": "Trier par date",
+        "sortByAmount": "Trier par montant"
+      },
+      "viewInvoice": "Voir Facture",
+      "rowsPerPage": "Lignes par page:",
+      "pageOf": "Page {current} sur {total}",
+      "previousPage": "Page précédente",
+      "nextPage": "Page suivante",
+      "tooltips": {
+        "notAnalyzed": "Cette facture n'a pas encore été analysée"
+      }
+    },
+    "gridView": {
+      "tooltips": {
+        "viewDetails": "Voir les détails"
+      },
+      "itemCount": "{count, plural, one {# article} other {# articles}}"
+    },
+    "tableViewActions": {
+      "actions": {
+        "edit": "Modifier",
+        "share": "Partager",
+        "delete": "Supprimer"
+      },
+      "tooltips": {
+        "moreActions": "Plus d'actions",
+        "edit": "Modifier les détails de la facture",
+        "share": "Partager facture via lien or e-mail",
+        "delete": "Supprimer définitivement cette facture"
+      }
+    },
+    "bulkActions": {
+      "selected": "{count, plural, one {# facture sélectionnée} other {# factures sélectionnées}}",
+      "clearSelection": "Effacer la sélection",
+      "export": "Exporter",
+      "delete": "Supprimer",
+      "changeCategory": "Changer de catégorie",
+      "deleteConfirm": {
+        "title": "Supprimer les factures",
+        "description": "{count, plural, one {Êtes-vous sûr de vouloir supprimer cette facture ? Cette action est irréversible.} other {Êtes-vous sûr de vouloir supprimer ces # factures ? Cette action est irréversible.}}",
+        "confirm": "Supprimer",
+        "cancel": "Annuler"
+      },
+      "deleteSuccess": "{count, plural, one {Facture supprimée avec succès} other {# factures supprimées avec succès}}",
+      "deleteError": "Échec de la suppression des factures. Veuillez réessayer.",
+      "deletePartialSuccess": "{success} facture(s) supprimée(s), {failed} en échec",
+      "categoryChanged": "{count, plural, one {Catégorie de la facture mise à jour avec succès} other {Catégories de # factures mises à jour avec succès}}",
+      "categoryChangeError": "Échec de la mise à jour des catégories de factures. Veuillez réessayer.",
+      "categoryPartialSuccess": "{success} facture(s) mise(s) à jour, {failed} en échec",
+      "categories": {
+        "notDefined": "Non défini",
+        "grocery": "Épicerie",
+        "fastFood": "Restauration rapide",
+        "homeCleaning": "Entretien ménager",
+        "carAuto": "Auto et véhicule",
+        "other": "Autre"
+      }
+    }
+  },
+  "IMS--Stats": {
+    "title": "Statistiques des factures",
+    "subtitle": "Gérez vos reçus et suivez vos habitudes de dépenses",
+    "calendarHeatmap": {
+      "days": {
+        "wed": "Mer",
+        "thu": "Jeu",
+        "fri": "Ven",
+        "sun": "Dim",
+        "mon": "Lun",
+        "sat": "Sam",
+        "tue": "Mar"
+      },
+      "tooltip": {
+        "noSpending": "Aucune dépense",
+        "amount": "Dépensé",
+        "invoices": "{count} factures"
+      },
+      "legend": {
+        "less": "Moins",
+        "more": "Plus"
+      },
+      "title": "Calendrier des dépenses",
+      "description": "Intensité des dépenses quotidiennes au fil du temps",
+      "navigation": {
+        "previous": "Mois précédent",
+        "next": "Mois suivant"
+      },
+      "aria": {
+        "calendarGrid": "Calendrier des dépenses quotidiennes"
+      }
+    },
+    "spendingOverTime": {
+      "labels": {
+        "amount": ""
+      },
+      "tooltip": {
+        "invoiceCount": "",
+        "andMore": "et {count} de plus..."
+      },
+      "title": "",
+      "description": ""
+    },
+    "categoryBreakdown": {
+      "title": "Dépenses par catégorie",
+      "description": "Répartition par catégories",
+      "totalLabel": "Dépenses totales",
+      "tooltip": {
+        "invoiceCount": "{count} factures"
+      }
+    },
+    "merchantLeaderboard": {
+      "title": "Principaux commerçants",
+      "description": "Où vous dépensez le plus",
+      "labels": {
+        "totalSpent": "Total dépensé"
+      },
+      "tooltip": {
+        "invoiceCount": "{count} factures"
+      },
+      "empty": "Aucune donnée de marchand disponible"
+    },
+    "priceDistribution": {
+      "title": "Distribution des prix",
+      "description": "Distribution des prix des articles",
+      "labels": {
+        "itemCount": "Nombre d'articles"
+      },
+      "tooltip": {
+        "itemCount": "{count} articles"
+      }
+    },
+    "timeOfDay": {
+      "title": "Habitudes d'achat",
+      "description": "Quand vous faites vos achats",
+      "labels": {
+        "invoiceCount": "Nombre de factures"
+      },
+      "tooltip": {
+        "invoiceCount": "{count} factures"
+      }
+    },
+    "currencyDistribution": {
+      "title": "Répartition par devise",
+      "description": "Répartition des dépenses par devise avec conversion en RON",
+      "toggleLabel": "Basculer la vue des devises",
+      "showOriginal": "Afficher l'original",
+      "showRON": "Afficher en RON",
+      "singleCurrency": "Toutes les factures en {currency} ({symbol})",
+      "invoiceCount": "{count} factures",
+      "originalAmount": "Original",
+      "ronEquivalent": "Équivalent RON",
+      "totalAmount": "Montant total",
+      "totalCurrencies": "Total des devises",
+      "totalSpending": "Dépenses totales"
+    },
+    "merchantTrends": {
+      "title": "Tendances de dépenses par commerçant",
+      "description": "Évolution mensuelle des dépenses chez les principaux commerçants",
+      "labels": {
+        "merchant": "Commerçant",
+        "totalSpend": "Total dépensé",
+        "trend": "Tendance (6 derniers mois)"
+      },
+      "aria": {
+        "sparkline": "Tendance des dépenses pour {merchant}"
+      },
+      "empty": "Aucune donnée de commerçant disponible"
+    },
+    "merchantVisit": {
+      "title": "Fréquentation des commerçants",
+      "description": "Fréquence d'achat et aperçu du panier",
+      "metrics": {
+        "totalVisits": "Visites totales",
+        "visitsPerMonth": "Visites/mois",
+        "basketSize": "Panier moyen",
+        "preferredDay": "Jour préféré",
+        "avgSpend": "Dépense moy./visite"
+      },
+      "empty": "Aucune donnée de visite disponible"
+    },
+    "productCategory": {
+      "description": "Répartition des dépenses par type de produit",
+      "tooltip": {
+        "productCount": "{count} produits"
+      },
+      "title": "Dépenses par catégorie de produit",
+      "empty": "Aucun produit à analyser pour le moment"
+    },
+    "topProducts": {
+      "ariaLabel": "Classement des produits les plus achetés",
+      "description": "Articles les plus achetés",
+      "headers": {
+        "rank": "#",
+        "avgPrice": "Prix moyen",
+        "quantity": "Qté",
+        "purchases": "Achats",
+        "product": "Produit",
+        "totalSpent": "Total"
+      },
+      "title": "Produits principaux",
+      "empty": "Aucun produit acheté pour le moment"
+    },
+    "allergenSummary": {
+      "ariaLabel": "Résumé de la fréquence des allergènes",
+      "description": "Exposition aux allergènes dans vos produits",
+      "stats": {
+        "products": "produits",
+        "ofTotal": "du total"
+      },
+      "title": "Résumé des allergènes",
+      "empty": "Aucun allergène détecté dans vos achats"
+    },
+    "kpi": {
+      "totalSpending": "Dépenses totales",
+      "invoiceCount": "Nombre de factures",
+      "topMerchant": "Commerçant principal",
+      "averageItems": "Articles moy.",
+      "vsLastMonth": "{delta}% par rapport au mois dernier",
+      "avgPerInvoice": "moy. {amount} par facture",
+      "visits": "{count} visites",
+      "acrossInvoices": "sur {count} factures",
+      "noneYet": "Pas encore de données"
+    },
+    "comparison": {
+      "title": "Mois par mois",
+      "description": "Comparaison avec le mois précédent",
+      "spendingDelta": "Variation des dépenses",
+      "invoiceCount": "Nombre de factures",
+      "newMerchants": "Nouveaux commerçants",
+      "discovered": "découverts",
+      "none": "aucun",
+      "increase": "augmentation",
+      "decrease": "diminution"
+    },
+    "empty": {
+      "title": "Pas encore de statistiques",
+      "subtitle": "Téléchargez des reçus pour voir les analyses",
+      "cta": "Télécharger un reçu"
+    },
+    "productAnalytics": {
+      "title": "Analyse des produits",
+      "subtitle": "Aperçu de vos articles achetés"
+    }
+  },
+  "IMS--UploadScans": {
+    "metadata": {
+      "description": "Téléchargez des scans de reçus sur votre compte pour un traitement ultérieur en factures.",
+      "title": "Système de Gestion des Factures - Télécharger des Scans"
+    },
+    "title": "Télécharger des Scans",
+    "subtitle": "Téléchargez des images de reçus ou des PDF. Créez des factures à partir de ceux-ci plus tard.",
+    "breadcrumb": "Retour aux Factures",
+    "header": {
+      "title": "Télécharger des Scans",
+      "description": "Téléchargez des images de reçus ou des PDF. Créez des factures à partir de ceux-ci plus tard.",
+      "tooltip": "Téléchargez vos reçus, factures ou notes ici. Vous pouvez sélectionner plusieurs fichiers et les organiser en factures plus tard depuis la page Voir les Scans."
+    },
+    "buttons": {
+      "viewScans": "Voir Vos Scans",
+      "myInvoices": "Mes Factures",
+      "uploadFirst": "Télécharger Votre Premier Scan"
+    },
+    "stats": {
+      "added": "Ajouté",
+      "pending": "En attente",
+      "uploading": "Téléchargement",
+      "completed": "Terminé",
+      "failed": "Échoué"
+    },
+    "sidebar": {
+      "formats": {
+        "title": "Formats Pris en Charge",
+        "images": "Images",
+        "imageExtensions": ".jpg, .jpeg, .png",
+        "documents": "Documents",
+        "documentExtensions": ".pdf",
+        "maxSize": "Taille maximale du fichier : 10 Mo par fichier"
+      },
+      "tips": {
+        "title": "Conseils pour de Meilleurs Résultats",
+        "tip1": "Utilisez un bon éclairage lors de la photographie des reçus",
+        "tip2": "Assurez-vous que le texte est clair et lisible",
+        "tip3": "Évitez les ombres et les reflets",
+        "tip4": "Capturez tout le reçu dans le cadre",
+        "tip5": "Les PDF fonctionnent mieux pour les reçus numériques"
+      },
+      "security": {
+        "title": "Stockage Sécurisé",
+        "description": "Vos scans sont chiffrés et stockés en toute sécurité. Vous seul pouvez y accéder."
+      },
+      "nextSteps": {
+        "title": "Tous les téléchargements terminés !",
+        "description": "Vos scans sont prêts. Allez sur Voir les Scans pour les organiser en factures.",
+        "button": "Continuer vers Voir les Scans"
+      }
+    },
+    "upload": {
+      "dropzone": "Glissez et déposez vos images de reçus ou PDF ici",
+      "browse": "Parcourir les fichiers",
+      "or": "ou"
+    },
+    "errors": {
+      "unsupportedType": "Type de fichier non pris en charge : {type}",
+      "tooLarge": "Fichier trop volumineux : {name} (max 10 Mo)"
+    },
+    "uploadArea": {
+      "aria": {
+        "uploadFiles": "Téléverser des fichiers"
+      },
+      "empty": {
+        "title": "Glissez-déposez vos fichiers ici",
+        "dropActive": "Déposez les fichiers pour les téléverser",
+        "dropInactive": "Cliquez ou glissez des fichiers pour les téléverser",
+        "formats": "Formats pris en charge : JPG, PNG, PDF (10 Mo max chacun)",
+        "note": "Vous pouvez sélectionner plusieurs fichiers.",
+        "chooseFiles": "Choisir des fichiers"
+      },
+      "compact": {
+        "dropActive": "Déposez les fichiers pour les ajouter",
+        "dropInactive": "Glissez des fichiers ici ou cliquez pour parcourir",
+        "subtitle": "JPG, PNG, PDF jusqu'à 10 Mo"
+      },
+      "actions": {
+        "clearAll": "Tout effacer",
+        "uploading": "Téléversement...",
+        "uploadScans": "Téléverser les scans"
+      },
+      "tooltips": {
+        "clearAll": "Supprimer tous les téléversements en attente",
+        "uploadScans": "Démarrer le téléversement de tous les scans en attente"
+      }
+    },
+    "preview": {
+      "title": "Téléversements en attente ({count})",
+      "status": {
+        "pending": "En attente",
+        "uploading": "Téléversement",
+        "retrying": "Nouvelle tentative",
+        "completed": "Terminé",
+        "failed": "Échoué"
+      },
+      "removeTooltip": "Supprimer ce fichier",
+      "retryAttempt": "Nouvelle tentative {attempt}",
+      "pendingTooltip": "Ce scan ne sera pas enregistré tant que vous n'aurez pas cliqué sur Télécharger",
+      "pagination": {
+        "previous": "Précédent",
+        "next": "Suivant",
+        "pageInfo": "{current} / {total} ({count} scans)"
+      }
+    },
+    "postUpload": {
+      "title": "Téléchargement terminé !",
+      "subtitle": "Ces numérisations représentent-elles un seul achat ?",
+      "createInvoice": "Oui, créer une facture",
+      "viewScans": "Non, je les combinerai plus tard",
+      "dismiss": "Fermer"
+    }
+  },
+  "IMS--View": {
+    "metadata": {
+      "description": "Consultez les détails de votre facture, les articles et les informations du commerçant associé.",
+      "title": "Système de Gestion des Factures - Voir la Facture"
+    },
+    "invoiceAnalytics": {
+      "title": "Analyses et insights",
+      "tabs": {
+        "current": "Cette facture",
+        "compare": "Comparaison"
+      }
+    },
+    "invoiceTimeline": {
+      "title": "Chronologie de la facture",
+      "subtitle": "Historique complet des actions et modifications",
+      "eventCount": "{count, plural, one {# événement} other {# événements}}"
+    },
+    "invoiceTabs": {
+      "tabs": {
+        "possibleRecipes": "Recettes possibles",
+        "additionalInfo": "Infos supplémentaires"
+      },
+      "recipe": {
+        "duration": "{minutes} min",
+        "prepCook": "Prépa : {prep}m • Cuisson : {cook}m",
+        "viewRecipe": "Voir Recipe",
+        "ingredients": "Ingrédients",
+        "instructions": "Instructions"
+      },
+      "empty": {
+        "recipes": "Aucune suggestion de recette disponible",
+        "additionalInfo": "Aucune information supplémentaire disponible"
+      },
+      "actions": {
+        "regenerate": "Régénérer les recettes",
+        "regenerateTooltip": "Réanalyser la facture pour générer de nouvelles suggestions de recettes",
+        "generate": "Générer des recettes"
+      }
+    },
+    "timelineItem": {
+      "aria": {
+        "moreInfo": "Plus d’infos sur {title}"
+      },
+      "confidence": "Confiance : {value}%",
+      "events": {
+        "created": {
+          "title": "Facture créée",
+          "description": "Scannée et numérisée depuis le reçu"
+        },
+        "aiAnalysis": {
+          "title": "Analyse IA terminée",
+          "description": "{count, plural, one {# article détecté et catégorisé} other {# articles détectés et catégorisés}}"
+        },
+        "recipesGenerated": {
+          "title": "Recettes générées",
+          "description": "{count, plural, one {# recette suggérée} other {# recettes suggérées}}"
+        },
+        "shared": {
+          "title": "Partagée avec d’autres",
+          "description": "Partagée avec {count, plural, one {# personne} other {# personnes}}"
+        },
+        "edited": {
+          "title": "Facture mise à jour"
+        },
+        "exported": {
+          "title": "Facture exportée"
+        },
+        "markedImportant": {
+          "title": "Marquée importante",
+          "description": "Signalée pour un suivi prioritaire"
+        },
+        "categorized": {
+          "title": "Catégorie attribuée",
+          "description": "Catégorisation automatique selon les articles"
+        }
+      },
+      "tooltips": {
+        "created": "La facture a été scannée et numérisée avec {method}.",
+        "aiAnalysis": "L’IA a traité cette facture en {duration} et analysé {count, plural, one {# article} other {# articles}}.",
+        "recipesGenerated": "D’après les ingrédients achetés, {count, plural, one {# recette a été générée} other {# recettes ont été générées}}.",
+        "shared": "La facture a été partagée avec {count, plural, one {# utilisateur} other {# utilisateurs}}.",
+        "edited": "Des modifications manuelles ont été apportées à la facture.",
+        "exported": "La facture a été exportée au format {format}.",
+        "markedImportant": "La facture a été marquée importante pour un accès rapide.",
+        "categorized": "La facture a reçu une catégorie pour une meilleure organisation.",
+        "unavailable": "Détails de l’événement indisponibles"
+      },
+      "relativeTime": {
+        "now": "À l’instant"
+      },
+      "fallbacks": {
+        "ocr": "OCR",
+        "pdf": "PDF"
+      }
+    },
+    "timelineSharedWithList": {
+      "header": {
+        "title": "Partagée avec",
+        "publicBadge": "Public"
+      },
+      "publicAccess": {
+        "title": "Accès public activé",
+        "description": "Cette facture est accessible publiquement. Toute personne disposant du lien peut la voir, y compris les invités sans compte."
+      },
+      "aria": {
+        "sendEmail": "Envoyer un e-mail à {user}"
+      },
+      "actions": {
+        "sendEmail": "Envoyer un e-mail",
+        "manageSharing": "Gérer le partage"
+      }
+    },
+    "invoiceGuestBanner": {
+      "title": "Vue invité",
+      "description": "Vous n’êtes actuellement pas le propriétaire de cette facture. L’affichage est limité à ce que le propriétaire a défini dans les paramètres de partage."
+    },
+    "categoryComparisonChart": {
+      "title": "Comparaison des catégories",
+      "description": "Cette facture vs votre moyenne",
+      "labels": {
+        "current": "Actuel",
+        "average": "Moyenne"
+      }
+    },
+    "itemsBreakdownChart": {
+      "title": "Articles les plus coûteux",
+      "description": "Articles avec les plus fortes dépenses",
+      "labels": {
+        "price": "Prix",
+        "quantity": "Qté"
+      }
+    },
+    "merchantBreakdownChart": {
+      "title": "Dépenses par magasin",
+      "description": "Totaux cumulés sur tous les commerçants",
+      "labels": {
+        "totalSpent": "Total dépensé",
+        "total": "Total",
+        "visits": "Visites",
+        "averagePerVisit": "Moy./visite"
+      }
+    },
+    "priceDistributionChart": {
+      "title": "Répartition des prix",
+      "description": "Articles par tranche de prix ({currency})",
+      "labels": {
+        "items": "Articles"
+      },
+      "tooltip": {
+        "itemCount": "{count, plural, one {# article} other {# articles}}"
+      }
+    },
+    "spendingByCategoryChart": {
+      "title": "Dépenses par catégorie",
+      "description": "Répartition des dépenses",
+      "totalLabel": "Total des dépenses",
+      "tooltip": {
+        "itemCount": "{count, plural, one {# article} other {# articles}}"
+      }
+    },
+    "spendingTrendChart": {
+      "title": "Évolution des dépenses",
+      "description": "Tendance de votre historique de factures",
+      "labels": {
+        "amount": "Montant"
+      },
+      "tooltip": {
+        "currentInvoice": "Facture actuelle"
+      }
+    },
+    "print": {
+      "generatedOn": "Imprimé le {date}",
+      "page": "Page",
+      "labels": {
+        "date": "Date",
+        "merchant": "Commerçant",
+        "total": "Montant total",
+        "items": "Articles"
+      }
+    },
+    "relatedInvoices": {
+      "noRelated": "Aucune facture associée trouvée",
+      "subtitle": "Factures similaires par commerçant, catégorie ou montant",
+      "sameCategory": "Même catégorie",
+      "viewInvoice": "Afficher",
+      "similarAmount": "Montant similaire",
+      "sameMerchant": "Même commerçant",
+      "title": "Factures associées"
+    },
+    "shareCollaborate": {
+      "title": "Partage et collaboration",
+      "private": "Privé",
+      "shared": "Partagé",
+      "public": "Public",
+      "sharedWith": "Partagé avec",
+      "copyLink": "Copier le lien",
+      "shareEmail": "Partager par e-mail",
+      "manageSharing": "Gérer le partage",
+      "copied": "Lien copié dans le presse-papiers !",
+      "activity": {
+        "title": "Activité",
+        "created": "Créé {time}",
+        "modified": "Dernière modification {time}",
+        "daysAgo": "{count, plural, one {il y a # jour} other {il y a # jours}}",
+        "today": "aujourd'hui"
+      },
+      "publicAccess": "Accès public",
+      "publicAccessDescription": "Toute personne ayant le lien peut voir cette facture",
+      "madePublic": "La facture est maintenant publique",
+      "madePrivate": "La facture est maintenant privée",
+      "toggleError": "Échec de la mise à jour des paramètres de partage",
+      "qrCode": "Code QR",
+      "qrCopied": "Lien copié ! Génération du code QR bientôt disponible.",
+      "copyError": "Échec de la copie du lien"
+    },
+    "healthScore": {
+      "title": "Invoice Completeness",
+      "subtitle": "How complete is your invoice data",
+      "points": "points",
+      "showDetails": "Show details",
+      "hideDetails": "Hide details",
+      "factors": {
+        "merchantLinked": "Commerçant associé",
+        "ocrConfidence": "Confiance OCR",
+        "recipesGenerated": "Recettes générées",
+        "paymentInfo": "Informations de paiement",
+        "productCompleteness": "Complétude des produits",
+        "productsPresent": "Produits extraits",
+        "categoriesAssigned": "Catégories attribuées"
+      },
+      "cta": {
+        "analyze": "Lancer l'analyse IA",
+        "edit": "Modifier la facture"
+      },
+      "status": {
+        "incomplete": "Incomplet",
+        "good": "Bon",
+        "needsAttention": "Nécessite une attention",
+        "excellent": "Excellent"
+      },
+      "suggestions": {
+        "noRecipes": "Aucune recette générée — lancez l'analyse IA pour découvrir des idées de repas",
+        "title": "Améliorations suggérées",
+        "incompletePayment": "Informations de paiement incomplètes — ajoutez la date, le montant et la devise de la transaction",
+        "fix": "Corriger",
+        "noMerchant": "Aucun commerçant associé — ajoutez les détails du commerçant pour de meilleures analyses",
+        "noProducts": "Aucun produit trouvé — téléchargez un reçu ou ajoutez des articles manuellement",
+        "lowOcrConfidence": "Faible confiance OCR sur <strong>{count}</strong> produits — vérifiez manuellement pour plus de précision",
+        "uncategorizedProducts": "<strong>{count}</strong> produits non catégorisés — attribuez des catégories pour l'analyse des dépenses",
+        "incompleteProducts": "<strong>{count}</strong> produits incomplets — vérifiez et complétez les champs manquants"
+      },
+      "seeReport": "Voir le rapport détaillé",
+      "dialogTitle": "Rapport de santé de la facture"
+    },
+    "itemAnalytics": {
+      "title": "Articles",
+      "searchPlaceholder": "Rechercher des articles...",
+      "columns": {
+        "name": "Nom",
+        "category": "Catégorie",
+        "price": "Prix",
+        "quantity": "Qté",
+        "total": "Total"
+      },
+      "summary": {
+        "title": "Résumé",
+        "mostExpensive": "Le plus cher",
+        "cheapest": "Le moins cher",
+        "categories": "{count} catégories",
+        "allergens": "{count} allergènes détectés"
+      },
+      "empty": {
+        "title": "Aucun article",
+        "subtitle": "Lancez l'analyse IA pour extraire les articles de votre reçu"
+      },
+      "totalLabel": "TOTAL",
+      "confidence": {
+        "label": "Confiance OCR",
+        "lowWarning": "Faible confiance — vérifiez cet article",
+        "ariaLabel": "Confiance {level}: {percent}%",
+        "high": "Elevee",
+        "medium": "Moyenne",
+        "low": "Faible"
+      }
+    },
+    "analysisPanel": {
+      "tooltips": {
+        "itemsOnly": "Recatégoriser et analyser uniquement les articles",
+        "completeAnalysis": "Extraction OCR complète + traitement IA de toutes les données de la facture",
+        "merchantOnly": "Réidentifier le commerçant et les données de localisation",
+        "invoiceOnly": "Réextraire les informations de base de la facture (date, total, paiement)",
+        "reanalyze": "Relancer l'analyse complète avec toutes les fonctionnalités IA"
+      },
+      "title": "Analyse IA",
+      "options": {
+        "itemsOnly": "Articles uniquement",
+        "completeAnalysis": "Analyse complète",
+        "merchantOnly": "Commerçant uniquement",
+        "invoiceOnly": "Facture uniquement"
+      },
+      "steps": {
+        "processing": "Traitement des articles...",
+        "finalizing": "Finalisation des résultats...",
+        "preparing": "Préparation du document...",
+        "complete": "Analyse terminée !",
+        "analyzing": "Analyse en cours avec l'IA...",
+        "extracting": "Extraction OCR en cours..."
+      },
+      "analyzing": {
+        "progress": "{progress}% terminé",
+        "title": "Analyse en cours..."
+      },
+      "labels": {
+        "lastAnalyzed": "Dernière analyse",
+        "updates": "{count, plural, one {# mise à jour} other {# mises à jour}}",
+        "granularOptions": "Ou choisissez une analyse spécifique",
+        "analysisComplete": "Analyse terminée — Toutes les données ont été extraites"
+      },
+      "toasts": {
+        "error": {
+          "description": "Impossible d'analyser la facture. Veuillez réessayer plus tard.",
+          "title": "Échec de l'analyse"
+        },
+        "success": {
+          "description": "La facture a été réanalysée avec succès avec des données mises à jour.",
+          "title": "Analyse terminée"
+        }
+      },
+      "description": "Réanalyser cette facture avec l'IA pour extraire ou mettre à jour les données",
+      "buttons": {
+        "reanalyze": "Réanalyser la facture"
+      },
+      "tip": "Astuce : L'analyse complète prend 30 à 60 secondes mais fournit les résultats les plus précis."
+    },
+    "export": {
+      "printError": "Échec de l'ouverture de la boîte de dialogue d'impression",
+      "printSuccess": "Boîte de dialogue d'impression ouverte",
+      "csv": {
+        "title": "Exporter en CSV",
+        "description": "Télécharger les articles sous forme de feuille de calcul"
+      },
+      "description": "Exportez vos données de facture dans différents formats",
+      "print": {
+        "title": "Imprimer",
+        "description": "Imprimer la facture via le navigateur"
+      },
+      "csvSuccess": "Fichier CSV téléchargé avec succès",
+      "copyError": "Échec de la copie du résumé",
+      "copySummary": {
+        "title": "Copier le résumé",
+        "description": "Copier le résumé texte dans le presse-papiers"
+      },
+      "copySuccess": "Résumé copié dans le presse-papiers",
+      "json": {
+        "title": "Exporter en JSON",
+        "description": "Télécharger les données complètes de la facture"
+      },
+      "jsonSuccess": "Fichier JSON téléchargé avec succès",
+      "jsonError": "Échec de l'export JSON",
+      "csvError": "Échec de l'export CSV",
+      "title": "Exporter la facture",
+      "pdf": {
+        "title": "Exporter en PDF",
+        "description": "Télécharger un document de facture professionnel"
+      },
+      "pdfSuccess": "Fichier PDF téléchargé avec succès",
+      "pdfError": "Échec de la génération du PDF",
+      "pdfGenerating": "Génération du PDF en cours..."
+    }
+  },
+  "IMS--ViewScans": {
+    "metadata": {
+      "description": "Consultez et gérez vos scans téléchargés. Créez des factures à partir des scans sélectionnés.",
+      "title": "Système de Gestion des Factures - Voir les Scans"
+    },
+    "title": "Vos Scans",
+    "subtitle": "Sélectionnez des scans pour créer des factures à partir de ceux-ci.",
+    "breadcrumb": "Retour aux Factures",
+    "header": {
+      "title": "Vos Scans",
+      "titleWithCount": "Vos Scans ({count})",
+      "subtitle": "Sélectionnez des scans pour créer des factures à partir de ceux-ci",
+      "lastSynced": "Dernière synchronisation : {time}",
+      "tooltip": "Sélectionnez des scans pour créer des factures. Vous pouvez créer une facture par scan ou combiner plusieurs scans en une seule facture.",
+      "uploadMore": "Télécharger Plus",
+      "upload": "Télécharger",
+      "uploadTooltip": "Téléchargez plus de scans sur votre compte",
+      "myInvoices": "Mes Factures",
+      "invoices": "Factures",
+      "myInvoicesTooltip": "Voir vos factures créées",
+      "sync": "Synchroniser",
+      "syncing": "Synchronisation...",
+      "syncTooltip": "Actualiser les scans depuis le serveur"
+    },
+    "stats": {
+      "totalScans": "Total des Scans",
+      "ready": "Prêt",
+      "selected": "Sélectionné",
+      "selectHint": "Cliquez sur les scans pour les sélectionner pour la création de factures",
+      "tapHint": "Appuyez pour sélectionner"
+    },
+    "sidebar": {
+      "howTo": {
+        "title": "Comment Créer des Factures",
+        "step1Title": "Sélectionner des Scans",
+        "step1Description": "Cliquez sur les scans pour les sélectionner",
+        "step2Title": "Choisir le Mode",
+        "step2Description": "Une facture par scan ou combiner plusieurs",
+        "step3Title": "Créer la Facture",
+        "step3Description": "L'IA extrait les données automatiquement"
+      },
+      "selectionStatus": {
+        "singular": "scan sélectionné",
+        "plural": "scans sélectionnés",
+        "readySingular": "Prêt à créer une facture",
+        "readyPlural": "Créez plusieurs factures ou combinez en une seule"
+      },
+      "quickUpload": {
+        "title": "Besoin de plus de scans ?",
+        "description": "Téléchargez des reçus supplémentaires",
+        "button": "Télécharger"
+      }
+    },
+    "emptyState": {
+      "title": "Pas encore de scans",
+      "description": "Commencez par télécharger vos reçus et factures. Voici comment cela fonctionne :",
+      "step1Title": "Téléchargez vos scans",
+      "step1Description": "Prenez des photos de reçus ou téléchargez des PDF de factures numériques",
+      "step2Title": "Sélectionnez et organisez",
+      "step2Description": "Choisissez quels scans convertir en factures",
+      "step3Title": "Créez des factures",
+      "step3Description": "Notre IA extrait automatiquement toutes les données pour vous",
+      "uploadButton": "Télécharger Votre Premier Scan",
+      "learnMoreButton": "En Savoir Plus"
+    },
+    "toolbar": {
+      "selected": "sélectionné",
+      "clearSelection": "Effacer",
+      "createInvoice": "Créer une Facture",
+      "createInvoices": "Créer des Factures",
+      "delete": {
+        "button": "Supprimer ({count})",
+        "confirmTitle": "Supprimer les scans sélectionnés ?",
+        "confirmDescription": "Cela supprimera définitivement {count} scan(s) du stockage. Cette action est irréversible.",
+        "cancel": "Annuler",
+        "confirm": "Supprimer",
+        "success": "{count} scan(s) supprimé(s) avec succès",
+        "partial": "{success} supprimé(s), {failed} échoué(s)",
+        "failed": "Échec de la suppression des scans",
+        "error": "Une erreur est survenue lors de la suppression des scans"
+      }
+    },
+    "scanCard": {
+      "loading": "Chargement...",
+      "delete": "Supprimer le scan",
+      "linked": "Lié",
+      "deleteDialog": {
+        "title": "Supprimer le scan ?",
+        "description": "Êtes-vous sûr de vouloir supprimer \"{name}\" ? Cette action ne peut pas être annulée et le scan sera définitivement supprimé du stockage.",
+        "linkedWarning": "Ce scan est lié à une facture.",
+        "linkedDescription": "Le supprimer retirera le scan du stockage, mais la facture conservera une copie de l'image. Cette action ne peut pas être annulée.",
+        "cancel": "Annuler",
+        "delete": "Supprimer",
+        "deleting": "Suppression...",
+        "success": "Scan supprimé avec succès",
+        "error": "Échec de la suppression du scan"
+      },
+      "rename": "Renommer le scan",
+      "renamePlaceholder": "Entrez le nouveau nom",
+      "preview": "Aperçu du scan",
+      "previewTitle": "Aperçu du scan",
+      "actions": {
+        "rename": "Renommer le scan",
+        "delete": "Supprimer le scan",
+        "rotateCW": "Pivoter de 90° dans le sens horaire",
+        "rotateCCW": "Pivoter de 90° dans le sens antihoraire",
+        "rotating": "Rotation en cours...",
+        "rotateSuccess": "Image pivotée avec succès",
+        "rotateError": "Échec de la rotation de l'image",
+        "rotateUnsupported": "Impossible de pivoter les fichiers PDF"
+      }
+    },
+    "createFromAll": {
+      "button": "Créer à partir de toutes les numérisations",
+      "title": "Toutes les numérisations sont prêtes !",
+      "description": "Créer des factures à partir de l'ensemble des {count} numérisations"
+    },
+    "groupBanner": {
+      "title": "{count} scans uploaded together — combine?",
+      "subtitle": "Créer une facture à partir de ces numérisations ?",
+      "createInvoice": "Créer une facture",
+      "dismiss": "Fermer"
+    },
+    "pagination": {
+      "previous": "Précédent",
+      "next": "Suivant",
+      "pageInfo": "{current} / {total} ({count} scans)"
+    }
   }
 }

--- a/sites/arolariu.ro/messages/ro.json
+++ b/sites/arolariu.ro/messages/ro.json
@@ -1191,2845 +1191,6 @@
       }
     }
   },
-  "Invoices": {
-    "metadata": {
-      "description": "Gestionează chitanțele, creează facturi și obține informații despre obiceiurile tale de cheltuieli.",
-      "title": "Sistemul de Management al Facturilor"
-    },
-    "Homepage": {
-      "metadata": {
-        "description": "Pagina principală pentru serviciul de domeniu Sistemul de Management al Facturilor.",
-        "title": "Sistemul de Management al Facturilor - Acasă"
-      },
-      "hero": {
-        "title": "Gestionează-ți",
-        "titleHighlight": "Facturile",
-        "titleSuffix": "cu Ușurință",
-        "description": "Încarcă chitanțele și facturile tale, organizează-le și obține informații despre obiceiurile tale de cheltuieli. Sistemul nostru bazat pe AI extrage datele automat.",
-        "getStarted": "Începe Acum",
-        "viewMyInvoices": "Vezi Facturile Mele",
-        "imageAlt": "Ilustrație pentru gestionarea facturilor"
-      },
-      "workflow": {
-        "title": "Cum Funcționează",
-        "description": "Trei pași simpli pentru a digitaliza și organiza documentele tale financiare",
-        "step1": {
-          "title": "Încarcă Scanări",
-          "description": "Trage și lasă chitanțele, facturile sau bonurile tale. Acceptăm fișiere JPG, PNG și PDF de până la 10MB fiecare.",
-          "button": "Încarcă Acum"
-        },
-        "step2": {
-          "title": "Vizualizează și Organizează",
-          "description": "Revizuiește scanările încărcate, selectează-le pe cele dorite și creează facturi din ele individual sau în loturi.",
-          "button": "Vezi Scanările"
-        },
-        "step3": {
-          "title": "Gestionează Facturile",
-          "description": "Vizualizează facturile, analizează tiparele de cheltuieli și obține perspective bazate pe AI despre obiceiurile tale financiare.",
-          "button": "Vezi Facturile"
-        }
-      },
-      "features": {
-        "title": "Funcționalități Puternice",
-        "description": "Tot ce ai nevoie pentru a gestiona facturile eficient",
-        "ocr": {
-          "title": "Extracție OCR Inteligentă",
-          "description": "AI-ul nostru extrage automat numele comercianților, datele, sumele și articolele din scanări."
-        },
-        "analytics": {
-          "title": "Analiză Cheltuieli",
-          "description": "Obține informații detaliate despre tiparele tale de cheltuieli cu grafice și rapoarte."
-        },
-        "batch": {
-          "title": "Procesare în Loturi",
-          "description": "Procesează mai multe scanări simultan - creează facturi individuale sau combină-le într-una singură."
-        },
-        "signInPrompt": "Conectează-te pentru a salva facturile permanent și a le accesa de pe orice dispozitiv.",
-        "imageAlt": "Ilustrație cu funcționalitățile facturilor",
-        "signIn": "Autentifică-te"
-      },
-      "bento": {
-        "title": "Tot Ce Ai Nevoie",
-        "description": "Funcționalități puternice concepute pentru a face gestionarea facturilor fără efort",
-        "ai": {
-          "title": "Bazat pe AI",
-          "description": "Extracție GPT-4"
-        },
-        "analyticsCard": {
-          "title": "Analiză",
-          "description": "Perspective cheltuieli"
-        },
-        "cloud": {
-          "title": "Sincronizare Cloud",
-          "description": "Acces de oriunde"
-        },
-        "ocr": {
-          "title": "OCR Inteligent",
-          "description": "Captură automată date"
-        },
-        "secure": {
-          "title": "Securizat",
-          "description": "Criptare de nivel bancar"
-        },
-        "share": {
-          "title": "Partajare",
-          "description": "Colaborare ușoară"
-        },
-        "mobile": "Funcționează excelent pe dispozitive mobile"
-      },
-      "cta": {
-        "title": "Gata să Începi?",
-        "description": "Încarcă prima ta scanare și experimentează magia gestionării facturilor bazată pe AI.",
-        "uploadButton": "Încarcă Prima Scanare",
-        "learnMore": "Află Mai Multe",
-        "badges": {
-          "secure": "Securizat și Privat",
-          "cloud": "Sincronizat în Cloud",
-          "ai": "Bazat pe AI"
-        }
-      }
-    },
-    "UploadScans": {
-      "metadata": {
-        "description": "Încărcați scanări de chitanțe în contul dvs. pentru procesare ulterioară în facturi.",
-        "title": "Sistem de gestionare a facturilor - Încărcare scanări"
-      },
-      "title": "Încărcare Scanări",
-      "subtitle": "Încărcați imagini sau PDF-uri cu chitanțe. Creați facturi din ele mai târziu.",
-      "breadcrumb": "Înapoi la Facturi",
-      "header": {
-        "title": "Încărcare Scanări",
-        "description": "Încărcați imagini sau PDF-uri cu chitanțe. Creați facturi din ele mai târziu.",
-        "tooltip": "Încărcați chitanțele, facturile sau bonurile dvs. aici. Puteți selecta mai multe fișiere și le puteți organiza în facturi mai târziu din pagina Vizualizare Scanări."
-      },
-      "buttons": {
-        "viewScans": "Vizualizați Scanările",
-        "myInvoices": "Facturile Mele",
-        "uploadFirst": "Încărcați Prima Scanare"
-      },
-      "stats": {
-        "added": "Adăugate",
-        "pending": "În așteptare",
-        "uploading": "Se încarcă",
-        "completed": "Finalizate",
-        "failed": "Eșuate"
-      },
-      "sidebar": {
-        "formats": {
-          "title": "Formate Acceptate",
-          "images": "Imagini",
-          "imageExtensions": ".jpg, .jpeg, .png",
-          "documents": "Documente",
-          "documentExtensions": ".pdf",
-          "maxSize": "Dimensiune maximă: 10MB per fișier"
-        },
-        "tips": {
-          "title": "Sfaturi pentru Rezultate Optime",
-          "tip1": "Folosiți iluminare bună când fotografiați chitanțele",
-          "tip2": "Asigurați-vă că textul este clar și lizibil",
-          "tip3": "Evitați umbrele și reflexiile",
-          "tip4": "Capturați întreaga chitanță în cadru",
-          "tip5": "PDF-urile funcționează cel mai bine pentru chitanțele digitale"
-        },
-        "security": {
-          "title": "Stocare Securizată",
-          "description": "Scanările dvs. sunt criptate și stocate în siguranță. Doar dvs. le puteți accesa."
-        },
-        "nextSteps": {
-          "title": "Toate încărcările sunt complete!",
-          "description": "Scanările dvs. sunt gata. Mergeți la Vizualizare Scanări pentru a le organiza în facturi.",
-          "button": "Continuați la Vizualizare Scanări"
-        }
-      },
-      "upload": {
-        "dropzone": "Trageți și plasați imaginile sau PDF-urile cu chitanțe aici",
-        "browse": "Răsfoiți fișiere",
-        "or": "sau"
-      },
-      "errors": {
-        "unsupportedType": "Tip de fișier neacceptat: {type}",
-        "tooLarge": "Fișier prea mare: {name} (max 10MB)"
-      },
-      "uploadArea": {
-        "aria": {
-          "uploadFiles": "Încarcă fișiere"
-        },
-        "empty": {
-          "title": "Trage și plasează fișierele aici",
-          "dropActive": "Plasează fișierele pentru încărcare",
-          "dropInactive": "Fă clic sau trage fișiere pentru încărcare",
-          "formats": "Formate acceptate: JPG, PNG, PDF (maxim 10MB fiecare)",
-          "note": "Poți selecta mai multe fișiere.",
-          "chooseFiles": "Alege fișiere"
-        },
-        "compact": {
-          "dropActive": "Plasează fișierele pentru a le adăuga",
-          "dropInactive": "Trage fișiere aici sau fă clic pentru a naviga",
-          "subtitle": "JPG, PNG, PDF până la 10MB"
-        },
-        "actions": {
-          "clearAll": "Șterge tot",
-          "uploading": "Se încarcă...",
-          "uploadScans": "Încarcă scanările"
-        },
-        "tooltips": {
-          "clearAll": "Elimină toate încărcările în așteptare",
-          "uploadScans": "Pornește încărcarea tuturor scanărilor în așteptare"
-        }
-      },
-      "preview": {
-        "title": "Încărcări în așteptare ({count})",
-        "status": {
-          "pending": "În așteptare",
-          "uploading": "Se încarcă",
-          "retrying": "Reîncercare",
-          "completed": "Finalizat",
-          "failed": "Eșuat"
-        },
-        "removeTooltip": "Elimină acest fișier",
-        "retryAttempt": "Reîncercarea {attempt}",
-        "pendingTooltip": "Această scanare nu va fi salvată până nu apăsați pe Încarcă",
-        "pagination": {
-          "previous": "Anterior",
-          "next": "Următor",
-          "pageInfo": "{current} / {total} ({count} scanări)"
-        }
-      },
-      "postUpload": {
-        "title": "Încărcare finalizată!",
-        "subtitle": "Aceste scanări reprezintă o singură achiziție?",
-        "createInvoice": "Da, creează factura",
-        "viewScans": "Nu, le voi combina mai târziu",
-        "dismiss": "Închide"
-      }
-    },
-    "ViewScans": {
-      "metadata": {
-        "description": "Vizualizați și gestionați scanările încărcate. Creați facturi din scanările selectate.",
-        "title": "Sistem de gestionare a facturilor - Vizualizare Scanări"
-      },
-      "title": "Scanările Tale",
-      "subtitle": "Selectați scanări pentru a crea facturi din ele.",
-      "breadcrumb": "Înapoi la Facturi",
-      "header": {
-        "title": "Scanările Tale",
-        "titleWithCount": "Scanările Tale ({count})",
-        "subtitle": "Selectați scanări pentru a crea facturi din ele",
-        "lastSynced": "Ultima sincronizare: {time}",
-        "tooltip": "Selectați scanări pentru a crea facturi din ele. Puteți crea o factură per scanare sau combina mai multe scanări într-o singură factură.",
-        "uploadMore": "Încărcați Mai Multe",
-        "upload": "Încărcați",
-        "uploadTooltip": "Încărcați mai multe scanări în contul dvs.",
-        "myInvoices": "Facturile Mele",
-        "invoices": "Facturi",
-        "myInvoicesTooltip": "Vizualizați facturile create",
-        "sync": "Sincronizare",
-        "syncing": "Se sincronizează...",
-        "syncTooltip": "Reîmprospătați scanările de pe server"
-      },
-      "stats": {
-        "totalScans": "Total Scanări",
-        "ready": "Pregătite",
-        "selected": "Selectate",
-        "selectHint": "Faceți clic pe scanări pentru a le selecta pentru crearea facturilor",
-        "tapHint": "Atingeți pentru a selecta"
-      },
-      "sidebar": {
-        "howTo": {
-          "title": "Cum să Creați Facturi",
-          "step1Title": "Selectați Scanări",
-          "step1Description": "Faceți clic pe scanări pentru a le selecta",
-          "step2Title": "Alegeți Modul",
-          "step2Description": "O factură per scanare sau combinați mai multe",
-          "step3Title": "Creați Factura",
-          "step3Description": "AI extrage datele automat"
-        },
-        "selectionStatus": {
-          "singular": "scanare selectată",
-          "plural": "scanări selectate",
-          "readySingular": "Pregătit pentru a crea o factură",
-          "readyPlural": "Creați mai multe facturi sau combinați-le într-una singură"
-        },
-        "quickUpload": {
-          "title": "Aveți nevoie de mai multe scanări?",
-          "description": "Încărcați chitanțe suplimentare",
-          "button": "Încărcare"
-        }
-      },
-      "emptyState": {
-        "title": "Nicio scanare încă",
-        "description": "Începeți prin a încărca chitanțele și facturile dvs. Iată cum funcționează:",
-        "step1Title": "Încărcați scanările",
-        "step1Description": "Fotografiați chitanțele sau încărcați PDF-uri cu facturi digitale",
-        "step2Title": "Selectați și organizați",
-        "step2Description": "Alegeți care scanări să fie convertite în facturi",
-        "step3Title": "Creați facturi",
-        "step3Description": "AI-ul nostru extrage automat toate datele pentru dvs.",
-        "uploadButton": "Încărcați Prima Scanare",
-        "learnMoreButton": "Aflați Mai Multe"
-      },
-      "toolbar": {
-        "selected": "selectat(e)",
-        "clearSelection": "Ștergeți",
-        "createInvoice": "Creați Factură",
-        "createInvoices": "Creați Facturi",
-        "delete": {
-          "button": "Șterge ({count})",
-          "confirmTitle": "Ștergeți scanările selectate?",
-          "confirmDescription": "Aceasta va șterge permanent {count} scanare(i) din stocare. Această acțiune nu poate fi anulată.",
-          "cancel": "Anulează",
-          "confirm": "Șterge",
-          "success": "{count} scanare(i) șterse cu succes",
-          "partial": "{success} șterse, {failed} eșuate",
-          "failed": "Nu s-au putut șterge scanările",
-          "error": "A apărut o eroare la ștergerea scanărilor"
-        }
-      },
-      "scanCard": {
-        "delete": "Ștergeți scanarea",
-        "linked": "Asociată",
-        "deleteDialog": {
-          "title": "Ștergeți scanarea?",
-          "description": "Sigur doriți să ștergeți \"{name}\"? Această acțiune nu poate fi anulată și scanarea va fi eliminată permanent din stocare.",
-          "linkedWarning": "Această scanare este asociată cu o factură.",
-          "linkedDescription": "Ștergerea acesteia va elimina scanarea din stocare, dar factura va păstra o copie a imaginii. Această acțiune nu poate fi anulată.",
-          "cancel": "Anulare",
-          "delete": "Ștergere",
-          "deleting": "Se șterge...",
-          "success": "Scanarea a fost ștearsă cu succes",
-          "error": "Nu s-a putut șterge scanarea"
-        },
-        "rename": "Redenumește scanarea",
-        "renamePlaceholder": "Introduceți un nume nou",
-        "preview": "Previzualizare scanare",
-        "previewTitle": "Previzualizare Scanare",
-        "loading": "Se încarcă...",
-        "actions": {
-          "rename": "Redenumește scanarea",
-          "delete": "Ștergeți scanarea",
-          "rotateCW": "Rotește 90° în sens orar",
-          "rotateCCW": "Rotește 90° în sens antiorar",
-          "rotating": "Se rotește...",
-          "rotateSuccess": "Imaginea a fost rotită cu succes",
-          "rotateError": "Nu s-a putut roti imaginea",
-          "rotateUnsupported": "Nu se pot roti fișierele PDF"
-        }
-      },
-      "createInvoiceDialog": {
-        "title": "Creați Factură",
-        "titlePlural": "Creați Facturi",
-        "description": "Transformați scanările în date structurate de factură cu extracție bazată pe AI.",
-        "selectedScans": "Scanări Selectate",
-        "totalSize": "total",
-        "chooseMode": "Alegeți Modul de Creare",
-        "singleMode": {
-          "title": "O factură per scanare",
-          "description": "Creează {count} facturi separate. Ideal când fiecare scanare este o chitanță diferită."
-        },
-        "batchMode": {
-          "title": "Combinați într-o singură factură",
-          "description": "Creează 1 factură cu toate cele {count} scanări atașate. Ideal pentru chitanțe cu mai multe pagini."
-        },
-        "singleScanInfo": {
-          "title": "Ce se întâmplă în continuare?",
-          "description": "AI-ul nostru va analiza scanarea dvs. și va extrage automat detaliile comerciantului, articolele, prețurile și totalurile. Puteți revizui și edita rezultatele ulterior."
-        },
-        "buttons": {
-          "cancel": "Anulare",
-          "createSingle": "Creați Factură",
-          "createMultiple": "Creați {count} Facturi",
-          "close": "Închide"
-        },
-        "creating": {
-          "title": "Se creează Factura",
-          "titlePlural": "Se creează Facturile",
-          "processing": "Se procesează {count} scanare...",
-          "processingPlural": "Se procesează {count} scanări...",
-          "step1Title": "Se încarcă scanările",
-          "step1Description": "Se trimit scanările către serverele noastre",
-          "step2Title": "Se creează înregistrările facturilor",
-          "step2Description": "Se configurează structurile de date ale facturilor",
-          "step3Title": "Finalizare",
-          "step3Description": "Se pregătesc facturile pentru vizualizare"
-        },
-        "complete": {
-          "title": "{count} Factură Creată!",
-          "titlePlural": "{count} Facturi Create!",
-          "description": "Factura dvs. este gata pentru vizualizare și editare.",
-          "descriptionPlural": "Facturile dvs. sunt gata pentru vizualizare și editare.",
-          "nextSteps": "Pași următori:",
-          "nextStepsDescription": "Revizuiți factura, verificați datele extrase și faceți orice modificări necesare. Puteți solicita și analiza AI pentru informații despre cheltuieli.",
-          "nextStepsDescriptionPlural": "Revizuiți facturile, verificați datele extrase și faceți orice modificări necesare. Puteți solicita și analiza AI pentru informații despre cheltuieli.",
-          "viewButton": "Vizualizați Factura",
-          "viewButtonPlural": "Vizualizați Facturile",
-          "failureTitle": "Creare Eșuată",
-          "failureDescription": "Nu am putut crea nicio factură. Vă rugăm să revedeți erorile de mai jos și să încercați din nou.",
-          "partialTitle": "{created} din {total} Facturi Create",
-          "partialDescription": "Unele scanări nu au putut fi procesate. Facturile create cu succes sunt gata pentru vizualizare.",
-          "errorsLabel": "Scanări Eșuate:",
-          "retryButton": "Încearcă Din Nou"
-        },
-        "errors": {
-          "partialFail": "Nu s-au putut crea {count} facturi",
-          "createFailed": "Nu s-au putut crea facturile: {message}",
-          "unknown": "Eroare necunoscută"
-        }
-      },
-      "createFromAll": {
-        "button": "Creează din Toate Scanările",
-        "title": "Toate scanările sunt gata!",
-        "description": "Creează facturi din toate cele {count} scanări deodată"
-      },
-      "groupBanner": {
-        "title": "Aceste {count} scanări au fost încărcate împreună",
-        "subtitle": "Creați o factură din aceste scanări?",
-        "createInvoice": "Creează Factură",
-        "dismiss": "Renunță"
-      },
-      "pagination": {
-        "previous": "Anterior",
-        "next": "Următor",
-        "pageInfo": "{current} / {total} ({count} scanări)"
-      }
-    },
-    "ViewInvoices": {
-      "metadata": {
-        "description": "Enumerați toate facturile din sistemul de gestionare a facturilor.",
-        "title": "Enumerați facturile"
-      },
-      "subtitle": "Acesta este inventarul dvs. de bonuri digitale. <br></br> Aici puteți găsi bonurile pe care le-ați încărcat până acum. <br></br> Făcând clic pe o chitanță, veți fi redirecționat către pagina chitanței specifice.",
-      "title": "Bine ați venit, {name}!",
-      "viewInvoicesPage": {
-        "guestName": "dragă oaspete"
-      },
-      "viewInvoicesIsland": {
-        "tabs": {
-          "invoices": "Facturi",
-          "statistics": "Statistici",
-          "liveAnalysis": "Analiză live"
-        }
-      },
-      "invoicesHeader": {
-        "title": "Gestionare facturi",
-        "description": "Gestionează-ți bonurile și urmărește-ți obiceiurile de cheltuieli",
-        "actions": {
-          "import": "Importă",
-          "export": "Exportă",
-          "print": "Printează",
-          "newInvoice": "Factură nouă"
-        },
-        "tooltips": {
-          "import": "Importă facturi din fișiere",
-          "export": "Exportă toate facturile",
-          "print": "Printează facturile",
-          "newInvoice": "Creează o factură nouă"
-        }
-      },
-      "invoicesView": {
-        "searchPlaceholder": "Caută facturi...",
-        "filters": {
-          "category": "Categorie",
-          "timeOfDay": "Momentul zilei",
-          "categories": "Categorii",
-          "paymentTypes": "Tipuri de plată",
-          "dateRange": "Interval de date",
-          "dateFrom": "De la data",
-          "dateTo": "Până la data",
-          "amountRange": "Interval de sumă",
-          "amountMin": "Sumă minimă",
-          "amountMax": "Sumă maximă",
-          "sortBy": "Sortare după",
-          "sortOptions": {
-            "dateNewest": "Dată (cele mai recente)",
-            "dateOldest": "Dată (cele mai vechi)",
-            "amountHighToLow": "Sumă (descrescător)",
-            "amountLowToHigh": "Sumă (crescător)",
-            "nameAZ": "Nume (A-Z)",
-            "nameZA": "Nume (Z-A)",
-            "none": "Fără sortare (ordine implicită)"
-          },
-          "title": "Filtre",
-          "button": "Filtre",
-          "clear": "Șterge tot",
-          "activeCount": "{count} active"
-        },
-        "categories": {
-          "all": "Toate categoriile",
-          "groceries": "Alimente",
-          "dining": "Mese în oraș",
-          "utilities": "Utilități",
-          "entertainment": "Divertisment",
-          "travel": "Călătorii",
-          "other": "Altele"
-        },
-        "times": {
-          "all": "Toate intervalele",
-          "day": "Zi (6-18)",
-          "night": "Noapte (18-6)"
-        },
-        "placeholderPanel": "Vor fi adăugate în curând mai multe controale de filtrare.",
-        "viewModes": {
-          "table": "Table vede",
-          "grid": "Grid vede"
-        }
-      },
-      "statisticsView": {
-        "title": "Statistici facturi",
-        "subtitle": "Gestionează bonurile și urmărește obiceiurile tale de cheltuieli",
-        "charts": {
-          "calendarHeatmap": {
-            "days": {
-              "wed": "Mie",
-              "thu": "Joi",
-              "fri": "Vin",
-              "sun": "Dum",
-              "mon": "Lun",
-              "sat": "Sâm",
-              "tue": "Mar"
-            },
-            "tooltip": {
-              "noSpending": "Fără cheltuieli",
-              "amount": "Cheltuit",
-              "invoices": "{count} facturi"
-            },
-            "legend": {
-              "less": "Mai puțin",
-              "more": "Mai mult"
-            },
-            "title": "Calendar Cheltuieli",
-            "description": "Intensitatea cheltuielilor zilnice în timp",
-            "navigation": {
-              "previous": "Luna anterioară",
-              "next": "Luna următoare"
-            },
-            "aria": {
-              "calendarGrid": "Calendar cheltuieli zilnice"
-            }
-          },
-          "spendingOverTime": {
-            "labels": {
-              "amount": "Sumă"
-            },
-            "tooltip": {
-              "invoiceCount": "{count} facturi",
-              "andMore": "și încă {count}..."
-            },
-            "title": "Cheltuieli în Timp",
-            "description": "Urmăriți tendințele cheltuielilor"
-          },
-          "categoryBreakdown": {
-            "title": "Cheltuieli pe categorii",
-            "description": "Distribuție pe categorii",
-            "totalLabel": "Cheltuieli totale",
-            "tooltip": {
-              "invoiceCount": "{count} facturi"
-            }
-          },
-          "currencyDistribution": {
-            "title": "Distribuție Valutară",
-            "description": "Defalcarea cheltuielilor pe valute cu conversie în RON",
-            "toggleLabel": "Comutați vizualizarea valutei",
-            "showOriginal": "Arată Original",
-            "showRON": "Arată RON",
-            "singleCurrency": "Toate facturile în {currency} ({symbol})",
-            "invoiceCount": "{count} facturi",
-            "originalAmount": "Original",
-            "ronEquivalent": "Echivalent RON",
-            "totalAmount": "Sumă Totală",
-            "totalCurrencies": "Total Valute",
-            "totalSpending": "Cheltuieli Totale"
-          },
-          "merchantLeaderboard": {
-            "title": "Comercianți de Top",
-            "description": "Unde cheltuiești cel mai mult",
-            "labels": {
-              "totalSpent": "Total Cheltuit"
-            },
-            "tooltip": {
-              "invoiceCount": "{count} facturi"
-            },
-            "empty": "Nu sunt date disponibile despre comercianți"
-          },
-          "merchantTrends": {
-            "title": "Tendințe Cheltuieli Comercianți",
-            "description": "Modele lunare de cheltuieli pentru comercianții de top",
-            "labels": {
-              "merchant": "Comerciant",
-              "totalSpend": "Total Cheltuit",
-              "trend": "Tendință (Ultimele 6 Luni)"
-            },
-            "aria": {
-              "sparkline": "Tendință cheltuieli pentru {merchant}"
-            },
-            "empty": "Nu există date despre comercianți încă"
-          },
-          "merchantVisit": {
-            "title": "Modele de Vizitare Comercianți",
-            "description": "Frecvența cumpărăturilor și informații despre coș",
-            "metrics": {
-              "totalVisits": "Total Vizite",
-              "visitsPerMonth": "Vizite/Lună",
-              "basketSize": "Coș Mediu",
-              "preferredDay": "Zi Preferată",
-              "avgSpend": "Cheltuială Medie/Vizită"
-            },
-            "empty": "Nu există date de vizite încă"
-          },
-          "priceDistribution": {
-            "title": "Distribuția prețurilor",
-            "description": "Distribuția prețurilor produselor",
-            "labels": {
-              "itemCount": "Număr de produse"
-            },
-            "tooltip": {
-              "itemCount": "{count} produse"
-            }
-          },
-          "timeOfDay": {
-            "title": "Obiceiuri de cumpărare",
-            "description": "Când faceți cumpărături",
-            "labels": {
-              "invoiceCount": "Număr de facturi"
-            },
-            "tooltip": {
-              "invoiceCount": "{count} facturi"
-            }
-          },
-          "productCategory": {
-            "tooltip": {
-              "productCount": "{count} produse"
-            },
-            "empty": "Niciun produs de analizat încă",
-            "title": "Cheltuieli pe Categorii de Produse",
-            "description": "Defalcare cheltuieli după tip de produs"
-          },
-          "topProducts": {
-            "headers": {
-              "totalSpent": "Total",
-              "rank": "#",
-              "avgPrice": "Preț Mediu",
-              "purchases": "Achiziții",
-              "product": "Produs",
-              "quantity": "Cant"
-            },
-            "empty": "Niciun produs cumpărat încă",
-            "title": "Produse Preferate",
-            "description": "Cele mai cumpărate articole",
-            "ariaLabel": "Clasament produse preferate"
-          },
-          "allergenSummary": {
-            "empty": "Niciun alergen detectat în achizițiile tale",
-            "stats": {
-              "ofTotal": "din total",
-              "products": "produse"
-            },
-            "title": "Rezumat Alergeni",
-            "description": "Expunerea la alergeni în produse",
-            "ariaLabel": "Rezumat frecvență alergeni"
-          }
-        },
-        "kpi": {
-          "totalSpending": "Cheltuieli totale",
-          "invoiceCount": "Număr de facturi",
-          "topMerchant": "Comerciant principal",
-          "averageItems": "Med. produse",
-          "vsLastMonth": "{delta}% față de luna trecută",
-          "avgPerInvoice": "medie {amount} per factură",
-          "visits": "{count} vizite",
-          "acrossInvoices": "din {count} facturi",
-          "noneYet": "Niciun rezultat încă"
-        },
-        "comparison": {
-          "title": "Lună de lună",
-          "description": "Comparație cu luna anterioară",
-          "spendingDelta": "Variația cheltuielilor",
-          "invoiceCount": "Număr de facturi",
-          "newMerchants": "Comercianți noi",
-          "discovered": "descoperiți",
-          "none": "niciunul",
-          "increase": "creștere",
-          "decrease": "scădere"
-        },
-        "empty": {
-          "title": "Nicio statistică încă",
-          "subtitle": "Încărcați bonuri pentru a vedea statisticile",
-          "cta": "Încarcă bon"
-        },
-        "productAnalytics": {
-          "title": "Analiză Produse",
-          "subtitle": "Detalii despre articolele achiziționate"
-        }
-      },
-      "messageList": {
-        "aiAssistant": "Asistent AI",
-        "you": "Tu"
-      },
-      "generativeView": {
-        "welcomeMessage": "Salut! Sunt asistentul tău de analiză a facturilor. Cu ce te pot ajuta astăzi? Încearcă comenzi precum /find pentru a căuta facturi.",
-        "title": "Analiză live",
-        "subtitle": "Discută cu AI pentru a-ți analiza facturile și pentru a primi analize utile",
-        "help": "Ajutor",
-        "tabs": {
-          "chat": "Conversație",
-          "settings": "Setări"
-        },
-        "chatDescription": "Discută cu AI pentru a-ți analiza facturile și pentru a primi analize utile. Încearcă comenzi precum /find pentru a căuta facturi.",
-        "settings": {
-          "title": "Chat setări",
-          "description": "Configurează preferințele asistentului tău AI",
-          "historyLabel": "Chat istoric",
-          "retentionPlaceholder": "Selectează perioada de păstrare",
-          "retention": {
-            "30": "Păstrează 30 de zile",
-            "60": "Păstrează 60 de zile",
-            "90": "Păstrează 90 de zile",
-            "none": "Don't salvează istoric"
-          },
-          "dataAccessTitle": "Acces la date",
-          "allowInvoiceData": "Permite accesul la datele facturii",
-          "allowMerchantData": "Permite accesul la datele comerciantului",
-          "notificationPreferences": "Preferințe de notificare",
-          "notifyInsights": "Notifică-mă despre analize noi",
-          "save": "Salvează setări"
-        }
-      },
-      "tableView": {
-        "empty": {
-          "title": "Nu există facturi încă",
-          "description": "Începeți prin a încărca chitanțele pentru a crea prima factură",
-          "uploadCta": "Încărcați prima chitanță"
-        },
-        "columns": {
-          "invoice": "Factură",
-          "category": "Categorie",
-          "date": "Dată",
-          "amount": "Sumă",
-          "actions": "Acțiuni"
-        },
-        "aria": {
-          "selectAllInvoices": "Selectează toate facturile",
-          "selectInvoice": "Selectează factură {name}",
-          "rowsPerPage": "Rânduri pe pagină",
-          "sortByDate": "Sortare după dată",
-          "sortByAmount": "Sortare după sumă"
-        },
-        "viewInvoice": "Vede Factură",
-        "rowsPerPage": "Rânduri pe pagină:",
-        "pageOf": "Pagina {current} din {total}",
-        "previousPage": "Pagina anterioară",
-        "nextPage": "Pagina următoare",
-        "tooltips": {
-          "notAnalyzed": "Această factură nu a fost încă analizată"
-        }
-      },
-      "gridView": {
-        "tooltips": {
-          "viewDetails": "Vezi detalii"
-        },
-        "itemCount": "{count, plural, one {# articol} few {# articole} other {# de articole}}"
-      },
-      "tableViewActions": {
-        "actions": {
-          "edit": "Editează",
-          "share": "Partajează",
-          "delete": "Șterge"
-        },
-        "tooltips": {
-          "moreActions": "Mai multe acțiuni",
-          "edit": "Editează detaliile facturii",
-          "share": "Partajează factura prin link sau e-mail",
-          "delete": "Șterge definitiv această factură"
-        }
-      },
-      "exportDialog": {
-        "title": "Exportă facturi",
-        "description": "Exportă {count} facturi în formatul preferat.",
-        "format": {
-          "title": "Format de export",
-          "labels": {
-            "csv": "CSV",
-            "json": "JSON",
-            "pdf": "PDF"
-          },
-          "descriptions": {
-            "json": "Format de date structurate",
-            "pdf": "Format document imprimabil",
-            "csv": "Format de foaie de calcul, compatibil cu Excel"
-          }
-        },
-        "options": {
-          "title": "Opțiuni",
-          "includeMetadata": "Include metadatele",
-          "includeProducts": "Include produsele",
-          "includeMerchant": "Include comerciantul",
-          "csv": {
-            "includeHeaders": "Include antetele CSV",
-            "delimiterLabel": "Suprascriere delimitator CSV (opțional):",
-            "delimiterPlaceholder": ","
-          },
-          "json": {
-            "prettyPrint": "Afișare formatată (2 spații)"
-          }
-        },
-        "buttons": {
-          "cancel": "Anulează",
-          "export": "Exportă",
-          "copy": "Copiază în Clipboard",
-          "copied": "Copiat!"
-        },
-        "filename": {
-          "hint": "Fișierul va fi salvat cu extensia bazată pe format",
-          "label": "Nume fișier"
-        },
-        "estimate": {
-          "label": "Dimensiune estimată fișier:"
-        }
-      },
-      "importDialog": {
-        "title": "Importă facturi",
-        "description": "Încarcă fișierele de facturi pentru a le importa în sistem.",
-        "tabs": {
-          "csv": "CSV",
-          "pdf": "PDF",
-          "xlsx": "Excel"
-        },
-        "dropzone": {
-          "dropHere": "Plasează fișierele aici...",
-          "dragAndDrop": "Trage și plasează fișierele aici",
-          "orClickBrowse": "sau apasă pentru a răsfoi fișierele",
-          "acceptsCsv": "Acceptă fișiere .csv (max 10MB)",
-          "acceptsPdf": "Acceptă fișiere .pdf (max 10MB)",
-          "acceptsXlsx": "Acceptă fișiere .xlsx și .xls (max. 10MB)"
-        },
-        "selectedFiles": "Fișiere selectate",
-        "remove": "Elimină",
-        "status": {
-          "success": "Fișiere importate cu succes!",
-          "error": "A apărut o eroare la importul fișierelor. Te rugăm să încerci din nou."
-        },
-        "buttons": {
-          "cancel": "Anulează",
-          "import": "Importă",
-          "importWithCount": "Importă ({count})"
-        }
-      },
-      "bulkActions": {
-        "selected": "{count, plural, one {# factură selectată} other {# facturi selectate}}",
-        "clearSelection": "Curăță selecția",
-        "export": "Exportă",
-        "delete": "Șterge",
-        "changeCategory": "Schimbă Categoria",
-        "deleteConfirm": {
-          "title": "Șterge Facturile",
-          "description": "{count, plural, one {Ești sigur că dorești să ștergi această factură? Această acțiune nu poate fi anulată.} other {Ești sigur că dorești să ștergi aceste # facturi? Această acțiune nu poate fi anulată.}}",
-          "confirm": "Șterge",
-          "cancel": "Anulează"
-        },
-        "deleteSuccess": "{count, plural, one {Factură ștearsă cu succes} other {# facturi șterse cu succes}}",
-        "deleteError": "Eroare la ștergerea facturilor. Vă rugăm încercați din nou.",
-        "deletePartialSuccess": "{success} factură/facturi șterse, {failed} eșuate",
-        "categoryChanged": "{count, plural, one {Categoria facturii actualizată cu succes} other {# categorii de facturi actualizate cu succes}}",
-        "categoryChangeError": "Eroare la actualizarea categoriilor facturilor. Vă rugăm încercați din nou.",
-        "categoryPartialSuccess": "{success} factură/facturi actualizate, {failed} eșuate",
-        "categories": {
-          "notDefined": "Nedefinit",
-          "grocery": "Alimente",
-          "fastFood": "Fast Food",
-          "homeCleaning": "Curățenie Casă",
-          "carAuto": "Mașină & Auto",
-          "other": "Altele"
-        }
-      }
-    },
-    "ViewInvoice": {
-      "metadata": {
-        "description": "Vizualizați detaliile facturii, articolele și informațiile despre comerciant.",
-        "title": "Vizualizare factură"
-      },
-      "invoiceAnalytics": {
-        "title": "Analize și insight-uri",
-        "tabs": {
-          "current": "Factura curentă",
-          "compare": "Comparație"
-        },
-        "emptyState": {
-          "title": "Date insuficiente pentru comparații",
-          "description": "Adaugă mai multe facturi pentru a vedea tendințe de cheltuieli, defalcări pe comercianți și comparații pe categorii."
-        }
-      },
-      "invoiceTimeline": {
-        "title": "Cronologia facturii",
-        "subtitle": "Istoric complet al acțiunilor și modificărilor",
-        "eventCount": "{count, plural, one {# eveniment} few {# evenimente} other {# de evenimente}}"
-      },
-      "invoiceTabs": {
-        "tabs": {
-          "possibleRecipes": "Rețete posibile",
-          "additionalInfo": "Informații suplimentare"
-        },
-        "recipe": {
-          "duration": "{minutes} min",
-          "prepCook": "Pregătire: {prep}m • Gătire: {cook}m",
-          "viewRecipe": "Vezi rețeta",
-          "ingredients": "Ingrediente",
-          "instructions": "Instrucțiuni"
-        },
-        "actions": {
-          "regenerate": "Regenerează rețetele",
-          "regenerateTooltip": "Re-analizează factura pentru a genera noi sugestii de rețete",
-          "generate": "Generează rețete"
-        },
-        "empty": {
-          "recipes": "Nu există sugestii de rețete",
-          "additionalInfo": "Nu există informații suplimentare"
-        }
-      },
-      "timelineItem": {
-        "aria": {
-          "moreInfo": "Mai multe informații despre {title}"
-        },
-        "confidence": "Încredere: {value}%",
-        "events": {
-          "created": {
-            "title": "Factură creată",
-            "description": "Scanată și digitalizată din bon"
-          },
-          "aiAnalysis": {
-            "title": "Analiză AI finalizată",
-            "description": "{count, plural, one {# articol detectat și categorisit} few {# articole detectate și categorisite} other {# de articole detectate și categorisite}}"
-          },
-          "recipesGenerated": {
-            "title": "Rețete generate",
-            "description": "{count, plural, one {# rețetă sugerată} few {# rețete sugerate} other {# de rețete sugerate}}"
-          },
-          "shared": {
-            "title": "Partajată cu alții",
-            "description": "Partajată cu {count, plural, one {# persoană} few {# persoane} other {# de persoane}}"
-          },
-          "edited": {
-            "title": "Factură actualizată"
-          },
-          "exported": {
-            "title": "Factură exportată"
-          },
-          "markedImportant": {
-            "title": "Marcată ca importantă",
-            "description": "Marcată pentru urmărire prioritară"
-          },
-          "categorized": {
-            "title": "Categorie atribuită",
-            "description": "Categorizare automată pe baza articolelor"
-          }
-        },
-        "tooltips": {
-          "created": "Factura a fost scanată și digitalizată folosind {method}.",
-          "aiAnalysis": "AI a procesat această factură în {duration} și a analizat {count, plural, one {# articol} few {# articole} other {# de articole}}.",
-          "recipesGenerated": "Pe baza ingredientelor cumpărate, {count, plural, one {a fost generată # rețetă} few {au fost generate # rețete} other {au fost generate # de rețete}}.",
-          "shared": "Factura a fost partajată cu {count, plural, one {# utilizator} few {# utilizatori} other {# de utilizatori}}.",
-          "edited": "Au fost făcute modificări manuale facturii.",
-          "exported": "Factura a fost exportată în format {format}.",
-          "markedImportant": "Factura a fost marcată ca importantă pentru acces rapid.",
-          "categorized": "Facturii i-a fost atribuită o categorie pentru o organizare mai bună.",
-          "unavailable": "Detaliile evenimentului nu sunt disponibile"
-        },
-        "relativeTime": {
-          "now": "Chiar acum"
-        },
-        "fallbacks": {
-          "ocr": "OCR",
-          "pdf": "PDF"
-        }
-      },
-      "timelineSharedWithList": {
-        "header": {
-          "title": "Partajată cu",
-          "publicBadge": "Public"
-        },
-        "publicAccess": {
-          "title": "Acces public activat",
-          "description": "Această factură este accesibilă public. Oricine are linkul o poate vedea, inclusiv invitații fără cont."
-        },
-        "aria": {
-          "sendEmail": "Trimite email către {user}"
-        },
-        "actions": {
-          "sendEmail": "Trimite email",
-          "manageSharing": "Gestionează partajarea"
-        }
-      },
-      "budgetImpactCard": {
-        "title": "Impact bugetar {month}",
-        "monthlyBudget": "Buget lunar",
-        "spent": "{amount} cheltuiți",
-        "invoiceUsed": "Această factură a folosit",
-        "ofMonthlyBudget": "din bugetul tău lunar",
-        "remaining": "Rămas",
-        "overBudget": "Peste buget",
-        "daysLeft": "Zile rămase",
-        "inMonth": "în {month}",
-        "dailyAllowance": "Alocație zilnică",
-        "dailyAllowanceValue": "{amount} / zi"
-      },
-      "comparisonStatsCard": {
-        "title": "Cum te compari",
-        "subtitle": "Comparativ cu ultimele tale {count} facturi",
-        "vsAverage": "vs medie",
-        "avgValue": "Medie: {amount} {currency}",
-        "thisValue": "Aceasta: {amount} {currency}",
-        "minValue": "Minim: {amount}",
-        "maxValue": "Maxim: {amount}",
-        "positionInRange": "Poziția ta în intervalul de cheltuieli",
-        "itemCount": "Articol Count",
-        "itemCountComparison": "{current} vs medie {average}",
-        "sameStore": "Același magazin",
-        "sameStoreComparison": "vs medie {average} {currency}"
-      },
-      "invoiceDetailsCard": {
-        "title": "Detalii factură",
-        "labels": {
-          "dateUtc": "Dată (UTC)",
-          "category": "Categorie",
-          "payment": "Plată",
-          "totalAmount": "Suma totală",
-          "receiptType": "Tip bon",
-          "countryRegion": "Țară/Regiune",
-          "subtotal": "Subtotal",
-          "tip": "Bacșiș",
-          "ronEquivalent": "Echivalent RON"
-        },
-        "itemsTitle": "Articole ({count})",
-        "table": {
-          "item": "Articol",
-          "qty": "Cant.",
-          "unit": "Unitate",
-          "price": "Preț",
-          "total": "Total general",
-          "grandTotal": "Total general"
-        },
-        "pagination": {
-          "pageOf": "Pagina {current} din {total}",
-          "previous": "Anterior",
-          "next": "Următor"
-        },
-        "tooltips": {
-          "exchangeRate": "1 {fromCurrency} = {rate} RON (medie {year})"
-        },
-        "sections": {
-          "paymentMethods": "Metode de plată",
-          "taxBreakdown": "Detalii taxe"
-        },
-        "taxLabels": {
-          "net": "Net",
-          "tax": "Taxă"
-        }
-      },
-      "merchantInfoCard": {
-        "title": "Informații comerciant",
-        "noMerchantLinked": "Niciun comerciant asociat acestei facturi",
-        "viewAllReceipts": "Vezi toate bonurile",
-        "viewAllInvoices": "Vezi toate facturile",
-        "viewOnMap": "Vezi pe hartă",
-        "spendingHistory": "Istoric cheltuieli",
-        "categoryDistribution": "Distribuție categorii",
-        "stats": {
-          "visits": "vizite",
-          "avgSpend": "Cheltuială medie",
-          "daysAgo": "zile în urmă"
-        }
-      },
-      "receiptScanCard": {
-        "title": "Scanare bon",
-        "dialogTitle": "Imagine bon",
-        "scanAlt": "Scanare bon {index}",
-        "scanAltFullSize": "Scanare bon {index} - dimensiune completă",
-        "buttons": {
-          "expand": "Extinde imaginea",
-          "previousScan": "Scanarea anterioară",
-          "nextScan": "Scanarea următoare"
-        },
-        "tooltips": {
-          "expand": "Vezi imaginea bonului la dimensiune completă",
-          "previousScan": "Vezi scanarea anterioară a bonului",
-          "nextScan": "Vezi următoarea scanare a bonului"
-        },
-        "titleWithIndex": "Scanare bon ({current}/{total})",
-        "dialogTitleWithIndex": "Imagine bon ({current}/{total})",
-        "controls": {
-          "zoomIn": "Mărește",
-          "zoomOut": "Micșorează",
-          "reset": "Resetează zoom",
-          "rotate": "Rotește",
-          "download": "Descarcă",
-          "fullScreen": "Ecran complet",
-          "toggleZoom": "Clic pentru a comuta zoom-ul"
-        },
-        "navigation": {
-          "previous": "Anterior",
-          "next": "Următor",
-          "of": "din"
-        }
-      },
-      "seasonalInsightsCard": {
-        "title": "Insight sezonier",
-        "month": {
-          "spendingSoFar": "{month} până acum",
-          "vsAverage": "vs media pe {month}: {amount}"
-        },
-        "insights": {
-          "spike": {
-            "title": "Creștere {category}",
-            "description": "+{percent}% vs media ta"
-          },
-          "holidaySeason": {
-            "title": "Sezonul sărbătorilor",
-            "description": "Cheltuielile din decembrie sunt de obicei cu 35% mai mari"
-          },
-          "stockUpTip": {
-            "title": "Sfat de aprovizionare",
-            "description": "Prețurile cresc cu ~15% după 15 decembrie"
-          },
-          "normalPattern": {
-            "title": "Model normal de cumpărături",
-            "description": "Cheltuielile tale sunt în intervalul obișnuit"
-          },
-          "insufficientData": {
-            "title": "Construim profilul tău de cheltuieli",
-            "description": "Adaugă mai multe facturi pentru a vedea informații sezoniere și modele de cheltuieli"
-          }
-        }
-      },
-      "shoppingCalendarCard": {
-        "title": "Calendar cumpărături",
-        "tooltip": {
-          "basedOnCachedInvoices": "Bazat pe {count} facturi din cache",
-          "currentInvoiceOnly": "Se afișează doar factura curentă",
-          "more": "+{count} în plus",
-          "vsAverage": "vs medie ({years} ani de date)",
-          "invoiceCount": "{count} factură(s)",
-          "currentInvoice": "Factura curentă"
-        },
-        "legend": {
-          "less": "Mai puțin",
-          "more": "Mai mult"
-        },
-        "stats": {
-          "monthTotal": "Total lună",
-          "shoppingDays": "Zile de cumpărături"
-        },
-        "insights": {
-          "shopEveryPrefix": "Faci cumpărături la fiecare",
-          "days": "{count} zile",
-          "onAverage": "în medie",
-          "spendingPrefix": ", cheltuind",
-          "perTrip": " per cumpărătură",
-          "mostActiveOn": "Cel mai activ în",
-          "weekdayLabel": "{weekday}"
-        }
-      },
-      "summaryStatsCard": {
-        "title": "Rezumat factură",
-        "description": "Statistici cheie dintr-o privire",
-        "stats": {
-          "totalItems": {
-            "label": "Total articole",
-            "description": "Produse cumpărate"
-          },
-          "categories": {
-            "label": "Categorii",
-            "description": "Categorii unice"
-          },
-          "averagePrice": {
-            "label": "Preț mediu",
-            "description": "{currency} per articol"
-          },
-          "taxRate": {
-            "label": "Rată taxă",
-            "description": "{amount} {currency}"
-          }
-        },
-        "extremes": {
-          "highest": "Cel mai mare",
-          "lowest": "Cel mai mic"
-        }
-      },
-      "invoiceGuestBanner": {
-        "title": "Vizualizare invitat",
-        "description": "În prezent nu ești proprietarul acestei facturi. Vizualizarea este limitată la ce a configurat proprietarul în setările de partajare."
-      },
-      "categoryComparisonChart": {
-        "title": "Comparație pe categorii",
-        "description": "Factura aceasta vs media ta",
-        "labels": {
-          "current": "Curent",
-          "average": "Medie"
-        }
-      },
-      "itemsBreakdownChart": {
-        "title": "Top articole după cost",
-        "description": "Articole cu cele mai mari cheltuieli",
-        "labels": {
-          "price": "Preț",
-          "quantity": "Cant."
-        }
-      },
-      "merchantBreakdownChart": {
-        "title": "Cheltuieli pe magazin",
-        "description": "Totaluri cumulative pe toți comercianții",
-        "labels": {
-          "totalSpent": "Total cheltuit",
-          "total": "Total",
-          "visits": "Vizite",
-          "averagePerVisit": "Medie/vizită"
-        },
-        "unknownMerchant": "Comerciant Necunoscut"
-      },
-      "priceDistributionChart": {
-        "title": "Distribuția prețurilor",
-        "description": "Articole pe intervale de preț ({currency})",
-        "labels": {
-          "items": "Articole"
-        },
-        "tooltip": {
-          "itemCount": "{count, plural, one {# articol} few {# articole} other {# de articole}}"
-        }
-      },
-      "spendingByCategoryChart": {
-        "title": "Cheltuieli pe categorie",
-        "description": "Distribuția cheltuielilor",
-        "totalLabel": "Total cheltuieli",
-        "tooltip": {
-          "itemCount": "{count, plural, one {# articol} few {# articole} other {# de articole}}"
-        }
-      },
-      "spendingTrendChart": {
-        "title": "Evoluția cheltuielilor",
-        "description": "Trendul istoricului tău de facturi",
-        "labels": {
-          "amount": "Sumă"
-        },
-        "tooltip": {
-          "currentInvoice": "Factura curentă",
-          "andMore": "și încă {count}..."
-        }
-      },
-      "shareAnalyticsDialog": {
-        "title": "Partajează Analytics",
-        "description": "Partajează analizele tale de cheltuieli pentru {merchant} cu alte persoane.",
-        "tabs": {
-          "image": "Imagine",
-          "email": "email"
-        },
-        "image": {
-          "description": "Descarcă sau copiază graficul de analiză ca imagine PNG, pe care o poți partaja sau salva.",
-          "previewPlaceholder": "Previzualizare analize",
-          "download": "Descarcă graficul",
-          "copyToClipboard": "Copiază graficul în clipboard"
-        },
-        "email": {
-          "description": "Trimite analizele la o adresă de email.",
-          "label": "Adresă email",
-          "placeholder": "name@example.com",
-          "send": "Trimite email"
-        },
-        "toasts": {
-          "imageCopied": {
-            "title": "Imagine copiată!",
-            "description": "Imaginea analizelor a fost copiată în clipboard"
-          },
-          "emailSent": {
-            "title": "Email trimis!",
-            "description": "Raportul de analiză a fost trimis la {email}"
-          },
-          "imageSaved": {
-            "title": "Imagine salvată!",
-            "description": "Analizele de cheltuieli pentru {merchant} au fost descărcate ca PNG"
-          }
-        }
-      },
-      "categorySuggestionCard": {
-        "title": "Ajută-ne să categorisim această factură",
-        "description": "Nu am putut categoriza automat această factură. Selectează categoria corectă pentru a debloca analize:",
-        "moreCategories": "Mai multe categorii:",
-        "gamification": "Categorisește {goal} facturi pentru a debloca analize detaliate!"
-      },
-      "diningCard": {
-        "title": "Informații despre mese",
-        "sodium": {
-          "high": "Ridicat",
-          "medium": "Mediu",
-          "low": "Scăzut"
-        },
-        "estimatedNutrition": {
-          "title": "Nutriție estimată",
-          "calories": "Calorii",
-          "caloriesValue": "~{value} kcal",
-          "protein": "Proteine",
-          "proteinValue": "~{value}g",
-          "sodium": "Sodiu",
-          "carbs": "Carbohidrați",
-          "carbsValue": "~{value}g"
-        },
-        "habits": {
-          "title": "Obiceiurile tale de fast-food",
-          "frequency": "Frecvență",
-          "frequencyValue": "{count}x/lună",
-          "frequencyDiff": "+1 vs medie",
-          "avgSpend": "Cheltuială medie",
-          "favorite": "Favorit",
-          "visits": "{count} vizite"
-        },
-        "swaps": {
-          "title": "Alternative mai sănătoase",
-          "grilled": "La grătar în loc de prăjit",
-          "water": "Apă în loc de suc",
-          "salad": "Salată garnitură în loc de cartofi prăjiți",
-          "caloriesSaved": "-{count} kcal",
-          "moneySaved": ", economisești {amount}"
-        },
-        "challenge": {
-          "title": "Provocare săptămânală",
-          "descriptionPrefix": "Evită fast-food-ul timp de 7 zile și salvează",
-          "descriptionSuffix": ""
-        }
-      },
-      "generalExpenseCard": {
-        "title": "Analiză cheltuieli",
-        "detectedCategory": "Electronice / Tehnologie",
-        "confidence": "Încredere: {value}%",
-        "sections": {
-          "autoDetectedCategory": "Auto-detected categorie",
-          "budgetImpact": "Impact bugetar",
-          "taxBusiness": "Opțiuni fiscale și de business",
-          "similarPurchases": "Achiziții similare anterioare"
-        },
-        "buttons": {
-          "correct": "Corect",
-          "change": "Schimbă",
-          "organize": "Organizează",
-          "export": "Exportă"
-        },
-        "aria": {
-          "confirmCategory": "Confirmă că categoria detectată este corectă",
-          "changeCategory": "Change detected categorie",
-          "organize": "Organizează această cheltuială în categorii",
-          "export": "Exportă datele cheltuielii"
-        },
-        "nearLimitAlert": "{name}: {percent}% utilizat (10 zile rămase în lună)",
-        "options": {
-          "businessExpense": "Marchează drept cheltuială de business",
-          "trackWarranty": "Urmărește garanția (standard 24 luni)",
-          "insuranceInventory": "Adaugă în inventarul de asigurare"
-        },
-        "vatReclaimable": "TVA recuperabil",
-        "budgetCategories": {
-          "electronics": "Electronice",
-          "entertainment": "Divertisment",
-          "shopping": "Cumpărături"
-        }
-      },
-      "homeInventoryCard": {
-        "title": "Inventar casă și consumabile",
-        "supplyNames": {
-          "laundryDetergent": "Detergent rufe",
-          "dishSoap": "Detergent vase",
-          "paperProducts": "Produse din hârtie",
-          "floorCleaner": "Soluție pentru podea"
-        },
-        "stockLevels": {
-          "title": "Niveluri stoc consumabile (estimate)",
-          "daysRemaining": "~{count} zile"
-        },
-        "eco": {
-          "title": "Scor ecologic",
-          "productsWithEcoLabels": "{count} produse cu etichete ecologice",
-          "recyclablePackaging": "{count} produs cu ambalaj reciclabil",
-          "tip": "Tip: Eco alternatives salvează 2kg plastic/year"
-        },
-        "bulk": {
-          "title": "Economii la cumpărături în vrac",
-          "description": "Detergent 5L față de 2L economisește 18% ({amount}/an)"
-        }
-      },
-      "nutritionCard": {
-        "title": "Privire generală nutriție",
-        "score": {
-          "title": "Scor echilibru alimentar",
-          "excellent": "Excelent",
-          "good": "Bun",
-          "fair": "Acceptabil",
-          "needsWork": "Necesită îmbunătățiri"
-        },
-        "composition": {
-          "title": "Compoziția coșului tău",
-          "wholeFoods": "Alimente integrale",
-          "processed": "Procesate",
-          "dairyOther": "Lactate/Altele"
-        },
-        "foodGroups": {
-          "fruits": "Fructe",
-          "vegetables": "Legume",
-          "protein": "Proteine",
-          "grains": "Cereale",
-          "itemsCount": "{count} articol(s)"
-        },
-        "allergens": {
-          "title": "Alergeni detectați",
-          "foundInItems": "Găsit în {count} articol(e)"
-        },
-        "suggestions": {
-          "addFruitsAndVegetables": "Adaugă mai multe fructe și legume pentru a-ți echilibra coșul",
-          "addVegetables": "Ia în calcul adăugarea de legume pentru o alimentație mai echilibrată",
-          "addFruits": "Adăugarea unor fructe ar îmbunătăți echilibrul nutrițional",
-          "swapProcessed": "Încearcă să înlocuiești unele produse procesate cu alimente integrale",
-          "greatBalance": "Cumpărături foarte bine echilibrate!"
-        }
-      },
-      "vehicleCard": {
-        "title": "Analiza cheltuielilor vehiculului",
-        "expenseType": "Tip cheltuială: Combustibil",
-        "details": {
-          "liters": "Litri",
-          "pricePerLiter": "Preț/L",
-          "station": "Stație",
-          "vehicle": "Vehicul",
-          "notSet": "Nesetat"
-        },
-        "chart": {
-          "title": "Cheltuieli lunare cu combustibilul",
-          "amount": "Sumă"
-        },
-        "stats": {
-          "thisMonth": "Luna aceasta",
-          "fillUps": "{count} alimentări",
-          "costPerKm": "Cost pe km",
-          "estimated": "estimat",
-          "fuelPrice": "Fuel Preț",
-          "thisMonthSuffix": "luna aceasta"
-        },
-        "maintenance": {
-          "title": "Mementouri întreținere"
-        },
-        "tip": {
-          "title": "Cel mai ieftin în apropiere",
-          "perLiter": "L"
-        },
-        "buttons": {
-          "addVehicle": "Adaugă Vehicul",
-          "fullReport": "Raport complet"
-        },
-        "months": {
-          "sep": "sept.",
-          "oct": "oct.",
-          "nov": "nov.",
-          "dec": "dec."
-        },
-        "reminders": {
-          "oilChange": "Schimb de ulei în ~1.200 km",
-          "tireRotation": "Se recomandă rotația anvelopelor"
-        }
-      },
-      "print": {
-        "generatedOn": "Tipărit pe {date}",
-        "page": "Pagina",
-        "labels": {
-          "date": "Data",
-          "merchant": "Comerciant",
-          "total": "Suma Totală",
-          "items": "Articole"
-        }
-      },
-      "relatedInvoices": {
-        "noRelated": "Nu s-au găsit facturi conexe",
-        "subtitle": "Facturi similare bazate pe comerciant, categorie sau sumă",
-        "sameCategory": "Aceeași Categorie",
-        "viewInvoice": "Vizualizare",
-        "similarAmount": "Sumă Similară",
-        "sameMerchant": "Același Comerciant",
-        "title": "Facturi Conexe"
-      },
-      "shareCollaborate": {
-        "title": "Partajare & Colaborare",
-        "private": "Privat",
-        "shared": "Partajat",
-        "public": "Public",
-        "sharedWith": "Partajat cu",
-        "copyLink": "Copiază Link",
-        "shareEmail": "Partajează prin Email",
-        "manageSharing": "Gestionează Partajarea",
-        "copied": "Link copiat în clipboard!",
-        "activity": {
-          "title": "Activitate",
-          "created": "Creat {time}",
-          "modified": "Ultima modificare {time}",
-          "daysAgo": "{count, plural, one {acum # zi} other {acum # zile}}",
-          "today": "astăzi"
-        },
-        "publicAccess": "Acces Public",
-        "publicAccessDescription": "Oricine cu link-ul poate vizualiza această factură",
-        "madePublic": "Factura este acum publică",
-        "madePrivate": "Factura este acum privată",
-        "toggleError": "Eroare la actualizarea setărilor de partajare",
-        "qrCode": "Cod QR",
-        "qrCopied": "Link copiat! Generarea codului QR va fi adăugată în curând.",
-        "copyError": "Nu s-a putut copia linkul"
-      },
-      "healthScore": {
-        "suggestions": {
-          "uncategorizedProducts": "<strong>{count}</strong> produse fără categorie — atribuie categorii pentru analiza cheltuielilor",
-          "incompleteProducts": "<strong>{count}</strong> produse incomplete — revizuiește și completează câmpurile lipsă",
-          "title": "Îmbunătățiri Sugerate",
-          "noMerchant": "Niciun comerciant asociat — adaugă detalii comerciant pentru statistici mai bune",
-          "lowOcrConfidence": "Confidență OCR scăzută la <strong>{count}</strong> produse — revizuiește manual pentru acuratețe",
-          "noRecipes": "Nu sunt rețete generate — rulează analiza AI pentru a descoperi idei de mese",
-          "incompletePayment": "Informații plată incomplete — adaugă data tranzacției, suma și moneda",
-          "fix": "Rezolvă",
-          "noProducts": "Nu sunt produse găsite — încarcă un bon sau adaugă articole manual"
-        },
-        "title": "Scor Sănătate Factură",
-        "subtitle": "Evaluare comprehensivă a calității datelor",
-        "factors": {
-          "ocrConfidence": "Confidență OCR",
-          "categoriesAssigned": "Categorii atribuite",
-          "paymentInfo": "Informații plată",
-          "merchantLinked": "Comerciant asociat",
-          "recipesGenerated": "Rețete generate",
-          "productsPresent": "Produse extrase",
-          "productCompleteness": "Completitudine produse"
-        },
-        "status": {
-          "incomplete": "Incomplet",
-          "needsAttention": "Necesită Atenție",
-          "excellent": "Excelent",
-          "good": "Bun"
-        },
-        "points": "puncte",
-        "showDetails": "Arată detalii factori",
-        "hideDetails": "Ascunde detalii factori",
-        "cta": {
-          "edit": "Editează Factura",
-          "analyze": "Rulează Analiza AI"
-        },
-        "seeReport": "Vezi raport detaliat",
-        "dialogTitle": "Raport de sănătate factură"
-      },
-      "itemAnalytics": {
-        "title": "Produse",
-        "searchPlaceholder": "Caută produse...",
-        "columns": {
-          "name": "Nume",
-          "category": "Categorie",
-          "price": "Preț",
-          "quantity": "Cant.",
-          "total": "Total"
-        },
-        "summary": {
-          "title": "Rezumat",
-          "mostExpensive": "Cel mai scump",
-          "cheapest": "Cel mai ieftin",
-          "categories": "{count} categorii",
-          "allergens": "{count} alergeni detectați"
-        },
-        "empty": {
-          "title": "Niciun produs",
-          "subtitle": "Rulați analiza AI pentru a extrage produsele din bon"
-        },
-        "totalLabel": "TOTAL",
-        "confidence": {
-          "label": "Încredere OCR",
-          "lowWarning": "Încredere scăzută — verificați acest produs"
-        }
-      },
-      "analysisPanel": {
-        "title": "Analiză AI",
-        "options": {
-          "completeAnalysis": "Analiză Completă",
-          "merchantOnly": "Doar Comerciant",
-          "itemsOnly": "Doar Articole",
-          "invoiceOnly": "Doar Factura"
-        },
-        "tooltips": {
-          "completeAnalysis": "Extragere OCR completă + procesare AI a tuturor datelor facturii",
-          "merchantOnly": "Re-identifică comerciantul și datele de locație",
-          "itemsOnly": "Re-categorizează și analizează doar articolele individuale",
-          "invoiceOnly": "Re-extrage informații de bază ale facturii (dată, total, plată)",
-          "reanalyze": "Declanșează re-analiza completă cu toate caracteristicile AI"
-        },
-        "steps": {
-          "processing": "Se procesează articolele...",
-          "complete": "Analiză completă!",
-          "finalizing": "Se finalizează rezultatele...",
-          "extracting": "Se rulează extragerea OCR...",
-          "analyzing": "Se analizează cu AI...",
-          "preparing": "Se pregătește documentul..."
-        },
-        "tip": "Sfat Rapid: Analiza completă durează 30-60 secunde, dar oferă cele mai precise rezultate.",
-        "buttons": {
-          "reanalyze": "Re-analizează Factura"
-        },
-        "description": "Re-analizează această factură cu AI pentru a extrage sau actualiza datele",
-        "toasts": {
-          "success": {
-            "title": "Analiză Completă",
-            "description": "Factura a fost re-analizată cu succes cu date actualizate."
-          },
-          "error": {
-            "title": "Analiză Eșuată",
-            "description": "Nu s-a putut analiza factura. Vă rugăm să încercați din nou mai târziu."
-          }
-        },
-        "analyzing": {
-          "title": "Se analizează...",
-          "progress": "{progress}% completat"
-        },
-        "labels": {
-          "granularOptions": "Sau alege o analiză specifică",
-          "updates": "{count, plural, one {# actualizare} other {# actualizări}}",
-          "lastAnalyzed": "Ultima Analiză",
-          "analysisComplete": "Analiză Completă — Toate datele au fost extrase"
-        }
-      },
-      "export": {
-        "print": {
-          "title": "Printare",
-          "description": "Printează factura folosind browserul"
-        },
-        "csv": {
-          "title": "Exportă ca CSV",
-          "description": "Descarcă articolele ca foaie de calcul"
-        },
-        "copyError": "Eroare la copierea rezumatului",
-        "csvSuccess": "Fișier CSV descărcat cu succes",
-        "jsonSuccess": "Fișier JSON descărcat cu succes",
-        "title": "Exportă Factură",
-        "printError": "Eroare la deschiderea dialogului de printare",
-        "copySuccess": "Rezumat copiat în clipboard",
-        "jsonError": "Eroare la exportul JSON",
-        "copySummary": {
-          "title": "Copiază Rezumat",
-          "description": "Copiază rezumatul text în clipboard"
-        },
-        "printSuccess": "Dialog de printare deschis",
-        "description": "Exportă datele facturii în diverse formate",
-        "csvError": "Eroare la exportul CSV",
-        "json": {
-          "title": "Exportă ca JSON",
-          "description": "Descarcă datele complete ale facturii"
-        },
-        "pdf": {
-          "description": "Descarcă document profesional de factură",
-          "title": "Exportă ca PDF"
-        },
-        "pdfSuccess": "Fișier PDF descărcat cu succes",
-        "pdfError": "Eroare la generarea PDF-ului",
-        "pdfGenerating": "Se generează PDF..."
-      }
-    },
-    "EditInvoice": {
-      "metadata": {
-        "description": "Vizualizați și editați detaliile facturii, articolele, rețetele și setările de partajare.",
-        "title": "Editare factură"
-      },
-      "editInvoiceContext": {
-        "toasts": {
-          "noChanges": "Nu există modificări de salvat",
-          "updated": "Factura a fost actualizată cu succes",
-          "saveFailed": "Salvarea modificărilor a eșuat"
-        },
-        "console": {
-          "saveFailed": "Salvarea facturii a eșuat:"
-        }
-      },
-      "triviaTips": {
-        "title": "Sfaturi de economisire",
-        "completeness": "Factura este completă în proporție de {percentage}%",
-        "completeLabel": "Factura este complet completă!",
-        "difficulty": {
-          "easy": "Ușor",
-          "medium": "Mediu"
-        },
-        "banner": {
-          "potentialSavingsLabel": "Economii potențiale",
-          "hint": "Aplică aceste sfaturi pentru a economisi la următoarea vizită la {merchantName}"
-        },
-        "contextTips": {
-          "noItems": "Rulează analiza AI pentru a extrage articolele din bon",
-          "noDescription": "Adaugă o descriere pentru a-ți aminti această achiziție",
-          "noCategory": "Setează o categorie pentru a urmări modelele de cheltuieli",
-          "defaultCategory": "Schimbă categoria din 'Necategorizat' pentru o urmărire mai bună",
-          "noRecipes": "AI poate sugera rețete bazate pe articolele tale alimentare"
-        },
-        "contextActions": {
-          "analyze": "Rulează Analiza",
-          "addDescription": "Adaugă Descriere",
-          "setCategory": "Setează Categoria"
-        },
-        "tips": {
-          "loyaltyProgram": {
-            "title": "Înscrie-te în programul de loialitate",
-            "description": "Înscrie-te în programul de loialitate {merchantName} pentru a câștiga puncte la fiecare achiziție."
-          },
-          "bulkPurchase": {
-            "title": "Cumpără la vrac",
-            "description": "Cumpără produse neperisabile la vrac pentru a reduce costul per unitate."
-          },
-          "digitalCoupons": {
-            "title": "Folosește cupoane digitale",
-            "description": "Verifică aplicația {merchantName} pentru cupoane digitale înainte de cumpărături."
-          }
-        },
-        "tooltips": {
-          "estimatedSavings": "Economii estimate cu acest sfat"
-        },
-        "buttons": {
-          "viewMoreSavingsTips": "Vezi mai multe sfaturi de economisire"
-        },
-        "disclaimer": "Economiile sunt estimări bazate pe prețuri și promoții medii"
-      },
-      "invoiceCard": {
-        "title": "Detalii factură",
-        "importantBadge": "IMPORTANT",
-        "markImportant": "Marchează ca important",
-        "tooltips": {
-          "unmarkFavorite": "Apasă pentru a scoate din favorite",
-          "markFavorite": "Apasă pentru a marca drept favorit"
-        },
-        "fromMerchant": "De la {merchant}",
-        "descriptionPlaceholder": "Introdu descrierea facturii...",
-        "labels": {
-          "dateUtc": "Dată (UTC)",
-          "hours": "Ore",
-          "minutes": "Minute",
-          "utc": "UTC",
-          "category": "Categorie",
-          "paymentMethod": "Metodă de plată",
-          "totalAmount": "Sumă totală"
-        },
-        "placeholders": {
-          "selectCategory": "Selectează categorie",
-          "selectPaymentType": "Selectează tipul de plată"
-        }
-      },
-      "merchantCard": {
-        "title": "Comerciant",
-        "noMerchantLinked": "Niciun comerciant asociat acestei facturi",
-        "addressLabel": "Adresă: {address}",
-        "buttons": {
-          "viewMerchantDetails": "Vezi detalii comerciant",
-          "viewAllReceipts": "Vezi toate bonurile"
-        },
-        "tooltips": {
-          "viewMerchantDetails": "Vezi informații detaliate despre acest comerciant",
-          "viewAllReceipts": "Vezi toate bonurile de la acest comerciant"
-        }
-      },
-      "imageCard": {
-        "title": "Scanare bon",
-        "dialogTitle": "Imagine bon",
-        "scanAlt": "Scanare bon {index}",
-        "scanAltFullSize": "Scanare bon {index} - dimensiune completă",
-        "buttons": {
-          "expand": "Extinde imaginea",
-          "previous": "Anterior",
-          "next": "Următor",
-          "addScan": "Adaugă scan",
-          "remove": "Elimină"
-        },
-        "tooltips": {
-          "expand": "Vezi imaginea bonului la dimensiune completă",
-          "previous": "Vezi scanarea anterioară a bonului",
-          "next": "Vezi următoarea scanare a bonului",
-          "addScan": "Încarcă și atașează o scanare nouă a bonului",
-          "remove": "Elimină scanarea curentă a bonului"
-        },
-        "aria": {
-          "expandImage": "Apasă pentru a extinde imaginea"
-        },
-        "titleWithIndex": "Scanare bon ({current}/{total})",
-        "dialogTitleWithIndex": "Imagine bon ({current}/{total})"
-      },
-      "recipeCard": {
-        "complexity": {
-          "unknown": "Necunoscut",
-          "easy": "Ușor",
-          "normal": "Normal",
-          "hard": "Greu"
-        },
-        "dropdown": {
-          "view": "Vezi",
-          "edit": "Editează",
-          "delete": "Șterge",
-          "share": "Distribuie",
-          "markAsFavorite": "Marchează ca favorit"
-        },
-        "ingredients": {
-          "label": "Ingrediente:",
-          "more": "+{count} în plus",
-          "additionalLabel": "Ingrediente suplimentare:"
-        },
-        "timing": {
-          "prepLabel": "Pregătire: {minutes}′",
-          "prepTooltip": "Timpul de pregătire este de {minutes} minute.",
-          "cookLabel": "Gătire: {minutes}′",
-          "cookTooltip": "Timpul de gătire este de {minutes} minute."
-        },
-        "buttons": {
-          "visitReference": "Vizitează referința",
-          "viewRecipe": "Vezi rețeta"
-        }
-      },
-      "sharingCard": {
-        "title": "Partajare",
-        "ownerAvatarAlt": "Utilizator",
-        "owner": "Proprietar",
-        "sharedWith": "Partajată cu",
-        "userWithId": "Utilizator {id}",
-        "publicInvoice": {
-          "title": "Factură publică",
-          "description": "Această factură este accesibilă public. Oricine are linkul o poate vedea."
-        },
-        "emptyShared": {
-          "public": "Niciun utilizator suplimentar nu are acces direct",
-          "private": "Nu este partajată"
-        },
-        "buttons": {
-          "manageSharing": "Gestionează Partajare",
-          "shareInvoice": "Partajează Factură",
-          "revokingAccess": "Se revocă accesul...",
-          "markAsPrivate": "Marchează ca privată"
-        },
-        "tooltips": {
-          "manageSharing": "Gestionează setările de partajare pentru această factură",
-          "removeAccess": "Elimină accesul",
-          "shareInvoice": "Partajează această factură cu alți utilizatori",
-          "markAsPrivate": "Marchează factura ca privată"
-        },
-        "toasts": {
-          "removeAccessComingSoon": {
-            "title": "Funcția de eliminare a accesului va fi disponibilă în curând",
-            "description": "Această funcționalitate este în curs de dezvoltare."
-          },
-          "revoke": {
-            "loading": "Se revocă accesul public...",
-            "success": "Factura este acum privată. Linkurile existente nu vor mai funcționa.",
-            "error": "Marcarea ca privată a eșuat: {message}"
-          }
-        }
-      },
-      "recipesTab": {
-        "header": {
-          "title": "Rețete pe care le poți prepara",
-          "description": "Pe baza articolelor din această factură"
-        },
-        "buttons": {
-          "generate": "Generează",
-          "addRecipe": "Adaugă rețetă",
-          "createFirstRecipe": "Creează prima ta rețetă"
-        },
-        "tooltips": {
-          "generateRecipeUsingAi": "Generează o rețetă cu IA!",
-          "createRecipeWithIngredients": "Creează o rețetă nouă cu aceste ingrediente"
-        },
-        "emptyState": {
-          "noRecipesAvailable": "Nu există încă rețete disponibile"
-        },
-        "pagination": {
-          "previous": "Anterior",
-          "next": "Următor",
-          "pageOf": "Pagina {currentPage} din {totalPages}"
-        },
-        "toasts": {
-          "aiGenerationComingSoon": {
-            "title": "Generarea rețetelor cu IA vine în curând",
-            "description": "Această funcționalitate este în curs de dezvoltare."
-          }
-        }
-      },
-      "metadataTab": {
-        "header": {
-          "title": "Informații suplimentare",
-          "description": "Metadate asociate acestei facturi"
-        },
-        "buttons": {
-          "addField": "Adaugă câmp",
-          "addFirstMetadataField": "Adaugă primul tău câmp de metadate"
-        },
-        "tooltips": {
-          "addCustomMetadata": "Adaugă metadate personalizate la această factură"
-        },
-        "badges": {
-          "readonly": "Doar citire"
-        },
-        "dropdown": {
-          "edit": "Editează",
-          "delete": "Șterge"
-        },
-        "emptyState": {
-          "noMetadataFields": "Nu au fost adăugate câmpuri de metadate"
-        }
-      },
-      "analyzeDialog": {
-        "header": {
-          "title": "Analizează factura",
-          "description": "Configurează o analiză cu IA pentru factura"
-        },
-        "options": {
-          "completeAnalysis": {
-            "title": "Analiză completă",
-            "description": "Analiză completă cu IA ce include toate datele facturii, articolele și informațiile comerciantului.",
-            "estimatedTime": "2-3 min",
-            "features": {
-              "ocrExtraction": "Extracție OCR",
-              "itemCategorization": "Categorisirea articolelor",
-              "merchantIdentification": "Identificarea comerciantului",
-              "priceAnalysis": "Analiza prețurilor",
-              "receiptValidation": "Validarea bonului"
-            }
-          },
-          "invoiceOnly": {
-            "title": "Doar datele facturii",
-            "description": "Analizează informațiile de bază ale facturii precum totaluri, date și detalii de plată.",
-            "estimatedTime": "30-60 sec",
-            "features": {
-              "totalExtraction": "Extracția totalului",
-              "dateParsing": "Interpretarea datelor",
-              "paymentMethodDetection": "Detectarea metodei de plată"
-            }
-          },
-          "itemsOnly": {
-            "title": "Analiza articolelor",
-            "description": "Se concentrează pe extragerea și categorisirea articolelor individuale din factură.",
-            "estimatedTime": "1-2 min",
-            "features": {
-              "itemExtraction": "Extracția articolelor",
-              "categoryAssignment": "Atribuirea categoriilor",
-              "pricePerItem": "Preț per articol",
-              "quantityDetection": "Detectarea cantității"
-            }
-          },
-          "merchantOnly": {
-            "title": "Analiza comerciantului",
-            "description": "Identifică și analizează informațiile comerciantului, inclusiv locația și categoria.",
-            "estimatedTime": "30-45 sec",
-            "features": {
-              "merchantIdentification": "Identificarea comerciantului",
-              "locationExtraction": "Extracția locației",
-              "businessCategory": "Categoria afacerii",
-              "contactInfo": "Informații de contact"
-            }
-          }
-        },
-        "analysisSteps": {
-          "preparingDocument": "Se pregătește documentul...",
-          "runningOcrExtraction": "Se rulează extracția OCR...",
-          "analyzingWithAi": "Se analizează cu IA...",
-          "categorizingItems": "Se categorisesc articolele...",
-          "finalizingResults": "Se finalizează rezultatele...",
-          "processing": "Se procesează..."
-        },
-        "analyzing": {
-          "title": "Se analizează factura",
-          "progressComplete": "{progress}% complet"
-        },
-        "sections": {
-          "analysisType": "Tip analiză",
-          "includedFeatures": "Funcționalități incluse",
-          "enhancementsOptional": "Îmbunătățiri (opțional)"
-        },
-        "enhancements": {
-          "priceComparison": {
-            "label": "Comparare prețuri",
-            "description": "Compară prețurile cu date istorice"
-          },
-          "savingsTips": {
-            "label": "Sugestii de economisire",
-            "description": "Primește recomandări de economisire cu IA"
-          },
-          "quickExtract": {
-            "label": "Mod de extragere rapidă",
-            "description": "Prioritizează viteza în locul acurateței"
-          }
-        },
-        "badges": {
-          "recommended": "Recomandat"
-        },
-        "summary": {
-          "enhancementsSelected": "+ {count} îmbunătățire(i)",
-          "noEnhancementsSelected": "Nicio îmbunătățire selectată",
-          "estimatedTime": "Durată estimată"
-        },
-        "buttons": {
-          "cancel": "Anulează",
-          "analyzing": "Se analizează...",
-          "startAnalysis": "Pornește analiza"
-        },
-        "toasts": {
-          "analysisComplete": {
-            "title": "Analiză finalizată",
-            "description": "Factura ta a fost analizată cu succes."
-          },
-          "analysisFailed": {
-            "title": "Analiza a eșuat",
-            "description": "Nu am putut analiza factura ta. Te rugăm să încerci din nou."
-          }
-        }
-      },
-      "addScanDialog": {
-        "title": "Adaugă o scanare nouă",
-        "description": "Încarcă o imagine nouă a bonului sau un document nou pentru a-l atașa la această factură.",
-        "dropzone": {
-          "dropHere": "Plasează fișierul aici...",
-          "dragAndDrop": "Trage și plasează un fișier aici",
-          "orClickBrowse": "sau apasă pentru a răsfoi",
-          "formats": "JPEG, PNG, PDF (max 10MB)"
-        },
-        "scanType": {
-          "label": "Tip scanare",
-          "placeholder": "Selectează tipul de scanare",
-          "jpeg": "Imagine JPEG",
-          "png": "Imagine PNG",
-          "pdf": "Document PDF",
-          "other": "Altele"
-        },
-        "buttons": {
-          "cancel": "Anulează",
-          "uploading": "Se încarcă...",
-          "upload": "Încarcă scan"
-        },
-        "errors": {
-          "uploadStorageFailed": "Încărcarea scanării în spațiul de stocare a eșuat",
-          "unknown": "A apărut o eroare necunoscută"
-        },
-        "toasts": {
-          "fileTooLargeTitle": "Fișier prea mare",
-          "fileTooLargeDescription": "Dimensiunea maximă a fișierului este 10MB",
-          "scanAddedTitle": "Scan adăugat cu succes",
-          "scanAddedDescription": "Scanarea a fost atașată la factură",
-          "scanFailedTitle": "Adăugarea scanării a eșuat"
-        },
-        "console": {
-          "uploadError": "Eroare la încărcarea scanării:"
-        }
-      },
-      "imageDialog": {
-        "title": "Imagine ({image})",
-        "imageAlt": "Fotografie a bonului"
-      },
-      "itemsDialog": {
-        "title": "Editează articolele facturii",
-        "description": "Actualizează cantitățile, prețurile sau adaugă articole noi în această factură",
-        "table": {
-          "item": "Articol",
-          "quantity": "Cantitate",
-          "unit": "Unitate",
-          "price": "Preț",
-          "total": "Total general",
-          "actions": "Acțiuni"
-        },
-        "footer": {
-          "itemsFound": "{total} articole găsite (se afișează {shown})",
-          "page": "Pagina {current} din {total}",
-          "itemsTotal": "{count, plural, one {# articol în total} few {# articole în total} other {# de articole în total}}"
-        },
-        "buttons": {
-          "previous": "Anterior",
-          "next": "Următor",
-          "addItem": "Adaugă articol",
-          "cancel": "Anulează",
-          "saveChanges": "Salvează changes"
-        },
-        "aria": {
-          "deleteItem": "Șterge articol: {name}",
-          "unnamedItem": "unnamed articol",
-          "previousPage": "Mergi la pagina anterioară (pagina {page})",
-          "nextPage": "Mergi la pagina următoare (pagina {page})",
-          "addItem": "Adaugă un articol nou în factură",
-          "cancel": "Anulează editarea și închide dialogul",
-          "save": "Salvează modificările articolelor facturii"
-        }
-      },
-      "merchantDialog": {
-        "title": "Detalii comerciant",
-        "noMerchantLinked": "Niciun comerciant asociat acestei facturi",
-        "description": "Informații despre {merchantName}",
-        "fields": {
-          "address": "Adresă",
-          "phone": "Telefon",
-          "parentCompany": "Companie mamă"
-        },
-        "buttons": {
-          "openInMaps": "Deschide în Maps"
-        }
-      },
-      "feedbackDialog": {
-        "title": "Oferă feedback",
-        "description": "Ajută-ne să îmbunătățim analizele pentru {merchant} împărtășindu-ne opinia ta",
-        "sections": {
-          "rating": "Cum ai evalua analizele?",
-          "features": "Care funcționalități au fost cele mai utile? (Selectează toate opțiunile aplicabile)",
-          "comments": "Comentarii suplimentare (opțional)"
-        },
-        "features": {
-          "spendingTrends": "Tendințe de cheltuieli",
-          "priceComparisons": "Preț Comparisons",
-          "savingsTips": "Sfaturi de economisire",
-          "merchantAnalysis": "Merchant Analiză",
-          "visualCharts": "Grafice vizuale",
-          "categoryBreakdown": "Categorie Breakdown"
-        },
-        "commentsPlaceholder": "Împărtășește-ne părerea ta despre analize...",
-        "buttons": {
-          "cancel": "Anulează",
-          "submit": "Trimite feedback"
-        },
-        "toasts": {
-          "sending": {
-            "title": "Se trimite feedback-ul...",
-            "description": "Te rugăm să aștepți cât timp trimitem feedback-ul."
-          },
-          "ratingRequired": {
-            "title": "Evaluare necesară",
-            "description": "Te rugăm să oferi un calificativ cu stele înainte de trimitere"
-          },
-          "success": {
-            "title": "Feedback trimis!",
-            "description": "Feedback trimis cu succes"
-          },
-          "error": {
-            "title": "A apărut o eroare la trimiterea feedback-ului",
-            "description": "Te rugăm să încerci din nou mai târziu."
-          }
-        }
-      },
-      "metadataDialog": {
-        "add": {
-          "title": "Adaugă metadate",
-          "description": "Adaugă informații suplimentare la această factură"
-        },
-        "edit": {
-          "title": "Editează metadatele",
-          "description": "Actualizează valoarea acestui câmp de metadate",
-          "fieldLabel": "Câmp metadate"
-        },
-        "delete": {
-          "title": "Șterge metadatele",
-          "description": "Sigur vrei să ștergi aceste metadate?"
-        },
-        "fields": {
-          "keyLabel": "Cheie metadate",
-          "valueLabel": "Valoare metadate",
-          "keyPlaceholder": "Introdu cheia",
-          "valuePlaceholder": "Introdu valoarea"
-        },
-        "buttons": {
-          "cancel": "Anulează",
-          "save": "Salvează",
-          "delete": "Șterge"
-        }
-      },
-      "recipeDialog": {
-        "create": {
-          "title": "Adaugă o rețetă nouă",
-          "description": "Completează detaliile pentru a crea o rețetă.",
-          "success": "Rețeta a fost creată cu succes",
-          "error": "Nu s-a putut crea rețeta"
-        },
-        "read": {
-          "description": "Detalii despre rețetă și instrucțiuni de preparare",
-          "noDescription": "Nu a fost furnizată nicio descriere.",
-          "notSpecified": "Nespecificat"
-        },
-        "update": {
-          "title": "Actualizează rețeta",
-          "description": "Actualizează detaliile rețetei."
-        },
-        "delete": {
-          "title": "Ești sigur?",
-          "description": "Această acțiune nu poate fi anulată. Va șterge definitiv rețeta <strong>{name}</strong> și toate datele asociate."
-        },
-        "fields": {
-          "recipeName": "Nume rețetă",
-          "description": "Descriere",
-          "ingredients": "Ingrediente",
-          "difficulty": "Nivel de dificultate",
-          "complexity": "Nivel de complexitate",
-          "instructions": "Instrucțiuni",
-          "prepTime": "Timp de pregătire",
-          "cookTime": "Timp de gătire",
-          "totalDuration": "Durata Totală"
-        },
-        "actions": {
-          "generateName": "Generează nume",
-          "enhanceInstructions": "Îmbunătățește instrucțiunile"
-        },
-        "tooltips": {
-          "generateName": "Generează un nume de rețetă pe baza ingredientelor și a nivelului de dificultate folosind AI",
-          "enhanceInstructions": "Folosește AI pentru a-ți îmbunătăți instrucțiunile cu mai multe detalii"
-        },
-        "placeholders": {
-          "recipeName": "Introdu numele rețetei",
-          "description": "Introdu o descriere scurtă a rețetei",
-          "selectDifficulty": "Selectează dificultatea",
-          "instructions": "Introdu instrucțiunile de gătire",
-          "prepTime": "ex. 15 minute",
-          "cookTime": "ex. 30 minute"
-        },
-        "difficulty": {
-          "easy": "Ușor",
-          "medium": "Mediu",
-          "hard": "Greu"
-        },
-        "buttons": {
-          "add": "Adaugă",
-          "cancel": "Anulează",
-          "save": "Salvează",
-          "saving": "Se salvează...",
-          "close": "Închide",
-          "delete": "Șterge"
-        },
-        "minutes": "minute"
-      },
-      "merchantReceiptsDialog": {
-        "title": "Toate bonurile de la {merchant}",
-        "description": "Vezi și filtrează toate bonurile tale de la acest comerciant",
-        "searchPlaceholder": "Caută receipts...",
-        "filters": {
-          "date": "Dată",
-          "sort": "Sortare"
-        },
-        "dateOptions": {
-          "allTime": "Toată perioada",
-          "last30Days": "Ultimele 30 de zile",
-          "last90Days": "Ultimele 90 de zile",
-          "thisYear": "Anul acesta"
-        },
-        "sortOptions": {
-          "newest": "Cele mai noi primele",
-          "oldest": "Cele mai vechi primele"
-        },
-        "table": {
-          "receipt": "Bon",
-          "date": "Dată",
-          "itemsCount": "Articole #",
-          "actions": "Acțiuni",
-          "view": "Vede"
-        },
-        "footer": {
-          "receiptsFound": "{count} bonuri găsite (afișate {showing})",
-          "page": "Pagina {current} din {total}"
-        },
-        "buttons": {
-          "previous": "Anterior",
-          "next": "Următor"
-        }
-      },
-      "removeScanDialog": {
-        "title": "Elimină scan",
-        "description": "Sigur vrei să elimini scanarea {current} din {total}?",
-        "descriptionLastScan": "Aceasta este singura scanare atașată la această factură. Nu o poți elimina.",
-        "scanAlt": "Scanare {index}",
-        "scanCaption": "Scanare {index}",
-        "warning": {
-          "title": "Nu poți elimina ultima scanare",
-          "description": "Fiecare factură trebuie să aibă cel puțin o scanare atașată. Adaugă o altă scanare înainte să o elimini pe aceasta."
-        },
-        "buttons": {
-          "cancel": "Anulează",
-          "removing": "Se elimină...",
-          "remove": "Elimină scan"
-        },
-        "toasts": {
-          "cannotDeleteLastTitle": "Nu poți șterge ultima scanare",
-          "cannotDeleteLastDescription": "O factură trebuie să aibă cel puțin o scanare atașată",
-          "removedTitle": "Scan eliminat cu succes",
-          "removedDescription": "Scanarea a fost eliminată din factură",
-          "removeFailedTitle": "Eliminarea scanării a eșuat"
-        },
-        "errors": {
-          "unknown": "A apărut o eroare necunoscută"
-        },
-        "console": {
-          "deleteError": "Eroare ștergere scan:"
-        }
-      },
-      "itemsTable": {
-        "title": "Articole",
-        "buttons": {
-          "editItems": "Editează articolele",
-          "addItem": "Adaugă articol"
-        },
-        "tooltips": {
-          "editInvoiceItemsAndQuantities": "Editează articolele și cantitățile facturii"
-        },
-        "columns": {
-          "selectAll": "Selectează toate articolele",
-          "selectRow": "Selectează {name}",
-          "name": "Nume",
-          "quantity": "Cantitate",
-          "price": "Preț",
-          "unit": "Unitate",
-          "total": "Total",
-          "actions": "Acțiuni"
-        },
-        "tableHeaders": {
-          "item": "Articol",
-          "quantity": "Cant.",
-          "price": "Preț",
-          "total": "Total"
-        },
-        "footer": {
-          "total": "Total"
-        },
-        "pagination": {
-          "totalItems": "{count, plural, one {# articol în total} few {# articole în total} other {# de articole în total}}",
-          "previous": "Anterior",
-          "next": "Următor",
-          "pageOf": "Pagina {currentPage} din {totalPages}"
-        },
-        "search": {
-          "placeholder": "Caută articole..."
-        },
-        "bulkToolbar": {
-          "selectedCount": "{count, plural, one {# articol selectat} few {# articole selectate} other {# de articole selectate}}",
-          "deleteSelected": "Șterge selecționate",
-          "changeCategory": "Schimbă Categoria",
-          "noSelection": "Niciun produs selectat"
-        },
-        "editing": {
-          "saved": "Articol actualizat cu succes",
-          "cancel": "Editare anulată",
-          "fieldLabel": "Editează {field} pentru {name}"
-        },
-        "deleteConfirm": {
-          "title": "Șterge articole",
-          "description": "{count, plural, one {Sigur doriți să ștergeți acest articol?} few {Sigur doriți să ștergeți aceste # articole?} other {Sigur doriți să ștergeți aceste # de articole?}}",
-          "confirm": "Șterge",
-          "cancel": "Anulează",
-          "success": "{count, plural, one {# articol șters} few {# articole șterse} other {# de articole șterse}}"
-        },
-        "newItem": {
-          "defaultName": "Articol nou",
-          "added": "Articol nou adăugat"
-        },
-        "indicators": {
-          "uncategorized": "Necategorizat",
-          "uncategorizedTooltip": "Acest produs necesită o categorie atribuită pentru o urmărire mai bună a cheltuielilor",
-          "missingName": "Nume lipsă",
-          "missingNameTooltip": "Traducerea numelui generic lipsește sau este identică cu textul OCR brut",
-          "lowConfidence": "Încredere scăzută",
-          "lowConfidenceTooltip": "Încrederea OCR este de {confidence}% - se recomandă revizuire manuală",
-          "edited": "Editat",
-          "editedTooltip": "Acest produs a fost modificat manual",
-          "allergens": "{count, plural, one {# alergen} other {# alergeni}}"
-        },
-        "actions": {
-          "restore": "Restabilește produs",
-          "editAllergens": "Editează alergeni",
-          "remove": "Elimină produs"
-        },
-        "softDelete": {
-          "error": "Eroare la eliminarea produsului",
-          "success": "Produsul '{name}' a fost eliminat"
-        },
-        "restore": {
-          "error": "Eroare la restabilirea produsului",
-          "success": "Produsul '{name}' a fost restabilit"
-        },
-        "bulkCategory": {
-          "noSelection": "Vă rugăm să selectați cel puțin un produs"
-        }
-      },
-      "guidedEdit": {
-        "banner": {
-          "title": "{count, plural, one {# produs necesită revizuire} few {# produse necesită revizuire} other {# de produse necesită revizuire}}",
-          "summary": {
-            "uncategorized": "{count, plural, one {# necategorizat} few {# necategorizate} other {# necategorizate}}",
-            "lowConfidence": "{count, plural, one {# încredere scăzută} few {# încredere scăzută} other {# încredere scăzută}}",
-            "missingName": "{count, plural, one {# nume lipsă} few {# nume lipsă} other {# nume lipsă}}"
-          },
-          "actions": {
-            "reviewAll": "Revizuiește toate",
-            "dismiss": "Închide"
-          },
-          "badges": {
-            "uncategorized": "{count, plural, one {# necategorizat} few {# necategorizate} other {# necategorizate}}",
-            "lowConfidence": "{count, plural, one {# încredere scăzută} few {# încredere scăzută} other {# încredere scăzută}}",
-            "missingName": "{count, plural, one {# nume lipsă} few {# nume lipsă} other {# nume lipsă}}"
-          }
-        }
-      },
-      "changeHistory": {
-        "unsavedChanges": "Modificări nesalvate",
-        "pending": "În așteptare",
-        "created": "Factură creată",
-        "title": "Istoric Modificări",
-        "time": {
-          "justNow": "Acum",
-          "secondsAgo": "acum {seconds} secunde",
-          "hoursAgo": "acum {hours} ore",
-          "daysAgo": "acum {days} zile",
-          "minutesAgo": "acum {minutes} minute"
-        },
-        "modified": "Ultima modificare",
-        "changes": {
-          "paymentTypeChanged": "Tip plată modificat",
-          "unmarkedImportant": "Demarcat ca important",
-          "categoryUpdated": "Categorie actualizată",
-          "transactionDateChanged": "Data tranzacției modificată",
-          "nameChanged": "Nume modificat",
-          "descriptionChanged": "Descriere modificată",
-          "markedImportant": "Marcat ca important",
-          "importanceChanged": "Importanță modificată"
-        }
-      },
-      "allergenDialog": {
-        "title": "Editează Alergeni",
-        "success": {
-          "saved": "Alergenii au fost actualizați cu succes",
-          "added": "Alergen adăugat: {name}",
-          "removed": "Alergen eliminat: {name}"
-        },
-        "labels": {
-          "currentAllergens": "Alergeni Actuali",
-          "customAllergen": "Adaugă Alergen Personalizat",
-          "quickAdd": "Adaugă Rapid Alergeni Comuni"
-        },
-        "description": "Gestionează alergenii pentru {productName}",
-        "placeholders": {
-          "customAllergen": "Introdu numele alergenului..."
-        },
-        "buttons": {
-          "saving": "Se salvează...",
-          "save": "Salvează Modificările",
-          "add": "Adaugă",
-          "cancel": "Anulează"
-        },
-        "empty": {
-          "noAllergens": "Niciun alergen detectat"
-        },
-        "aria": {
-          "removeAllergen": "Elimină alergenul {name}"
-        },
-        "defaultDescription": "Conține {name}",
-        "errors": {
-          "duplicate": "Alergenul '{name}' este deja adăugat",
-          "saveFailed": "Eroare la salvarea alergenilor",
-          "missingData": "Datele produsului lipsesc",
-          "emptyName": "Numele alergenului nu poate fi gol"
-        }
-      },
-      "bulkCategoryDialog": {
-        "success": {
-          "saved": "{count, plural, one {Categoria actualizată pentru # produs} other {Categoria actualizată pentru # produse}}"
-        },
-        "placeholders": {
-          "selectCategory": "Selectează o categorie"
-        },
-        "buttons": {
-          "saving": "Se salvează...",
-          "save": "Aplică Tuturor",
-          "cancel": "Anulează"
-        },
-        "description": "{count, plural, one {Schimbă categoria pentru # produs} other {Schimbă categoria pentru # produse}}",
-        "title": "Schimbă Categoria",
-        "labels": {
-          "andMore": "...și încă {count}",
-          "selectedProducts": "Produse Selectate",
-          "newCategory": "Categorie Nouă"
-        },
-        "errors": {
-          "noProducts": "Niciun produs selectat",
-          "saveFailed": "Eroare la actualizarea categoriilor",
-          "missingData": "Date lipsă"
-        }
-      }
-    },
-    "Shared": {
-      "invoiceHeader": {
-        "tooltips": {
-          "importantInvoice": "Factură importantă",
-          "edit": "Editează această factură",
-          "delete": "Șterge definitiv această factură",
-          "print": "Printează această factură",
-          "saveAllPendingChanges": "Salvează toate modificările în așteptare",
-          "discardAllPendingChanges": "Renunță la toate modificările în așteptare",
-          "printInvoiceWithAllDetails": "Tipărește această factură cu toate detaliile",
-          "analyzeSpendingPatterns": "Analizează tiparele de cheltuieli pentru această factură",
-          "deleteInvoicePermanently": "Șterge permanent această factură",
-          "export": "Exportă datele facturii în diverse formate"
-        },
-        "id": "Identificator: {id}",
-        "buttons": {
-          "edit": "Editează",
-          "delete": "Șterge",
-          "print": "Printează",
-          "save": "Salvează",
-          "saving": "Se salvează...",
-          "discard": "Renunță",
-          "analyzeWithAi": "Analizează cu IA",
-          "export": "Exportă"
-        }
-      },
-      "states": {
-        "notFound": {
-          "title": "Factură negăsită",
-          "description": "Factura cu identificatorul {invoiceIdentifier} nu a fost găsită."
-        },
-        "loading": {
-          "title": "Se încarcă factura",
-          "description": "Se încarcă factura cu identificatorul {invoiceIdentifier}."
-        }
-      },
-      "loadingInvoices": {
-        "title": "Se încarcă facturi",
-        "description": "Se încarcă facturi..."
-      },
-      "invoicesNotFound": {
-        "title": "Lipsește ceva aici...",
-        "description": "Se pare că nu ai nicio factură asociată contului tău. Te rugăm să încarci câteva facturi și să revii mai târziu.",
-        "cta": "Încarcă aici o factură."
-      },
-      "shareInvoiceDialog": {
-        "title": "Partajează factură",
-        "selection": {
-          "description": "Alege cum vrei să partajezi această factură. Opțiunea aleasă influențează cine poate avea acces.",
-          "publicTitle": "Partajare publică",
-          "publicDescription": "Generează un link sau un cod QR pe care <strong>oricine</strong> îl poate folosi pentru a vedea această factură.",
-          "privateTitle": "Privat sharing",
-          "privateDescription": "Trimite o invitație pe email unei <strong>persoane specifice</strong>. Doar acea persoană va avea acces.",
-          "privacyNoticeTitle": "Notă de confidențialitate",
-          "privacyNoticeDescription": "Linkurile publice pot fi accesate de oricine are URL-ul. Partajarea privată limitează accesul la destinatarul specificat."
-        },
-        "dialogDescription": {
-          "currentlyPublic": "\"{invoiceName}\" este publică în acest moment",
-          "selection": "Alege cum să partajezi „{invoiceName}”",
-          "public": "Partajează \"{invoiceName}\" public",
-          "private": "Trimite \"{invoiceName}\" în privat"
-        },
-        "toasts": {
-          "copyLink": {
-            "loadingPublic": "Se copiază linkul...",
-            "loadingMakePublic": "Factura devine publică...",
-            "successPublic": "Link copiat în clipboard!",
-            "successMadePublic": "Factura este acum publică! Link copiat în clipboard.",
-            "error": "Eșuat: {message}"
-          },
-          "copyQr": {
-            "loadingPublic": "Se copiază codul QR...",
-            "loadingMakePublic": "Factura devine publică...",
-            "successPublic": "Cod QR copiat în clipboard!",
-            "successMadePublic": "Factura este acum publică! Cod QR copiat în clipboard.",
-            "error": "Eșuat: {message}"
-          },
-          "sendEmail": {
-            "loading": "Se trimite invitația către {email}...",
-            "success": "Invitație trimisă către {email}!",
-            "error": "Eșuat: {message}",
-            "comingSoon": "Partajarea prin email va fi disponibilă în curând"
-          },
-          "revoke": {
-            "loading": "Se trimite cererea de revocare către server...",
-            "success": "Factura este acum privată. Linkurile existente nu vor mai funcționa.",
-            "error": "Revocarea accesului a eșuat: {message}"
-          }
-        },
-        "errors": {
-          "qrNotFound": "Elementul codului QR nu a fost găsit"
-        }
-      },
-      "shareInvoiceDialogPublic": {
-        "tabs": {
-          "directLink": "Link direct",
-          "qrCode": "Cod QR"
-        },
-        "hints": {
-          "link": "Copiază acest link și partajează-l. Oricine îl primește va putea vedea factura.",
-          "qr": "Oricine scanează acest cod QR va fi redirecționat pentru a vedea factura."
-        },
-        "copyQrImage": "Copiază codul QR ca imagine",
-        "alreadyPublic": {
-          "title": "Această factură este publică în acest moment",
-          "description": "Această factură este accesibilă public. <strong>Oricine are linkul o poate vedea</strong>, inclusiv toate detaliile facturii, articolele și sumele. Poți revoca accesul public oricând pentru a o face din nou privată.",
-          "revoke": "Revocă accesul public",
-          "revoking": "Se revocă accesul...",
-          "revokeHint": "Factura va deveni privată. Linkurile existente nu vor mai funcționa."
-        },
-        "backToOptions": "Înapoi la opțiuni",
-        "warning": {
-          "title": "Avertisment privind accesul public",
-          "description": "Prin partajarea publică a acestei facturi, <strong>oricine are linkul o va putea vedea</strong>. Asta include toate detaliile facturii, articolele și sumele. Continuă doar dacă vrei ca această factură să fie accesibilă publicului."
-        }
-      },
-      "shareInvoiceDialogPrivate": {
-        "backToOptions": "Înapoi la opțiuni",
-        "title": "Privat sharing",
-        "description": "Invitația va fi trimisă direct la adresa de email pe care o specifici. Doar acest destinatar va primi acces pentru a vedea factura.",
-        "emailLabel": "Adresa de email a destinatarului",
-        "emailPlaceholder": "name@example.com",
-        "emailHint": "O invitație pe email va fi trimisă la această adresă cu un link privat pentru a vedea factura.",
-        "sendInvitation": "Trimite invitație privată",
-        "sending": "Se trimite invitația...",
-        "comingSoonTooltip": "Funcția de partajare prin email va fi disponibilă în curând"
-      },
-      "deleteInvoiceDialog": {
-        "title": "Șterge factură",
-        "description": "Această acțiune nu poate fi anulată. Te rugăm să verifici atent înainte de a continua.",
-        "deleting": {
-          "title": "Ștergere factură...",
-          "description": "Te rugăm să aștepți cât timp ștergem toate datele asociate."
-        },
-        "impact": {
-          "title": "Ștergere permanentă",
-          "intro": "Următoarele date vor fi șterse definitiv:",
-          "invoiceRecord": "Înregistrarea facturii și metadatele",
-          "uploadedScans": "{count} scanare(i) încărcată(e)",
-          "lineItems": "{count} line articol(s)",
-          "sharedAccess": "Acces partajat pentru {count} utilizator(i)"
-        },
-        "confirmation": {
-          "typeToConfirm": "Tastează <highlight>{name}</highlight> pentru confirmare:",
-          "understoodLabel": "Înțeleg că această acțiune este permanentă",
-          "understoodDescription": "Această factură și toate datele ei vor fi șterse definitiv și nu vor putea fi recuperate."
-        },
-        "buttons": {
-          "cancel": "Anulează",
-          "deleting": "Se șterge...",
-          "deletePermanently": "Șterge permanent"
-        },
-        "toasts": {
-          "deletedTitle": "Factură ștearsă",
-          "deletedDescription": "Factura a fost ștearsă cu succes.",
-          "deleteFailedTitle": "Șterge eșuat",
-          "deleteFailedDescription": "Nu am putut șterge această factură. Te rugăm să încerci din nou."
-        },
-        "console": {
-          "deleteError": "Eroare ștergere factură:"
-        }
-      },
-      "shortcuts": {
-        "title": "Scurtături de la Tastatură",
-        "description": "Acces rapid la acțiuni comune folosind tastatura",
-        "openSearch": "Deschide căutarea",
-        "newInvoice": "Factură nouă",
-        "uploadScan": "Încarcă scanare",
-        "showHelp": "Arată acest ajutor",
-        "closeDialog": "Închide dialogul",
-        "close": "Închide"
-      },
-      "commandPalette": {
-        "placeholder": "Caută facturi, comercianți, articole...",
-        "noResults": "Nu s-au găsit rezultate",
-        "groups": {
-          "quickActions": "Acțiuni Rapide",
-          "recentInvoices": "Facturi Recente",
-          "searchResults": "Rezultate Căutare"
-        },
-        "actions": {
-          "uploadScans": "Încarcă Scanări",
-          "createInvoice": "Crează Factură",
-          "viewStatistics": "Vezi Statistici",
-          "viewAll": "Vezi Toate Facturile"
-        }
-      },
-      "onboarding": {
-        "steps": {
-          "upload": {
-            "description": "Fă o fotografie sau încarcă un PDF al chitanței tale. Sistemul nostru acceptă multiple formate și poate procesa loturi de chitanțe deodată.",
-            "title": "Încarcă Chitanțele Tale"
-          },
-          "analyze": {
-            "description": "Sistemul nostru bazat pe AI extrage automat numele comercianților, datele, sumele și articolele din chitanțele tale cu acuratețe ridicată.",
-            "title": "AI Extrage Detaliile"
-          },
-          "track": {
-            "description": "Vizualizează analize detaliate și perspective asupra tiparelor tale de cheltuieli. Înțelege unde se duc banii tăi cu diagrame și rapoarte interactive.",
-            "title": "Urmărește Cheltuielile Tale"
-          }
-        },
-        "getStarted": "Începe",
-        "stepOf": "Pasul {current} din {total}",
-        "next": "Următorul",
-        "skip": "Sari peste",
-        "back": "Înapoi",
-        "dontShowAgain": "Nu mai afișa din nou"
-      },
-      "notifications": {
-        "timeAgo": {
-          "hours": "{count, plural, one {acum # oră} other {acum # ore}}",
-          "minutes": "{count, plural, one {acum # minut} other {acum # minute}}",
-          "days": "{count, plural, one {acum # zi} other {acum # zile}}",
-          "now": "Chiar acum"
-        },
-        "types": {
-          "invoiceCreated": "Factură creată",
-          "analysisComplete": "Analiza AI finalizată",
-          "monthlyReport": "Raportul lunar este gata"
-        },
-        "title": "Notificări",
-        "noNotifications": "Nu există notificări încă",
-        "markAllRead": "Marchează toate ca citite"
-      },
-      "preferences": {
-        "title": "Preferințe Facturi",
-        "defaultView": "Vizualizare Implicită",
-        "sortBy": "Sortează După",
-        "pageSize": "Elemente pe Pagină",
-        "currency": "Monedă",
-        "showStats": "Afișează statistici pe pagina principală",
-        "save": "Salvează Preferințele",
-        "saved": "Preferințele au fost salvate cu succes",
-        "views": {
-          "table": "Vizualizare Tabel",
-          "grid": "Vizualizare Grilă"
-        },
-        "sortOptions": {
-          "dateDesc": "Dată (Cele mai Recente)",
-          "dateAsc": "Dată (Cele mai Vechi)",
-          "amountDesc": "Sumă (Mare la Mic)",
-          "amountAsc": "Sumă (Mic la Mare)",
-          "nameAsc": "Nume (A la Z)"
-        }
-      },
-      "mobileNav": {
-        "profile": "Profil",
-        "ariaLabel": "Navigare mobilă",
-        "home": "Acasă",
-        "scan": "Scanare",
-        "invoices": "Facturi"
-      },
-      "workflowProgress": {
-        "upload": "Încărcare",
-        "review": "Revizuire",
-        "create": "Creare"
-      },
-      "unknownMerchant": "Comerciant Necunoscut"
-    },
-    "CreateInvoice": {
-      "metadata": {
-        "title": "Sistem de gestionare a facturilor - Creare factură",
-        "description": "Creați o factură nouă din scanările încărcate."
-      },
-      "navigation": {
-        "back": "Înapoi",
-        "next": "Înainte"
-      },
-      "emptyState": {
-        "title": "Nicio scanare disponibilă",
-        "description": "Încărcați mai întâi câteva scanări de bonuri pentru a crea o factură.",
-        "uploadButton": "Încarcă scanări",
-        "viewScansButton": "Vezi scanările"
-      },
-      "header": {
-        "backToInvoices": "Înapoi la facturi",
-        "title": "Creare factură",
-        "subtitle": "Urmați pașii de mai jos pentru a crea o factură nouă din scanările dvs."
-      },
-      "steps": {
-        "selectScans": "Selectare scanări",
-        "details": "Detalii factură",
-        "review": "Verificare și creare",
-        "selectScansDesc": "Alege scanările",
-        "detailsDesc": "Completează detalii",
-        "reviewDesc": "Confirmă și creează"
-      },
-      "scanSelector": {
-        "title": "Selectare scanări",
-        "subtitle": "Alegeți scanările care aparțin acestei facturi",
-        "selectedCount": "{count} selectate",
-        "clearAll": "Golește",
-        "selectAll": "Selectează tot",
-        "noScans": "Nicio scanare disponibilă",
-        "previous": "Înapoi",
-        "next": "Înainte",
-        "scansCount": "scanări"
-      },
-      "detailsForm": {
-        "title": "Detalii factură",
-        "subtitle": "Completați detaliile pentru factura nouă",
-        "scanPreview": {
-          "title": "Previzualizare Scanare"
-        },
-        "fields": {
-          "name": {
-            "label": "Nume factură",
-            "placeholder": "ex., Cumpărături săptămânale",
-            "hint": "Dați facturii un nume descriptiv"
-          },
-          "category": {
-            "label": "Categorie",
-            "placeholder": "Selectați o categorie",
-            "options": {
-              "notDefined": "Necategorizat",
-              "grocery": "Alimente",
-              "fastFood": "Restaurante",
-              "homeCleaning": "Casă și curățenie",
-              "carAuto": "Auto și vehicule",
-              "other": "Altele"
-            }
-          },
-          "paymentType": {
-            "label": "Metodă de plată",
-            "placeholder": "Selectați metoda de plată",
-            "options": {
-              "unknown": "Necunoscut",
-              "cash": "Numerar",
-              "card": "Card",
-              "transfer": "Transfer bancar",
-              "mobilePayment": "Plată mobilă",
-              "voucher": "Voucher",
-              "other": "Altele"
-            }
-          },
-          "transactionDate": {
-            "label": "Data tranzacției"
-          },
-          "description": {
-            "label": "Descriere",
-            "placeholder": "Adăugați orice notițe despre această factură (opțional)",
-            "hint": "Note opționale despre această achiziție"
-          }
-        }
-      },
-      "reviewStep": {
-        "title": "Verificare și creare",
-        "subtitle": "Verificați detaliile facturii înainte de creare",
-        "categories": {
-          "notDefined": "Necategorizat",
-          "grocery": "Alimente",
-          "fastFood": "Restaurante",
-          "homeCleaning": "Casă și curățenie",
-          "carAuto": "Auto și vehicule",
-          "other": "Altele"
-        },
-        "paymentTypes": {
-          "unknown": "Necunoscut",
-          "cash": "Numerar",
-          "card": "Card",
-          "transfer": "Transfer bancar",
-          "mobilePayment": "Plată mobilă",
-          "voucher": "Voucher",
-          "other": "Altele"
-        },
-        "sections": {
-          "scans": {
-            "title": "Scanări"
-          },
-          "details": {
-            "title": "Detalii factură",
-            "name": "Nume",
-            "category": "Categorie",
-            "paymentType": "Metodă de plată",
-            "transactionDate": "Data tranzacției",
-            "description": "Descriere"
-          }
-        },
-        "actions": {
-          "creating": "Se creează factura...",
-          "create": "Creează factură",
-          "hint": "Factura va fi creată și scanările selectate vor fi încărcate."
-        }
-      }
-    }
-  },
   "Profile": {
     "metadata": {
       "title": "Profilul Meu",
@@ -4675,5 +1836,2846 @@
       }
     },
     "title": "Mulțumiri"
+  },
+  "IMS--Cards": {
+    "budgetImpactCard": {
+      "title": "Impact bugetar {month}",
+      "monthlyBudget": "Buget lunar",
+      "spent": "{amount} cheltuiți",
+      "invoiceUsed": "Această factură a folosit",
+      "ofMonthlyBudget": "din bugetul tău lunar",
+      "remaining": "Rămas",
+      "overBudget": "Peste buget",
+      "daysLeft": "Zile rămase",
+      "inMonth": "în {month}",
+      "dailyAllowance": "Alocație zilnică",
+      "dailyAllowanceValue": "{amount} / zi"
+    },
+    "comparisonStatsCard": {
+      "title": "Cum te compari",
+      "subtitle": "Comparativ cu ultimele tale {count} facturi",
+      "vsAverage": "vs medie",
+      "avgValue": "Medie: {amount} {currency}",
+      "thisValue": "Aceasta: {amount} {currency}",
+      "minValue": "Minim: {amount}",
+      "maxValue": "Maxim: {amount}",
+      "positionInRange": "Poziția ta în intervalul de cheltuieli",
+      "itemCount": "Articol Count",
+      "itemCountComparison": "{current} vs medie {average}",
+      "sameStore": "Același magazin",
+      "sameStoreComparison": "vs medie {average} {currency}"
+    },
+    "invoiceDetailsCard": {
+      "title": "Detalii factură",
+      "labels": {
+        "dateUtc": "Dată (UTC)",
+        "category": "Categorie",
+        "payment": "Plată",
+        "totalAmount": "Suma totală",
+        "receiptType": "Tip bon",
+        "countryRegion": "Țară/Regiune",
+        "subtotal": "Subtotal",
+        "tip": "Bacșiș",
+        "ronEquivalent": "Echivalent RON"
+      },
+      "itemsTitle": "Articole ({count})",
+      "table": {
+        "item": "Articol",
+        "qty": "Cant.",
+        "unit": "Unitate",
+        "price": "Preț",
+        "total": "Total general",
+        "grandTotal": "Total general"
+      },
+      "pagination": {
+        "pageOf": "Pagina {current} din {total}",
+        "previous": "Anterior",
+        "next": "Următor"
+      },
+      "tooltips": {
+        "exchangeRate": "1 {fromCurrency} = {rate} RON (medie {year})"
+      },
+      "sections": {
+        "paymentMethods": "Metode de plată",
+        "taxBreakdown": "Detalii taxe"
+      },
+      "taxLabels": {
+        "net": "Net",
+        "tax": "Taxă"
+      }
+    },
+    "merchantInfoCard": {
+      "title": "Informații comerciant",
+      "noMerchantLinked": "Niciun comerciant asociat acestei facturi",
+      "viewAllReceipts": "Vezi toate bonurile",
+      "viewAllInvoices": "Vezi toate facturile",
+      "viewOnMap": "Vezi pe hartă",
+      "spendingHistory": "Istoric cheltuieli",
+      "categoryDistribution": "Distribuție categorii",
+      "stats": {
+        "visits": "vizite",
+        "avgSpend": "Cheltuială medie",
+        "daysAgo": "zile în urmă"
+      }
+    },
+    "receiptScanCard": {
+      "title": "Scanare bon",
+      "dialogTitle": "Imagine bon",
+      "scanAlt": "Scanare bon {index}",
+      "scanAltFullSize": "Scanare bon {index} - dimensiune completă",
+      "buttons": {
+        "expand": "Extinde imaginea",
+        "previousScan": "Scanarea anterioară",
+        "nextScan": "Scanarea următoare"
+      },
+      "tooltips": {
+        "expand": "Vezi imaginea bonului la dimensiune completă",
+        "previousScan": "Vezi scanarea anterioară a bonului",
+        "nextScan": "Vezi următoarea scanare a bonului"
+      },
+      "titleWithIndex": "Scanare bon ({current}/{total})",
+      "dialogTitleWithIndex": "Imagine bon ({current}/{total})",
+      "controls": {
+        "zoomIn": "Mărește",
+        "zoomOut": "Micșorează",
+        "reset": "Resetează zoom",
+        "rotate": "Rotește",
+        "download": "Descarcă",
+        "fullScreen": "Ecran complet",
+        "toggleZoom": "Clic pentru a comuta zoom-ul"
+      },
+      "navigation": {
+        "previous": "Anterior",
+        "next": "Următor",
+        "of": "din"
+      }
+    },
+    "seasonalInsightsCard": {
+      "title": "Insight sezonier",
+      "month": {
+        "spendingSoFar": "{month} până acum",
+        "vsAverage": "vs media pe {month}: {amount}"
+      },
+      "insights": {
+        "spike": {
+          "title": "Creștere {category}",
+          "description": "+{percent}% vs media ta"
+        },
+        "holidaySeason": {
+          "title": "Sezonul sărbătorilor",
+          "description": "Cheltuielile din decembrie sunt de obicei cu 35% mai mari"
+        },
+        "stockUpTip": {
+          "title": "Sfat de aprovizionare",
+          "description": "Prețurile cresc cu ~15% după 15 decembrie"
+        },
+        "normalPattern": {
+          "title": "Model normal de cumpărături",
+          "description": "Cheltuielile tale sunt în intervalul obișnuit"
+        },
+        "insufficientData": {
+          "title": "Construim profilul tău de cheltuieli",
+          "description": "Adaugă mai multe facturi pentru a vedea informații sezoniere și modele de cheltuieli"
+        }
+      }
+    },
+    "shoppingCalendarCard": {
+      "title": "Calendar cumpărături",
+      "tooltip": {
+        "basedOnCachedInvoices": "Bazat pe {count} facturi din cache",
+        "currentInvoiceOnly": "Se afișează doar factura curentă",
+        "more": "+{count} în plus",
+        "vsAverage": "vs medie ({years} ani de date)",
+        "invoiceCount": "{count} factură(s)",
+        "currentInvoice": "Factura curentă"
+      },
+      "legend": {
+        "less": "Mai puțin",
+        "more": "Mai mult"
+      },
+      "stats": {
+        "monthTotal": "Total lună",
+        "shoppingDays": "Zile de cumpărături"
+      },
+      "insights": {
+        "shopEveryPrefix": "Faci cumpărături la fiecare",
+        "days": "{count} zile",
+        "onAverage": "în medie",
+        "spendingPrefix": ", cheltuind",
+        "perTrip": " per cumpărătură",
+        "mostActiveOn": "Cel mai activ în",
+        "weekdayLabel": "{weekday}"
+      }
+    },
+    "summaryStatsCard": {
+      "title": "Rezumat factură",
+      "description": "Statistici cheie dintr-o privire",
+      "stats": {
+        "totalItems": {
+          "label": "Total articole",
+          "description": "Produse cumpărate"
+        },
+        "categories": {
+          "label": "Categorii",
+          "description": "Categorii unice"
+        },
+        "averagePrice": {
+          "label": "Preț mediu",
+          "description": "{currency} per articol"
+        },
+        "taxRate": {
+          "label": "Rată taxă",
+          "description": "{amount} {currency}"
+        }
+      },
+      "extremes": {
+        "highest": "Cel mai mare",
+        "lowest": "Cel mai mic"
+      }
+    },
+    "categorySuggestionCard": {
+      "title": "Ajută-ne să categorisim această factură",
+      "description": "Nu am putut categoriza automat această factură. Selectează categoria corectă pentru a debloca analize:",
+      "moreCategories": "Mai multe categorii:",
+      "gamification": "Categorisește {goal} facturi pentru a debloca analize detaliate!"
+    },
+    "diningCard": {
+      "title": "Informații despre mese",
+      "sodium": {
+        "high": "Ridicat",
+        "medium": "Mediu",
+        "low": "Scăzut"
+      },
+      "estimatedNutrition": {
+        "title": "Nutriție estimată",
+        "calories": "Calorii",
+        "caloriesValue": "~{value} kcal",
+        "protein": "Proteine",
+        "proteinValue": "~{value}g",
+        "sodium": "Sodiu",
+        "carbs": "Carbohidrați",
+        "carbsValue": "~{value}g"
+      },
+      "habits": {
+        "title": "Obiceiurile tale de fast-food",
+        "frequency": "Frecvență",
+        "frequencyValue": "{count}x/lună",
+        "frequencyDiff": "+1 vs medie",
+        "avgSpend": "Cheltuială medie",
+        "favorite": "Favorit",
+        "visits": "{count} vizite"
+      },
+      "swaps": {
+        "title": "Alternative mai sănătoase",
+        "grilled": "La grătar în loc de prăjit",
+        "water": "Apă în loc de suc",
+        "salad": "Salată garnitură în loc de cartofi prăjiți",
+        "caloriesSaved": "-{count} kcal",
+        "moneySaved": ", economisești {amount}"
+      },
+      "challenge": {
+        "title": "Provocare săptămânală",
+        "descriptionPrefix": "Evită fast-food-ul timp de 7 zile și salvează",
+        "descriptionSuffix": ""
+      }
+    },
+    "generalExpenseCard": {
+      "title": "Analiză cheltuieli",
+      "detectedCategory": "Electronice / Tehnologie",
+      "confidence": "Încredere: {value}%",
+      "sections": {
+        "autoDetectedCategory": "Auto-detected categorie",
+        "budgetImpact": "Impact bugetar",
+        "taxBusiness": "Opțiuni fiscale și de business",
+        "similarPurchases": "Achiziții similare anterioare"
+      },
+      "buttons": {
+        "correct": "Corect",
+        "change": "Schimbă",
+        "organize": "Organizează",
+        "export": "Exportă"
+      },
+      "aria": {
+        "confirmCategory": "Confirmă că categoria detectată este corectă",
+        "changeCategory": "Change detected categorie",
+        "organize": "Organizează această cheltuială în categorii",
+        "export": "Exportă datele cheltuielii"
+      },
+      "nearLimitAlert": "{name}: {percent}% utilizat (10 zile rămase în lună)",
+      "options": {
+        "businessExpense": "Marchează drept cheltuială de business",
+        "trackWarranty": "Urmărește garanția (standard 24 luni)",
+        "insuranceInventory": "Adaugă în inventarul de asigurare"
+      },
+      "vatReclaimable": "TVA recuperabil",
+      "budgetCategories": {
+        "electronics": "Electronice",
+        "entertainment": "Divertisment",
+        "shopping": "Cumpărături"
+      }
+    },
+    "homeInventoryCard": {
+      "title": "Inventar casă și consumabile",
+      "supplyNames": {
+        "laundryDetergent": "Detergent rufe",
+        "dishSoap": "Detergent vase",
+        "paperProducts": "Produse din hârtie",
+        "floorCleaner": "Soluție pentru podea"
+      },
+      "stockLevels": {
+        "title": "Niveluri stoc consumabile (estimate)",
+        "daysRemaining": "~{count} zile"
+      },
+      "eco": {
+        "title": "Scor ecologic",
+        "productsWithEcoLabels": "{count} produse cu etichete ecologice",
+        "recyclablePackaging": "{count} produs cu ambalaj reciclabil",
+        "tip": "Tip: Eco alternatives salvează 2kg plastic/year"
+      },
+      "bulk": {
+        "title": "Economii la cumpărături în vrac",
+        "description": "Detergent 5L față de 2L economisește 18% ({amount}/an)"
+      }
+    },
+    "nutritionCard": {
+      "title": "Privire generală nutriție",
+      "score": {
+        "title": "Scor echilibru alimentar",
+        "excellent": "Excelent",
+        "good": "Bun",
+        "fair": "Acceptabil",
+        "needsWork": "Necesită îmbunătățiri"
+      },
+      "composition": {
+        "title": "Compoziția coșului tău",
+        "wholeFoods": "Alimente integrale",
+        "processed": "Procesate",
+        "dairyOther": "Lactate/Altele"
+      },
+      "foodGroups": {
+        "fruits": "Fructe",
+        "vegetables": "Legume",
+        "protein": "Proteine",
+        "grains": "Cereale",
+        "itemsCount": "{count} articol(s)"
+      },
+      "allergens": {
+        "title": "Alergeni detectați",
+        "foundInItems": "Găsit în {count} articol(e)"
+      },
+      "suggestions": {
+        "addFruitsAndVegetables": "Adaugă mai multe fructe și legume pentru a-ți echilibra coșul",
+        "addVegetables": "Ia în calcul adăugarea de legume pentru o alimentație mai echilibrată",
+        "addFruits": "Adăugarea unor fructe ar îmbunătăți echilibrul nutrițional",
+        "swapProcessed": "Încearcă să înlocuiești unele produse procesate cu alimente integrale",
+        "greatBalance": "Cumpărături foarte bine echilibrate!"
+      }
+    },
+    "vehicleCard": {
+      "title": "Analiza cheltuielilor vehiculului",
+      "expenseType": "Tip cheltuială: Combustibil",
+      "details": {
+        "liters": "Litri",
+        "pricePerLiter": "Preț/L",
+        "station": "Stație",
+        "vehicle": "Vehicul",
+        "notSet": "Nesetat"
+      },
+      "chart": {
+        "title": "Cheltuieli lunare cu combustibilul",
+        "amount": "Sumă"
+      },
+      "stats": {
+        "thisMonth": "Luna aceasta",
+        "fillUps": "{count} alimentări",
+        "costPerKm": "Cost pe km",
+        "estimated": "estimat",
+        "fuelPrice": "Fuel Preț",
+        "thisMonthSuffix": "luna aceasta"
+      },
+      "maintenance": {
+        "title": "Mementouri întreținere"
+      },
+      "tip": {
+        "title": "Cel mai ieftin în apropiere",
+        "perLiter": "L"
+      },
+      "buttons": {
+        "addVehicle": "Adaugă Vehicul",
+        "fullReport": "Raport complet"
+      },
+      "months": {
+        "sep": "sept.",
+        "oct": "oct.",
+        "nov": "nov.",
+        "dec": "dec."
+      },
+      "reminders": {
+        "oilChange": "Schimb de ulei în ~1.200 km",
+        "tireRotation": "Se recomandă rotația anvelopelor"
+      }
+    },
+    "invoiceCard": {
+      "title": "Detalii factură",
+      "importantBadge": "IMPORTANT",
+      "markImportant": "Marchează ca important",
+      "tooltips": {
+        "unmarkFavorite": "Apasă pentru a scoate din favorite",
+        "markFavorite": "Apasă pentru a marca drept favorit"
+      },
+      "fromMerchant": "De la {merchant}",
+      "descriptionPlaceholder": "Introdu descrierea facturii...",
+      "labels": {
+        "dateUtc": "Dată (UTC)",
+        "hours": "Ore",
+        "minutes": "Minute",
+        "utc": "UTC",
+        "category": "Categorie",
+        "paymentMethod": "Metodă de plată",
+        "totalAmount": "Sumă totală"
+      },
+      "placeholders": {
+        "selectCategory": "Selectează categorie",
+        "selectPaymentType": "Selectează tipul de plată"
+      }
+    },
+    "merchantCard": {
+      "title": "Comerciant",
+      "noMerchantLinked": "Niciun comerciant asociat acestei facturi",
+      "addressLabel": "Adresă: {address}",
+      "buttons": {
+        "viewMerchantDetails": "Vezi detalii comerciant",
+        "viewAllReceipts": "Vezi toate bonurile"
+      },
+      "tooltips": {
+        "viewMerchantDetails": "Vezi informații detaliate despre acest comerciant",
+        "viewAllReceipts": "Vezi toate bonurile de la acest comerciant"
+      }
+    },
+    "imageCard": {
+      "title": "Scanare bon",
+      "dialogTitle": "Imagine bon",
+      "scanAlt": "Scanare bon {index}",
+      "scanAltFullSize": "Scanare bon {index} - dimensiune completă",
+      "buttons": {
+        "expand": "Extinde imaginea",
+        "previous": "Anterior",
+        "next": "Următor",
+        "addScan": "Adaugă scan",
+        "remove": "Elimină"
+      },
+      "tooltips": {
+        "expand": "Vezi imaginea bonului la dimensiune completă",
+        "previous": "Vezi scanarea anterioară a bonului",
+        "next": "Vezi următoarea scanare a bonului",
+        "addScan": "Încarcă și atașează o scanare nouă a bonului",
+        "remove": "Elimină scanarea curentă a bonului"
+      },
+      "aria": {
+        "expandImage": "Apasă pentru a extinde imaginea"
+      },
+      "titleWithIndex": "Scanare bon ({current}/{total})",
+      "dialogTitleWithIndex": "Imagine bon ({current}/{total})"
+    },
+    "recipeCard": {
+      "complexity": {
+        "unknown": "Necunoscut",
+        "easy": "Ușor",
+        "normal": "Normal",
+        "hard": "Greu"
+      },
+      "dropdown": {
+        "view": "Vezi",
+        "edit": "Editează",
+        "delete": "Șterge",
+        "share": "Distribuie",
+        "markAsFavorite": "Marchează ca favorit"
+      },
+      "ingredients": {
+        "label": "Ingrediente:",
+        "more": "+{count} în plus",
+        "additionalLabel": "Ingrediente suplimentare:"
+      },
+      "timing": {
+        "prepLabel": "Pregătire: {minutes}′",
+        "prepTooltip": "Timpul de pregătire este de {minutes} minute.",
+        "cookLabel": "Gătire: {minutes}′",
+        "cookTooltip": "Timpul de gătire este de {minutes} minute."
+      },
+      "buttons": {
+        "visitReference": "Vizitează referința",
+        "viewRecipe": "Vezi rețeta"
+      }
+    },
+    "sharingCard": {
+      "title": "Partajare",
+      "ownerAvatarAlt": "Utilizator",
+      "owner": "Proprietar",
+      "sharedWith": "Partajată cu",
+      "userWithId": "Utilizator {id}",
+      "publicInvoice": {
+        "title": "Factură publică",
+        "description": "Această factură este accesibilă public. Oricine are linkul o poate vedea."
+      },
+      "emptyShared": {
+        "public": "Niciun utilizator suplimentar nu are acces direct",
+        "private": "Nu este partajată"
+      },
+      "buttons": {
+        "manageSharing": "Gestionează Partajare",
+        "shareInvoice": "Partajează Factură",
+        "revokingAccess": "Se revocă accesul...",
+        "markAsPrivate": "Marchează ca privată"
+      },
+      "tooltips": {
+        "manageSharing": "Gestionează setările de partajare pentru această factură",
+        "removeAccess": "Elimină accesul",
+        "shareInvoice": "Partajează această factură cu alți utilizatori",
+        "markAsPrivate": "Marchează factura ca privată"
+      },
+      "toasts": {
+        "removeAccessComingSoon": {
+          "title": "Funcția de eliminare a accesului va fi disponibilă în curând",
+          "description": "Această funcționalitate este în curs de dezvoltare."
+        },
+        "revoke": {
+          "loading": "Se revocă accesul public...",
+          "success": "Factura este acum privată. Linkurile existente nu vor mai funcționa.",
+          "error": "Marcarea ca privată a eșuat: {message}"
+        }
+      }
+    }
+  },
+  "IMS--Common": {
+    "invoiceHeader": {
+      "tooltips": {
+        "importantInvoice": "Factură importantă",
+        "edit": "Editează această factură",
+        "delete": "Șterge definitiv această factură",
+        "print": "Printează această factură",
+        "saveAllPendingChanges": "Salvează toate modificările în așteptare",
+        "discardAllPendingChanges": "Renunță la toate modificările în așteptare",
+        "printInvoiceWithAllDetails": "Tipărește această factură cu toate detaliile",
+        "analyzeSpendingPatterns": "Analizează tiparele de cheltuieli pentru această factură",
+        "deleteInvoicePermanently": "Șterge permanent această factură",
+        "export": "Exportă datele facturii în diverse formate"
+      },
+      "id": "Identificator: {id}",
+      "buttons": {
+        "edit": "Editează",
+        "delete": "Șterge",
+        "print": "Printează",
+        "save": "Salvează",
+        "saving": "Se salvează...",
+        "discard": "Renunță",
+        "analyzeWithAi": "Analizează cu IA",
+        "export": "Exportă"
+      }
+    },
+    "statesNotFound": {
+      "title": "Factură negăsită",
+      "description": "Factura cu identificatorul {invoiceIdentifier} nu a fost găsită."
+    },
+    "statesLoading": {
+      "title": "Se încarcă factura",
+      "description": "Se încarcă factura cu identificatorul {invoiceIdentifier}."
+    },
+    "loadingInvoices": {
+      "title": "Se încarcă facturi",
+      "description": "Se încarcă facturi..."
+    },
+    "invoicesNotFound": {
+      "title": "Lipsește ceva aici...",
+      "description": "Se pare că nu ai nicio factură asociată contului tău. Te rugăm să încarci câteva facturi și să revii mai târziu.",
+      "cta": "Încarcă aici o factură."
+    },
+    "shortcuts": {
+      "title": "Scurtături de la Tastatură",
+      "description": "Acces rapid la acțiuni comune folosind tastatura",
+      "openSearch": "Deschide căutarea",
+      "newInvoice": "Factură nouă",
+      "uploadScan": "Încarcă scanare",
+      "showHelp": "Arată acest ajutor",
+      "closeDialog": "Închide dialogul",
+      "close": "Închide"
+    },
+    "commandPalette": {
+      "placeholder": "Caută facturi, comercianți, articole...",
+      "noResults": "Nu s-au găsit rezultate",
+      "groups": {
+        "quickActions": "Acțiuni Rapide",
+        "recentInvoices": "Facturi Recente",
+        "searchResults": "Rezultate Căutare"
+      },
+      "actions": {
+        "uploadScans": "Încarcă Scanări",
+        "createInvoice": "Crează Factură",
+        "viewStatistics": "Vezi Statistici",
+        "viewAll": "Vezi Toate Facturile"
+      }
+    },
+    "onboarding": {
+      "steps": {
+        "upload": {
+          "description": "Fă o fotografie sau încarcă un PDF al chitanței tale. Sistemul nostru acceptă multiple formate și poate procesa loturi de chitanțe deodată.",
+          "title": "Încarcă Chitanțele Tale"
+        },
+        "analyze": {
+          "description": "Sistemul nostru bazat pe AI extrage automat numele comercianților, datele, sumele și articolele din chitanțele tale cu acuratețe ridicată.",
+          "title": "AI Extrage Detaliile"
+        },
+        "track": {
+          "description": "Vizualizează analize detaliate și perspective asupra tiparelor tale de cheltuieli. Înțelege unde se duc banii tăi cu diagrame și rapoarte interactive.",
+          "title": "Urmărește Cheltuielile Tale"
+        }
+      },
+      "getStarted": "Începe",
+      "stepOf": "Pasul {current} din {total}",
+      "next": "Următorul",
+      "skip": "Sari peste",
+      "back": "Înapoi",
+      "dontShowAgain": "Nu mai afișa din nou"
+    },
+    "notifications": {
+      "timeAgo": {
+        "hours": "{count, plural, one {acum # oră} other {acum # ore}}",
+        "minutes": "{count, plural, one {acum # minut} other {acum # minute}}",
+        "days": "{count, plural, one {acum # zi} other {acum # zile}}",
+        "now": "Chiar acum"
+      },
+      "types": {
+        "invoiceCreated": "Factură creată",
+        "analysisComplete": "Analiza AI finalizată",
+        "monthlyReport": "Raportul lunar este gata"
+      },
+      "title": "Notificări",
+      "noNotifications": "Nu există notificări încă",
+      "markAllRead": "Marchează toate ca citite"
+    },
+    "preferences": {
+      "title": "Preferințe Facturi",
+      "defaultView": "Vizualizare Implicită",
+      "sortBy": "Sortează După",
+      "pageSize": "Elemente pe Pagină",
+      "currency": "Monedă",
+      "showStats": "Afișează statistici pe pagina principală",
+      "save": "Salvează Preferințele",
+      "saved": "Preferințele au fost salvate cu succes",
+      "views": {
+        "table": "Vizualizare Tabel",
+        "grid": "Vizualizare Grilă"
+      },
+      "sortOptions": {
+        "dateDesc": "Dată (Cele mai Recente)",
+        "dateAsc": "Dată (Cele mai Vechi)",
+        "amountDesc": "Sumă (Mare la Mic)",
+        "amountAsc": "Sumă (Mic la Mare)",
+        "nameAsc": "Nume (A la Z)"
+      }
+    },
+    "mobileNav": {
+      "profile": "Profil",
+      "ariaLabel": "Navigare mobilă",
+      "home": "Acasă",
+      "scan": "Scanare",
+      "invoices": "Facturi"
+    },
+    "workflowProgress": {
+      "upload": "Încărcare",
+      "review": "Revizuire",
+      "create": "Creare"
+    },
+    "unknownMerchant": "Comerciant Necunoscut"
+  },
+  "IMS--Create": {
+    "metadata": {
+      "title": "Sistem de gestionare a facturilor - Creare factură",
+      "description": "Creați o factură nouă din scanările încărcate."
+    },
+    "navigation": {
+      "back": "Înapoi",
+      "next": "Înainte"
+    },
+    "emptyState": {
+      "title": "Nicio scanare disponibilă",
+      "description": "Încărcați mai întâi câteva scanări de bonuri pentru a crea o factură.",
+      "uploadButton": "Încarcă scanări",
+      "viewScansButton": "Vezi scanările"
+    },
+    "header": {
+      "backToInvoices": "Înapoi la facturi",
+      "title": "Creare factură",
+      "subtitle": "Urmați pașii de mai jos pentru a crea o factură nouă din scanările dvs."
+    },
+    "steps": {
+      "selectScans": "Selectare scanări",
+      "details": "Detalii factură",
+      "review": "Verificare și creare",
+      "selectScansDesc": "Alege scanările",
+      "detailsDesc": "Completează detalii",
+      "reviewDesc": "Confirmă și creează"
+    },
+    "scanSelector": {
+      "title": "Selectare scanări",
+      "subtitle": "Alegeți scanările care aparțin acestei facturi",
+      "selectedCount": "{count} selectate",
+      "clearAll": "Golește",
+      "selectAll": "Selectează tot",
+      "noScans": "Nicio scanare disponibilă",
+      "previous": "Înapoi",
+      "next": "Înainte",
+      "scansCount": "scanări"
+    },
+    "detailsForm": {
+      "title": "Detalii factură",
+      "subtitle": "Completați detaliile pentru factura nouă",
+      "scanPreview": {
+        "title": "Previzualizare Scanare"
+      },
+      "fields": {
+        "name": {
+          "label": "Nume factură",
+          "placeholder": "ex., Cumpărături săptămânale",
+          "hint": "Dați facturii un nume descriptiv"
+        },
+        "category": {
+          "label": "Categorie",
+          "placeholder": "Selectați o categorie",
+          "options": {
+            "notDefined": "Necategorizat",
+            "grocery": "Alimente",
+            "fastFood": "Restaurante",
+            "homeCleaning": "Casă și curățenie",
+            "carAuto": "Auto și vehicule",
+            "other": "Altele"
+          }
+        },
+        "paymentType": {
+          "label": "Metodă de plată",
+          "placeholder": "Selectați metoda de plată",
+          "options": {
+            "unknown": "Necunoscut",
+            "cash": "Numerar",
+            "card": "Card",
+            "transfer": "Transfer bancar",
+            "mobilePayment": "Plată mobilă",
+            "voucher": "Voucher",
+            "other": "Altele"
+          }
+        },
+        "transactionDate": {
+          "label": "Data tranzacției"
+        },
+        "description": {
+          "label": "Descriere",
+          "placeholder": "Adăugați orice notițe despre această factură (opțional)",
+          "hint": "Note opționale despre această achiziție"
+        }
+      }
+    },
+    "reviewStep": {
+      "title": "Verificare și creare",
+      "subtitle": "Verificați detaliile facturii înainte de creare",
+      "categories": {
+        "notDefined": "Necategorizat",
+        "grocery": "Alimente",
+        "fastFood": "Restaurante",
+        "homeCleaning": "Casă și curățenie",
+        "carAuto": "Auto și vehicule",
+        "other": "Altele"
+      },
+      "paymentTypes": {
+        "unknown": "Necunoscut",
+        "cash": "Numerar",
+        "card": "Card",
+        "transfer": "Transfer bancar",
+        "mobilePayment": "Plată mobilă",
+        "voucher": "Voucher",
+        "other": "Altele"
+      },
+      "sections": {
+        "scans": {
+          "title": "Scanări"
+        },
+        "details": {
+          "title": "Detalii factură",
+          "name": "Nume",
+          "category": "Categorie",
+          "paymentType": "Metodă de plată",
+          "transactionDate": "Data tranzacției",
+          "description": "Descriere"
+        }
+      },
+      "actions": {
+        "creating": "Se creează factura...",
+        "create": "Creează factură",
+        "hint": "Factura va fi creată și scanările selectate vor fi încărcate."
+      }
+    }
+  },
+  "IMS--Dialogs": {
+    "shareAnalyticsDialog": {
+      "title": "Partajează Analytics",
+      "description": "Partajează analizele tale de cheltuieli pentru {merchant} cu alte persoane.",
+      "tabs": {
+        "image": "Imagine",
+        "email": "email"
+      },
+      "image": {
+        "description": "Descarcă sau copiază graficul de analiză ca imagine PNG, pe care o poți partaja sau salva.",
+        "previewPlaceholder": "Previzualizare analize",
+        "download": "Descarcă graficul",
+        "copyToClipboard": "Copiază graficul în clipboard"
+      },
+      "email": {
+        "description": "Trimite analizele la o adresă de email.",
+        "label": "Adresă email",
+        "placeholder": "name@example.com",
+        "send": "Trimite email"
+      },
+      "toasts": {
+        "imageCopied": {
+          "title": "Imagine copiată!",
+          "description": "Imaginea analizelor a fost copiată în clipboard"
+        },
+        "emailSent": {
+          "title": "Email trimis!",
+          "description": "Raportul de analiză a fost trimis la {email}"
+        },
+        "imageSaved": {
+          "title": "Imagine salvată!",
+          "description": "Analizele de cheltuieli pentru {merchant} au fost descărcate ca PNG"
+        }
+      }
+    },
+    "analyzeDialog": {
+      "header": {
+        "title": "Analizează factura",
+        "description": "Configurează o analiză cu IA pentru factura"
+      },
+      "options": {
+        "completeAnalysis": {
+          "title": "Analiză completă",
+          "description": "Analiză completă cu IA ce include toate datele facturii, articolele și informațiile comerciantului.",
+          "estimatedTime": "2-3 min",
+          "features": {
+            "ocrExtraction": "Extracție OCR",
+            "itemCategorization": "Categorisirea articolelor",
+            "merchantIdentification": "Identificarea comerciantului",
+            "priceAnalysis": "Analiza prețurilor",
+            "receiptValidation": "Validarea bonului"
+          }
+        },
+        "invoiceOnly": {
+          "title": "Doar datele facturii",
+          "description": "Analizează informațiile de bază ale facturii precum totaluri, date și detalii de plată.",
+          "estimatedTime": "30-60 sec",
+          "features": {
+            "totalExtraction": "Extracția totalului",
+            "dateParsing": "Interpretarea datelor",
+            "paymentMethodDetection": "Detectarea metodei de plată"
+          }
+        },
+        "itemsOnly": {
+          "title": "Analiza articolelor",
+          "description": "Se concentrează pe extragerea și categorisirea articolelor individuale din factură.",
+          "estimatedTime": "1-2 min",
+          "features": {
+            "itemExtraction": "Extracția articolelor",
+            "categoryAssignment": "Atribuirea categoriilor",
+            "pricePerItem": "Preț per articol",
+            "quantityDetection": "Detectarea cantității"
+          }
+        },
+        "merchantOnly": {
+          "title": "Analiza comerciantului",
+          "description": "Identifică și analizează informațiile comerciantului, inclusiv locația și categoria.",
+          "estimatedTime": "30-45 sec",
+          "features": {
+            "merchantIdentification": "Identificarea comerciantului",
+            "locationExtraction": "Extracția locației",
+            "businessCategory": "Categoria afacerii",
+            "contactInfo": "Informații de contact"
+          }
+        }
+      },
+      "analysisSteps": {
+        "preparingDocument": "Se pregătește documentul...",
+        "runningOcrExtraction": "Se rulează extracția OCR...",
+        "analyzingWithAi": "Se analizează cu IA...",
+        "categorizingItems": "Se categorisesc articolele...",
+        "finalizingResults": "Se finalizează rezultatele...",
+        "processing": "Se procesează..."
+      },
+      "analyzing": {
+        "title": "Se analizează factura",
+        "progressComplete": "{progress}% complet"
+      },
+      "sections": {
+        "analysisType": "Tip analiză",
+        "includedFeatures": "Funcționalități incluse",
+        "enhancementsOptional": "Îmbunătățiri (opțional)"
+      },
+      "enhancements": {
+        "priceComparison": {
+          "label": "Comparare prețuri",
+          "description": "Compară prețurile cu date istorice"
+        },
+        "savingsTips": {
+          "label": "Sugestii de economisire",
+          "description": "Primește recomandări de economisire cu IA"
+        },
+        "quickExtract": {
+          "label": "Mod de extragere rapidă",
+          "description": "Prioritizează viteza în locul acurateței"
+        }
+      },
+      "badges": {
+        "recommended": "Recomandat"
+      },
+      "summary": {
+        "enhancementsSelected": "+ {count} îmbunătățire(i)",
+        "noEnhancementsSelected": "Nicio îmbunătățire selectată",
+        "estimatedTime": "Durată estimată"
+      },
+      "buttons": {
+        "cancel": "Anulează",
+        "analyzing": "Se analizează...",
+        "startAnalysis": "Pornește analiza"
+      },
+      "toasts": {
+        "analysisComplete": {
+          "title": "Analiză finalizată",
+          "description": "Factura ta a fost analizată cu succes."
+        },
+        "analysisFailed": {
+          "title": "Analiza a eșuat",
+          "description": "Nu am putut analiza factura ta. Te rugăm să încerci din nou."
+        }
+      }
+    },
+    "addScanDialog": {
+      "title": "Adaugă o scanare nouă",
+      "description": "Încarcă o imagine nouă a bonului sau un document nou pentru a-l atașa la această factură.",
+      "dropzone": {
+        "dropHere": "Plasează fișierul aici...",
+        "dragAndDrop": "Trage și plasează un fișier aici",
+        "orClickBrowse": "sau apasă pentru a răsfoi",
+        "formats": "JPEG, PNG, PDF (max 10MB)"
+      },
+      "scanType": {
+        "label": "Tip scanare",
+        "placeholder": "Selectează tipul de scanare",
+        "jpeg": "Imagine JPEG",
+        "png": "Imagine PNG",
+        "pdf": "Document PDF",
+        "other": "Altele"
+      },
+      "buttons": {
+        "cancel": "Anulează",
+        "uploading": "Se încarcă...",
+        "upload": "Încarcă scan"
+      },
+      "errors": {
+        "uploadStorageFailed": "Încărcarea scanării în spațiul de stocare a eșuat",
+        "unknown": "A apărut o eroare necunoscută"
+      },
+      "toasts": {
+        "fileTooLargeTitle": "Fișier prea mare",
+        "fileTooLargeDescription": "Dimensiunea maximă a fișierului este 10MB",
+        "scanAddedTitle": "Scan adăugat cu succes",
+        "scanAddedDescription": "Scanarea a fost atașată la factură",
+        "scanFailedTitle": "Adăugarea scanării a eșuat"
+      },
+      "console": {
+        "uploadError": "Eroare la încărcarea scanării:"
+      }
+    },
+    "imageDialog": {
+      "title": "Imagine ({image})",
+      "imageAlt": "Fotografie a bonului"
+    },
+    "itemsDialog": {
+      "title": "Editează articolele facturii",
+      "description": "Actualizează cantitățile, prețurile sau adaugă articole noi în această factură",
+      "table": {
+        "item": "Articol",
+        "quantity": "Cantitate",
+        "unit": "Unitate",
+        "price": "Preț",
+        "total": "Total general",
+        "actions": "Acțiuni"
+      },
+      "footer": {
+        "itemsFound": "{total} articole găsite (se afișează {shown})",
+        "page": "Pagina {current} din {total}",
+        "itemsTotal": "{count, plural, one {# articol în total} few {# articole în total} other {# de articole în total}}"
+      },
+      "buttons": {
+        "previous": "Anterior",
+        "next": "Următor",
+        "addItem": "Adaugă articol",
+        "cancel": "Anulează",
+        "saveChanges": "Salvează changes"
+      },
+      "aria": {
+        "deleteItem": "Șterge articol: {name}",
+        "unnamedItem": "unnamed articol",
+        "previousPage": "Mergi la pagina anterioară (pagina {page})",
+        "nextPage": "Mergi la pagina următoare (pagina {page})",
+        "addItem": "Adaugă un articol nou în factură",
+        "cancel": "Anulează editarea și închide dialogul",
+        "save": "Salvează modificările articolelor facturii"
+      }
+    },
+    "merchantDialog": {
+      "title": "Detalii comerciant",
+      "noMerchantLinked": "Niciun comerciant asociat acestei facturi",
+      "description": "Informații despre {merchantName}",
+      "fields": {
+        "address": "Adresă",
+        "phone": "Telefon",
+        "parentCompany": "Companie mamă"
+      },
+      "buttons": {
+        "openInMaps": "Deschide în Maps"
+      }
+    },
+    "feedbackDialog": {
+      "title": "Oferă feedback",
+      "description": "Ajută-ne să îmbunătățim analizele pentru {merchant} împărtășindu-ne opinia ta",
+      "sections": {
+        "rating": "Cum ai evalua analizele?",
+        "features": "Care funcționalități au fost cele mai utile? (Selectează toate opțiunile aplicabile)",
+        "comments": "Comentarii suplimentare (opțional)"
+      },
+      "features": {
+        "spendingTrends": "Tendințe de cheltuieli",
+        "priceComparisons": "Preț Comparisons",
+        "savingsTips": "Sfaturi de economisire",
+        "merchantAnalysis": "Merchant Analiză",
+        "visualCharts": "Grafice vizuale",
+        "categoryBreakdown": "Categorie Breakdown"
+      },
+      "commentsPlaceholder": "Împărtășește-ne părerea ta despre analize...",
+      "buttons": {
+        "cancel": "Anulează",
+        "submit": "Trimite feedback"
+      },
+      "toasts": {
+        "sending": {
+          "title": "Se trimite feedback-ul...",
+          "description": "Te rugăm să aștepți cât timp trimitem feedback-ul."
+        },
+        "ratingRequired": {
+          "title": "Evaluare necesară",
+          "description": "Te rugăm să oferi un calificativ cu stele înainte de trimitere"
+        },
+        "success": {
+          "title": "Feedback trimis!",
+          "description": "Feedback trimis cu succes"
+        },
+        "error": {
+          "title": "A apărut o eroare la trimiterea feedback-ului",
+          "description": "Te rugăm să încerci din nou mai târziu."
+        }
+      }
+    },
+    "metadataDialog": {
+      "add": {
+        "title": "Adaugă metadate",
+        "description": "Adaugă informații suplimentare la această factură"
+      },
+      "edit": {
+        "title": "Editează metadatele",
+        "description": "Actualizează valoarea acestui câmp de metadate",
+        "fieldLabel": "Câmp metadate"
+      },
+      "delete": {
+        "title": "Șterge metadatele",
+        "description": "Sigur vrei să ștergi aceste metadate?"
+      },
+      "fields": {
+        "keyLabel": "Cheie metadate",
+        "valueLabel": "Valoare metadate",
+        "keyPlaceholder": "Introdu cheia",
+        "valuePlaceholder": "Introdu valoarea"
+      },
+      "buttons": {
+        "cancel": "Anulează",
+        "save": "Salvează",
+        "delete": "Șterge"
+      }
+    },
+    "recipeDialog": {
+      "create": {
+        "title": "Adaugă o rețetă nouă",
+        "description": "Completează detaliile pentru a crea o rețetă.",
+        "success": "Rețeta a fost creată cu succes",
+        "error": "Nu s-a putut crea rețeta"
+      },
+      "read": {
+        "description": "Detalii despre rețetă și instrucțiuni de preparare",
+        "noDescription": "Nu a fost furnizată nicio descriere.",
+        "notSpecified": "Nespecificat"
+      },
+      "update": {
+        "title": "Actualizează rețeta",
+        "description": "Actualizează detaliile rețetei."
+      },
+      "delete": {
+        "title": "Ești sigur?",
+        "description": "Această acțiune nu poate fi anulată. Va șterge definitiv rețeta <strong>{name}</strong> și toate datele asociate."
+      },
+      "fields": {
+        "recipeName": "Nume rețetă",
+        "description": "Descriere",
+        "ingredients": "Ingrediente",
+        "difficulty": "Nivel de dificultate",
+        "complexity": "Nivel de complexitate",
+        "instructions": "Instrucțiuni",
+        "prepTime": "Timp de pregătire",
+        "cookTime": "Timp de gătire",
+        "totalDuration": "Durata Totală"
+      },
+      "actions": {
+        "generateName": "Generează nume",
+        "enhanceInstructions": "Îmbunătățește instrucțiunile"
+      },
+      "tooltips": {
+        "generateName": "Generează un nume de rețetă pe baza ingredientelor și a nivelului de dificultate folosind AI",
+        "enhanceInstructions": "Folosește AI pentru a-ți îmbunătăți instrucțiunile cu mai multe detalii"
+      },
+      "placeholders": {
+        "recipeName": "Introdu numele rețetei",
+        "description": "Introdu o descriere scurtă a rețetei",
+        "selectDifficulty": "Selectează dificultatea",
+        "instructions": "Introdu instrucțiunile de gătire",
+        "prepTime": "ex. 15 minute",
+        "cookTime": "ex. 30 minute"
+      },
+      "difficulty": {
+        "easy": "Ușor",
+        "medium": "Mediu",
+        "hard": "Greu"
+      },
+      "buttons": {
+        "add": "Adaugă",
+        "cancel": "Anulează",
+        "save": "Salvează",
+        "saving": "Se salvează...",
+        "close": "Închide",
+        "delete": "Șterge"
+      },
+      "minutes": "minute"
+    },
+    "merchantReceiptsDialog": {
+      "title": "Toate bonurile de la {merchant}",
+      "description": "Vezi și filtrează toate bonurile tale de la acest comerciant",
+      "searchPlaceholder": "Caută receipts...",
+      "filters": {
+        "date": "Dată",
+        "sort": "Sortare"
+      },
+      "dateOptions": {
+        "allTime": "Toată perioada",
+        "last30Days": "Ultimele 30 de zile",
+        "last90Days": "Ultimele 90 de zile",
+        "thisYear": "Anul acesta"
+      },
+      "sortOptions": {
+        "newest": "Cele mai noi primele",
+        "oldest": "Cele mai vechi primele"
+      },
+      "table": {
+        "receipt": "Bon",
+        "date": "Dată",
+        "itemsCount": "Articole #",
+        "actions": "Acțiuni",
+        "view": "Vede"
+      },
+      "footer": {
+        "receiptsFound": "{count} bonuri găsite (afișate {showing})",
+        "page": "Pagina {current} din {total}"
+      },
+      "buttons": {
+        "previous": "Anterior",
+        "next": "Următor"
+      }
+    },
+    "removeScanDialog": {
+      "title": "Elimină scan",
+      "description": "Sigur vrei să elimini scanarea {current} din {total}?",
+      "descriptionLastScan": "Aceasta este singura scanare atașată la această factură. Nu o poți elimina.",
+      "scanAlt": "Scanare {index}",
+      "scanCaption": "Scanare {index}",
+      "warning": {
+        "title": "Nu poți elimina ultima scanare",
+        "description": "Fiecare factură trebuie să aibă cel puțin o scanare atașată. Adaugă o altă scanare înainte să o elimini pe aceasta."
+      },
+      "buttons": {
+        "cancel": "Anulează",
+        "removing": "Se elimină...",
+        "remove": "Elimină scan"
+      },
+      "toasts": {
+        "cannotDeleteLastTitle": "Nu poți șterge ultima scanare",
+        "cannotDeleteLastDescription": "O factură trebuie să aibă cel puțin o scanare atașată",
+        "removedTitle": "Scan eliminat cu succes",
+        "removedDescription": "Scanarea a fost eliminată din factură",
+        "removeFailedTitle": "Eliminarea scanării a eșuat"
+      },
+      "errors": {
+        "unknown": "A apărut o eroare necunoscută"
+      },
+      "console": {
+        "deleteError": "Eroare ștergere scan:"
+      }
+    },
+    "allergenDialog": {
+      "title": "Editează Alergeni",
+      "success": {
+        "saved": "Alergenii au fost actualizați cu succes",
+        "added": "Alergen adăugat: {name}",
+        "removed": "Alergen eliminat: {name}"
+      },
+      "labels": {
+        "currentAllergens": "Alergeni Actuali",
+        "customAllergen": "Adaugă Alergen Personalizat",
+        "quickAdd": "Adaugă Rapid Alergeni Comuni"
+      },
+      "description": "Gestionează alergenii pentru {productName}",
+      "placeholders": {
+        "customAllergen": "Introdu numele alergenului..."
+      },
+      "buttons": {
+        "saving": "Se salvează...",
+        "save": "Salvează Modificările",
+        "add": "Adaugă",
+        "cancel": "Anulează"
+      },
+      "empty": {
+        "noAllergens": "Niciun alergen detectat"
+      },
+      "aria": {
+        "removeAllergen": "Elimină alergenul {name}"
+      },
+      "defaultDescription": "Conține {name}",
+      "errors": {
+        "duplicate": "Alergenul '{name}' este deja adăugat",
+        "saveFailed": "Eroare la salvarea alergenilor",
+        "missingData": "Datele produsului lipsesc",
+        "emptyName": "Numele alergenului nu poate fi gol"
+      }
+    },
+    "bulkCategoryDialog": {
+      "success": {
+        "saved": "{count, plural, one {Categoria actualizată pentru # produs} other {Categoria actualizată pentru # produse}}",
+        "partialSuccess": "{success} produse actualizate, {failed} esuate"
+      },
+      "placeholders": {
+        "selectCategory": "Selectează o categorie"
+      },
+      "buttons": {
+        "saving": "Se salvează...",
+        "save": "Aplică Tuturor",
+        "cancel": "Anulează"
+      },
+      "description": "{count, plural, one {Schimbă categoria pentru # produs} other {Schimbă categoria pentru # produse}}",
+      "title": "Schimbă Categoria",
+      "labels": {
+        "andMore": "...și încă {count}",
+        "selectedProducts": "Produse Selectate",
+        "newCategory": "Categorie Nouă",
+        "progress": "Progres"
+      },
+      "errors": {
+        "noProducts": "Niciun produs selectat",
+        "saveFailed": "Eroare la actualizarea categoriilor",
+        "missingData": "Date lipsă",
+        "allFailed": "Toate produsele nu au putut fi actualizate"
+      },
+      "progress": {
+        "updating": "Se actualizeaza {current} din {total}..."
+      }
+    },
+    "exportDialog": {
+      "title": "Exportă facturi",
+      "description": "Exportă {count} facturi în formatul preferat.",
+      "format": {
+        "title": "Format de export",
+        "labels": {
+          "csv": "CSV",
+          "json": "JSON",
+          "pdf": "PDF"
+        },
+        "descriptions": {
+          "json": "Format de date structurate",
+          "pdf": "Format document imprimabil",
+          "csv": "Format de foaie de calcul, compatibil cu Excel"
+        }
+      },
+      "options": {
+        "title": "Opțiuni",
+        "includeMetadata": "Include metadatele",
+        "includeProducts": "Include produsele",
+        "includeMerchant": "Include comerciantul",
+        "csv": {
+          "includeHeaders": "Include antetele CSV",
+          "delimiterLabel": "Suprascriere delimitator CSV (opțional):",
+          "delimiterPlaceholder": ","
+        },
+        "json": {
+          "prettyPrint": "Afișare formatată (2 spații)"
+        }
+      },
+      "buttons": {
+        "cancel": "Anulează",
+        "export": "Exportă",
+        "copy": "Copiază în Clipboard",
+        "copied": "Copiat!"
+      },
+      "filename": {
+        "hint": "Fișierul va fi salvat cu extensia bazată pe format",
+        "label": "Nume fișier"
+      },
+      "estimate": {
+        "label": "Dimensiune estimată fișier:"
+      }
+    },
+    "importDialog": {
+      "title": "Importă facturi",
+      "description": "Încarcă fișierele de facturi pentru a le importa în sistem.",
+      "tabs": {
+        "csv": "CSV",
+        "pdf": "PDF",
+        "xlsx": "Excel"
+      },
+      "dropzone": {
+        "dropHere": "Plasează fișierele aici...",
+        "dragAndDrop": "Trage și plasează fișierele aici",
+        "orClickBrowse": "sau apasă pentru a răsfoi fișierele",
+        "acceptsCsv": "Acceptă fișiere .csv (max 10MB)",
+        "acceptsPdf": "Acceptă fișiere .pdf (max 10MB)",
+        "acceptsXlsx": "Acceptă fișiere .xlsx și .xls (max. 10MB)"
+      },
+      "selectedFiles": "Fișiere selectate",
+      "remove": "Elimină",
+      "status": {
+        "success": "Fișiere importate cu succes!",
+        "error": "A apărut o eroare la importul fișierelor. Te rugăm să încerci din nou."
+      },
+      "buttons": {
+        "cancel": "Anulează",
+        "import": "Importă",
+        "importWithCount": "Importă ({count})"
+      }
+    },
+    "shareInvoiceDialog": {
+      "title": "Partajează factură",
+      "selection": {
+        "description": "Alege cum vrei să partajezi această factură. Opțiunea aleasă influențează cine poate avea acces.",
+        "publicTitle": "Partajare publică",
+        "publicDescription": "Generează un link sau un cod QR pe care <strong>oricine</strong> îl poate folosi pentru a vedea această factură.",
+        "privateTitle": "Privat sharing",
+        "privateDescription": "Trimite o invitație pe email unei <strong>persoane specifice</strong>. Doar acea persoană va avea acces.",
+        "privacyNoticeTitle": "Notă de confidențialitate",
+        "privacyNoticeDescription": "Linkurile publice pot fi accesate de oricine are URL-ul. Partajarea privată limitează accesul la destinatarul specificat."
+      },
+      "dialogDescription": {
+        "currentlyPublic": "\"{invoiceName}\" este publică în acest moment",
+        "selection": "Alege cum să partajezi „{invoiceName}”",
+        "public": "Partajează \"{invoiceName}\" public",
+        "private": "Trimite \"{invoiceName}\" în privat"
+      },
+      "toasts": {
+        "copyLink": {
+          "loadingPublic": "Se copiază linkul...",
+          "loadingMakePublic": "Factura devine publică...",
+          "successPublic": "Link copiat în clipboard!",
+          "successMadePublic": "Factura este acum publică! Link copiat în clipboard.",
+          "error": "Eșuat: {message}"
+        },
+        "copyQr": {
+          "loadingPublic": "Se copiază codul QR...",
+          "loadingMakePublic": "Factura devine publică...",
+          "successPublic": "Cod QR copiat în clipboard!",
+          "successMadePublic": "Factura este acum publică! Cod QR copiat în clipboard.",
+          "error": "Eșuat: {message}"
+        },
+        "sendEmail": {
+          "loading": "Se trimite invitația către {email}...",
+          "success": "Invitație trimisă către {email}!",
+          "error": "Eșuat: {message}",
+          "comingSoon": "Partajarea prin email va fi disponibilă în curând"
+        },
+        "revoke": {
+          "loading": "Se trimite cererea de revocare către server...",
+          "success": "Factura este acum privată. Linkurile existente nu vor mai funcționa.",
+          "error": "Revocarea accesului a eșuat: {message}"
+        }
+      },
+      "errors": {
+        "qrNotFound": "Elementul codului QR nu a fost găsit"
+      }
+    },
+    "shareInvoiceDialogPublic": {
+      "tabs": {
+        "directLink": "Link direct",
+        "qrCode": "Cod QR"
+      },
+      "hints": {
+        "link": "Copiază acest link și partajează-l. Oricine îl primește va putea vedea factura.",
+        "qr": "Oricine scanează acest cod QR va fi redirecționat pentru a vedea factura."
+      },
+      "copyQrImage": "Copiază codul QR ca imagine",
+      "alreadyPublic": {
+        "title": "Această factură este publică în acest moment",
+        "description": "Această factură este accesibilă public. <strong>Oricine are linkul o poate vedea</strong>, inclusiv toate detaliile facturii, articolele și sumele. Poți revoca accesul public oricând pentru a o face din nou privată.",
+        "revoke": "Revocă accesul public",
+        "revoking": "Se revocă accesul...",
+        "revokeHint": "Factura va deveni privată. Linkurile existente nu vor mai funcționa."
+      },
+      "backToOptions": "Înapoi la opțiuni",
+      "warning": {
+        "title": "Avertisment privind accesul public",
+        "description": "Prin partajarea publică a acestei facturi, <strong>oricine are linkul o va putea vedea</strong>. Asta include toate detaliile facturii, articolele și sumele. Continuă doar dacă vrei ca această factură să fie accesibilă publicului."
+      }
+    },
+    "shareInvoiceDialogPrivate": {
+      "backToOptions": "Înapoi la opțiuni",
+      "title": "Privat sharing",
+      "description": "Invitația va fi trimisă direct la adresa de email pe care o specifici. Doar acest destinatar va primi acces pentru a vedea factura.",
+      "emailLabel": "Adresa de email a destinatarului",
+      "emailPlaceholder": "name@example.com",
+      "emailHint": "O invitație pe email va fi trimisă la această adresă cu un link privat pentru a vedea factura.",
+      "sendInvitation": "Trimite invitație privată",
+      "sending": "Se trimite invitația...",
+      "comingSoonTooltip": "Funcția de partajare prin email va fi disponibilă în curând"
+    },
+    "deleteInvoiceDialog": {
+      "title": "Șterge factură",
+      "description": "Această acțiune nu poate fi anulată. Te rugăm să verifici atent înainte de a continua.",
+      "deleting": {
+        "title": "Ștergere factură...",
+        "description": "Te rugăm să aștepți cât timp ștergem toate datele asociate."
+      },
+      "impact": {
+        "title": "Ștergere permanentă",
+        "intro": "Următoarele date vor fi șterse definitiv:",
+        "invoiceRecord": "Înregistrarea facturii și metadatele",
+        "uploadedScans": "{count} scanare(i) încărcată(e)",
+        "lineItems": "{count} line articol(s)",
+        "sharedAccess": "Acces partajat pentru {count} utilizator(i)"
+      },
+      "confirmation": {
+        "typeToConfirm": "Tastează <highlight>{name}</highlight> pentru confirmare:",
+        "understoodLabel": "Înțeleg că această acțiune este permanentă",
+        "understoodDescription": "Această factură și toate datele ei vor fi șterse definitiv și nu vor putea fi recuperate."
+      },
+      "buttons": {
+        "cancel": "Anulează",
+        "deleting": "Se șterge...",
+        "deletePermanently": "Șterge permanent"
+      },
+      "toasts": {
+        "deletedTitle": "Factură ștearsă",
+        "deletedDescription": "Factura a fost ștearsă cu succes.",
+        "deleteFailedTitle": "Șterge eșuat",
+        "deleteFailedDescription": "Nu am putut șterge această factură. Te rugăm să încerci din nou."
+      },
+      "console": {
+        "deleteError": "Eroare ștergere factură:"
+      }
+    },
+    "createInvoiceDialog": {
+      "title": "Creați Factură",
+      "titlePlural": "Creați Facturi",
+      "description": "Transformați scanările în date structurate de factură cu extracție bazată pe AI.",
+      "selectedScans": "Scanări Selectate",
+      "totalSize": "total",
+      "chooseMode": "Alegeți Modul de Creare",
+      "singleMode": {
+        "title": "O factură per scanare",
+        "description": "Creează {count} facturi separate. Ideal când fiecare scanare este o chitanță diferită."
+      },
+      "batchMode": {
+        "title": "Combinați într-o singură factură",
+        "description": "Creează 1 factură cu toate cele {count} scanări atașate. Ideal pentru chitanțe cu mai multe pagini."
+      },
+      "singleScanInfo": {
+        "title": "Ce se întâmplă în continuare?",
+        "description": "AI-ul nostru va analiza scanarea dvs. și va extrage automat detaliile comerciantului, articolele, prețurile și totalurile. Puteți revizui și edita rezultatele ulterior."
+      },
+      "buttons": {
+        "cancel": "Anulare",
+        "createSingle": "Creați Factură",
+        "createMultiple": "Creați {count} Facturi",
+        "close": "Închide"
+      },
+      "creating": {
+        "title": "Se creează Factura",
+        "titlePlural": "Se creează Facturile",
+        "processing": "Se procesează {count} scanare...",
+        "processingPlural": "Se procesează {count} scanări...",
+        "step1Title": "Se încarcă scanările",
+        "step1Description": "Se trimit scanările către serverele noastre",
+        "step2Title": "Se creează înregistrările facturilor",
+        "step2Description": "Se configurează structurile de date ale facturilor",
+        "step3Title": "Finalizare",
+        "step3Description": "Se pregătesc facturile pentru vizualizare"
+      },
+      "complete": {
+        "title": "{count} Factură Creată!",
+        "titlePlural": "{count} Facturi Create!",
+        "description": "Factura dvs. este gata pentru vizualizare și editare.",
+        "descriptionPlural": "Facturile dvs. sunt gata pentru vizualizare și editare.",
+        "nextSteps": "Pași următori:",
+        "nextStepsDescription": "Revizuiți factura, verificați datele extrase și faceți orice modificări necesare. Puteți solicita și analiza AI pentru informații despre cheltuieli.",
+        "nextStepsDescriptionPlural": "Revizuiți facturile, verificați datele extrase și faceți orice modificări necesare. Puteți solicita și analiza AI pentru informații despre cheltuieli.",
+        "viewButton": "Vizualizați Factura",
+        "viewButtonPlural": "Vizualizați Facturile",
+        "failureTitle": "Creare Eșuată",
+        "failureDescription": "Nu am putut crea nicio factură. Vă rugăm să revedeți erorile de mai jos și să încercați din nou.",
+        "partialTitle": "{created} din {total} Facturi Create",
+        "partialDescription": "Unele scanări nu au putut fi procesate. Facturile create cu succes sunt gata pentru vizualizare.",
+        "errorsLabel": "Scanări Eșuate:",
+        "retryButton": "Încearcă Din Nou"
+      },
+      "errors": {
+        "partialFail": "Nu s-au putut crea {count} facturi",
+        "createFailed": "Nu s-au putut crea facturile: {message}",
+        "unknown": "Eroare necunoscută"
+      }
+    }
+  },
+  "IMS--Edit": {
+    "metadata": {
+      "description": "Vizualizați și editați detaliile facturii, articolele, rețetele și setările de partajare.",
+      "title": "Editare factură"
+    },
+    "editInvoiceContext": {
+      "toasts": {
+        "noChanges": "Nu există modificări de salvat",
+        "updated": "Factura a fost actualizată cu succes",
+        "saveFailed": "Salvarea modificărilor a eșuat"
+      },
+      "console": {
+        "saveFailed": "Salvarea facturii a eșuat:"
+      }
+    },
+    "triviaTips": {
+      "title": "Sfaturi de economisire",
+      "completeness": "Factura este completă în proporție de {percentage}%",
+      "completeLabel": "Factura este complet completă!",
+      "difficulty": {
+        "easy": "Ușor",
+        "medium": "Mediu"
+      },
+      "banner": {
+        "potentialSavingsLabel": "Economii potențiale",
+        "hint": "Aplică aceste sfaturi pentru a economisi la următoarea vizită la {merchantName}"
+      },
+      "contextTips": {
+        "noItems": "Rulează analiza AI pentru a extrage articolele din bon",
+        "noDescription": "Adaugă o descriere pentru a-ți aminti această achiziție",
+        "noCategory": "Setează o categorie pentru a urmări modelele de cheltuieli",
+        "defaultCategory": "Schimbă categoria din 'Necategorizat' pentru o urmărire mai bună",
+        "noRecipes": "AI poate sugera rețete bazate pe articolele tale alimentare"
+      },
+      "contextActions": {
+        "analyze": "Rulează Analiza",
+        "addDescription": "Adaugă Descriere",
+        "setCategory": "Setează Categoria"
+      },
+      "tips": {
+        "loyaltyProgram": {
+          "title": "Înscrie-te în programul de loialitate",
+          "description": "Înscrie-te în programul de loialitate {merchantName} pentru a câștiga puncte la fiecare achiziție."
+        },
+        "bulkPurchase": {
+          "title": "Cumpără la vrac",
+          "description": "Cumpără produse neperisabile la vrac pentru a reduce costul per unitate."
+        },
+        "digitalCoupons": {
+          "title": "Folosește cupoane digitale",
+          "description": "Verifică aplicația {merchantName} pentru cupoane digitale înainte de cumpărături."
+        }
+      },
+      "tooltips": {
+        "estimatedSavings": "Economii estimate cu acest sfat"
+      },
+      "buttons": {
+        "viewMoreSavingsTips": "Vezi mai multe sfaturi de economisire"
+      },
+      "disclaimer": "Economiile sunt estimări bazate pe prețuri și promoții medii"
+    },
+    "recipesTab": {
+      "header": {
+        "title": "Rețete pe care le poți prepara",
+        "description": "Pe baza articolelor din această factură"
+      },
+      "buttons": {
+        "generate": "Generează",
+        "addRecipe": "Adaugă rețetă",
+        "createFirstRecipe": "Creează prima ta rețetă"
+      },
+      "tooltips": {
+        "generateRecipeUsingAi": "Generează o rețetă cu IA!",
+        "createRecipeWithIngredients": "Creează o rețetă nouă cu aceste ingrediente"
+      },
+      "emptyState": {
+        "noRecipesAvailable": "Nu există încă rețete disponibile"
+      },
+      "pagination": {
+        "previous": "Anterior",
+        "next": "Următor",
+        "pageOf": "Pagina {currentPage} din {totalPages}"
+      },
+      "toasts": {
+        "aiGenerationComingSoon": {
+          "title": "Generarea rețetelor cu IA vine în curând",
+          "description": "Această funcționalitate este în curs de dezvoltare."
+        }
+      }
+    },
+    "metadataTab": {
+      "header": {
+        "title": "Informații suplimentare",
+        "description": "Metadate asociate acestei facturi"
+      },
+      "buttons": {
+        "addField": "Adaugă câmp",
+        "addFirstMetadataField": "Adaugă primul tău câmp de metadate"
+      },
+      "tooltips": {
+        "addCustomMetadata": "Adaugă metadate personalizate la această factură"
+      },
+      "badges": {
+        "readonly": "Doar citire"
+      },
+      "dropdown": {
+        "edit": "Editează",
+        "delete": "Șterge"
+      },
+      "emptyState": {
+        "noMetadataFields": "Nu au fost adăugate câmpuri de metadate"
+      }
+    },
+    "itemsTable": {
+      "title": "Articole",
+      "buttons": {
+        "editItems": "Editează articolele",
+        "addItem": "Adaugă articol"
+      },
+      "tooltips": {
+        "editInvoiceItemsAndQuantities": "Editează articolele și cantitățile facturii"
+      },
+      "columns": {
+        "selectAll": "Selectează toate articolele",
+        "selectRow": "Selectează {name}",
+        "name": "Nume",
+        "quantity": "Cantitate",
+        "price": "Preț",
+        "unit": "Unitate",
+        "total": "Total",
+        "actions": "Acțiuni"
+      },
+      "tableHeaders": {
+        "item": "Articol",
+        "quantity": "Cant.",
+        "price": "Preț",
+        "total": "Total"
+      },
+      "footer": {
+        "total": "Total"
+      },
+      "pagination": {
+        "totalItems": "{count, plural, one {# articol în total} few {# articole în total} other {# de articole în total}}",
+        "previous": "Anterior",
+        "next": "Următor",
+        "pageOf": "Pagina {currentPage} din {totalPages}"
+      },
+      "search": {
+        "placeholder": "Caută articole..."
+      },
+      "bulkToolbar": {
+        "selectedCount": "{count, plural, one {# articol selectat} few {# articole selectate} other {# de articole selectate}}",
+        "deleteSelected": "Șterge selecționate",
+        "changeCategory": "Schimbă Categoria",
+        "noSelection": "Niciun produs selectat"
+      },
+      "editing": {
+        "saved": "Articol actualizat cu succes",
+        "cancel": "Editare anulată",
+        "fieldLabel": "Editează {field} pentru {name}"
+      },
+      "deleteConfirm": {
+        "title": "Șterge articole",
+        "description": "{count, plural, one {Sigur doriți să ștergeți acest articol?} few {Sigur doriți să ștergeți aceste # articole?} other {Sigur doriți să ștergeți aceste # de articole?}}",
+        "confirm": "Șterge",
+        "cancel": "Anulează",
+        "success": "{count, plural, one {# articol șters} few {# articole șterse} other {# de articole șterse}}"
+      },
+      "newItem": {
+        "defaultName": "Articol nou",
+        "added": "Articol nou adăugat"
+      },
+      "indicators": {
+        "uncategorized": "Necategorizat",
+        "uncategorizedTooltip": "Acest produs necesită o categorie atribuită pentru o urmărire mai bună a cheltuielilor",
+        "missingName": "Nume lipsă",
+        "missingNameTooltip": "Traducerea numelui generic lipsește sau este identică cu textul OCR brut",
+        "lowConfidence": "Încredere scăzută",
+        "lowConfidenceTooltip": "Încrederea OCR este de {confidence}% - se recomandă revizuire manuală",
+        "edited": "Editat",
+        "editedTooltip": "Acest produs a fost modificat manual",
+        "allergens": "{count, plural, one {# alergen} other {# alergeni}}"
+      },
+      "actions": {
+        "restore": "Restabilește produs",
+        "editAllergens": "Editează alergeni",
+        "remove": "Elimină produs"
+      },
+      "softDelete": {
+        "error": "Eroare la eliminarea produsului",
+        "success": "Produsul '{name}' a fost eliminat"
+      },
+      "restore": {
+        "error": "Eroare la restabilirea produsului",
+        "success": "Produsul '{name}' a fost restabilit"
+      },
+      "bulkCategory": {
+        "noSelection": "Vă rugăm să selectați cel puțin un produs"
+      }
+    },
+    "changeHistory": {
+      "unsavedChanges": "Modificări nesalvate",
+      "pending": "În așteptare",
+      "created": "Factură creată",
+      "title": "Istoric Modificări",
+      "time": {
+        "justNow": "Acum",
+        "secondsAgo": "acum {seconds} secunde",
+        "hoursAgo": "acum {hours} ore",
+        "daysAgo": "acum {days} zile",
+        "minutesAgo": "acum {minutes} minute"
+      },
+      "modified": "Ultima modificare",
+      "changes": {
+        "paymentTypeChanged": "Tip plată modificat",
+        "unmarkedImportant": "Demarcat ca important",
+        "categoryUpdated": "Categorie actualizată",
+        "transactionDateChanged": "Data tranzacției modificată",
+        "nameChanged": "Nume modificat",
+        "descriptionChanged": "Descriere modificată",
+        "markedImportant": "Marcat ca important",
+        "importanceChanged": "Importanță modificată"
+      }
+    },
+    "guidedEditBanner": {
+      "title": "{count, plural, one {# produs necesită revizuire} few {# produse necesită revizuire} other {# de produse necesită revizuire}}",
+      "summary": {
+        "uncategorized": "{count, plural, one {# necategorizat} few {# necategorizate} other {# necategorizate}}",
+        "lowConfidence": "{count, plural, one {# încredere scăzută} few {# încredere scăzută} other {# încredere scăzută}}",
+        "missingName": "{count, plural, one {# nume lipsă} few {# nume lipsă} other {# nume lipsă}}"
+      },
+      "actions": {
+        "reviewAll": "Revizuiește toate",
+        "dismiss": "Închide"
+      },
+      "badges": {
+        "uncategorized": "{count, plural, one {# necategorizat} few {# necategorizate} other {# necategorizate}}",
+        "lowConfidence": "{count, plural, one {# încredere scăzută} few {# încredere scăzută} other {# încredere scăzută}}",
+        "missingName": "{count, plural, one {# nume lipsă} few {# nume lipsă} other {# nume lipsă}}"
+      }
+    }
+  },
+  "IMS--Landing": {
+    "metadata": {
+      "description": "Gestionează chitanțele, creează facturi și obține informații despre obiceiurile tale de cheltuieli.",
+      "title": "Sistemul de Management al Facturilor"
+    },
+    "hero": {
+      "title": "Gestionează-ți",
+      "titleHighlight": "Facturile",
+      "titleSuffix": "cu Ușurință",
+      "description": "Încarcă chitanțele și facturile tale, organizează-le și obține informații despre obiceiurile tale de cheltuieli. Sistemul nostru bazat pe AI extrage datele automat.",
+      "getStarted": "Începe Acum",
+      "viewMyInvoices": "Vezi Facturile Mele",
+      "imageAlt": "Ilustrație pentru gestionarea facturilor"
+    },
+    "workflow": {
+      "title": "Cum Funcționează",
+      "description": "Trei pași simpli pentru a digitaliza și organiza documentele tale financiare",
+      "step1": {
+        "title": "Încarcă Scanări",
+        "description": "Trage și lasă chitanțele, facturile sau bonurile tale. Acceptăm fișiere JPG, PNG și PDF de până la 10MB fiecare.",
+        "button": "Încarcă Acum"
+      },
+      "step2": {
+        "title": "Vizualizează și Organizează",
+        "description": "Revizuiește scanările încărcate, selectează-le pe cele dorite și creează facturi din ele individual sau în loturi.",
+        "button": "Vezi Scanările"
+      },
+      "step3": {
+        "title": "Gestionează Facturile",
+        "description": "Vizualizează facturile, analizează tiparele de cheltuieli și obține perspective bazate pe AI despre obiceiurile tale financiare.",
+        "button": "Vezi Facturile"
+      }
+    },
+    "features": {
+      "title": "Funcționalități Puternice",
+      "description": "Tot ce ai nevoie pentru a gestiona facturile eficient",
+      "ocr": {
+        "title": "Extracție OCR Inteligentă",
+        "description": "AI-ul nostru extrage automat numele comercianților, datele, sumele și articolele din scanări."
+      },
+      "analytics": {
+        "title": "Analiză Cheltuieli",
+        "description": "Obține informații detaliate despre tiparele tale de cheltuieli cu grafice și rapoarte."
+      },
+      "batch": {
+        "title": "Procesare în Loturi",
+        "description": "Procesează mai multe scanări simultan - creează facturi individuale sau combină-le într-una singură."
+      },
+      "signInPrompt": "Conectează-te pentru a salva facturile permanent și a le accesa de pe orice dispozitiv.",
+      "imageAlt": "Ilustrație cu funcționalitățile facturilor",
+      "signIn": "Autentifică-te"
+    },
+    "bento": {
+      "title": "Tot Ce Ai Nevoie",
+      "description": "Funcționalități puternice concepute pentru a face gestionarea facturilor fără efort",
+      "ai": {
+        "title": "Bazat pe AI",
+        "description": "Extracție GPT-4"
+      },
+      "analyticsCard": {
+        "title": "Analiză",
+        "description": "Perspective cheltuieli"
+      },
+      "cloud": {
+        "title": "Sincronizare Cloud",
+        "description": "Acces de oriunde"
+      },
+      "ocr": {
+        "title": "OCR Inteligent",
+        "description": "Captură automată date"
+      },
+      "secure": {
+        "title": "Securizat",
+        "description": "Criptare de nivel bancar"
+      },
+      "share": {
+        "title": "Partajare",
+        "description": "Colaborare ușoară"
+      },
+      "mobile": "Funcționează excelent pe dispozitive mobile"
+    },
+    "cta": {
+      "title": "Gata să Începi?",
+      "description": "Încarcă prima ta scanare și experimentează magia gestionării facturilor bazată pe AI.",
+      "uploadButton": "Încarcă Prima Scanare",
+      "learnMore": "Află Mai Multe",
+      "badges": {
+        "secure": "Securizat și Privat",
+        "cloud": "Sincronizat în Cloud",
+        "ai": "Bazat pe AI"
+      }
+    }
+  },
+  "IMS--List": {
+    "metadata": {
+      "description": "Enumerați toate facturile din sistemul de gestionare a facturilor.",
+      "title": "Enumerați facturile"
+    },
+    "subtitle": "Acesta este inventarul dvs. de bonuri digitale. <br></br> Aici puteți găsi bonurile pe care le-ați încărcat până acum. <br></br> Făcând clic pe o chitanță, veți fi redirecționat către pagina chitanței specifice.",
+    "title": "Bine ați venit, {name}!",
+    "viewInvoicesPage": {
+      "guestName": "dragă oaspete"
+    },
+    "viewInvoicesIsland": {
+      "tabs": {
+        "invoices": "Facturi",
+        "statistics": "Statistici",
+        "liveAnalysis": "Analiză live"
+      }
+    },
+    "invoicesHeader": {
+      "title": "Gestionare facturi",
+      "description": "Gestionează-ți bonurile și urmărește-ți obiceiurile de cheltuieli",
+      "actions": {
+        "import": "Importă",
+        "export": "Exportă",
+        "print": "Printează",
+        "newInvoice": "Factură nouă"
+      },
+      "tooltips": {
+        "import": "Importă facturi din fișiere",
+        "export": "Exportă toate facturile",
+        "print": "Printează facturile",
+        "newInvoice": "Creează o factură nouă"
+      }
+    },
+    "invoicesView": {
+      "searchPlaceholder": "Caută facturi...",
+      "filters": {
+        "category": "Categorie",
+        "timeOfDay": "Momentul zilei",
+        "categories": "Categorii",
+        "paymentTypes": "Tipuri de plată",
+        "dateRange": "Interval de date",
+        "dateFrom": "De la data",
+        "dateTo": "Până la data",
+        "amountRange": "Interval de sumă",
+        "amountMin": "Sumă minimă",
+        "amountMax": "Sumă maximă",
+        "sortBy": "Sortare după",
+        "sortOptions": {
+          "dateNewest": "Dată (cele mai recente)",
+          "dateOldest": "Dată (cele mai vechi)",
+          "amountHighToLow": "Sumă (descrescător)",
+          "amountLowToHigh": "Sumă (crescător)",
+          "nameAZ": "Nume (A-Z)",
+          "nameZA": "Nume (Z-A)",
+          "none": "Fără sortare (ordine implicită)"
+        },
+        "title": "Filtre",
+        "button": "Filtre",
+        "clear": "Șterge tot",
+        "activeCount": "{count} active"
+      },
+      "categories": {
+        "all": "Toate categoriile",
+        "groceries": "Alimente",
+        "dining": "Mese în oraș",
+        "utilities": "Utilități",
+        "entertainment": "Divertisment",
+        "travel": "Călătorii",
+        "other": "Altele"
+      },
+      "times": {
+        "all": "Toate intervalele",
+        "day": "Zi (6-18)",
+        "night": "Noapte (18-6)"
+      },
+      "placeholderPanel": "Vor fi adăugate în curând mai multe controale de filtrare.",
+      "viewModes": {
+        "table": "Table vede",
+        "grid": "Grid vede"
+      }
+    },
+    "messageList": {
+      "aiAssistant": "Asistent AI",
+      "you": "Tu"
+    },
+    "generativeView": {
+      "welcomeMessage": "Salut! Sunt asistentul tău de analiză a facturilor. Cu ce te pot ajuta astăzi? Încearcă comenzi precum /find pentru a căuta facturi.",
+      "title": "Analiză live",
+      "subtitle": "Discută cu AI pentru a-ți analiza facturile și pentru a primi analize utile",
+      "help": "Ajutor",
+      "tabs": {
+        "chat": "Conversație",
+        "settings": "Setări"
+      },
+      "chatDescription": "Discută cu AI pentru a-ți analiza facturile și pentru a primi analize utile. Încearcă comenzi precum /find pentru a căuta facturi.",
+      "settings": {
+        "title": "Chat setări",
+        "description": "Configurează preferințele asistentului tău AI",
+        "historyLabel": "Chat istoric",
+        "retentionPlaceholder": "Selectează perioada de păstrare",
+        "retention": {
+          "30": "Păstrează 30 de zile",
+          "60": "Păstrează 60 de zile",
+          "90": "Păstrează 90 de zile",
+          "none": "Don't salvează istoric"
+        },
+        "dataAccessTitle": "Acces la date",
+        "allowInvoiceData": "Permite accesul la datele facturii",
+        "allowMerchantData": "Permite accesul la datele comerciantului",
+        "notificationPreferences": "Preferințe de notificare",
+        "notifyInsights": "Notifică-mă despre analize noi",
+        "save": "Salvează setări"
+      }
+    },
+    "tableView": {
+      "empty": {
+        "title": "Nu există facturi încă",
+        "description": "Începeți prin a încărca chitanțele pentru a crea prima factură",
+        "uploadCta": "Încărcați prima chitanță"
+      },
+      "columns": {
+        "invoice": "Factură",
+        "category": "Categorie",
+        "date": "Dată",
+        "amount": "Sumă",
+        "actions": "Acțiuni"
+      },
+      "aria": {
+        "selectAllInvoices": "Selectează toate facturile",
+        "selectInvoice": "Selectează factură {name}",
+        "rowsPerPage": "Rânduri pe pagină",
+        "sortByDate": "Sortare după dată",
+        "sortByAmount": "Sortare după sumă"
+      },
+      "viewInvoice": "Vede Factură",
+      "rowsPerPage": "Rânduri pe pagină:",
+      "pageOf": "Pagina {current} din {total}",
+      "previousPage": "Pagina anterioară",
+      "nextPage": "Pagina următoare",
+      "tooltips": {
+        "notAnalyzed": "Această factură nu a fost încă analizată"
+      }
+    },
+    "gridView": {
+      "tooltips": {
+        "viewDetails": "Vezi detalii"
+      },
+      "itemCount": "{count, plural, one {# articol} few {# articole} other {# de articole}}"
+    },
+    "tableViewActions": {
+      "actions": {
+        "edit": "Editează",
+        "share": "Partajează",
+        "delete": "Șterge"
+      },
+      "tooltips": {
+        "moreActions": "Mai multe acțiuni",
+        "edit": "Editează detaliile facturii",
+        "share": "Partajează factura prin link sau e-mail",
+        "delete": "Șterge definitiv această factură"
+      }
+    },
+    "bulkActions": {
+      "selected": "{count, plural, one {# factură selectată} other {# facturi selectate}}",
+      "clearSelection": "Curăță selecția",
+      "export": "Exportă",
+      "delete": "Șterge",
+      "changeCategory": "Schimbă Categoria",
+      "deleteConfirm": {
+        "title": "Șterge Facturile",
+        "description": "{count, plural, one {Ești sigur că dorești să ștergi această factură? Această acțiune nu poate fi anulată.} other {Ești sigur că dorești să ștergi aceste # facturi? Această acțiune nu poate fi anulată.}}",
+        "confirm": "Șterge",
+        "cancel": "Anulează"
+      },
+      "deleteSuccess": "{count, plural, one {Factură ștearsă cu succes} other {# facturi șterse cu succes}}",
+      "deleteError": "Eroare la ștergerea facturilor. Vă rugăm încercați din nou.",
+      "deletePartialSuccess": "{success} factură/facturi șterse, {failed} eșuate",
+      "categoryChanged": "{count, plural, one {Categoria facturii actualizată cu succes} other {# categorii de facturi actualizate cu succes}}",
+      "categoryChangeError": "Eroare la actualizarea categoriilor facturilor. Vă rugăm încercați din nou.",
+      "categoryPartialSuccess": "{success} factură/facturi actualizate, {failed} eșuate",
+      "categories": {
+        "notDefined": "Nedefinit",
+        "grocery": "Alimente",
+        "fastFood": "Fast Food",
+        "homeCleaning": "Curățenie Casă",
+        "carAuto": "Mașină & Auto",
+        "other": "Altele"
+      }
+    }
+  },
+  "IMS--Stats": {
+    "title": "Statistici facturi",
+    "subtitle": "Gestionează bonurile și urmărește obiceiurile tale de cheltuieli",
+    "calendarHeatmap": {
+      "days": {
+        "wed": "Mie",
+        "thu": "Joi",
+        "fri": "Vin",
+        "sun": "Dum",
+        "mon": "Lun",
+        "sat": "Sâm",
+        "tue": "Mar"
+      },
+      "tooltip": {
+        "noSpending": "Fără cheltuieli",
+        "amount": "Cheltuit",
+        "invoices": "{count} facturi"
+      },
+      "legend": {
+        "less": "Mai puțin",
+        "more": "Mai mult"
+      },
+      "title": "Calendar Cheltuieli",
+      "description": "Intensitatea cheltuielilor zilnice în timp",
+      "navigation": {
+        "previous": "Luna anterioară",
+        "next": "Luna următoare"
+      },
+      "aria": {
+        "calendarGrid": "Calendar cheltuieli zilnice"
+      }
+    },
+    "spendingOverTime": {
+      "labels": {
+        "amount": "Sumă"
+      },
+      "tooltip": {
+        "invoiceCount": "{count} facturi",
+        "andMore": "și încă {count}..."
+      },
+      "title": "Cheltuieli în Timp",
+      "description": "Urmăriți tendințele cheltuielilor"
+    },
+    "categoryBreakdown": {
+      "title": "Cheltuieli pe categorii",
+      "description": "Distribuție pe categorii",
+      "totalLabel": "Cheltuieli totale",
+      "tooltip": {
+        "invoiceCount": "{count} facturi"
+      }
+    },
+    "currencyDistribution": {
+      "title": "Distribuție Valutară",
+      "description": "Defalcarea cheltuielilor pe valute cu conversie în RON",
+      "toggleLabel": "Comutați vizualizarea valutei",
+      "showOriginal": "Arată Original",
+      "showRON": "Arată RON",
+      "singleCurrency": "Toate facturile în {currency} ({symbol})",
+      "invoiceCount": "{count} facturi",
+      "originalAmount": "Original",
+      "ronEquivalent": "Echivalent RON",
+      "totalAmount": "Sumă Totală",
+      "totalCurrencies": "Total Valute",
+      "totalSpending": "Cheltuieli Totale"
+    },
+    "merchantLeaderboard": {
+      "title": "Comercianți de Top",
+      "description": "Unde cheltuiești cel mai mult",
+      "labels": {
+        "totalSpent": "Total Cheltuit"
+      },
+      "tooltip": {
+        "invoiceCount": "{count} facturi"
+      },
+      "empty": "Nu sunt date disponibile despre comercianți"
+    },
+    "merchantTrends": {
+      "title": "Tendințe Cheltuieli Comercianți",
+      "description": "Modele lunare de cheltuieli pentru comercianții de top",
+      "labels": {
+        "merchant": "Comerciant",
+        "totalSpend": "Total Cheltuit",
+        "trend": "Tendință (Ultimele 6 Luni)"
+      },
+      "aria": {
+        "sparkline": "Tendință cheltuieli pentru {merchant}"
+      },
+      "empty": "Nu există date despre comercianți încă"
+    },
+    "merchantVisit": {
+      "title": "Modele de Vizitare Comercianți",
+      "description": "Frecvența cumpărăturilor și informații despre coș",
+      "metrics": {
+        "totalVisits": "Total Vizite",
+        "visitsPerMonth": "Vizite/Lună",
+        "basketSize": "Coș Mediu",
+        "preferredDay": "Zi Preferată",
+        "avgSpend": "Cheltuială Medie/Vizită"
+      },
+      "empty": "Nu există date de vizite încă"
+    },
+    "priceDistribution": {
+      "title": "Distribuția prețurilor",
+      "description": "Distribuția prețurilor produselor",
+      "labels": {
+        "itemCount": "Număr de produse"
+      },
+      "tooltip": {
+        "itemCount": "{count} produse"
+      }
+    },
+    "timeOfDay": {
+      "title": "Obiceiuri de cumpărare",
+      "description": "Când faceți cumpărături",
+      "labels": {
+        "invoiceCount": "Număr de facturi"
+      },
+      "tooltip": {
+        "invoiceCount": "{count} facturi"
+      }
+    },
+    "productCategory": {
+      "tooltip": {
+        "productCount": "{count} produse"
+      },
+      "empty": "Niciun produs de analizat încă",
+      "title": "Cheltuieli pe Categorii de Produse",
+      "description": "Defalcare cheltuieli după tip de produs"
+    },
+    "topProducts": {
+      "headers": {
+        "totalSpent": "Total",
+        "rank": "#",
+        "avgPrice": "Preț Mediu",
+        "purchases": "Achiziții",
+        "product": "Produs",
+        "quantity": "Cant"
+      },
+      "empty": "Niciun produs cumpărat încă",
+      "title": "Produse Preferate",
+      "description": "Cele mai cumpărate articole",
+      "ariaLabel": "Clasament produse preferate"
+    },
+    "allergenSummary": {
+      "empty": "Niciun alergen detectat în achizițiile tale",
+      "stats": {
+        "ofTotal": "din total",
+        "products": "produse"
+      },
+      "title": "Rezumat Alergeni",
+      "description": "Expunerea la alergeni în produse",
+      "ariaLabel": "Rezumat frecvență alergeni"
+    },
+    "kpi": {
+      "totalSpending": "Cheltuieli totale",
+      "invoiceCount": "Număr de facturi",
+      "topMerchant": "Comerciant principal",
+      "averageItems": "Med. produse",
+      "vsLastMonth": "{delta}% față de luna trecută",
+      "avgPerInvoice": "medie {amount} per factură",
+      "visits": "{count} vizite",
+      "acrossInvoices": "din {count} facturi",
+      "noneYet": "Niciun rezultat încă"
+    },
+    "comparison": {
+      "title": "Lună de lună",
+      "description": "Comparație cu luna anterioară",
+      "spendingDelta": "Variația cheltuielilor",
+      "invoiceCount": "Număr de facturi",
+      "newMerchants": "Comercianți noi",
+      "discovered": "descoperiți",
+      "none": "niciunul",
+      "increase": "creștere",
+      "decrease": "scădere"
+    },
+    "empty": {
+      "title": "Nicio statistică încă",
+      "subtitle": "Încărcați bonuri pentru a vedea statisticile",
+      "cta": "Încarcă bon"
+    },
+    "productAnalytics": {
+      "title": "Analiză Produse",
+      "subtitle": "Detalii despre articolele achiziționate"
+    }
+  },
+  "IMS--UploadScans": {
+    "metadata": {
+      "description": "Încărcați scanări de chitanțe în contul dvs. pentru procesare ulterioară în facturi.",
+      "title": "Sistem de gestionare a facturilor - Încărcare scanări"
+    },
+    "title": "Încărcare Scanări",
+    "subtitle": "Încărcați imagini sau PDF-uri cu chitanțe. Creați facturi din ele mai târziu.",
+    "breadcrumb": "Înapoi la Facturi",
+    "header": {
+      "title": "Încărcare Scanări",
+      "description": "Încărcați imagini sau PDF-uri cu chitanțe. Creați facturi din ele mai târziu.",
+      "tooltip": "Încărcați chitanțele, facturile sau bonurile dvs. aici. Puteți selecta mai multe fișiere și le puteți organiza în facturi mai târziu din pagina Vizualizare Scanări."
+    },
+    "buttons": {
+      "viewScans": "Vizualizați Scanările",
+      "myInvoices": "Facturile Mele",
+      "uploadFirst": "Încărcați Prima Scanare"
+    },
+    "stats": {
+      "added": "Adăugate",
+      "pending": "În așteptare",
+      "uploading": "Se încarcă",
+      "completed": "Finalizate",
+      "failed": "Eșuate"
+    },
+    "sidebar": {
+      "formats": {
+        "title": "Formate Acceptate",
+        "images": "Imagini",
+        "imageExtensions": ".jpg, .jpeg, .png",
+        "documents": "Documente",
+        "documentExtensions": ".pdf",
+        "maxSize": "Dimensiune maximă: 10MB per fișier"
+      },
+      "tips": {
+        "title": "Sfaturi pentru Rezultate Optime",
+        "tip1": "Folosiți iluminare bună când fotografiați chitanțele",
+        "tip2": "Asigurați-vă că textul este clar și lizibil",
+        "tip3": "Evitați umbrele și reflexiile",
+        "tip4": "Capturați întreaga chitanță în cadru",
+        "tip5": "PDF-urile funcționează cel mai bine pentru chitanțele digitale"
+      },
+      "security": {
+        "title": "Stocare Securizată",
+        "description": "Scanările dvs. sunt criptate și stocate în siguranță. Doar dvs. le puteți accesa."
+      },
+      "nextSteps": {
+        "title": "Toate încărcările sunt complete!",
+        "description": "Scanările dvs. sunt gata. Mergeți la Vizualizare Scanări pentru a le organiza în facturi.",
+        "button": "Continuați la Vizualizare Scanări"
+      }
+    },
+    "upload": {
+      "dropzone": "Trageți și plasați imaginile sau PDF-urile cu chitanțe aici",
+      "browse": "Răsfoiți fișiere",
+      "or": "sau"
+    },
+    "errors": {
+      "unsupportedType": "Tip de fișier neacceptat: {type}",
+      "tooLarge": "Fișier prea mare: {name} (max 10MB)"
+    },
+    "uploadArea": {
+      "aria": {
+        "uploadFiles": "Încarcă fișiere"
+      },
+      "empty": {
+        "title": "Trage și plasează fișierele aici",
+        "dropActive": "Plasează fișierele pentru încărcare",
+        "dropInactive": "Fă clic sau trage fișiere pentru încărcare",
+        "formats": "Formate acceptate: JPG, PNG, PDF (maxim 10MB fiecare)",
+        "note": "Poți selecta mai multe fișiere.",
+        "chooseFiles": "Alege fișiere"
+      },
+      "compact": {
+        "dropActive": "Plasează fișierele pentru a le adăuga",
+        "dropInactive": "Trage fișiere aici sau fă clic pentru a naviga",
+        "subtitle": "JPG, PNG, PDF până la 10MB"
+      },
+      "actions": {
+        "clearAll": "Șterge tot",
+        "uploading": "Se încarcă...",
+        "uploadScans": "Încarcă scanările"
+      },
+      "tooltips": {
+        "clearAll": "Elimină toate încărcările în așteptare",
+        "uploadScans": "Pornește încărcarea tuturor scanărilor în așteptare"
+      }
+    },
+    "preview": {
+      "title": "Încărcări în așteptare ({count})",
+      "status": {
+        "pending": "În așteptare",
+        "uploading": "Se încarcă",
+        "retrying": "Reîncercare",
+        "completed": "Finalizat",
+        "failed": "Eșuat"
+      },
+      "removeTooltip": "Elimină acest fișier",
+      "retryAttempt": "Reîncercarea {attempt}",
+      "pendingTooltip": "Această scanare nu va fi salvată până nu apăsați pe Încarcă",
+      "pagination": {
+        "previous": "Anterior",
+        "next": "Următor",
+        "pageInfo": "{current} / {total} ({count} scanări)"
+      }
+    },
+    "postUpload": {
+      "title": "Încărcare finalizată!",
+      "subtitle": "Aceste scanări reprezintă o singură achiziție?",
+      "createInvoice": "Da, creează factura",
+      "viewScans": "Nu, le voi combina mai târziu",
+      "dismiss": "Închide"
+    }
+  },
+  "IMS--View": {
+    "metadata": {
+      "description": "Vizualizați detaliile facturii, articolele și informațiile despre comerciant.",
+      "title": "Vizualizare factură"
+    },
+    "invoiceAnalytics": {
+      "title": "Analize și insight-uri",
+      "tabs": {
+        "current": "Factura curentă",
+        "compare": "Comparație"
+      },
+      "emptyState": {
+        "title": "Date insuficiente pentru comparații",
+        "description": "Adaugă mai multe facturi pentru a vedea tendințe de cheltuieli, defalcări pe comercianți și comparații pe categorii."
+      }
+    },
+    "invoiceTimeline": {
+      "title": "Cronologia facturii",
+      "subtitle": "Istoric complet al acțiunilor și modificărilor",
+      "eventCount": "{count, plural, one {# eveniment} few {# evenimente} other {# de evenimente}}"
+    },
+    "invoiceTabs": {
+      "tabs": {
+        "possibleRecipes": "Rețete posibile",
+        "additionalInfo": "Informații suplimentare"
+      },
+      "recipe": {
+        "duration": "{minutes} min",
+        "prepCook": "Pregătire: {prep}m • Gătire: {cook}m",
+        "viewRecipe": "Vezi rețeta",
+        "ingredients": "Ingrediente",
+        "instructions": "Instrucțiuni"
+      },
+      "actions": {
+        "regenerate": "Regenerează rețetele",
+        "regenerateTooltip": "Re-analizează factura pentru a genera noi sugestii de rețete",
+        "generate": "Generează rețete"
+      },
+      "empty": {
+        "recipes": "Nu există sugestii de rețete",
+        "additionalInfo": "Nu există informații suplimentare"
+      }
+    },
+    "timelineItem": {
+      "aria": {
+        "moreInfo": "Mai multe informații despre {title}"
+      },
+      "confidence": "Încredere: {value}%",
+      "events": {
+        "created": {
+          "title": "Factură creată",
+          "description": "Scanată și digitalizată din bon"
+        },
+        "aiAnalysis": {
+          "title": "Analiză AI finalizată",
+          "description": "{count, plural, one {# articol detectat și categorisit} few {# articole detectate și categorisite} other {# de articole detectate și categorisite}}"
+        },
+        "recipesGenerated": {
+          "title": "Rețete generate",
+          "description": "{count, plural, one {# rețetă sugerată} few {# rețete sugerate} other {# de rețete sugerate}}"
+        },
+        "shared": {
+          "title": "Partajată cu alții",
+          "description": "Partajată cu {count, plural, one {# persoană} few {# persoane} other {# de persoane}}"
+        },
+        "edited": {
+          "title": "Factură actualizată"
+        },
+        "exported": {
+          "title": "Factură exportată"
+        },
+        "markedImportant": {
+          "title": "Marcată ca importantă",
+          "description": "Marcată pentru urmărire prioritară"
+        },
+        "categorized": {
+          "title": "Categorie atribuită",
+          "description": "Categorizare automată pe baza articolelor"
+        }
+      },
+      "tooltips": {
+        "created": "Factura a fost scanată și digitalizată folosind {method}.",
+        "aiAnalysis": "AI a procesat această factură în {duration} și a analizat {count, plural, one {# articol} few {# articole} other {# de articole}}.",
+        "recipesGenerated": "Pe baza ingredientelor cumpărate, {count, plural, one {a fost generată # rețetă} few {au fost generate # rețete} other {au fost generate # de rețete}}.",
+        "shared": "Factura a fost partajată cu {count, plural, one {# utilizator} few {# utilizatori} other {# de utilizatori}}.",
+        "edited": "Au fost făcute modificări manuale facturii.",
+        "exported": "Factura a fost exportată în format {format}.",
+        "markedImportant": "Factura a fost marcată ca importantă pentru acces rapid.",
+        "categorized": "Facturii i-a fost atribuită o categorie pentru o organizare mai bună.",
+        "unavailable": "Detaliile evenimentului nu sunt disponibile"
+      },
+      "relativeTime": {
+        "now": "Chiar acum"
+      },
+      "fallbacks": {
+        "ocr": "OCR",
+        "pdf": "PDF"
+      }
+    },
+    "timelineSharedWithList": {
+      "header": {
+        "title": "Partajată cu",
+        "publicBadge": "Public"
+      },
+      "publicAccess": {
+        "title": "Acces public activat",
+        "description": "Această factură este accesibilă public. Oricine are linkul o poate vedea, inclusiv invitații fără cont."
+      },
+      "aria": {
+        "sendEmail": "Trimite email către {user}"
+      },
+      "actions": {
+        "sendEmail": "Trimite email",
+        "manageSharing": "Gestionează partajarea"
+      }
+    },
+    "invoiceGuestBanner": {
+      "title": "Vizualizare invitat",
+      "description": "În prezent nu ești proprietarul acestei facturi. Vizualizarea este limitată la ce a configurat proprietarul în setările de partajare."
+    },
+    "categoryComparisonChart": {
+      "title": "Comparație pe categorii",
+      "description": "Factura aceasta vs media ta",
+      "labels": {
+        "current": "Curent",
+        "average": "Medie"
+      }
+    },
+    "itemsBreakdownChart": {
+      "title": "Top articole după cost",
+      "description": "Articole cu cele mai mari cheltuieli",
+      "labels": {
+        "price": "Preț",
+        "quantity": "Cant."
+      }
+    },
+    "merchantBreakdownChart": {
+      "title": "Cheltuieli pe magazin",
+      "description": "Totaluri cumulative pe toți comercianții",
+      "labels": {
+        "totalSpent": "Total cheltuit",
+        "total": "Total",
+        "visits": "Vizite",
+        "averagePerVisit": "Medie/vizită"
+      },
+      "unknownMerchant": "Comerciant Necunoscut"
+    },
+    "priceDistributionChart": {
+      "title": "Distribuția prețurilor",
+      "description": "Articole pe intervale de preț ({currency})",
+      "labels": {
+        "items": "Articole"
+      },
+      "tooltip": {
+        "itemCount": "{count, plural, one {# articol} few {# articole} other {# de articole}}"
+      }
+    },
+    "spendingByCategoryChart": {
+      "title": "Cheltuieli pe categorie",
+      "description": "Distribuția cheltuielilor",
+      "totalLabel": "Total cheltuieli",
+      "tooltip": {
+        "itemCount": "{count, plural, one {# articol} few {# articole} other {# de articole}}"
+      }
+    },
+    "spendingTrendChart": {
+      "title": "Evoluția cheltuielilor",
+      "description": "Trendul istoricului tău de facturi",
+      "labels": {
+        "amount": "Sumă"
+      },
+      "tooltip": {
+        "currentInvoice": "Factura curentă",
+        "andMore": "și încă {count}..."
+      }
+    },
+    "print": {
+      "generatedOn": "Tipărit pe {date}",
+      "page": "Pagina",
+      "labels": {
+        "date": "Data",
+        "merchant": "Comerciant",
+        "total": "Suma Totală",
+        "items": "Articole"
+      }
+    },
+    "relatedInvoices": {
+      "noRelated": "Nu s-au găsit facturi conexe",
+      "subtitle": "Facturi similare bazate pe comerciant, categorie sau sumă",
+      "sameCategory": "Aceeași Categorie",
+      "viewInvoice": "Vizualizare",
+      "similarAmount": "Sumă Similară",
+      "sameMerchant": "Același Comerciant",
+      "title": "Facturi Conexe"
+    },
+    "shareCollaborate": {
+      "title": "Partajare & Colaborare",
+      "private": "Privat",
+      "shared": "Partajat",
+      "public": "Public",
+      "sharedWith": "Partajat cu",
+      "copyLink": "Copiază Link",
+      "shareEmail": "Partajează prin Email",
+      "manageSharing": "Gestionează Partajarea",
+      "copied": "Link copiat în clipboard!",
+      "activity": {
+        "title": "Activitate",
+        "created": "Creat {time}",
+        "modified": "Ultima modificare {time}",
+        "daysAgo": "{count, plural, one {acum # zi} other {acum # zile}}",
+        "today": "astăzi"
+      },
+      "publicAccess": "Acces Public",
+      "publicAccessDescription": "Oricine cu link-ul poate vizualiza această factură",
+      "madePublic": "Factura este acum publică",
+      "madePrivate": "Factura este acum privată",
+      "toggleError": "Eroare la actualizarea setărilor de partajare",
+      "qrCode": "Cod QR",
+      "qrCopied": "Link copiat! Generarea codului QR va fi adăugată în curând.",
+      "copyError": "Nu s-a putut copia linkul"
+    },
+    "healthScore": {
+      "suggestions": {
+        "uncategorizedProducts": "<strong>{count}</strong> produse fără categorie — atribuie categorii pentru analiza cheltuielilor",
+        "incompleteProducts": "<strong>{count}</strong> produse incomplete — revizuiește și completează câmpurile lipsă",
+        "title": "Îmbunătățiri Sugerate",
+        "noMerchant": "Niciun comerciant asociat — adaugă detalii comerciant pentru statistici mai bune",
+        "lowOcrConfidence": "Confidență OCR scăzută la <strong>{count}</strong> produse — revizuiește manual pentru acuratețe",
+        "noRecipes": "Nu sunt rețete generate — rulează analiza AI pentru a descoperi idei de mese",
+        "incompletePayment": "Informații plată incomplete — adaugă data tranzacției, suma și moneda",
+        "fix": "Rezolvă",
+        "noProducts": "Nu sunt produse găsite — încarcă un bon sau adaugă articole manual"
+      },
+      "title": "Scor Sănătate Factură",
+      "subtitle": "Evaluare comprehensivă a calității datelor",
+      "factors": {
+        "ocrConfidence": "Confidență OCR",
+        "categoriesAssigned": "Categorii atribuite",
+        "paymentInfo": "Informații plată",
+        "merchantLinked": "Comerciant asociat",
+        "recipesGenerated": "Rețete generate",
+        "productsPresent": "Produse extrase",
+        "productCompleteness": "Completitudine produse"
+      },
+      "status": {
+        "incomplete": "Incomplet",
+        "needsAttention": "Necesită Atenție",
+        "excellent": "Excelent",
+        "good": "Bun"
+      },
+      "points": "puncte",
+      "showDetails": "Arată detalii factori",
+      "hideDetails": "Ascunde detalii factori",
+      "cta": {
+        "edit": "Editează Factura",
+        "analyze": "Rulează Analiza AI"
+      },
+      "seeReport": "Vezi raport detaliat",
+      "dialogTitle": "Raport de sănătate factură"
+    },
+    "itemAnalytics": {
+      "title": "Produse",
+      "searchPlaceholder": "Caută produse...",
+      "columns": {
+        "name": "Nume",
+        "category": "Categorie",
+        "price": "Preț",
+        "quantity": "Cant.",
+        "total": "Total"
+      },
+      "summary": {
+        "title": "Rezumat",
+        "mostExpensive": "Cel mai scump",
+        "cheapest": "Cel mai ieftin",
+        "categories": "{count} categorii",
+        "allergens": "{count} alergeni detectați"
+      },
+      "empty": {
+        "title": "Niciun produs",
+        "subtitle": "Rulați analiza AI pentru a extrage produsele din bon"
+      },
+      "totalLabel": "TOTAL",
+      "confidence": {
+        "label": "Încredere OCR",
+        "lowWarning": "Încredere scăzută — verificați acest produs",
+        "ariaLabel": "Incredere {level}: {percent}%",
+        "high": "Ridicata",
+        "medium": "Medie",
+        "low": "Scazuta"
+      }
+    },
+    "analysisPanel": {
+      "title": "Analiză AI",
+      "options": {
+        "completeAnalysis": "Analiză Completă",
+        "merchantOnly": "Doar Comerciant",
+        "itemsOnly": "Doar Articole",
+        "invoiceOnly": "Doar Factura"
+      },
+      "tooltips": {
+        "completeAnalysis": "Extragere OCR completă + procesare AI a tuturor datelor facturii",
+        "merchantOnly": "Re-identifică comerciantul și datele de locație",
+        "itemsOnly": "Re-categorizează și analizează doar articolele individuale",
+        "invoiceOnly": "Re-extrage informații de bază ale facturii (dată, total, plată)",
+        "reanalyze": "Declanșează re-analiza completă cu toate caracteristicile AI"
+      },
+      "steps": {
+        "processing": "Se procesează articolele...",
+        "complete": "Analiză completă!",
+        "finalizing": "Se finalizează rezultatele...",
+        "extracting": "Se rulează extragerea OCR...",
+        "analyzing": "Se analizează cu AI...",
+        "preparing": "Se pregătește documentul..."
+      },
+      "tip": "Sfat Rapid: Analiza completă durează 30-60 secunde, dar oferă cele mai precise rezultate.",
+      "buttons": {
+        "reanalyze": "Re-analizează Factura"
+      },
+      "description": "Re-analizează această factură cu AI pentru a extrage sau actualiza datele",
+      "toasts": {
+        "success": {
+          "title": "Analiză Completă",
+          "description": "Factura a fost re-analizată cu succes cu date actualizate."
+        },
+        "error": {
+          "title": "Analiză Eșuată",
+          "description": "Nu s-a putut analiza factura. Vă rugăm să încercați din nou mai târziu."
+        }
+      },
+      "analyzing": {
+        "title": "Se analizează...",
+        "progress": "{progress}% completat"
+      },
+      "labels": {
+        "granularOptions": "Sau alege o analiză specifică",
+        "updates": "{count, plural, one {# actualizare} other {# actualizări}}",
+        "lastAnalyzed": "Ultima Analiză",
+        "analysisComplete": "Analiză Completă — Toate datele au fost extrase"
+      }
+    },
+    "export": {
+      "print": {
+        "title": "Printare",
+        "description": "Printează factura folosind browserul"
+      },
+      "csv": {
+        "title": "Exportă ca CSV",
+        "description": "Descarcă articolele ca foaie de calcul"
+      },
+      "copyError": "Eroare la copierea rezumatului",
+      "csvSuccess": "Fișier CSV descărcat cu succes",
+      "jsonSuccess": "Fișier JSON descărcat cu succes",
+      "title": "Exportă Factură",
+      "printError": "Eroare la deschiderea dialogului de printare",
+      "copySuccess": "Rezumat copiat în clipboard",
+      "jsonError": "Eroare la exportul JSON",
+      "copySummary": {
+        "title": "Copiază Rezumat",
+        "description": "Copiază rezumatul text în clipboard"
+      },
+      "printSuccess": "Dialog de printare deschis",
+      "description": "Exportă datele facturii în diverse formate",
+      "csvError": "Eroare la exportul CSV",
+      "json": {
+        "title": "Exportă ca JSON",
+        "description": "Descarcă datele complete ale facturii"
+      },
+      "pdf": {
+        "description": "Descarcă document profesional de factură",
+        "title": "Exportă ca PDF"
+      },
+      "pdfSuccess": "Fișier PDF descărcat cu succes",
+      "pdfError": "Eroare la generarea PDF-ului",
+      "pdfGenerating": "Se generează PDF..."
+    }
+  },
+  "IMS--ViewScans": {
+    "metadata": {
+      "description": "Vizualizați și gestionați scanările încărcate. Creați facturi din scanările selectate.",
+      "title": "Sistem de gestionare a facturilor - Vizualizare Scanări"
+    },
+    "title": "Scanările Tale",
+    "subtitle": "Selectați scanări pentru a crea facturi din ele.",
+    "breadcrumb": "Înapoi la Facturi",
+    "header": {
+      "title": "Scanările Tale",
+      "titleWithCount": "Scanările Tale ({count})",
+      "subtitle": "Selectați scanări pentru a crea facturi din ele",
+      "lastSynced": "Ultima sincronizare: {time}",
+      "tooltip": "Selectați scanări pentru a crea facturi din ele. Puteți crea o factură per scanare sau combina mai multe scanări într-o singură factură.",
+      "uploadMore": "Încărcați Mai Multe",
+      "upload": "Încărcați",
+      "uploadTooltip": "Încărcați mai multe scanări în contul dvs.",
+      "myInvoices": "Facturile Mele",
+      "invoices": "Facturi",
+      "myInvoicesTooltip": "Vizualizați facturile create",
+      "sync": "Sincronizare",
+      "syncing": "Se sincronizează...",
+      "syncTooltip": "Reîmprospătați scanările de pe server"
+    },
+    "stats": {
+      "totalScans": "Total Scanări",
+      "ready": "Pregătite",
+      "selected": "Selectate",
+      "selectHint": "Faceți clic pe scanări pentru a le selecta pentru crearea facturilor",
+      "tapHint": "Atingeți pentru a selecta"
+    },
+    "sidebar": {
+      "howTo": {
+        "title": "Cum să Creați Facturi",
+        "step1Title": "Selectați Scanări",
+        "step1Description": "Faceți clic pe scanări pentru a le selecta",
+        "step2Title": "Alegeți Modul",
+        "step2Description": "O factură per scanare sau combinați mai multe",
+        "step3Title": "Creați Factura",
+        "step3Description": "AI extrage datele automat"
+      },
+      "selectionStatus": {
+        "singular": "scanare selectată",
+        "plural": "scanări selectate",
+        "readySingular": "Pregătit pentru a crea o factură",
+        "readyPlural": "Creați mai multe facturi sau combinați-le într-una singură"
+      },
+      "quickUpload": {
+        "title": "Aveți nevoie de mai multe scanări?",
+        "description": "Încărcați chitanțe suplimentare",
+        "button": "Încărcare"
+      }
+    },
+    "emptyState": {
+      "title": "Nicio scanare încă",
+      "description": "Începeți prin a încărca chitanțele și facturile dvs. Iată cum funcționează:",
+      "step1Title": "Încărcați scanările",
+      "step1Description": "Fotografiați chitanțele sau încărcați PDF-uri cu facturi digitale",
+      "step2Title": "Selectați și organizați",
+      "step2Description": "Alegeți care scanări să fie convertite în facturi",
+      "step3Title": "Creați facturi",
+      "step3Description": "AI-ul nostru extrage automat toate datele pentru dvs.",
+      "uploadButton": "Încărcați Prima Scanare",
+      "learnMoreButton": "Aflați Mai Multe"
+    },
+    "toolbar": {
+      "selected": "selectat(e)",
+      "clearSelection": "Ștergeți",
+      "createInvoice": "Creați Factură",
+      "createInvoices": "Creați Facturi",
+      "delete": {
+        "button": "Șterge ({count})",
+        "confirmTitle": "Ștergeți scanările selectate?",
+        "confirmDescription": "Aceasta va șterge permanent {count} scanare(i) din stocare. Această acțiune nu poate fi anulată.",
+        "cancel": "Anulează",
+        "confirm": "Șterge",
+        "success": "{count} scanare(i) șterse cu succes",
+        "partial": "{success} șterse, {failed} eșuate",
+        "failed": "Nu s-au putut șterge scanările",
+        "error": "A apărut o eroare la ștergerea scanărilor"
+      }
+    },
+    "scanCard": {
+      "delete": "Ștergeți scanarea",
+      "linked": "Asociată",
+      "deleteDialog": {
+        "title": "Ștergeți scanarea?",
+        "description": "Sigur doriți să ștergeți \"{name}\"? Această acțiune nu poate fi anulată și scanarea va fi eliminată permanent din stocare.",
+        "linkedWarning": "Această scanare este asociată cu o factură.",
+        "linkedDescription": "Ștergerea acesteia va elimina scanarea din stocare, dar factura va păstra o copie a imaginii. Această acțiune nu poate fi anulată.",
+        "cancel": "Anulare",
+        "delete": "Ștergere",
+        "deleting": "Se șterge...",
+        "success": "Scanarea a fost ștearsă cu succes",
+        "error": "Nu s-a putut șterge scanarea"
+      },
+      "rename": "Redenumește scanarea",
+      "renamePlaceholder": "Introduceți un nume nou",
+      "preview": "Previzualizare scanare",
+      "previewTitle": "Previzualizare Scanare",
+      "loading": "Se încarcă...",
+      "actions": {
+        "rename": "Redenumește scanarea",
+        "delete": "Ștergeți scanarea",
+        "rotateCW": "Rotește 90° în sens orar",
+        "rotateCCW": "Rotește 90° în sens antiorar",
+        "rotating": "Se rotește...",
+        "rotateSuccess": "Imaginea a fost rotită cu succes",
+        "rotateError": "Nu s-a putut roti imaginea",
+        "rotateUnsupported": "Nu se pot roti fișierele PDF"
+      }
+    },
+    "createFromAll": {
+      "button": "Creează din Toate Scanările",
+      "title": "Toate scanările sunt gata!",
+      "description": "Creează facturi din toate cele {count} scanări deodată"
+    },
+    "groupBanner": {
+      "title": "Aceste {count} scanări au fost încărcate împreună",
+      "subtitle": "Creați o factură din aceste scanări?",
+      "createInvoice": "Creează Factură",
+      "dismiss": "Renunță"
+    },
+    "pagination": {
+      "previous": "Anterior",
+      "next": "Următor",
+      "pageInfo": "{current} / {total} ({count} scanări)"
+    }
   }
 }

--- a/sites/arolariu.ro/src/app/api/email/route.ts
+++ b/sites/arolariu.ro/src/app/api/email/route.ts
@@ -99,7 +99,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
       // 2. Parse and validate request body
       addSpanEvent("request.body.parse");
-      const body = (await request.json()) as Partial<EmailRequestBody>;
+      const body = (await request.json()) as EmailRequestBody;
       const {toEmail, toName, fromName, invoiceId} = body;
 
       if (!toEmail || !invoiceId) {

--- a/sites/arolariu.ro/src/app/domains/invoices/_components/InvoiceNotFound.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_components/InvoiceNotFound.tsx
@@ -8,7 +8,7 @@ import styles from "./InvoiceNotFound.module.scss";
  * @returns The JSX for the invoice not found view.
  */
 export default function InvoiceNotFound({invoiceIdentifier}: Readonly<{invoiceIdentifier: string}>) {
-  const t = useTranslations("Invoices.Shared.states.notFound");
+  const t = useTranslations("IMS--Common.statesNotFound");
 
   return (
     <section className={styles["section"]}>

--- a/sites/arolariu.ro/src/app/domains/invoices/_components/InvoicePreferences.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_components/InvoicePreferences.tsx
@@ -70,7 +70,7 @@ const DEFAULT_PREFERENCES: InvoicePreferences = {
  * @returns The InvoicePreferences component
  */
 export default function InvoicePreferences(): React.JSX.Element {
-  const t = useTranslations("Invoices.Shared.preferences");
+  const t = useTranslations("IMS--Common.preferences");
 
   const [preferences, setPreferences] = useLocalStorage<InvoicePreferences>("invoice-preferences", DEFAULT_PREFERENCES);
 

--- a/sites/arolariu.ro/src/app/domains/invoices/_components/InvoicesNotFound.stories.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_components/InvoicesNotFound.stories.tsx
@@ -12,7 +12,7 @@ import messages from "../../../../../messages/en.json";
  * and styling using the English i18n strings directly.
  */
 
-const namespace = messages.Invoices.Shared.invoicesNotFound;
+const namespace = messages["IMS--Common"].invoicesNotFound;
 
 const meta = {
   title: "Invoices/States/InvoicesNotFound",

--- a/sites/arolariu.ro/src/app/domains/invoices/_components/InvoicesNotFound.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_components/InvoicesNotFound.tsx
@@ -7,7 +7,7 @@ import styles from "./InvoicesNotFound.module.scss";
  * @returns The JSX for the invoices not found view.
  */
 export default async function InvoicesNotFound(): Promise<React.JSX.Element> {
-  const t = await getTranslations("Invoices.Shared.invoicesNotFound");
+  const t = await getTranslations("IMS--Common.invoicesNotFound");
   return (
     <div className={styles["container"]}>
       <h1 className={styles["title"]}>{t("title")}</h1>

--- a/sites/arolariu.ro/src/app/domains/invoices/_components/LoadingInvoice.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_components/LoadingInvoice.tsx
@@ -8,7 +8,7 @@ import styles from "./LoadingInvoice.module.scss";
  * @returns The JSX for the loading invoice view.
  */
 export default function LoadingInvoice({invoiceIdentifier}: Readonly<{invoiceIdentifier: string}>) {
-  const t = useTranslations("Invoices.Shared.states.loading");
+  const t = useTranslations("IMS--Common.statesLoading");
 
   return (
     <section className={styles["section"]}>

--- a/sites/arolariu.ro/src/app/domains/invoices/_components/LoadingInvoices.stories.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_components/LoadingInvoices.stories.tsx
@@ -11,7 +11,7 @@ import messages from "../../../../../messages/en.json";
  * using the same i18n messages and SCSS module styles.
  */
 
-const namespace = messages.Invoices.Shared.loadingInvoices;
+const namespace = messages["IMS--Common"].loadingInvoices;
 
 const meta = {
   title: "Invoices/States/LoadingInvoices",

--- a/sites/arolariu.ro/src/app/domains/invoices/_components/LoadingInvoices.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_components/LoadingInvoices.tsx
@@ -6,7 +6,7 @@ import styles from "./LoadingInvoices.module.scss";
  * @returns The JSX for the loading invoices view.
  */
 export default async function LoadingInvoices(): Promise<React.JSX.Element> {
-  const t = await getTranslations("Invoices.Shared.loadingInvoices");
+  const t = await getTranslations("IMS--Common.loadingInvoices");
   return (
     <section className={styles["section"]}>
       <article className={styles["article"]}>

--- a/sites/arolariu.ro/src/app/domains/invoices/_components/MobileBottomNav.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_components/MobileBottomNav.tsx
@@ -61,7 +61,7 @@ interface NavItem {
  */
 export default function MobileBottomNav(): React.JSX.Element {
   const pathname = usePathname();
-  const t = useTranslations("Invoices.Shared.mobileNav");
+  const t = useTranslations("IMS--Common.mobileNav");
 
   /**
    * Navigation items configuration.

--- a/sites/arolariu.ro/src/app/domains/invoices/_components/OnboardingOverlay.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_components/OnboardingOverlay.tsx
@@ -46,7 +46,7 @@ type Step = {
  * @returns The OnboardingOverlay component (only visible when not completed or dismissed)
  */
 export default function OnboardingOverlay(_props: Readonly<Props>): React.JSX.Element | null {
-  const t = useTranslations("Invoices.Shared.onboarding");
+  const t = useTranslations("IMS--Common.onboarding");
   const [onboardingComplete, setOnboardingComplete] = useLocalStorage<boolean>("invoice-onboarding-complete", false);
   const [onboardingDismissed, setOnboardingDismissed] = useLocalStorage<boolean>("invoice-onboarding-dismissed", false);
   const [currentStep, setCurrentStep] = useState(0);

--- a/sites/arolariu.ro/src/app/domains/invoices/_components/ScanCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_components/ScanCard.tsx
@@ -71,7 +71,7 @@ function formatFileSize(bytes: number): string {
  * Individual scan card with selection checkbox, inline rename, and preview.
  */
 export default function ScanCard({scan, isSelected, onToggleSelect}: Readonly<ScanCardProps>): React.JSX.Element {
-  const t = useTranslations("Invoices.ViewScans.scanCard");
+  const t = useTranslations("IMS--ViewScans.scanCard");
 
   // Guard against incomplete scan data
   if (!scan.blobUrl && !scan.name) {

--- a/sites/arolariu.ro/src/app/domains/invoices/_components/ShortcutsHelpDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_components/ShortcutsHelpDialog.tsx
@@ -82,7 +82,7 @@ type ShortcutItem = {
  * ```
  */
 export default function ShortcutsHelpDialog({open, onClose}: Readonly<ShortcutsHelpDialogProps>): React.JSX.Element {
-  const t = useTranslations("Invoices.Shared.shortcuts");
+  const t = useTranslations("IMS--Common.shortcuts");
 
   // Detect if user is on macOS for Cmd vs Ctrl display
   const isMac = typeof window !== "undefined" && navigator.platform.toUpperCase().includes("MAC");

--- a/sites/arolariu.ro/src/app/domains/invoices/_components/WorkflowProgress.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_components/WorkflowProgress.tsx
@@ -96,7 +96,7 @@ function Connector({isCompleted}: Readonly<{isCompleted: boolean}>): React.JSX.E
  * ```
  */
 export default function WorkflowProgress({currentStep}: Readonly<Props>): React.JSX.Element {
-  const t = useTranslations("Invoices.Shared.workflowProgress");
+  const t = useTranslations("IMS--Common.workflowProgress");
 
   const currentOrder = STEP_ORDER[currentStep];
 

--- a/sites/arolariu.ro/src/app/domains/invoices/_components/homepage/EnhancedCTASection.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_components/homepage/EnhancedCTASection.tsx
@@ -22,7 +22,7 @@ type CtaTranslations = Readonly<{
  * @returns The CTA section.
  */
 export default function EnhancedCTASection(): React.JSX.Element {
-  const t = useTranslations("Invoices.Homepage");
+  const t = useTranslations("IMS--Landing");
   const sectionRef = useRef<HTMLElement>(null);
   const isInView = useInView(sectionRef, {once: true, margin: "-50px"});
   const translations: CtaTranslations = {

--- a/sites/arolariu.ro/src/app/domains/invoices/_components/homepage/FeaturesSection.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_components/homepage/FeaturesSection.tsx
@@ -18,7 +18,7 @@ interface Props {
  * @returns The features section.
  */
 export default function FeaturesSection({isAuthenticated}: Readonly<Props>): React.JSX.Element {
-  const t = useTranslations("Invoices.Homepage");
+  const t = useTranslations("IMS--Landing");
 
   return (
     <section className={styles["featuresSection"]}>

--- a/sites/arolariu.ro/src/app/domains/invoices/_components/homepage/HeroSection.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_components/homepage/HeroSection.tsx
@@ -19,7 +19,7 @@ interface Props {
  * @returns The hero section.
  */
 export default function HeroSection({isAuthenticated}: Readonly<Props>): React.JSX.Element {
-  const t = useTranslations("Invoices.Homepage");
+  const t = useTranslations("IMS--Landing");
 
   return (
     <section className={styles["heroSection"]}>

--- a/sites/arolariu.ro/src/app/domains/invoices/_components/homepage/WorkflowSection.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_components/homepage/WorkflowSection.tsx
@@ -12,7 +12,7 @@ import styles from "./WorkflowSection.module.scss";
  * @returns The workflow section.
  */
 export default function WorkflowSection(): React.JSX.Element {
-  const t = useTranslations("Invoices.Homepage");
+  const t = useTranslations("IMS--Landing");
 
   return (
     <section className={styles["workflowSection"]}>

--- a/sites/arolariu.ro/src/app/domains/invoices/_dialogs/DeleteInvoiceDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_dialogs/DeleteInvoiceDialog.tsx
@@ -55,7 +55,7 @@ import styles from "./DeleteInvoiceDialog.module.scss";
  */
 export default function DeleteInvoiceDialog(): React.JSX.Element {
   const router = useRouter();
-  const t = useTranslations("Invoices.Shared.deleteInvoiceDialog");
+  const t = useTranslations("IMS--Dialogs.deleteInvoiceDialog");
   const removeInvoice = useInvoicesStore((state) => state.removeInvoice);
 
   const {

--- a/sites/arolariu.ro/src/app/domains/invoices/_dialogs/ShareInvoiceDialog.Private.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_dialogs/ShareInvoiceDialog.Private.tsx
@@ -43,7 +43,7 @@ export interface PrivateModeProps {
  * @returns The private sharing mode UI
  */
 export function PrivateMode({onBack, email, onEmailChange, onSendEmail, isSending = false}: PrivateModeProps): React.JSX.Element {
-  const t = useTranslations("Invoices.Shared.shareInvoiceDialogPrivate");
+  const t = useTranslations("IMS--Dialogs.shareInvoiceDialogPrivate");
   return (
     <div className={styles["body"]}>
       <Button

--- a/sites/arolariu.ro/src/app/domains/invoices/_dialogs/ShareInvoiceDialog.Public.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_dialogs/ShareInvoiceDialog.Public.tsx
@@ -57,7 +57,7 @@ export interface PublicModeProps {
  * @returns The link and QR code tabs UI
  */
 export function ShareLinkAndQRTabs({shareUrl, copied, onCopyLink, onCopyQRCode}: ShareLinkAndQRTabsProps): React.JSX.Element {
-  const t = useTranslations("Invoices.Shared.shareInvoiceDialogPublic");
+  const t = useTranslations("IMS--Dialogs.shareInvoiceDialogPublic");
   return (
     <Tabs
       defaultValue='link'
@@ -144,7 +144,7 @@ export function AlreadyPublicMode({
   onRevokeAccess,
   isRevoking,
 }: AlreadyPublicModeProps): React.JSX.Element {
-  const t = useTranslations("Invoices.Shared.shareInvoiceDialogPublic");
+  const t = useTranslations("IMS--Dialogs.shareInvoiceDialogPublic");
   return (
     <div className={styles["body"]}>
       <Alert
@@ -192,7 +192,7 @@ export function AlreadyPublicMode({
  * @returns The public sharing mode UI
  */
 export function PublicMode({onBack, shareUrl, copied, onCopyLink, onCopyQRCode}: PublicModeProps): React.JSX.Element {
-  const t = useTranslations("Invoices.Shared.shareInvoiceDialogPublic");
+  const t = useTranslations("IMS--Dialogs.shareInvoiceDialogPublic");
   return (
     <div className={styles["body"]}>
       <Button

--- a/sites/arolariu.ro/src/app/domains/invoices/_dialogs/ShareInvoiceDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_dialogs/ShareInvoiceDialog.tsx
@@ -45,7 +45,7 @@ type SharingMode = "selection" | "public" | "private";
 interface SelectionModeProps {
   readonly onSelectPublic: () => void;
   readonly onSelectPrivate: () => void;
-  readonly t: ReturnType<typeof useTranslations>;
+  readonly t: ReturnType<typeof useTranslations<"IMS--Dialogs.shareInvoiceDialog">>;
 }
 
 /**
@@ -139,7 +139,7 @@ function SelectionMode({onSelectPublic, onSelectPrivate, t}: Readonly<SelectionM
  * @see {@link useDialog} - Dialog state management hook
  */
 export default function ShareInvoiceDialog(): React.JSX.Element {
-  const t = useTranslations("Invoices.Shared.shareInvoiceDialog");
+  const t = useTranslations("IMS--Dialogs.shareInvoiceDialog");
   const [sharingMode, setSharingMode] = useState<SharingMode>("selection");
   const [copied, setCopied] = useState<boolean>(false);
   const [email, setEmail] = useState<string>("");

--- a/sites/arolariu.ro/src/app/domains/invoices/create-invoice/_components/InvoiceDetailsForm.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/create-invoice/_components/InvoiceDetailsForm.tsx
@@ -42,7 +42,7 @@ const dateFormatter = new Intl.DateTimeFormat(undefined, {dateStyle: "long"});
  * Scan thumbnail preview component.
  */
 function ScanThumbnail({scan}: Readonly<{scan: {name: string; blobUrl: string; scanType: string}}>): React.JSX.Element {
-  const t = useTranslations("Invoices.CreateInvoice.detailsForm");
+  const t = useTranslations("IMS--Create.detailsForm");
   const isPdf = scan.scanType === "PDF";
 
   return (
@@ -77,7 +77,7 @@ function ScanThumbnail({scan}: Readonly<{scan: {name: string; blobUrl: string; s
  * @returns JSX element with form UI
  */
 export default function InvoiceDetailsForm(): React.JSX.Element {
-  const t = useTranslations("Invoices.CreateInvoice.detailsForm");
+  const t = useTranslations("IMS--Create.detailsForm");
   const {invoiceDetails, setName, setCategory, setPaymentType, setTransactionDate, setDescription, selectedScans} =
     useCreateInvoiceContext();
 

--- a/sites/arolariu.ro/src/app/domains/invoices/create-invoice/_components/ReviewStep.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/create-invoice/_components/ReviewStep.tsx
@@ -46,7 +46,7 @@ const PAYMENT_TYPE_KEYS: Record<number, "unknown" | "cash" | "card" | "transfer"
  * @returns JSX element with review UI
  */
 export default function ReviewStep(): React.JSX.Element {
-  const t = useTranslations("Invoices.CreateInvoice.reviewStep");
+  const t = useTranslations("IMS--Create.reviewStep");
   const {selectedScans, invoiceDetails, isCreating, createInvoiceWithScans} = useCreateInvoiceContext();
   const format = useFormatter();
 

--- a/sites/arolariu.ro/src/app/domains/invoices/create-invoice/_components/ScanSelector.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/create-invoice/_components/ScanSelector.tsx
@@ -29,7 +29,7 @@ import styles from "./ScanSelector.module.scss";
  * @returns JSX element with scan selection UI
  */
 export default function ScanSelector(): React.JSX.Element {
-  const t = useTranslations("Invoices.CreateInvoice.scanSelector");
+  const t = useTranslations("IMS--Create.scanSelector");
   const {scans} = useScansStore();
   const {selectedScans, toggleScan, selectAllScans, clearSelection} = useCreateInvoiceContext();
 

--- a/sites/arolariu.ro/src/app/domains/invoices/create-invoice/_components/StepIndicator.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/create-invoice/_components/StepIndicator.tsx
@@ -45,7 +45,7 @@ function StepItem({
   isActive: boolean;
   isCompleted: boolean;
 }>): React.JSX.Element {
-  const t = useTranslations("Invoices.CreateInvoice.steps");
+  const t = useTranslations("IMS--Create.steps");
 
   const circleClassName = [styles["stepCircle"], isActive && styles["stepCircleActive"], isCompleted && styles["stepCircleCompleted"]]
     .filter(Boolean)

--- a/sites/arolariu.ro/src/app/domains/invoices/create-invoice/island.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/create-invoice/island.tsx
@@ -69,7 +69,7 @@ function WizardContent(): React.JSX.Element {
  * Navigation buttons component.
  */
 function WizardNavigation(): React.JSX.Element {
-  const t = useTranslations("Invoices.CreateInvoice");
+  const t = useTranslations("IMS--Create");
   const {currentStep, canGoNext, goBack, goNext, isCreating} = useCreateInvoiceContext();
 
   const showBack = currentStep !== "select-scans";
@@ -103,7 +103,7 @@ function WizardNavigation(): React.JSX.Element {
  * Empty state component when no scans are available.
  */
 function EmptyState(): React.JSX.Element {
-  const t = useTranslations("Invoices.CreateInvoice");
+  const t = useTranslations("IMS--Create");
 
   return (
     <Card className={styles["emptyState"]}>
@@ -128,7 +128,7 @@ function EmptyState(): React.JSX.Element {
  * Main wizard component wrapped with context.
  */
 function CreateInvoiceWizard(): React.JSX.Element {
-  const t = useTranslations("Invoices.CreateInvoice");
+  const t = useTranslations("IMS--Create");
   const {hasScans} = useCreateInvoiceContext();
 
   if (!hasScans) {

--- a/sites/arolariu.ro/src/app/domains/invoices/create-invoice/page.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/create-invoice/page.tsx
@@ -12,7 +12,7 @@ import styles from "./page.module.scss";
  * @returns Promise resolving to page metadata
  */
 export async function generateMetadata(): Promise<Metadata> {
-  const t = await getTranslations("Invoices.CreateInvoice.metadata");
+  const t = await getTranslations("IMS--Create.metadata");
   const locale = await getLocale();
   return createMetadata({
     locale,

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/GuidedEditBanner.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/GuidedEditBanner.tsx
@@ -63,7 +63,7 @@ type Props = Readonly<{
  * @see {@link ProductCategory} - Product category enum
  */
 export default function GuidedEditBanner({items, onReviewAll}: Props): React.JSX.Element | null {
-  const t = useTranslations("Invoices.EditInvoice.guidedEdit.banner");
+  const t = useTranslations("IMS--Edit.guidedEditBanner");
   const [isDismissed, setIsDismissed] = useState(false);
 
   // Check localStorage on mount for dismissal state

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/InvoiceHeader.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/InvoiceHeader.tsx
@@ -46,7 +46,7 @@ import styles from "./InvoiceHeader.module.scss";
  * @see {@link useEditInvoiceContext} - Context for tracking pending changes
  */
 export default function InvoiceHeader(): React.JSX.Element {
-  const t = useTranslations("Invoices.Shared.invoiceHeader");
+  const t = useTranslations("IMS--Common.invoiceHeader");
   const {invoice, pendingChanges, hasChanges, isSaving, setName, saveChanges, discardChanges} = useEditInvoiceContext();
   const {open: openDeleteDialog} = useDialog("SHARED__INVOICE_DELETE", "delete", {invoice});
   const {open: openAnalysisDialog} = useDialog("EDIT_INVOICE__ANALYSIS", "view", {invoice});

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/TriviaTips.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/TriviaTips.tsx
@@ -112,7 +112,7 @@ type ContextTip = {
  * @see {@link InvoiceHealthScore} - Reference implementation for scoring logic
  */
 export default function TriviaTipsCard({merchant, invoice}: Readonly<Props>) {
-  const t = useTranslations("Invoices.EditInvoice.triviaTips");
+  const t = useTranslations("IMS--Edit.triviaTips");
 
   // State for dismissed tips (persisted to localStorage)
   const [dismissedTips, setDismissedTips] = useLocalStorage<string[]>("invoice-dismissed-tips", []);

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/cards/ImageCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/cards/ImageCard.tsx
@@ -55,7 +55,7 @@ type Props = {invoice: Invoice};
  * @see {@link RemoveScanDialog} - Dialog for removing scans
  */
 export default function ImageCard({invoice}: Readonly<Props>): React.JSX.Element {
-  const t = useTranslations("Invoices.EditInvoice.imageCard");
+  const t = useTranslations("IMS--Cards.imageCard");
   const [currentScanIndex, setCurrentScanIndex] = useState(0);
   const [isTransitioning, setIsTransitioning] = useState(false);
   const [isZoomOpen, setIsZoomOpen] = useState(false);

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/cards/InvoiceCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/cards/InvoiceCard.tsx
@@ -74,7 +74,7 @@ import styles from "./InvoiceCard.module.scss";
  */
 export default function InvoiceCard(): React.JSX.Element {
   const locale = useLocale();
-  const t = useTranslations("Invoices.EditInvoice.invoiceCard");
+  const t = useTranslations("IMS--Cards.invoiceCard");
   const {invoice, merchant, pendingChanges, setPaymentType, setIsImportant, setCategory, setDescription, setTransactionDate} =
     useEditInvoiceContext();
   const {paymentInformation, category, isImportant, description} = invoice;

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/cards/MerchantCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/cards/MerchantCard.tsx
@@ -55,7 +55,7 @@ type Props = {
  * @see {@link Merchant} - Merchant type definition
  */
 export default function MerchantCard({merchant}: Readonly<Props>): React.JSX.Element {
-  const t = useTranslations("Invoices.EditInvoice.merchantCard");
+  const t = useTranslations("IMS--Cards.merchantCard");
   const {open: openMerchantInfoDialog} = useDialog("EDIT_INVOICE__MERCHANT", "view", merchant);
   const {open: openMerchantReceiptsDialog} = useDialog("EDIT_INVOICE__MERCHANT_INVOICES", "view", merchant);
 

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/cards/RecipeCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/cards/RecipeCard.tsx
@@ -80,7 +80,7 @@ type Props = {
  * @see {@link RecipeComplexity} - Complexity enum for badge styling
  */
 export default function RecipeCard({recipe}: Readonly<Props>): React.JSX.Element {
-  const t = useTranslations("Invoices.EditInvoice.recipeCard");
+  const t = useTranslations("IMS--Cards.recipeCard");
   const {name, complexity, description, ingredients, preparationTime, cookingTime} = recipe;
 
   const complexityLabelMap: Readonly<Record<RecipeComplexity, string>> = {

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/cards/SharingCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/cards/SharingCard.tsx
@@ -71,7 +71,7 @@ type Props = {
  * @see {@link Invoice} - Invoice type with sharedWith array
  */
 export default function SharingCard({invoice}: Readonly<Props>): React.JSX.Element {
-  const t = useTranslations("Invoices.EditInvoice.sharingCard");
+  const t = useTranslations("IMS--Cards.sharingCard");
   const {open} = useDialog("SHARED__INVOICE_SHARE", "share", {invoice});
   const {userInformation} = useUserInformation();
   const router = useRouter();

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/AddScanDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/AddScanDialog.tsx
@@ -60,7 +60,7 @@ function getDropzoneClassName(
  * @see {@link attachInvoiceScan} - Attaches scan URL to invoice
  */
 export default function AddScanDialog(): React.JSX.Element {
-  const t = useTranslations("Invoices.EditInvoice.addScanDialog");
+  const t = useTranslations("IMS--Dialogs.addScanDialog");
   const router = useRouter();
   const {
     currentDialog: {payload},

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/AllergenDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/AllergenDialog.tsx
@@ -110,7 +110,7 @@ interface AllergenDialogPayload {
  * @see {@link Allergen} - Allergen type definition
  */
 export default function AllergenDialog(): React.JSX.Element {
-  const t = useTranslations("Invoices.EditInvoice.allergenDialog");
+  const t = useTranslations("IMS--Dialogs.allergenDialog");
   const {
     currentDialog: {payload},
     isOpen,

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/AnalyzeDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/AnalyzeDialog.tsx
@@ -80,7 +80,7 @@ type AnalysisEnhancement = {
  * @returns The AnalyzeDialog component, CSR'ed.
  */
 export default function AnalyzeDialog(): React.JSX.Element {
-  const t = useTranslations("Invoices.EditInvoice.analyzeDialog");
+  const t = useTranslations("IMS--Dialogs.analyzeDialog");
   const {
     isOpen,
     open,

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/BulkCategoryDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/BulkCategoryDialog.tsx
@@ -92,7 +92,7 @@ interface BulkCategoryDialogPayload {
  * @see {@link ProductCategory} - Product category enum
  */
 export default function BulkCategoryDialog(): React.JSX.Element {
-  const t = useTranslations("Invoices.EditInvoice.bulkCategoryDialog");
+  const t = useTranslations("IMS--Dialogs.bulkCategoryDialog");
   const router = useRouter();
   const {
     currentDialog: {payload},

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/FeedbackDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/FeedbackDialog.tsx
@@ -60,7 +60,7 @@ import styles from "./FeedbackDialog.module.scss";
  * @see {@link AnalyticsCard} - Parent component that opens this dialog
  */
 export default function FeedbackDialog(): React.JSX.Element {
-  const t = useTranslations("Invoices.EditInvoice.feedbackDialog");
+  const t = useTranslations("IMS--Dialogs.feedbackDialog");
   const [rating, setRating] = useState<number>(0);
   const [feedback, setFeedback] = useState<string>("");
   const [hoveredRating, setHoveredRating] = useState<number>(0);

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/ImageDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/ImageDialog.tsx
@@ -38,7 +38,7 @@ import styles from "./ImageDialog.module.scss";
  * @see {@link useDialog} - Dialog state management hook
  */
 export default function ImageDialog(): React.JSX.Element {
-  const t = useTranslations("Invoices.EditInvoice.imageDialog");
+  const t = useTranslations("IMS--Dialogs.imageDialog");
   const {
     currentDialog: {payload},
     isOpen,

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/ItemsDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/ItemsDialog.tsx
@@ -69,7 +69,7 @@ import styles from "./ItemsDialog.module.scss";
  * @see {@link useDialog} - Dialog state management hook
  */
 export default function ItemsDialog(): React.JSX.Element {
-  const t = useTranslations("Invoices.EditInvoice.itemsDialog");
+  const t = useTranslations("IMS--Dialogs.itemsDialog");
   const {
     currentDialog: {payload},
     isOpen,

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/MerchantDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/MerchantDialog.tsx
@@ -57,7 +57,7 @@ import styles from "./MerchantDialog.module.scss";
  * @see {@link MerchantCategory} - Category enum for badge display
  */
 export default function MerchantDialog(): React.JSX.Element {
-  const t = useTranslations("Invoices.EditInvoice.merchantDialog");
+  const t = useTranslations("IMS--Dialogs.merchantDialog");
   const {
     currentDialog: {payload},
     isOpen,

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/MerchantReceiptsDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/MerchantReceiptsDialog.tsx
@@ -77,7 +77,7 @@ import styles from "./MerchantReceiptsDialog.module.scss";
  */
 export default function MerchantReceiptsDialog(): React.JSX.Element {
   const locale = useLocale();
-  const t = useTranslations("Invoices.EditInvoice.merchantReceiptsDialog");
+  const t = useTranslations("IMS--Dialogs.merchantReceiptsDialog");
   const {
     currentDialog: {payload},
     isOpen,

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/MetadataDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/MetadataDialog.tsx
@@ -31,7 +31,7 @@ export const VALID_METADATA_KEYS = [
 ];
 
 const AddDialog = () => {
-  const t = useTranslations("Invoices.EditInvoice.metadataDialog");
+  const t = useTranslations("IMS--Dialogs.metadataDialog");
   const {isOpen, open, close} = useDialog("EDIT_INVOICE__METADATA");
   const [addedMetadata, setAddedMetadata] = useState<{key: string; value: string}>({
     key: "",
@@ -107,7 +107,7 @@ const AddDialog = () => {
 };
 
 const UpdateDialog = ({metadata}: Readonly<{metadata: Record<string, string>}>) => {
-  const t = useTranslations("Invoices.EditInvoice.metadataDialog");
+  const t = useTranslations("IMS--Dialogs.metadataDialog");
   const {isOpen, open, close} = useDialog("EDIT_INVOICE__METADATA");
   const [editedMetadata, setEditedMetadata] = useState<Record<string, string>>(metadata);
 
@@ -173,7 +173,7 @@ const UpdateDialog = ({metadata}: Readonly<{metadata: Record<string, string>}>) 
 };
 
 const DeleteDialog = ({metadata}: Readonly<{metadata: Record<string, string>}>) => {
-  const t = useTranslations("Invoices.EditInvoice.metadataDialog");
+  const t = useTranslations("IMS--Dialogs.metadataDialog");
   const {isOpen, open, close} = useDialog("EDIT_INVOICE__METADATA");
 
   const handleDelete = useCallback(() => {

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/RecipeDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/RecipeDialog.tsx
@@ -68,7 +68,7 @@ function RichTextStrong(chunks: React.ReactNode): React.JSX.Element {
 }
 
 const CreateDialog = () => {
-  const t = useTranslations("Invoices.EditInvoice.recipeDialog");
+  const t = useTranslations("IMS--Dialogs.recipeDialog");
   const {invoice} = useEditInvoiceContext();
   const router = useRouter();
   const {isOpen, open, close} = useDialog("EDIT_INVOICE__RECIPE");
@@ -358,7 +358,7 @@ const CreateDialog = () => {
 };
 
 const ReadDialog = ({recipe}: Readonly<{recipe: Recipe}>) => {
-  const t = useTranslations("Invoices.EditInvoice.recipeDialog");
+  const t = useTranslations("IMS--Dialogs.recipeDialog");
   const {isOpen, open, close} = useDialog("EDIT_INVOICE__RECIPE");
 
   return (
@@ -436,7 +436,7 @@ const ReadDialog = ({recipe}: Readonly<{recipe: Recipe}>) => {
 };
 
 const UpdateDialog = ({recipe}: Readonly<{recipe: Recipe}>) => {
-  const t = useTranslations("Invoices.EditInvoice.recipeDialog");
+  const t = useTranslations("IMS--Dialogs.recipeDialog");
   const {isOpen, open, close} = useDialog("EDIT_INVOICE__RECIPE");
 
   const [recipeDetails, setRecipeDetails] = useState<Recipe>(recipe);
@@ -663,7 +663,7 @@ const UpdateDialog = ({recipe}: Readonly<{recipe: Recipe}>) => {
 };
 
 const DeleteDialog = ({recipe}: Readonly<{recipe: Recipe}>) => {
-  const t = useTranslations("Invoices.EditInvoice.recipeDialog");
+  const t = useTranslations("IMS--Dialogs.recipeDialog");
   const {isOpen, open, close} = useDialog("EDIT_INVOICE__RECIPE");
 
   const handleDelete = useCallback(() => {}, []);

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/RemoveScanDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/RemoveScanDialog.tsx
@@ -38,7 +38,7 @@ type RemoveScanPayload = {
  * @see {@link deleteInvoiceScan} - Server action for scan removal
  */
 export default function RemoveScanDialog(): React.JSX.Element {
-  const t = useTranslations("Invoices.EditInvoice.removeScanDialog");
+  const t = useTranslations("IMS--Dialogs.removeScanDialog");
   const router = useRouter();
   const {
     currentDialog: {payload},

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/tables/ItemsTable.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/tables/ItemsTable.tsx
@@ -118,7 +118,7 @@ type SortDirection = "asc" | "desc";
  */
 export default function ItemsTable({invoice}: Readonly<Props>) {
   const locale = useLocale();
-  const t = useTranslations("Invoices.EditInvoice.itemsTable");
+  const t = useTranslations("IMS--Edit.itemsTable");
   const {open} = useDialog("EDIT_INVOICE__ITEMS", "edit", invoice);
   const {open: openAllergenDialog} = useDialog("EDIT_INVOICE__ALLERGENS");
   const {open: openBulkCategoryDialog} = useDialog("EDIT_INVOICE__BULK_CATEGORY");

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/tabs/MetadataTab.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/tabs/MetadataTab.tsx
@@ -63,7 +63,7 @@ type Props = {
  * @see {@link VALID_METADATA_KEYS} - Predefined metadata key definitions
  */
 export default function MetadataTab({metadata}: Readonly<Props>): React.JSX.Element {
-  const t = useTranslations("Invoices.EditInvoice.metadataTab");
+  const t = useTranslations("IMS--Edit.metadataTab");
   const {open: openAddDialog} = useDialog("EDIT_INVOICE__METADATA", "add");
   const {open: openEditDialog} = useDialog("EDIT_INVOICE__METADATA", "edit", metadata);
   const {open: openDeleteDialog} = useDialog("EDIT_INVOICE__METADATA", "delete", metadata);

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/tabs/RecipesTab.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/tabs/RecipesTab.tsx
@@ -64,7 +64,7 @@ type Props = {
  * @see {@link usePaginationWithSearch} - Pagination hook
  */
 export default function RecipesTab({recipes}: Readonly<Props>): React.JSX.Element {
-  const t = useTranslations("Invoices.EditInvoice.recipesTab");
+  const t = useTranslations("IMS--Edit.recipesTab");
   const {open: openAddDialog} = useDialog("EDIT_INVOICE__RECIPE", "add");
 
   const {paginatedItems, currentPage, setCurrentPage, totalPages} = usePaginationWithSearch({items: recipes, initialPageSize: 4});

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_context/EditInvoiceContext.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_context/EditInvoiceContext.tsx
@@ -101,7 +101,7 @@ interface EditInvoiceContextProviderProps {
  * @returns Provider component wrapping children
  */
 export function EditInvoiceContextProvider({invoice, merchant, children}: Readonly<EditInvoiceContextProviderProps>): React.JSX.Element {
-  const t = useTranslations("Invoices.EditInvoice.editInvoiceContext");
+  const t = useTranslations("IMS--Edit.editInvoiceContext");
   const [pendingChanges, setPendingChanges] = useState<PendingChanges>({});
   const [isSaving, setIsSaving] = useState(false);
 

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/page.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/page.tsx
@@ -57,7 +57,7 @@ import styles from "./page.module.scss";
  * @see RFC 2001 - Domain-Driven Design Architecture (invoices bounded context)
  */
 export async function generateMetadata(): Promise<Metadata> {
-  const t = await getTranslations("Invoices.EditInvoice.metadata");
+  const t = await getTranslations("IMS--Edit.metadata");
   const locale = await getLocale();
   return createMetadata({
     locale,

--- a/sites/arolariu.ro/src/app/domains/invoices/page.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/page.tsx
@@ -34,7 +34,7 @@ import RenderInvoiceDomainScreen from "./island";
  * ```
  */
 export async function generateMetadata(): Promise<Metadata> {
-  const t = await getTranslations("Invoices.metadata");
+  const t = await getTranslations("IMS--UNKNOWN.metadata");
   const locale = await getLocale();
   return createMetadata({
     locale,

--- a/sites/arolariu.ro/src/app/domains/invoices/upload-scans/_components/PostUploadPrompt.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/upload-scans/_components/PostUploadPrompt.tsx
@@ -80,7 +80,7 @@ export default function PostUploadPrompt({
   onDismiss,
   isVisible,
 }: Readonly<Props>): React.JSX.Element {
-  const t = useTranslations("Invoices.UploadScans.postUpload");
+  const t = useTranslations("IMS--UploadScans.postUpload");
 
   return (
     <AnimatePresence>

--- a/sites/arolariu.ro/src/app/domains/invoices/upload-scans/_components/UploadArea.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/upload-scans/_components/UploadArea.tsx
@@ -85,7 +85,7 @@ function filterValidFilesFromDataTransfer(items: DataTransferItemList): File[] {
  * Uses native HTML5 drag-and-drop APIs for file handling.
  */
 export default function UploadArea(): React.JSX.Element {
-  const t = useTranslations("Invoices.UploadScans");
+  const t = useTranslations("IMS--UploadScans");
   const {pendingUploads, isUploading, addFiles, clearAll, uploadAll} = useScanUpload();
   const [isDragActive, setIsDragActive] = useState(false);
   const [dragCount, setDragCount] = useState(0);

--- a/sites/arolariu.ro/src/app/domains/invoices/upload-scans/_components/UploadPreview.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/upload-scans/_components/UploadPreview.tsx
@@ -62,7 +62,7 @@ function UploadCard({
   error,
   onRemove,
 }: Readonly<PendingUploadCardProps>): React.JSX.Element {
-  const t = useTranslations("Invoices.UploadScans");
+  const t = useTranslations("IMS--UploadScans");
   const handleRemove = useCallback(() => {
     onRemove([id]);
   }, [onRemove, id]);
@@ -215,7 +215,7 @@ const DESKTOP_PAGE_SIZE = 50;
  * Paginates uploads with different page sizes for mobile (7) and desktop (50).
  */
 export default function UploadPreview(): React.JSX.Element | null {
-  const t = useTranslations("Invoices.UploadScans");
+  const t = useTranslations("IMS--UploadScans");
   const {pendingUploads, removeFiles} = useScanUpload();
   const [page, setPage] = useState(0);
 

--- a/sites/arolariu.ro/src/app/domains/invoices/upload-scans/island.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/upload-scans/island.tsx
@@ -71,7 +71,7 @@ function TipItem({children}: Readonly<{children: React.ReactNode}>): React.JSX.E
  * Upload statistics component.
  */
 function UploadStats(): React.JSX.Element | null {
-  const t = useTranslations("Invoices.UploadScans");
+  const t = useTranslations("IMS--UploadScans");
   const {pendingUploads, sessionStats} = useScanUpload();
 
   // Current batch stats (from pending uploads)
@@ -160,7 +160,7 @@ function UploadStats(): React.JSX.Element | null {
  * Main upload content component (uses context).
  */
 function UploadContent(): React.JSX.Element {
-  const t = useTranslations("Invoices.UploadScans");
+  const t = useTranslations("IMS--UploadScans");
   const router = useRouter();
   const {pendingUploads, sessionStats} = useScanUpload();
   const [showPrompt, setShowPrompt] = useState(false);

--- a/sites/arolariu.ro/src/app/domains/invoices/upload-scans/page.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/upload-scans/page.tsx
@@ -10,7 +10,7 @@ import styles from "./page.module.scss";
  * Generates SEO metadata for the scan upload page.
  */
 export async function generateMetadata(): Promise<Metadata> {
-  const t = await getTranslations("Invoices.UploadScans.metadata");
+  const t = await getTranslations("IMS--UploadScans.metadata");
   const locale = await getLocale();
   return createMetadata({
     locale,

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/InvoiceAnalytics.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/InvoiceAnalytics.tsx
@@ -28,7 +28,7 @@ import {SpendingTrendChart} from "./charts/SpendingTrendChart";
 import styles from "./InvoiceAnalytics.module.scss";
 
 export function InvoiceAnalytics(): React.JSX.Element {
-  const t = useTranslations("Invoices.ViewInvoice.invoiceAnalytics");
+  const t = useTranslations("IMS--View.invoiceAnalytics");
   const {invoice, merchant} = useInvoiceContext();
   const {
     userInformation: {userIdentifier},

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/InvoiceHeader.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/InvoiceHeader.tsx
@@ -11,7 +11,7 @@ import {useInvoiceContext} from "../_context/InvoiceContext";
 import styles from "./InvoiceHeader.module.scss";
 
 export function InvoiceHeader(): React.JSX.Element {
-  const t = useTranslations("Invoices.Shared.invoiceHeader");
+  const t = useTranslations("IMS--Common.invoiceHeader");
   const {invoice} = useInvoiceContext();
   const {
     userInformation: {userIdentifier},

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/PrintHeader.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/PrintHeader.tsx
@@ -22,7 +22,7 @@ interface PrintHeaderProps {
  */
 export function PrintHeader(props: Readonly<PrintHeaderProps>): React.JSX.Element {
   const {invoice, merchant} = props;
-  const t = useTranslations("Invoices.ViewInvoice.print");
+  const t = useTranslations("IMS--View.print");
   const formatter = useFormatter();
   const locale = useLocale();
 

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/banners/InvoiceGuestBanner.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/banners/InvoiceGuestBanner.tsx
@@ -6,7 +6,7 @@ import {TbInfoCircle} from "react-icons/tb";
 import styles from "./InvoiceGuestBanner.module.scss";
 
 export function InvoiceGuestBanner(): React.JSX.Element {
-  const t = useTranslations("Invoices.ViewInvoice.invoiceGuestBanner");
+  const t = useTranslations("IMS--View.invoiceGuestBanner");
   return (
     <Alert
       variant='default'

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/AnalysisPanel.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/AnalysisPanel.tsx
@@ -67,7 +67,7 @@ type AnalysisOption = Readonly<{
  * @returns The AnalysisPanel component.
  */
 export function AnalysisPanel(): React.JSX.Element {
-  const t = useTranslations("Invoices.ViewInvoice.analysisPanel");
+  const t = useTranslations("IMS--View.analysisPanel");
   const {invoice} = useInvoiceContext();
   const router = useRouter();
 

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/BudgetImpactCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/BudgetImpactCard.tsx
@@ -10,7 +10,7 @@ import styles from "./BudgetImpactCard.module.scss";
 
 export function BudgetImpactCard(): React.JSX.Element {
   const locale = useLocale();
-  const t = useTranslations("Invoices.ViewInvoice.budgetImpactCard");
+  const t = useTranslations("IMS--Cards.budgetImpactCard");
   const {invoice} = useInvoiceContext();
   const {paymentInformation} = invoice;
   const {currency} = paymentInformation;

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/ComparisonStatsCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/ComparisonStatsCard.tsx
@@ -24,7 +24,7 @@ function getTrendColor(value: number): string {
 }
 
 export function ComparisonStatsCard({stats, currency}: Readonly<Props>): React.JSX.Element {
-  const t = useTranslations("Invoices.ViewInvoice.comparisonStatsCard");
+  const t = useTranslations("IMS--Cards.comparisonStatsCard");
   const percentageProgress = Math.min(((stats.currentAmount - stats.minAmount) / (stats.maxAmount - stats.minAmount)) * 100, 100);
 
   return (

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/InvoiceDetailsCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/InvoiceDetailsCard.tsx
@@ -49,7 +49,7 @@ const RECEIPT_TYPE_ICONS: Record<string, string> = {
 
 export function InvoiceDetailsCard(): React.JSX.Element {
   const locale = useLocale();
-  const t = useTranslations("Invoices.ViewInvoice.invoiceDetailsCard");
+  const t = useTranslations("IMS--Cards.invoiceDetailsCard");
   const {invoice, merchant} = useInvoiceContext();
   const [currentPage, setCurrentPage] = useState(1);
 

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/InvoiceHealthScore.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/InvoiceHealthScore.tsx
@@ -90,9 +90,26 @@ type ScoreFactor = {
  * @remarks
  * Suggestions are dynamically generated based on incomplete factors.
  */
+/** Known suggestion key names matching `suggestions.*` in the i18n messages. */
+type SuggestionKey =
+  | "noProducts"
+  | "incompleteProducts"
+  | "lowOcrConfidence"
+  | "noMerchant"
+  | "incompletePayment"
+  | "uncategorizedProducts"
+  | "noRecipes"
+  | "productsPresent"
+  | "productCompleteness"
+  | "ocrConfidence"
+  | "merchantLinked"
+  | "paymentInfo"
+  | "categoriesAssigned"
+  | "recipesGenerated";
+
 type ImprovementSuggestion = {
-  /** i18n key for the suggestion text */
-  readonly key: string;
+  /** i18n key for the suggestion text (must match a `suggestions.*` key) */
+  readonly key: SuggestionKey;
   /** Icon component to display */
   readonly icon: React.ComponentType<{className?: string}>;
   /** Optional link to navigate to for action */
@@ -145,7 +162,7 @@ const EMPTY_GUID = "00000000-0000-0000-0000-000000000000";
  */
 export function InvoiceHealthScore(): React.JSX.Element {
   const {invoice} = useInvoiceContext();
-  const t = useTranslations("Invoices.ViewInvoice.healthScore");
+  const t = useTranslations("IMS--View.healthScore");
   const [isExpanded, setIsExpanded] = useState<boolean>(false);
   const [showSuggestions, setShowSuggestions] = useState<boolean>(true);
 

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/InvoiceTimelineCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/InvoiceTimelineCard.tsx
@@ -14,7 +14,7 @@ type Props = Readonly<{
 
 export function InvoiceTimelineCard({invoice}: Readonly<Props>): React.JSX.Element {
   const locale = useLocale();
-  const t = useTranslations("Invoices.ViewInvoice.invoiceTimeline");
+  const t = useTranslations("IMS--View.invoiceTimeline");
   const events = generateTimelineFromInvoice(invoice);
   const groupedEvents = groupEventsByDate(events, locale);
 

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/ItemAnalyticsCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/ItemAnalyticsCard.tsx
@@ -137,7 +137,7 @@ const categoryColors: Record<number, "default" | "secondary" | "outline" | "dest
  */
 export function ItemAnalyticsCard(): React.JSX.Element {
   const locale = useLocale();
-  const t = useTranslations("Invoices.ViewInvoice.itemAnalytics");
+  const t = useTranslations("IMS--View.itemAnalytics");
   const {invoice} = useInvoiceContext();
 
   const [searchQuery, setSearchQuery] = useState("");

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/MerchantInfoCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/MerchantInfoCard.tsx
@@ -101,7 +101,7 @@ type CategoryDistribution = {
 export function MerchantInfoCard(): React.JSX.Element {
   const {invoice, merchant} = useInvoiceContext();
   const {invoices} = useInvoicesStore();
-  const t = useTranslations("Invoices.ViewInvoice.merchantInfoCard");
+  const t = useTranslations("IMS--Cards.merchantInfoCard");
 
   // Early return if merchant is null
   if (!merchant) {

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/ReceiptScanCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/ReceiptScanCard.tsx
@@ -25,7 +25,7 @@ import {useInvoiceContext} from "../../_context/InvoiceContext";
 import styles from "./ReceiptScanCard.module.scss";
 
 export function ReceiptScanCard(): React.JSX.Element {
-  const t = useTranslations("Invoices.ViewInvoice.receiptScanCard");
+  const t = useTranslations("IMS--Cards.receiptScanCard");
   const {invoice} = useInvoiceContext();
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [currentScanIndex, setCurrentScanIndex] = useState<number>(0);

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/RelatedInvoicesCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/RelatedInvoicesCard.tsx
@@ -124,7 +124,7 @@ function isSimilarAmount(amount1: number, amount2: number): boolean {
  * ```
  */
 export function RelatedInvoicesCard(): React.JSX.Element | null {
-  const t = useTranslations("Invoices.ViewInvoice.relatedInvoices");
+  const t = useTranslations("IMS--View.relatedInvoices");
   const {invoice: currentInvoice} = useInvoiceContext();
   const invoices = useInvoicesStore(useShallow((state) => state.invoices));
 
@@ -262,7 +262,7 @@ interface RelatedInvoiceMiniCardProps {
  * @returns Mini invoice card component
  */
 function RelatedInvoiceMiniCard({invoice, relationType}: Readonly<RelatedInvoiceMiniCardProps>): React.JSX.Element {
-  const t = useTranslations("Invoices.ViewInvoice.relatedInvoices");
+  const t = useTranslations("IMS--View.relatedInvoices");
 
   const formattedDate = formatDate(invoice.createdAt, {
     locale: "en-US",

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/SeasonalInsightsCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/SeasonalInsightsCard.tsx
@@ -169,7 +169,7 @@ function getInsightIconClass(type: Insight["type"]): string {
 
 export function SeasonalInsightsCard(): React.JSX.Element {
   const locale = useLocale();
-  const t = useTranslations("Invoices.ViewInvoice.seasonalInsightsCard");
+  const t = useTranslations("IMS--Cards.seasonalInsightsCard");
   const {invoice} = useInvoiceContext();
   const allInvoices = useInvoicesStore((state) => state.invoices);
   const date = toSafeDate(invoice.paymentInformation.transactionDate);

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/ShareCollaborateCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/ShareCollaborateCard.tsx
@@ -82,7 +82,7 @@ type SharingStatus = "private" | "public" | "shared";
  * ```
  */
 export function ShareCollaborateCard(): React.JSX.Element {
-  const t = useTranslations("Invoices.ViewInvoice.shareCollaborate");
+  const t = useTranslations("IMS--View.shareCollaborate");
   const {invoice, setInvoice} = useInvoiceContext();
   const {open: openShareDialog} = useDialog("SHARED__INVOICE_SHARE");
   const [isPending, startTransition] = useTransition();

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/ShoppingCalendarCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/ShoppingCalendarCard.tsx
@@ -163,7 +163,7 @@ function CustomDayButton({
   tabIndex = 0,
 }: DayButtonProps): React.JSX.Element {
   const {locale, currency, month, transactionDate, spendingByDay, historicalByDay, maxDayAmount} = useCalendarData();
-  const t = useTranslations("Invoices.ViewInvoice.shoppingCalendarCard");
+  const t = useTranslations("IMS--Cards.shoppingCalendarCard");
   const {date} = day;
   const dayNum = date.getDate();
   const isCurrentMonth = date.getMonth() === month.getMonth() && date.getFullYear() === month.getFullYear();
@@ -209,7 +209,7 @@ function CustomDayButton({
 
 export function ShoppingCalendarCard(): React.JSX.Element {
   const locale = useLocale();
-  const t = useTranslations("Invoices.ViewInvoice.shoppingCalendarCard");
+  const t = useTranslations("IMS--Cards.shoppingCalendarCard");
   const {invoice} = useInvoiceContext();
   const transactionDate = useMemo(
     () => toSafeDate(invoice.paymentInformation.transactionDate),

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/SummaryStatsCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/SummaryStatsCard.tsx
@@ -14,7 +14,7 @@ type Props = {
 
 export function SummaryStatsCard({summary, currency}: Readonly<Props>): React.JSX.Element {
   const locale = useLocale();
-  const t = useTranslations("Invoices.ViewInvoice.summaryStatsCard");
+  const t = useTranslations("IMS--Cards.summaryStatsCard");
   const stats = [
     {
       label: t("stats.totalItems.label"),

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/insights/CategorySuggestionCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/insights/CategorySuggestionCard.tsx
@@ -45,7 +45,7 @@ function CategoryButton({category, isSelected, onSelect, variant}: Readonly<Cate
 
 export function CategorySuggestionCard(): React.JSX.Element {
   const [selected, setSelected] = useState<InvoiceCategory | string | null>(null);
-  const t = useTranslations("Invoices.ViewInvoice.categorySuggestionCard");
+  const t = useTranslations("IMS--Cards.categorySuggestionCard");
 
   // Gamification progress (mock)
   const categorizedCount = 8;

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/insights/DiningCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/insights/DiningCard.tsx
@@ -20,7 +20,7 @@ import styles from "./DiningCard.module.scss";
 
 export function DiningCard(): React.JSX.Element {
   const locale = useLocale();
-  const t = useTranslations("Invoices.ViewInvoice.diningCard");
+  const t = useTranslations("IMS--Cards.diningCard");
   const {invoice} = useInvoiceContext();
   const {paymentInformation, items} = invoice;
   const {currency, totalCostAmount: totalAmount} = paymentInformation;

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/insights/GeneralExpenseCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/insights/GeneralExpenseCard.tsx
@@ -10,7 +10,7 @@ import styles from "./GeneralExpenseCard.module.scss";
 
 export function GeneralExpenseCard(): React.JSX.Element {
   const locale = useLocale();
-  const t = useTranslations("Invoices.ViewInvoice.generalExpenseCard");
+  const t = useTranslations("IMS--Cards.generalExpenseCard");
   const {invoice} = useInvoiceContext();
   const {paymentInformation} = invoice;
   const {currency, totalCostAmount: totalAmount} = paymentInformation;

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/insights/HomeInventoryCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/insights/HomeInventoryCard.tsx
@@ -27,7 +27,7 @@ function getSupplyProgressColor(percentage: number, moduleStyles: Record<string,
 
 export function HomeInventoryCard(): React.JSX.Element {
   const locale = useLocale();
-  const t = useTranslations("Invoices.ViewInvoice.homeInventoryCard");
+  const t = useTranslations("IMS--Cards.homeInventoryCard");
   const {invoice} = useInvoiceContext();
   const {items, paymentInformation} = invoice;
   const {currency} = paymentInformation;

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/insights/NutritionCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/insights/NutritionCard.tsx
@@ -72,7 +72,7 @@ function generateSuggestion(hasVeggies: boolean, hasFruits: boolean, processedPc
 
 export function NutritionCard(): React.JSX.Element {
   const locale = useLocale();
-  const t = useTranslations("Invoices.ViewInvoice.nutritionCard");
+  const t = useTranslations("IMS--Cards.nutritionCard");
   const {invoice} = useInvoiceContext();
   const {items, paymentInformation} = invoice;
   const {currency} = paymentInformation;

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/insights/VehicleCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/insights/VehicleCard.tsx
@@ -24,7 +24,7 @@ import styles from "./VehicleCard.module.scss";
 
 export function VehicleCard(): React.JSX.Element {
   const locale = useLocale();
-  const t = useTranslations("Invoices.ViewInvoice.vehicleCard");
+  const t = useTranslations("IMS--Cards.vehicleCard");
   const {invoice} = useInvoiceContext();
   const {paymentInformation} = invoice;
   const {currency, totalCostAmount: totalAmount} = paymentInformation;

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/charts/CategoryComparisonChart.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/charts/CategoryComparisonChart.tsx
@@ -62,7 +62,7 @@ function CustomTooltip({active, payload, currency, currentLabel, averageLabel}: 
 }
 
 export function CategoryComparisonChart({data, currency}: Props): React.JSX.Element {
-  const t = useTranslations("Invoices.ViewInvoice.categoryComparisonChart");
+  const t = useTranslations("IMS--View.categoryComparisonChart");
   const chartConfig = {
     current: {
       label: t("labels.current"),

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/charts/ItemsBreakdownChart.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/charts/ItemsBreakdownChart.tsx
@@ -53,7 +53,7 @@ function CustomTooltip({active, payload, currency, quantityLabel}: CustomTooltip
 }
 
 export function ItemsBreakdownChart({data, currency}: Props): React.JSX.Element {
-  const t = useTranslations("Invoices.ViewInvoice.itemsBreakdownChart");
+  const t = useTranslations("IMS--View.itemsBreakdownChart");
   const chartConfig = {
     price: {
       label: t("labels.price"),

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/charts/MerchantBreakdownChart.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/charts/MerchantBreakdownChart.tsx
@@ -75,7 +75,7 @@ function CustomTooltip({
 }
 
 export function MerchantBreakdownChart({data, currency, currentMerchant}: Props): React.JSX.Element {
-  const t = useTranslations("Invoices.ViewInvoice.merchantBreakdownChart");
+  const t = useTranslations("IMS--View.merchantBreakdownChart");
   const merchants = useMerchantsStore((state) => state.merchants);
 
   // Resolve merchant names from Zustand store

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/charts/PriceDistributionChart.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/charts/PriceDistributionChart.tsx
@@ -33,7 +33,7 @@ type CustomTooltipProps = {
 };
 
 function CustomTooltip({active, payload}: CustomTooltipProps): React.JSX.Element | null {
-  const t = useTranslations("Invoices.ViewInvoice.priceDistributionChart");
+  const t = useTranslations("IMS--View.priceDistributionChart");
   const [firstItem] = payload;
   if (!active || payload.length === 0 || !firstItem) return null;
   const data = firstItem.payload;
@@ -48,7 +48,7 @@ function CustomTooltip({active, payload}: CustomTooltipProps): React.JSX.Element
 }
 
 export function PriceDistributionChart({data, currency}: Readonly<Props>): React.JSX.Element {
-  const t = useTranslations("Invoices.ViewInvoice.priceDistributionChart");
+  const t = useTranslations("IMS--View.priceDistributionChart");
   const chartConfig = {
     count: {
       label: t("labels.items"),

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/charts/SpendingByCategoryChart.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/charts/SpendingByCategoryChart.tsx
@@ -42,7 +42,7 @@ type CustomLegendProps = {
 };
 
 function CustomTooltip({active, payload, currency}: CustomTooltipProps): React.JSX.Element | null {
-  const t = useTranslations("Invoices.ViewInvoice.spendingByCategoryChart");
+  const t = useTranslations("IMS--View.spendingByCategoryChart");
   const [firstItem] = payload;
   if (!active || payload.length === 0 || !firstItem) return null;
   const data = firstItem.payload;
@@ -76,7 +76,7 @@ function CustomLegend({payload}: CustomLegendProps): React.JSX.Element {
 }
 
 export function SpendingByCategoryChart({data, currency}: Props): React.JSX.Element {
-  const t = useTranslations("Invoices.ViewInvoice.spendingByCategoryChart");
+  const t = useTranslations("IMS--View.spendingByCategoryChart");
   const chartConfig: Record<string, {label: string; color: string}> = {};
   for (const [index, item] of data.entries()) {
     chartConfig[item.category] = {

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/charts/SpendingTrendChart.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/charts/SpendingTrendChart.tsx
@@ -45,7 +45,7 @@ type CustomTooltipProps = {
 };
 
 function CustomTooltip({active, payload, currency}: CustomTooltipProps): React.JSX.Element | null {
-  const t = useTranslations("Invoices.ViewInvoice.spendingTrendChart");
+  const t = useTranslations("IMS--View.spendingTrendChart");
   const [firstItem] = payload;
   if (!active || payload.length === 0 || !firstItem) return null;
   const data = firstItem.payload;
@@ -87,7 +87,7 @@ function CustomTooltip({active, payload, currency}: CustomTooltipProps): React.J
 }
 
 export function SpendingTrendChart({data, currency}: Props): React.JSX.Element {
-  const t = useTranslations("Invoices.ViewInvoice.spendingTrendChart");
+  const t = useTranslations("IMS--View.spendingTrendChart");
   const chartConfig = {
     amount: {
       label: t("labels.amount"),

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/dialogs/ExportDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/dialogs/ExportDialog.tsx
@@ -84,7 +84,7 @@ import styles from "./ExportDialog.module.scss";
  * ```
  */
 export function ExportDialog(): React.JSX.Element {
-  const t = useTranslations("Invoices.ViewInvoice.export");
+  const t = useTranslations("IMS--View.export");
   const {invoice, merchant} = useInvoiceContext();
   const {isOpen, close} = useDialog("VIEW_INVOICE__EXPORT");
   const [isGeneratingPDF, setIsGeneratingPDF] = useState(false);

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/dialogs/ShareAnalyticsDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/dialogs/ShareAnalyticsDialog.tsx
@@ -63,7 +63,7 @@ import styles from "./ShareAnalyticsDialog.module.scss";
  * @see {@link useDialog} - Dialog state management hook
  */
 export default function ShareAnalyticsDialog(): React.JSX.Element {
-  const t = useTranslations("Invoices.ViewInvoice.shareAnalyticsDialog");
+  const t = useTranslations("IMS--Dialogs.shareAnalyticsDialog");
   const [email, setEmail] = useState<string>("");
   const {
     currentDialog: {payload},

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/tabs/InvoiceTabs.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/tabs/InvoiceTabs.tsx
@@ -65,7 +65,7 @@ function getComplexityEmoji(complexity: RecipeComplexity): string {
  */
 export function InvoiceTabs(): React.JSX.Element {
   const {invoice} = useInvoiceContext();
-  const t = useTranslations("Invoices.ViewInvoice.invoiceTabs");
+  const t = useTranslations("IMS--View.invoiceTabs");
 
   return (
     <Card className={styles["card"]}>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/timeline/InvoiceTimeline.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/timeline/InvoiceTimeline.tsx
@@ -27,7 +27,7 @@ import {TimelineSharedWithList} from "./TimelineSharedWithList";
  * \`\`\`
  */
 export function InvoiceTimeline(): React.JSX.Element {
-  const t = useTranslations("Invoices.ViewInvoice.invoiceTimeline");
+  const t = useTranslations("IMS--View.invoiceTimeline");
   const locale = useLocale();
   const {invoice} = useInvoiceContext();
   const events = generateTimelineFromInvoice(invoice);

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/timeline/TimelineItem.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/timeline/TimelineItem.tsx
@@ -134,7 +134,7 @@ type Props = Readonly<{
  * ```
  */
 export function TimelineItem({event, icon, isLast = false}: Readonly<Props>): React.JSX.Element {
-  const t = useTranslations("Invoices.ViewInvoice.timelineItem");
+  const t = useTranslations("IMS--View.timelineItem");
   const locale = useLocale();
   const tooltipContent = getTooltipContent(event, t);
   const eventTitle = getEventTitle(event, t);

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/timeline/TimelineSharedWithList.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/timeline/TimelineSharedWithList.tsx
@@ -40,7 +40,7 @@ import styles from "./TimelineSharedWithList.module.scss";
  * ```
  */
 export function TimelineSharedWithList(): React.JSX.Element | null {
-  const t = useTranslations("Invoices.ViewInvoice.timelineSharedWithList");
+  const t = useTranslations("IMS--View.timelineSharedWithList");
   const {invoice} = useInvoiceContext();
   const {userInformation} = useUserInformation();
   const {open: openShareDialog} = useDialog("SHARED__INVOICE_SHARE", "share", {invoice});

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/island.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/island.tsx
@@ -37,7 +37,7 @@ type Props = Readonly<{
 
 export default function RenderViewInvoiceScreen(props: Readonly<Props>): React.JSX.Element {
   const {invoice, merchant} = props;
-  const t = useTranslations("Invoices.ViewInvoice");
+  const t = useTranslations("IMS--View");
   const upsertInvoice = useInvoicesStore((state) => state.upsertInvoice);
   const upsertMerchant = useMerchantsStore((state) => state.upsertMerchant);
   const {

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/page.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/page.tsx
@@ -56,7 +56,7 @@ import styles from "./page.module.scss";
  * @see RFC 2001 - Domain-Driven Design Architecture (invoices bounded context)
  */
 export async function generateMetadata(): Promise<Metadata> {
-  const t = await getTranslations("Invoices.ViewInvoice.metadata");
+  const t = await getTranslations("IMS--View.metadata");
   const locale = await getLocale();
   return createMetadata({
     locale,

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/BulkActionsToolbar.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/BulkActionsToolbar.tsx
@@ -78,7 +78,7 @@ import styles from "./BulkActionsToolbar.module.scss";
  * @returns The bulk actions toolbar or null if no invoices are selected
  */
 export default function BulkActionsToolbar(): React.JSX.Element | null {
-  const t = useTranslations("Invoices.ViewInvoices.bulkActions");
+  const t = useTranslations("IMS--List.bulkActions");
   const {open: openExportDialog} = useDialog("VIEW_INVOICES__EXPORT");
 
   // Use shallow selector to optimize re-renders

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/InvoicesHeader.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/InvoicesHeader.tsx
@@ -15,7 +15,7 @@ import styles from "./InvoicesHeader.module.scss";
  * @returns The rendered invoices header.
  */
 export default function InvoicesHeader(): React.JSX.Element {
-  const t = useTranslations("Invoices.ViewInvoices.invoicesHeader");
+  const t = useTranslations("IMS--List.invoicesHeader");
   const {open: openImportDialog} = useDialog("VIEW_INVOICES__IMPORT");
   const {open: openExportDialog} = useDialog("VIEW_INVOICES__EXPORT");
 

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/MessageList.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/MessageList.tsx
@@ -23,7 +23,7 @@ type Props = {
  */
 export function MessageList({messages}: Readonly<Props>): React.JSX.Element {
   const locale = useLocale();
-  const t = useTranslations("Invoices.ViewInvoices.messageList");
+  const t = useTranslations("IMS--List.messageList");
 
   return (
     <div className={styles["messageList"]}>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/dialogs/ExportDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/dialogs/ExportDialog.tsx
@@ -33,7 +33,7 @@ import styles from "./ExportDialog.module.scss";
  * @returns The ExportDialog component, CSR'ed.
  */
 export default function ExportDialog(): React.JSX.Element {
-  const t = useTranslations("Invoices.ViewInvoices.exportDialog");
+  const t = useTranslations("IMS--Dialogs.exportDialog");
   const [exportOptions, setExportOptions] = useState<InvoiceExportRequest>({
     format: "csv",
     includeMetadata: false,

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/dialogs/ImportDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/dialogs/ImportDialog.tsx
@@ -36,7 +36,7 @@ const ACCEPT_TYPES: Record<ImportFileFormat, Accept> = {
  * @returns The ImportDialog component, CSR'ed.
  */
 export default function ImportDialog(): React.JSX.Element {
-  const t = useTranslations("Invoices.ViewInvoices.importDialog");
+  const t = useTranslations("IMS--Dialogs.importDialog");
   const [files, setFiles] = useState<File[]>([]);
   const {isOpen, open, close} = useDialog("VIEW_INVOICES__IMPORT");
   const [activeTab, setActiveTab] = useState<ImportFileFormat>("csv");

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/FilterBar.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/FilterBar.tsx
@@ -101,7 +101,7 @@ export default function FilterBar({
   viewMode,
   onViewModeChange,
 }: Readonly<Props>): React.JSX.Element {
-  const t = useTranslations("Invoices.ViewInvoices.invoicesView");
+  const t = useTranslations("IMS--List.invoicesView");
   const locale = useLocale();
   const {isMobile} = useWindowSize();
   const [searchInput, setSearchInput] = useState<string>(filters.search);

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/tables/GridView.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/tables/GridView.tsx
@@ -42,8 +42,8 @@ type Props = Readonly<{
 export const GridView = (props: Readonly<Props>): React.JSX.Element => {
   const {invoices, pageSize, currentPage, totalPages, handlePrevPage, handleNextPage, handlePageSizeChange} = props;
   const locale = useLocale();
-  const tTableView = useTranslations("Invoices.ViewInvoices.tableView");
-  const t = useTranslations("Invoices.ViewInvoices.gridView");
+  const tTableView = useTranslations("IMS--List.tableView");
+  const t = useTranslations("IMS--List.gridView");
   const selectedInvoices = useInvoicesStore((state) => state.selectedInvoices);
   const setSelectedInvoices = useInvoicesStore((state) => state.setSelectedInvoices);
 

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/tables/TableView.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/tables/TableView.tsx
@@ -45,7 +45,7 @@ type Props = Readonly<{
 
 export const TableView = (props: Readonly<Props>): React.JSX.Element => {
   const locale = useLocale();
-  const t = useTranslations("Invoices.ViewInvoices.tableView");
+  const t = useTranslations("IMS--List.tableView");
   const {invoices, currentPage, pageSize, totalPages, handlePrevPage, handleNextPage, handlePageSizeChange, sortBy, sortDirection, onSort} =
     props;
   const selectedInvoices = useInvoicesStore((state) => state.selectedInvoices);

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/tables/TableViewActions.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/tables/TableViewActions.tsx
@@ -27,7 +27,7 @@ type Props = {invoice: Invoice};
  * @returns The rendered invoice table actions.
  */
 export default function TableViewActions({invoice}: Readonly<Props>): React.JSX.Element {
-  const t = useTranslations("Invoices.ViewInvoices.tableViewActions");
+  const t = useTranslations("IMS--List.tableViewActions");
   const {open: openShareDialog} = useDialog("SHARED__INVOICE_SHARE", "share", {invoice});
   const {open: openDeleteDialog} = useDialog("SHARED__INVOICE_DELETE", "delete", {invoice});
 

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/GenerativeView.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/GenerativeView.tsx
@@ -44,7 +44,7 @@ type Props = Readonly<{
  * @returns This function renders the generative view for invoice analysis.
  */
 export default function RenderGenerativeView({invoices}: Readonly<Props>): React.JSX.Element {
-  const t = useTranslations("Invoices.ViewInvoices.generativeView");
+  const t = useTranslations("IMS--List.generativeView");
   const [messages, setMessages] = useState<Message[]>(() => [
     {
       id: "welcome",

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/StatisticsView.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/StatisticsView.tsx
@@ -67,7 +67,7 @@ type Props = {
  * Empty state component when no invoices exist.
  */
 function EmptyState(): React.JSX.Element {
-  const t = useTranslations("Invoices.ViewInvoices.statisticsView.empty");
+  const t = useTranslations("IMS--Stats.empty");
 
   return (
     <motion.div
@@ -106,7 +106,7 @@ function EmptyState(): React.JSX.Element {
  * @returns Statistics dashboard JSX element or empty state
  */
 export default function RenderStatisticsView({invoices}: Readonly<Props>): React.JSX.Element {
-  const t = useTranslations("Invoices.ViewInvoices.statisticsView");
+  const t = useTranslations("IMS--Stats");
 
   // Compute all statistics data with memoization
   const kpiData = useMemo(() => computeKPIs(invoices), [invoices]);

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/AllergenSummaryChart.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/AllergenSummaryChart.tsx
@@ -48,7 +48,7 @@ function getWarningLevel(percentage: number): "high" | "medium" | "low" {
  * @returns Allergen card component
  */
 function AllergenCard({allergen}: {readonly allergen: AllergenFrequency}): React.JSX.Element {
-  const t = useTranslations("Invoices.ViewInvoices.statisticsView.charts.allergenSummary");
+  const t = useTranslations("IMS--Stats.allergenSummary");
   const warningLevel = getWarningLevel(allergen.percentage);
 
   return (
@@ -105,7 +105,7 @@ function AllergenCard({allergen}: {readonly allergen: AllergenFrequency}): React
  * @returns Grid of allergen cards
  */
 export function AllergenSummaryChart({data}: Props): React.JSX.Element {
-  const t = useTranslations("Invoices.ViewInvoices.statisticsView.charts.allergenSummary");
+  const t = useTranslations("IMS--Stats.allergenSummary");
 
   // Empty state - positive message
   if (data.length === 0) {

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/CategoryBreakdownChart.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/CategoryBreakdownChart.tsx
@@ -51,7 +51,7 @@ type CustomLegendProps = {
  * Custom tooltip for the category pie chart.
  */
 function CustomTooltip({active, payload, currency}: CustomTooltipProps): React.JSX.Element | null {
-  const t = useTranslations("Invoices.ViewInvoices.statisticsView.charts.categoryBreakdown");
+  const t = useTranslations("IMS--Stats.categoryBreakdown");
   const [firstItem] = payload;
   if (!active || payload.length === 0 || !firstItem) return null;
   const data = firstItem.payload;
@@ -97,7 +97,7 @@ function CustomLegend({payload}: CustomLegendProps): React.JSX.Element {
  * @returns Pie chart component
  */
 export function CategoryBreakdownChart({data, currency}: Props): React.JSX.Element {
-  const t = useTranslations("Invoices.ViewInvoices.statisticsView.charts.categoryBreakdown");
+  const t = useTranslations("IMS--Stats.categoryBreakdown");
 
   const chartConfig: Record<string, {label: string; color: string}> = {};
   for (const [index, item] of data.entries()) {

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/ComparisonCards.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/ComparisonCards.tsx
@@ -83,7 +83,7 @@ function ComparisonCard({icon, label, value, delta, isPositive, progressValue, i
  * @returns Grid of comparison cards
  */
 export function ComparisonCards({data, currency}: Props): React.JSX.Element {
-  const t = useTranslations("Invoices.ViewInvoices.statisticsView.comparison");
+  const t = useTranslations("IMS--Stats.comparison");
 
   const spendingIcon = data.spendingDelta < 0 ? <TbArrowDown size={20} /> : <TbArrowUp size={20} />;
   const invoiceIcon = data.invoiceCountDelta < 0 ? <TbArrowDown size={20} /> : <TbArrowUp size={20} />;

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/CurrencyDistributionChart.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/CurrencyDistributionChart.tsx
@@ -68,7 +68,7 @@ const CURRENCY_FLAGS: Record<string, string> = {
  * Empty state component for single-currency scenario.
  */
 function SingleCurrencyMessage({currency}: {readonly currency: CurrencyDistribution}): React.JSX.Element {
-  const t = useTranslations("Invoices.ViewInvoices.statisticsView.charts.currencyDistribution");
+  const t = useTranslations("IMS--Stats.currencyDistribution");
   const flag = CURRENCY_FLAGS[currency.currencyCode] ?? "🌐";
 
   return (
@@ -123,7 +123,7 @@ function SingleCurrencyMessage({currency}: {readonly currency: CurrencyDistribut
  * @returns Currency distribution chart JSX element
  */
 export function CurrencyDistributionChart({data}: Props): React.JSX.Element {
-  const t = useTranslations("Invoices.ViewInvoices.statisticsView.charts.currencyDistribution");
+  const t = useTranslations("IMS--Stats.currencyDistribution");
   const [showRON, setShowRON] = useState(false);
 
   // Handle single currency scenario

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/KPISummaryRow.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/KPISummaryRow.tsx
@@ -72,7 +72,7 @@ function KPICard({icon, label, value, subtitle, trend, index}: KPICardProps): Re
  * @returns Row of animated KPI cards
  */
 export function KPISummaryRow({data, currency}: Props): React.JSX.Element {
-  const t = useTranslations("Invoices.ViewInvoices.statisticsView.kpi");
+  const t = useTranslations("IMS--Stats.kpi");
 
   const kpiCards: Omit<KPICardProps, "index">[] = [
     {

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/MerchantLeaderboard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/MerchantLeaderboard.tsx
@@ -46,7 +46,7 @@ type CustomTooltipProps = {
  * Custom tooltip for the merchant leaderboard.
  */
 function CustomTooltip({active, payload, currency, getMerchantName}: CustomTooltipProps): React.JSX.Element | null {
-  const t = useTranslations("Invoices.ViewInvoices.statisticsView.charts.merchantLeaderboard");
+  const t = useTranslations("IMS--Stats.merchantLeaderboard");
   if (!active || !payload || payload.length === 0) return null;
   const [firstItem] = payload;
   if (!firstItem) return null;
@@ -71,7 +71,7 @@ function CustomTooltip({active, payload, currency, getMerchantName}: CustomToolt
  * @returns Horizontal bar chart component
  */
 export function MerchantLeaderboard({data, currency}: Props): React.JSX.Element {
-  const t = useTranslations("Invoices.ViewInvoices.statisticsView.charts.merchantLeaderboard");
+  const t = useTranslations("IMS--Stats.merchantLeaderboard");
   const getMerchantById = useMerchantsStore((state) => state.getMerchantById);
 
   // Create a function to get merchant name or fallback to ID

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/MerchantTrendsChart.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/MerchantTrendsChart.tsx
@@ -61,7 +61,7 @@ function formatMonthLabel(monthKey: string, locale: string): string {
  * @returns Merchant trends visualization component
  */
 export function MerchantTrendsChart({data, currency}: Props): React.JSX.Element {
-  const t = useTranslations("Invoices.ViewInvoices.statisticsView.charts.merchantTrends");
+  const t = useTranslations("IMS--Stats.merchantTrends");
   const locale = useLocale();
   const getMerchantById = useMerchantsStore((state) => state.getMerchantById);
 

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/MerchantVisitChart.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/MerchantVisitChart.tsx
@@ -38,7 +38,7 @@ function MerchantVisitCard({
   readonly merchantName: string;
   readonly locale: string;
 }): React.JSX.Element {
-  const t = useTranslations("Invoices.ViewInvoices.statisticsView.charts.merchantVisit");
+  const t = useTranslations("IMS--Stats.merchantVisit");
 
   // Format day name using Intl.DateTimeFormat for i18n support
   const dayName = new Intl.DateTimeFormat(locale, {weekday: "long"}).format(new Date(2024, 0, pattern.mostCommonDayOfWeek + 1));
@@ -133,7 +133,7 @@ function MerchantVisitCard({
  * @returns Merchant visit patterns grid component
  */
 export function MerchantVisitChart({data, currency, topN = 6}: Props): React.JSX.Element {
-  const t = useTranslations("Invoices.ViewInvoices.statisticsView.charts.merchantVisit");
+  const t = useTranslations("IMS--Stats.merchantVisit");
   const locale = useLocale();
   const getMerchantById = useMerchantsStore((state) => state.getMerchantById);
 

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/PriceDistributionChart.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/PriceDistributionChart.tsx
@@ -42,7 +42,7 @@ type CustomTooltipProps = {
  * Custom tooltip for the price distribution chart.
  */
 function CustomTooltip({active, payload, currency}: CustomTooltipProps): React.JSX.Element | null {
-  const t = useTranslations("Invoices.ViewInvoices.statisticsView.charts.priceDistribution");
+  const t = useTranslations("IMS--Stats.priceDistribution");
   const [firstItem] = payload;
   if (!active || payload.length === 0 || !firstItem) return null;
   const data = firstItem.payload;
@@ -65,7 +65,7 @@ function CustomTooltip({active, payload, currency}: CustomTooltipProps): React.J
  * @returns Bar chart component
  */
 export function PriceDistributionChart({data, currency}: Props): React.JSX.Element {
-  const t = useTranslations("Invoices.ViewInvoices.statisticsView.charts.priceDistribution");
+  const t = useTranslations("IMS--Stats.priceDistribution");
 
   const chartConfig = {
     count: {

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/ProductCategoryChart.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/ProductCategoryChart.tsx
@@ -61,7 +61,7 @@ type CustomTooltipProps = {
  * in a formatted card overlay.
  */
 function CustomTooltip({active, payload = [], currency}: CustomTooltipProps): React.JSX.Element | null {
-  const t = useTranslations("Invoices.ViewInvoices.statisticsView.charts.productCategory");
+  const t = useTranslations("IMS--Stats.productCategory");
   if (!active || !payload || payload.length === 0) return null;
   const [firstItem] = payload;
   if (!firstItem) return null;
@@ -101,7 +101,7 @@ function CustomTooltip({active, payload = [], currency}: CustomTooltipProps): Re
  * @returns Horizontal bar chart component
  */
 export function ProductCategoryChart({data, currency}: Props): React.JSX.Element {
-  const t = useTranslations("Invoices.ViewInvoices.statisticsView.charts.productCategory");
+  const t = useTranslations("IMS--Stats.productCategory");
 
   // Empty state
   if (data.length === 0) {

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/SpendingCalendarHeatmap.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/SpendingCalendarHeatmap.tsx
@@ -208,7 +208,7 @@ function generateCalendarGrid(data: DailySpending[], monthOffset: number): {week
  * Individual day cell component with tooltip.
  */
 function DayCell({day, currency, locale}: {day: DayCell; currency: string; locale: string}): React.JSX.Element {
-  const t = useTranslations("Invoices.ViewInvoices.statisticsView.charts.calendarHeatmap.tooltip");
+  const t = useTranslations("IMS--Stats.calendarHeatmap.tooltip");
 
   if (!day.date) {
     return <div className={`${styles["dayCell"]} ${styles["dayCellEmpty"]}`} />;
@@ -265,7 +265,7 @@ function DayCell({day, currency, locale}: {day: DayCell; currency: string; local
  * @returns Calendar heatmap JSX element
  */
 export default function SpendingCalendarHeatmap({data, currency}: Props): React.JSX.Element {
-  const t = useTranslations("Invoices.ViewInvoices.statisticsView.charts.calendarHeatmap");
+  const t = useTranslations("IMS--Stats.calendarHeatmap");
   const locale = useLocale();
   const [monthOffset, setMonthOffset] = useState(0);
 

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/SpendingOverTimeChart.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/SpendingOverTimeChart.tsx
@@ -44,7 +44,7 @@ type CustomTooltipProps = {
  * Custom tooltip for the spending chart.
  */
 function CustomTooltip({active, payload, currency}: CustomTooltipProps): React.JSX.Element | null {
-  const t = useTranslations("Invoices.ViewInvoices.statisticsView.charts.spendingOverTime");
+  const t = useTranslations("IMS--Stats.spendingOverTime");
   const [firstItem] = payload;
   if (!active || payload.length === 0 || !firstItem) return null;
   const data = firstItem.payload;
@@ -93,7 +93,7 @@ function formatYAxisTick(value: number): string {
  * @returns Area chart component
  */
 export function SpendingOverTimeChart({data, currency}: Props): React.JSX.Element {
-  const t = useTranslations("Invoices.ViewInvoices.statisticsView.charts.spendingOverTime");
+  const t = useTranslations("IMS--Stats.spendingOverTime");
 
   const chartConfig = {
     amount: {

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/TimeOfDayChart.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/TimeOfDayChart.tsx
@@ -41,7 +41,7 @@ type CustomTooltipProps = {
  * Custom tooltip for the time-of-day radar chart.
  */
 function CustomTooltip({active, payload}: CustomTooltipProps): React.JSX.Element | null {
-  const t = useTranslations("Invoices.ViewInvoices.statisticsView.charts.timeOfDay");
+  const t = useTranslations("IMS--Stats.timeOfDay");
   const [firstItem] = payload;
   if (!active || payload.length === 0 || !firstItem) return null;
   const data = firstItem.payload;
@@ -76,7 +76,7 @@ function CustomTooltip({active, payload}: CustomTooltipProps): React.JSX.Element
  * ```
  */
 export function TimeOfDayChart({data}: Props): React.JSX.Element {
-  const t = useTranslations("Invoices.ViewInvoices.statisticsView.charts.timeOfDay");
+  const t = useTranslations("IMS--Stats.timeOfDay");
 
   // IMPORTANT: This key must match the field name in TimeOfDaySegment
   const chartConfig = {

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/TopProductsChart.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/TopProductsChart.tsx
@@ -94,7 +94,7 @@ function RankBadge({rank}: {readonly rank: number}): React.JSX.Element {
  * @returns Table component with product leaderboard
  */
 export function TopProductsChart({data, currency}: Props): React.JSX.Element {
-  const t = useTranslations("Invoices.ViewInvoices.statisticsView.charts.topProducts");
+  const t = useTranslations("IMS--Stats.topProducts");
 
   // Empty state
   if (data.length === 0) {

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/island.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/island.tsx
@@ -19,7 +19,7 @@ import styles from "./island.module.scss";
  */
 export default function RenderViewInvoicesScreen(): React.JSX.Element {
   const {invoices, isLoading} = useInvoices();
-  const t = useTranslations("Invoices.ViewInvoices.viewInvoicesIsland");
+  const t = useTranslations("IMS--List.viewInvoicesIsland");
 
   if (isLoading) {
     return (

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/page.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/page.tsx
@@ -56,7 +56,7 @@ import pageStyles from "./page.module.scss";
  * @see RFC 2001 - Domain-Driven Design Architecture (invoices bounded context)
  */
 export async function generateMetadata(): Promise<Metadata> {
-  const t = await getTranslations("Invoices.ViewInvoices.metadata");
+  const t = await getTranslations("IMS--List.metadata");
   const locale = await getLocale();
   return createMetadata({
     locale,
@@ -132,8 +132,8 @@ export async function generateMetadata(): Promise<Metadata> {
  * @see RFC 1003 - Internationalization System (rich text formatting)
  */
 export default async function ViewInvoicesPage(_props: Readonly<PageProps<"/domains/invoices/view-invoices">>): Promise<React.JSX.Element> {
-  const t = await getTranslations("Invoices.ViewInvoices");
-  const tCommon = await getTranslations("Invoices.ViewInvoices.viewInvoicesPage");
+  const t = await getTranslations("IMS--List");
+  const tCommon = await getTranslations("IMS--List.viewInvoicesPage");
   const {user} = await fetchAaaSUserFromAuthService();
   const username = user?.fullName ?? tCommon("guestName");
 

--- a/sites/arolariu.ro/src/app/domains/invoices/view-scans/_components/ScanGroupBanner.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-scans/_components/ScanGroupBanner.tsx
@@ -49,7 +49,7 @@ interface ScanGroupBannerProps {
  * @returns The ScanGroupBanner component
  */
 export default function ScanGroupBanner({initialVisible = true}: Readonly<ScanGroupBannerProps>): React.JSX.Element | null {
-  const t = useTranslations("Invoices.ViewScans.groupBanner");
+  const t = useTranslations("IMS--ViewScans.groupBanner");
   const router = useRouter();
   const {scans, setSelectedScans} = useScansStore();
   const [isDismissed, setIsDismissed] = useState<boolean>(!initialVisible);

--- a/sites/arolariu.ro/src/app/domains/invoices/view-scans/_components/ScanSelectionToolbar.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-scans/_components/ScanSelectionToolbar.tsx
@@ -40,7 +40,7 @@ type ScanSelectionToolbarProps = {
  * Provides bulk actions like create invoice, delete, and deselect all.
  */
 export default function ScanSelectionToolbar({onCreateInvoice}: Readonly<ScanSelectionToolbarProps>): React.JSX.Element | null {
-  const t = useTranslations("Invoices.ViewScans.toolbar");
+  const t = useTranslations("IMS--ViewScans.toolbar");
   const router = useRouter();
   const {selectedScans, clearSelection, removeScan} = useScans();
   const [isDeleting, setIsDeleting] = useState(false);

--- a/sites/arolariu.ro/src/app/domains/invoices/view-scans/_components/ScansGrid.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-scans/_components/ScansGrid.tsx
@@ -52,7 +52,7 @@ function ScanCardWrapper({scan, isSelected, onToggleSelection}: Readonly<ScanCar
  * Grid display for scans with selection support.
  */
 export default function ScansGrid(): React.JSX.Element {
-  const t = useTranslations("Invoices.ViewScans");
+  const t = useTranslations("IMS--ViewScans");
   const {scans, selectedScans, hasHydrated, isSyncing, toggleSelection} = useScans();
   const [page, setPage] = useState(0);
 

--- a/sites/arolariu.ro/src/app/domains/invoices/view-scans/_components/ScansHeader.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-scans/_components/ScansHeader.tsx
@@ -33,7 +33,7 @@ function formatRelativeTime(date: Date): string {
  * Header component showing scan count and sync button.
  */
 export default function ScansHeader(): React.JSX.Element {
-  const t = useTranslations("Invoices.ViewScans.header");
+  const t = useTranslations("IMS--ViewScans.header");
   const {scans, isSyncing, lastSyncTimestamp, syncScans} = useScans();
 
   return (

--- a/sites/arolariu.ro/src/app/domains/invoices/view-scans/_components/dialogs/CreateInvoiceDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-scans/_components/dialogs/CreateInvoiceDialog.tsx
@@ -117,7 +117,7 @@ function ProcessStep({
  * Uses the DialogContext for state management.
  */
 export default function CreateInvoiceDialog(): React.JSX.Element {
-  const t = useTranslations("Invoices.ViewScans.createInvoiceDialog");
+  const t = useTranslations("IMS--Dialogs.createInvoiceDialog");
   const router = useRouter();
 
   // Dialog state from context

--- a/sites/arolariu.ro/src/app/domains/invoices/view-scans/island.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-scans/island.tsx
@@ -55,7 +55,7 @@ function StatsCard({value, label, colorClass}: Readonly<{value: number; label: s
  * Scan statistics component.
  */
 function ScanStats(): React.JSX.Element | null {
-  const t = useTranslations("Invoices.ViewScans");
+  const t = useTranslations("IMS--ViewScans");
   const {scans, selectedScans} = useScans();
   const readyScans = scans.filter((s) => s.status === "ready").length;
 
@@ -101,7 +101,7 @@ function ScanStats(): React.JSX.Element | null {
  * Shows when all scans are ready and none are selected.
  */
 function CreateFromAllButton(): React.JSX.Element | null {
-  const t = useTranslations("Invoices.ViewScans");
+  const t = useTranslations("IMS--ViewScans");
   const {scans, selectedScans} = useScans();
   const {openDialog} = useDialogs();
 
@@ -146,7 +146,7 @@ function CreateFromAllButton(): React.JSX.Element | null {
  * Sidebar content component (reused in both desktop sidebar and mobile Sheet).
  */
 function SidebarContent(): React.JSX.Element {
-  const t = useTranslations("Invoices.ViewScans");
+  const t = useTranslations("IMS--ViewScans");
   const {selectedScans} = useScans();
 
   return (
@@ -245,7 +245,7 @@ function Sidebar(): React.JSX.Element | null {
  * Mobile tips button that opens a Sheet with sidebar content.
  */
 function MobileTipsButton(): React.JSX.Element | null {
-  const t = useTranslations("Invoices.ViewScans");
+  const t = useTranslations("IMS--ViewScans");
   const {scans} = useScans();
   const isMobile = useIsMobile();
 
@@ -280,7 +280,7 @@ function MobileTipsButton(): React.JSX.Element | null {
  * Inner content component that uses the dialog context.
  */
 function ViewScansContent(): React.JSX.Element {
-  const t = useTranslations("Invoices.ViewScans");
+  const t = useTranslations("IMS--ViewScans");
   const {scans, selectedScans} = useScans();
   const {openDialog} = useDialogs();
 

--- a/sites/arolariu.ro/src/app/domains/invoices/view-scans/page.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-scans/page.tsx
@@ -10,7 +10,7 @@ import styles from "./page.module.scss";
  * Generates SEO metadata for the view scans page.
  */
 export async function generateMetadata(): Promise<Metadata> {
-  const t = await getTranslations("Invoices.ViewScans.metadata");
+  const t = await getTranslations("IMS--ViewScans.metadata");
   const locale = await getLocale();
   return createMetadata({
     locale,


### PR DESCRIPTION
## Problem

The `Invoices` namespace in `messages/en.json` contained **1,733 leaf keys** (61% of all translations) at **depth 6**, causing `RangeError: Map maximum size exceeded` during `next build` TypeScript type-checking ([next-intl#2296](https://github.com/amannn/next-intl/issues/2296)).

**Root cause:** next-intl's `NestedKeyOf<Messages>` recursive type generates a string literal union of ALL ~2,833 dot-separated key paths. With 211 `useTranslations()` call sites (96% using nested namespaces), TypeScript's internal Map exceeds V8's 2^24 entry limit.

## Solution

Split the monolithic `Invoices` namespace into **11 flat `IMS--*` top-level keys** using a double-dash prefix to visually mark the Invoice Management System domain.

### New namespace structure

| Key | Keys | Content |
|-----|------|---------|
| `IMS--View` | 220 | Invoice detail page |
| `IMS--Edit` | 132 | Invoice editor |
| `IMS--List` | 126 | Invoice list page |
| `IMS--Create` | 78 | New invoice wizard |
| `IMS--ViewScans` | 95 | Scan gallery |
| `IMS--UploadScans` | 70 | Scan upload |
| `IMS--Landing` | 55 | Domain homepage |
| `IMS--Dialogs` | 436 | ALL dialog components |
| `IMS--Cards` | 319 | ALL card components |
| `IMS--Stats` | 111 | Statistics & charts |
| `IMS--Common` | 91 | Shared utilities |

### Impact

| Metric | Before | After |
|--------|--------|-------|
| Largest namespace | 1,733 keys | 436 keys |
| Max depth | 6 | 3 |
| NestedKeyOf paths | ~16,000 | ~3,500 |
| TS type-check | RangeError crash | Completes successfully |
| i18n type errors | N/A | 0 |

### Additional fixes
- Added 6 missing translation keys
- Narrowed `ImprovementSuggestion.key` to string literal union (fixes TS2345)
- Typed `SelectionMode.t` prop with namespace generic (fixes TS2589)
- Fixed email route type cast

134 files changed (3 locale JSONs + 131 TypeScript files).
