### PR TITLE
refactor(backend): harden exception boundary + HTTP response contract

### DIFF
--- a/docs/rfc/2003-the-standard-implementation.md
+++ b/docs/rfc/2003-the-standard-implementation.md
@@ -1184,11 +1184,11 @@ problem-type URIs are declared as constants in
 API contract (do not rename without a major version bump).
 
 The following mapping — implemented by `SelectStatus` at
-`sites/api.arolariu.ro/src/Common/Http/ExceptionToHttpResultMapper.cs:73-86` — is
+`sites/api.arolariu.ro/src/Common/Http/ExceptionToHttpResultMapper.cs:74-87` — is
 authoritative. Rows appear in the same order as the `switch` arms; the unclassified
 default arm maps to 500:
 
-| Marker Interface                  | HTTP Status | Problem Type URI constant                      |
+| Marker Interface / Type           | HTTP Status | Problem Type URI constant                      |
 |-----------------------------------|-------------|------------------------------------------------|
 | `IUnauthorizedException`          | 401         | `ProblemTypeUris.Unauthorized`                 |
 | `IForbiddenException`             | 403         | `ProblemTypeUris.Forbidden`                    |
@@ -1196,6 +1196,7 @@ default arm maps to 500:
 | `IAlreadyExistsException`         | 409         | `ProblemTypeUris.Conflict`                     |
 | `ILockedException`                | 423         | `ProblemTypeUris.Locked`                       |
 | `IRateLimitedException`           | 429         | `ProblemTypeUris.RateLimited`                  |
+| `BadHttpRequestException`         | ex.StatusCode | `ProblemTypeUris.Validation`                  |
 | `IValidationException`            | 400         | `ProblemTypeUris.Validation`                   |
 | `IDependencyValidationException`  | 400         | `ProblemTypeUris.Validation`                   |
 | `IDependencyException`            | 503         | `ProblemTypeUris.ServiceUnavailable`           |
@@ -1265,12 +1266,13 @@ On every caught exception the handler records the exception on the current `Acti
 runs the same mapping function, and writes the resulting `ProblemDetails` to the
 response.
 
-### Known Gap: `BadHttpRequestException`
+### Status of `BadHttpRequestException`
 
 `Microsoft.AspNetCore.Http.BadHttpRequestException` (thrown by the Kestrel / model
-binding layers on malformed payloads) does not currently implement any of the marker
-interfaces. It falls through to the default arm of `SelectStatus` and is therefore
-mapped to **500 Internal Server Error**, even though its own `StatusCode` property is
-typically 400. A follow-up task may add an explicit switch arm that propagates
-`ex.StatusCode` for this type; until then this remains a documented deviation from the
-otherwise-aligned status model.
+binding layers on malformed payloads) is now explicitly handled by `ExceptionToHttpResultMapper`.
+The mapper includes a dedicated switch arm that propagates its `StatusCode` property
+(typically 400) instead of defaulting to 500. The exception is also registered in
+`IsClassifiable` so that the chain-walk algorithm in `FindClassifiableException` recognizes it
+as a classifiable exception. This ensures model binding faults, JSON parsing errors, and
+similar pre-handler faults route correctly to 400 Bad Request (with `ProblemTypeUris.Validation`)
+via both the endpoint `try/catch` and the `ExceptionMappingHandler` middleware defense layer.

--- a/docs/rfc/2003-the-standard-implementation.md
+++ b/docs/rfc/2003-the-standard-implementation.md
@@ -37,6 +37,7 @@ If any example in this RFC diverges from the live implementation, source code in
 11. [Exception Classification](#exception-classification)
 12. [Testing Approach](#testing-approach)
 13. [Future Enhancements](#future-enhancements)
+14. [Exception → HTTP Status Mapping Contract](#exception--http-status-mapping-contract)
 
 ---
 
@@ -644,16 +645,22 @@ public static partial class InvoiceEndpoints
 
 ### Handler Implementation
 
-**File**: `Endpoints/InvoiceEndpoints.Handlers.cs`
+**File**: `sites/api.arolariu.ro/src/Invoices/Endpoints/InvoiceEndpoints.Handlers.cs`
+
+Handlers wrap their body in a single `try / catch (Exception ex)`. The catch delegates
+to `ExceptionToHttpResultMapper.ToHttpResult` (see
+`sites/api.arolariu.ro/src/Common/Http/ExceptionToHttpResultMapper.cs`), which walks the
+exception chain, picks the innermost classifiable marker, and emits an RFC 7807
+`ProblemDetails` with the correct HTTP status. Per-type `catch` blocks are no longer
+needed — that responsibility is centralized in the mapper.
 
 ```csharp
 public static partial class InvoiceEndpoints
 {
-  internal static async partial Task<IResult> CreateNewInvoiceAsync(
-    [FromServices] IInvoiceProcessingService invoiceProcessingService,
-    [FromServices] IHttpContextAccessor httpContext,
-    [FromBody] CreateInvoiceDto invoiceDto,
-    ClaimsPrincipal principal)
+  public static async partial Task<IResult> CreateNewInvoiceAsync(
+    IInvoiceProcessingService invoiceProcessingService,
+    IHttpContextAccessor httpContext,
+    CreateInvoiceRequestDto invoiceDto)
   {
     try
     {
@@ -667,78 +674,18 @@ public static partial class InvoiceEndpoints
         .CreateInvoice(invoice)
         .ConfigureAwait(false);
 
-      return TypedResults.Created($"/rest/v1/invoices/{invoice.id}", invoice);
+      var responseDto = InvoiceResponseDto.FromInvoice(invoice);
+      return TypedResults.Created($"/rest/v1/invoices/{invoice.id}", responseDto);
     }
-    catch (InvoiceProcessingServiceValidationException exception)
+    catch (Exception ex)
     {
-      return TypedResults.Problem(
-        detail: exception.Message + exception.Source,
-        statusCode: StatusCodes.Status500InternalServerError,
-        title: "The service encountered a processing service validation error.");
-    }
-    catch (InvoiceProcessingServiceDependencyException exception)
-    {
-      return TypedResults.Problem(
-        detail: exception.Message + exception.Source,
-        statusCode: StatusCodes.Status500InternalServerError,
-        title: "The service encountered a processing service dependency error.");
-    }
-    catch (InvoiceProcessingServiceDependencyValidationException exception)
-    {
-      return TypedResults.Problem(
-        detail: exception.Message + exception.Source,
-        statusCode: StatusCodes.Status500InternalServerError,
-        title: "The service encountered a processing service dependency validation error.");
-    }
-    catch (InvoiceProcessingServiceException exception)
-    {
-      return TypedResults.Problem(
-        detail: exception.Message + exception.Source,
-        statusCode: StatusCodes.Status500InternalServerError,
-        title: "The service encountered a processing service error.");
-    }
-    catch (Exception exception)
-    {
-      return TypedResults.Problem(
-        detail: exception.Message + exception.Source,
-        statusCode: StatusCodes.Status500InternalServerError,
-        title: "The service encountered an unexpected internal service error.");
+      Activity.Current?.RecordException(ex);
+      Activity.Current?.SetStatus(ActivityStatusCode.Error, ex.GetType().Name);
+      return ExceptionToHttpResultMapper.ToHttpResult(ex, Activity.Current);
     }
   }
 
-  internal static async partial Task<IResult> RetrieveSpecificInvoiceAsync(
-    [FromServices] IInvoiceProcessingService invoiceProcessingService,
-    [FromServices] IHttpContextAccessor httpContext,
-    [FromRoute] Guid id,
-    ClaimsPrincipal principal)
-  {
-    try
-    {
-      using var activity = InvoicePackageTracing.StartActivity(
-        nameof(RetrieveSpecificInvoiceAsync),
-        ActivityKind.Server);
-
-      var potentialUserIdentifier = RetrieveUserIdentifierClaimFromPrincipal(principal);
-
-      var possibleInvoice = await invoiceProcessingService
-        .ReadInvoice(id, potentialUserIdentifier)
-        .ConfigureAwait(false);
-
-      return possibleInvoice is null
-        ? TypedResults.NotFound()
-        : TypedResults.Ok(possibleInvoice);
-    }
-    catch (InvoiceProcessingServiceValidationException exception)
-    {
-      return TypedResults.Problem(
-        detail: exception.Message + exception.Source,
-        statusCode: StatusCodes.Status500InternalServerError,
-        title: "The service encountered a processing service validation error.");
-    }
-    // Additional exception handlers...
-  }
-
-  // Additional handlers: UpdateInvoiceAsync, DeleteInvoiceAsync, etc.
+  // Additional handlers (Retrieve/Update/Delete) follow the same single-catch pattern.
 }
 ```
 
@@ -945,59 +892,47 @@ InvoiceOrchestrationServiceDependencyValidationException    // Processing threw 
 
 ### Exception Handling in Exposers
 
-**File**: `Endpoints/InvoiceEndpoints.Handlers.cs`
+**File**: `sites/api.arolariu.ro/src/Invoices/Endpoints/InvoiceEndpoints.Handlers.cs`
+
+Endpoints do not carry a catch-per-exception-type ladder. They wrap the handler body in
+a single `try / catch (Exception ex)` and route the exception through
+`ExceptionToHttpResultMapper.ToHttpResult`, which emits an RFC 7807
+`ProblemDetails` response with the correct HTTP status:
 
 ```csharp
-internal static async partial Task<IResult> CreateNewInvoiceAsync(
-  [FromServices] IInvoiceProcessingService invoiceProcessingService,
-  [FromBody] CreateInvoiceDto invoiceDto,
-  ClaimsPrincipal principal)
+public static async partial Task<IResult> CreateNewInvoiceAsync(
+  IInvoiceProcessingService invoiceProcessingService,
+  IHttpContextAccessor httpContext,
+  CreateInvoiceRequestDto invoiceDto)
 {
   try
   {
+    using var activity = InvoicePackageTracing.StartActivity(
+      nameof(CreateNewInvoiceAsync),
+      ActivityKind.Server);
+
     var invoice = invoiceDto.ToInvoice();
-    await invoiceProcessingService.CreateInvoice(invoice);
-    return TypedResults.Created($"/rest/v1/invoices/{invoice.id}", invoice);
+    await invoiceProcessingService.CreateInvoice(invoice).ConfigureAwait(false);
+
+    var responseDto = InvoiceResponseDto.FromInvoice(invoice);
+    return TypedResults.Created($"/rest/v1/invoices/{invoice.id}", responseDto);
   }
-  catch (InvoiceProcessingServiceValidationException exception)
+  catch (Exception ex)
   {
-    // 500 Internal Server Error (service validation failed)
-    return TypedResults.Problem(
-      detail: exception.Message,
-      statusCode: StatusCodes.Status500InternalServerError,
-      title: "Processing service validation error.");
-  }
-  catch (InvoiceProcessingServiceDependencyException exception)
-  {
-    // 500 Internal Server Error (downstream service failed)
-    return TypedResults.Problem(
-      detail: exception.Message,
-      statusCode: StatusCodes.Status500InternalServerError,
-      title: "Processing service dependency error.");
-  }
-  catch (InvoiceProcessingServiceDependencyValidationException exception)
-  {
-    // 500 Internal Server Error (downstream validation failed)
-    return TypedResults.Problem(
-      detail: exception.Message,
-      statusCode: StatusCodes.Status500InternalServerError,
-      title: "Processing service dependency validation error.");
-  }
-  catch (Exception exception)
-  {
-    // 500 Internal Server Error (unexpected error)
-    return TypedResults.Problem(
-      detail: exception.Message,
-      statusCode: StatusCodes.Status500InternalServerError,
-      title: "Unexpected internal service error.");
+    Activity.Current?.RecordException(ex);
+    Activity.Current?.SetStatus(ActivityStatusCode.Error, ex.GetType().Name);
+    return ExceptionToHttpResultMapper.ToHttpResult(ex, Activity.Current);
   }
 }
 ```
 
-**Note**: Current implementation maps all exceptions to `500 Internal Server Error`. Future enhancement should map:
-- `ValidationException` → `400 Bad Request`
-- `DependencyValidationException` → `400 Bad Request` (client's fault propagated)
-- `DependencyException` → `500 Internal Server Error` (server's fault)
+The mapper derives the HTTP status from marker interfaces on the exception chain
+(`IValidationException`, `IDependencyValidationException`, `IDependencyException`,
+`IServiceException`, plus the refinement markers `INotFoundException`,
+`IAlreadyExistsException`, `ILockedException`, `IRateLimitedException`,
+`IUnauthorizedException`, `IForbiddenException`). The full mapping is defined in the
+[Exception → HTTP Status Mapping Contract](#exception--http-status-mapping-contract)
+section below.
 
 ---
 
@@ -1089,19 +1024,14 @@ sites/api.arolariu.ro/tests/
 
 **Rationale**: Stronger alignment with The Standard's business language principle.
 
-### 2. Exception-to-HTTP-Status Mapping Refinement
+### 2. Exception-to-HTTP-Status Mapping Refinement — Shipped
 
-**Current**: All exceptions map to `500 Internal Server Error`
-
-**Target**:
-
-- `ValidationException` → `400 Bad Request`
-- `DependencyValidationException` → `400 Bad Request` (client error propagated)
-- `DependencyException` → `500 Internal Server Error` (server error)
-- `NotFoundException` → `404 Not Found`
-- `ConflictException` → `409 Conflict`
-
-**Implementation**: Middleware or exposer-level exception filter.
+Previously listed as a future enhancement. Shipped via `ExceptionToHttpResultMapper`
+(see `sites/api.arolariu.ro/src/Common/Http/ExceptionToHttpResultMapper.cs:73-86`) and
+the belt-and-suspenders `ExceptionMappingHandler` middleware
+(`sites/api.arolariu.ro/src/Common/Http/ExceptionMappingHandler.cs`). See the
+[Exception → HTTP Status Mapping Contract](#exception--http-status-mapping-contract)
+section for the authoritative table.
 
 ### 3. Coordination/Management Services Layer
 
@@ -1246,22 +1176,101 @@ This RFC serves as living documentation for how The Standard is applied in pract
 ## Exception → HTTP Status Mapping Contract
 
 All bounded contexts MUST classify exceptions using marker interfaces from
-`arolariu.Backend.Common.Exceptions` and delegate HTTP response construction to
-`IExceptionToHttpResultMapper`. The following mapping is authoritative:
+`arolariu.Backend.Common.Exceptions` and delegate HTTP response construction to the
+static `ExceptionToHttpResultMapper` at
+`sites/api.arolariu.ro/src/Common/Http/ExceptionToHttpResultMapper.cs`. The stable
+problem-type URIs are declared as constants in
+`sites/api.arolariu.ro/src/Common/Http/ProblemTypeUris.cs` and are part of the public
+API contract (do not rename without a major version bump).
 
-| Marker Interface                  | HTTP Status | Problem `type`                                       |
-|-----------------------------------|-------------|------------------------------------------------------|
-| `IValidationException`            | 400         | `https://api.arolariu.ro/problems/validation`        |
-| `IDependencyValidationException`  | 400         | `https://api.arolariu.ro/problems/validation`        |
-| `IUnauthorizedException`          | 401         | `https://api.arolariu.ro/problems/unauthorized`      |
-| `IForbiddenException`             | 403         | `https://api.arolariu.ro/problems/forbidden`         |
-| `INotFoundException`              | 404         | `https://api.arolariu.ro/problems/not-found`         |
-| `IAlreadyExistsException`         | 409         | `https://api.arolariu.ro/problems/conflict`          |
-| `ILockedException`                | 423         | `https://api.arolariu.ro/problems/locked`            |
-| `IRateLimitedException`           | 429         | `https://api.arolariu.ro/problems/rate-limited`      |
-| `IDependencyException`            | 503         | `https://api.arolariu.ro/problems/service-unavailable` |
-| `IServiceException`               | 500         | `https://api.arolariu.ro/problems/internal-error`    |
+The following mapping — implemented by `SelectStatus` at
+`sites/api.arolariu.ro/src/Common/Http/ExceptionToHttpResultMapper.cs:73-86` — is
+authoritative. Rows appear in the same order as the `switch` arms; the unclassified
+default arm maps to 500:
+
+| Marker Interface                  | HTTP Status | Problem Type URI constant                      |
+|-----------------------------------|-------------|------------------------------------------------|
+| `IUnauthorizedException`          | 401         | `ProblemTypeUris.Unauthorized`                 |
+| `IForbiddenException`             | 403         | `ProblemTypeUris.Forbidden`                    |
+| `INotFoundException`              | 404         | `ProblemTypeUris.NotFound`                     |
+| `IAlreadyExistsException`         | 409         | `ProblemTypeUris.Conflict`                     |
+| `ILockedException`                | 423         | `ProblemTypeUris.Locked`                       |
+| `IRateLimitedException`           | 429         | `ProblemTypeUris.RateLimited`                  |
+| `IValidationException`            | 400         | `ProblemTypeUris.Validation`                   |
+| `IDependencyValidationException`  | 400         | `ProblemTypeUris.Validation`                   |
+| `IDependencyException`            | 503         | `ProblemTypeUris.ServiceUnavailable`           |
+| `IServiceException`               | 500         | `ProblemTypeUris.InternalServerError`          |
+| _(unclassified)_                  | 500         | `ProblemTypeUris.InternalServerError`          |
 
 ProblemDetails responses MUST include a `traceId` extension (correlating to the
 current `Activity.TraceId`) and MUST NOT include `exception.Source`, stack traces,
-or exception type names.
+or exception type names. For 401/403/500/503 responses the `detail` field is a fixed,
+non-leaking message; for client-attributable statuses it echoes the exception message
+truncated to 512 characters. For 429 responses, a `retryAfterSeconds` extension is
+emitted (sourced from a `RetryAfter` TimeSpan property on the exception, defaulting to
+one second).
+
+### Inner-exception Refinement Markers
+
+Outer exceptions thrown by Foundation / Orchestration / Processing services (e.g.
+`InvoiceStorageFoundationServiceDependencyValidationException`) carry coarse markers
+(`IDependencyValidationException`, `IDependencyException`, etc.). They wrap the
+concrete inner exception as `InnerException`, and it is the inner type that carries
+the refinement marker that decides the HTTP status.
+
+The Invoices bounded context ships 21 inner exceptions across two folders:
+
+- `sites/api.arolariu.ro/src/Invoices/DDD/AggregatorRoots/Invoices/Exceptions/Inner/`
+  — 12 classes: `InvoiceAlreadyExistsException`, `InvoiceCosmosDbRateLimitException`,
+  `InvoiceDescriptionNotSetException`, `InvoiceFailedStorageException`,
+  `InvoiceForbiddenAccessException`, `InvoiceIdNotSetException`,
+  `InvoiceLockedException`, `InvoiceNotFoundException`,
+  `InvoicePaymentInformationNotCorrectException`,
+  `InvoicePhotoLocationNotCorrectException`,
+  `InvoiceTimeInformationNotCorrectException`, `InvoiceUnauthorizedAccessException`.
+- `sites/api.arolariu.ro/src/Invoices/DDD/Entities/Merchants/Exceptions/Inner/`
+  — 9 classes: `MerchantAlreadyExistsException`, `MerchantCosmosDbRateLimitException`,
+  `MerchantFailedStorageException`, `MerchantForbiddenAccessException`,
+  `MerchantIdNotSetException`, `MerchantLockedException`,
+  `MerchantNotFoundException`, `MerchantParentCompanyIdNotSetException`,
+  `MerchantUnauthorizedAccessException`.
+
+Each of these implements a refinement marker (`INotFoundException`,
+`IAlreadyExistsException`, `ILockedException`, `IRateLimitedException`,
+`IUnauthorizedException`, `IForbiddenException`, or `IValidationException`). The
+mapper's chain walk — `FindClassifiableException` at
+`sites/api.arolariu.ro/src/Common/Http/ExceptionToHttpResultMapper.cs:49-59` — iterates
+down `InnerException` and picks the **innermost** classifiable exception. This lets
+wrapping layers stay on coarse markers (Foundation / Orchestration / Processing outer
+exceptions) while still producing the correct refined HTTP status (404, 409, 423, 429,
+401, 403, or 400) based on the root cause.
+
+### Defense-in-Depth: `ExceptionMappingHandler`
+
+Endpoint handlers wrap their body in a single `try / catch (Exception ex)` that routes
+through `ExceptionToHttpResultMapper`. As a belt-and-suspenders layer, exceptions that
+escape an endpoint (model binding faults, authentication middleware throws, routing
+faults) are caught by `ExceptionMappingHandler` — an `IExceptionHandler` registered as
+the first piece of middleware in the pipeline:
+
+- Handler: `sites/api.arolariu.ro/src/Common/Http/ExceptionMappingHandler.cs`
+- Registration: `services.AddExceptionHandler<ExceptionMappingHandler>()` followed by
+  `services.AddProblemDetails()` in
+  `sites/api.arolariu.ro/src/Core/Domain/General/Extensions/WebApplicationBuilderExtensions.cs:330-331`.
+- Pipeline slot: `app.UseExceptionHandler()` as the **first** middleware in
+  `sites/api.arolariu.ro/src/Core/Domain/General/Extensions/WebApplicationExtensions.cs:109-113`,
+  so it wraps routing, model binding, auth, and endpoint handlers.
+
+On every caught exception the handler records the exception on the current `Activity`,
+runs the same mapping function, and writes the resulting `ProblemDetails` to the
+response.
+
+### Known Gap: `BadHttpRequestException`
+
+`Microsoft.AspNetCore.Http.BadHttpRequestException` (thrown by the Kestrel / model
+binding layers on malformed payloads) does not currently implement any of the marker
+interfaces. It falls through to the default arm of `SelectStatus` and is therefore
+mapped to **500 Internal Server Error**, even though its own `StatusCode` property is
+typically 400. A follow-up task may add an explicit switch arm that propagates
+`ex.StatusCode` for this type; until then this remains a documented deviation from the
+otherwise-aligned status model.

--- a/sites/api.arolariu.ro/src/Common/Http/ExceptionMappingHandler.cs
+++ b/sites/api.arolariu.ro/src/Common/Http/ExceptionMappingHandler.cs
@@ -32,7 +32,12 @@ public sealed class ExceptionMappingHandler : IExceptionHandler
   /// <param name="httpContext">The current request context; must not be <see langword="null"/>.</param>
   /// <param name="exception">The caught exception; must not be <see langword="null"/>.</param>
   /// <param name="cancellationToken">Propagated cancellation token.</param>
-  /// <returns><see langword="true"/> once the exception has been mapped and written.</returns>
+  /// <returns>
+  /// <see langword="true"/> once the exception has been mapped and written; or
+  /// <see langword="false"/> if the response has already started writing and cannot be
+  /// safely replaced with a ProblemDetails payload (the framework's fallback handler
+  /// will observe the caller-provided partial response).
+  /// </returns>
   public async ValueTask<bool> TryHandleAsync(
     HttpContext httpContext,
     Exception exception,
@@ -40,6 +45,15 @@ public sealed class ExceptionMappingHandler : IExceptionHandler
   {
     ArgumentNullException.ThrowIfNull(httpContext);
     ArgumentNullException.ThrowIfNull(exception);
+
+    if (httpContext.Response.HasStarted)
+    {
+      // Response has already started writing — we cannot safely emit ProblemDetails now.
+      // Let the framework's default handler or the client observe the partial response.
+      return false;
+    }
+
+    httpContext.Response.Clear();
 
     Activity.Current?.RecordException(exception);
     Activity.Current?.SetStatus(ActivityStatusCode.Error, exception.GetType().Name);

--- a/sites/api.arolariu.ro/src/Common/Http/ExceptionMappingHandler.cs
+++ b/sites/api.arolariu.ro/src/Common/Http/ExceptionMappingHandler.cs
@@ -1,0 +1,51 @@
+namespace arolariu.Backend.Common.Http;
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+using arolariu.Backend.Common.Telemetry.Tracing;
+
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Http;
+
+/// <summary>
+/// Global <see cref="IExceptionHandler"/> that routes unhandled exceptions through
+/// <see cref="ExceptionToHttpResultMapper"/>, ensuring a consistent RFC 7807 ProblemDetails
+/// response even when an exception escapes an endpoint's local try/catch.
+/// </summary>
+/// <remarks>
+/// Endpoints still wrap their handler bodies in try/catch for fast-path telemetry; this
+/// handler is belt-and-suspenders for middleware faults and pre-handler throws (model
+/// binding, routing, authentication middleware, etc.). On any caught exception it
+/// records the exception on the current <see cref="Activity"/>, maps it to a ProblemDetails
+/// result, executes the result, and returns <c>true</c> to mark the exception as handled.
+/// </remarks>
+public sealed class ExceptionMappingHandler : IExceptionHandler
+{
+  /// <summary>
+  /// Translates <paramref name="exception"/> into an RFC 7807 ProblemDetails response
+  /// via <see cref="ExceptionToHttpResultMapper.ToHttpResult"/> and writes it to
+  /// <paramref name="httpContext"/>.
+  /// </summary>
+  /// <param name="httpContext">The current request context; must not be <see langword="null"/>.</param>
+  /// <param name="exception">The caught exception; must not be <see langword="null"/>.</param>
+  /// <param name="cancellationToken">Propagated cancellation token.</param>
+  /// <returns><see langword="true"/> once the exception has been mapped and written.</returns>
+  public async ValueTask<bool> TryHandleAsync(
+    HttpContext httpContext,
+    Exception exception,
+    CancellationToken cancellationToken)
+  {
+    ArgumentNullException.ThrowIfNull(httpContext);
+    ArgumentNullException.ThrowIfNull(exception);
+
+    Activity.Current?.RecordException(exception);
+    Activity.Current?.SetStatus(ActivityStatusCode.Error, exception.GetType().Name);
+
+    var result = ExceptionToHttpResultMapper.ToHttpResult(exception, Activity.Current);
+    await result.ExecuteAsync(httpContext).ConfigureAwait(false);
+    return true;
+  }
+}

--- a/sites/api.arolariu.ro/src/Common/Http/ExceptionToHttpResultMapper.cs
+++ b/sites/api.arolariu.ro/src/Common/Http/ExceptionToHttpResultMapper.cs
@@ -68,7 +68,8 @@ public static class ExceptionToHttpResultMapper
       or ILockedException
       or IRateLimitedException
       or IUnauthorizedException
-      or IForbiddenException;
+      or IForbiddenException
+      or BadHttpRequestException;
 
   private static (int Status, string Title, string Type) SelectStatus(Exception ex) => ex switch
   {
@@ -78,6 +79,7 @@ public static class ExceptionToHttpResultMapper
     IAlreadyExistsException        => (409, "Resource conflict",     ProblemTypeUris.Conflict),
     ILockedException               => (423, "Resource locked",       ProblemTypeUris.Locked),
     IRateLimitedException          => (429, "Too many requests",     ProblemTypeUris.RateLimited),
+    BadHttpRequestException badReq => (badReq.StatusCode, "Bad request", ProblemTypeUris.Validation),
     IValidationException           => (400, "Validation failed",     ProblemTypeUris.Validation),
     IDependencyValidationException => (400, "Dependency validation", ProblemTypeUris.Validation),
     IDependencyException           => (503, "Service unavailable",   ProblemTypeUris.ServiceUnavailable),

--- a/sites/api.arolariu.ro/src/Common/Http/ExceptionToHttpResultMapper.cs
+++ b/sites/api.arolariu.ro/src/Common/Http/ExceptionToHttpResultMapper.cs
@@ -73,18 +73,18 @@ public static class ExceptionToHttpResultMapper
 
   private static (int Status, string Title, string Type) SelectStatus(Exception ex) => ex switch
   {
-    IUnauthorizedException         => (401, "Unauthorized",          ProblemTypeUris.Unauthorized),
-    IForbiddenException            => (403, "Forbidden",             ProblemTypeUris.Forbidden),
-    INotFoundException             => (404, "Resource not found",    ProblemTypeUris.NotFound),
-    IAlreadyExistsException        => (409, "Resource conflict",     ProblemTypeUris.Conflict),
-    ILockedException               => (423, "Resource locked",       ProblemTypeUris.Locked),
-    IRateLimitedException          => (429, "Too many requests",     ProblemTypeUris.RateLimited),
+    IUnauthorizedException => (401, "Unauthorized", ProblemTypeUris.Unauthorized),
+    IForbiddenException => (403, "Forbidden", ProblemTypeUris.Forbidden),
+    INotFoundException => (404, "Resource not found", ProblemTypeUris.NotFound),
+    IAlreadyExistsException => (409, "Resource conflict", ProblemTypeUris.Conflict),
+    ILockedException => (423, "Resource locked", ProblemTypeUris.Locked),
+    IRateLimitedException => (429, "Too many requests", ProblemTypeUris.RateLimited),
     BadHttpRequestException badReq => (badReq.StatusCode, "Bad request", ProblemTypeUris.Validation),
-    IValidationException           => (400, "Validation failed",     ProblemTypeUris.Validation),
+    IValidationException => (400, "Validation failed", ProblemTypeUris.Validation),
     IDependencyValidationException => (400, "Dependency validation", ProblemTypeUris.Validation),
-    IDependencyException           => (503, "Service unavailable",   ProblemTypeUris.ServiceUnavailable),
-    IServiceException              => (500, "Internal server error", ProblemTypeUris.InternalServerError),
-    _                              => (500, "Internal server error", ProblemTypeUris.InternalServerError),
+    IDependencyException => (503, "Service unavailable", ProblemTypeUris.ServiceUnavailable),
+    IServiceException => (500, "Internal server error", ProblemTypeUris.InternalServerError),
+    _ => (500, "Internal server error", ProblemTypeUris.InternalServerError),
   };
 
   private static TimeSpan TryGetRetryAfter(Exception ex)

--- a/sites/api.arolariu.ro/src/Common/Http/ProblemTypeUris.cs
+++ b/sites/api.arolariu.ro/src/Common/Http/ProblemTypeUris.cs
@@ -10,28 +10,28 @@ public static class ProblemTypeUris
   private const string Root = "https://api.arolariu.ro/problems/";
 
   /// <summary>Problem type URI for validation failures (HTTP 400).</summary>
-  public const string Validation          = Root + "validation";
+  public const string Validation = Root + "validation";
 
   /// <summary>Problem type URI for missing resources (HTTP 404).</summary>
-  public const string NotFound            = Root + "not-found";
+  public const string NotFound = Root + "not-found";
 
   /// <summary>Problem type URI for resource conflicts (HTTP 409).</summary>
-  public const string Conflict            = Root + "conflict";
+  public const string Conflict = Root + "conflict";
 
   /// <summary>Problem type URI for locked resources (HTTP 423).</summary>
-  public const string Locked              = Root + "locked";
+  public const string Locked = Root + "locked";
 
   /// <summary>Problem type URI for rate-limited requests (HTTP 429).</summary>
-  public const string RateLimited         = Root + "rate-limited";
+  public const string RateLimited = Root + "rate-limited";
 
   /// <summary>Problem type URI for unauthenticated requests (HTTP 401).</summary>
-  public const string Unauthorized        = Root + "unauthorized";
+  public const string Unauthorized = Root + "unauthorized";
 
   /// <summary>Problem type URI for forbidden requests (HTTP 403).</summary>
-  public const string Forbidden           = Root + "forbidden";
+  public const string Forbidden = Root + "forbidden";
 
   /// <summary>Problem type URI for unavailable services (HTTP 503).</summary>
-  public const string ServiceUnavailable  = Root + "service-unavailable";
+  public const string ServiceUnavailable = Root + "service-unavailable";
 
   /// <summary>Problem type URI for unhandled internal errors (HTTP 500).</summary>
   public const string InternalServerError = Root + "internal-error";

--- a/sites/api.arolariu.ro/src/Core/Domain/General/Extensions/WebApplicationBuilderExtensions.cs
+++ b/sites/api.arolariu.ro/src/Core/Domain/General/Extensions/WebApplicationBuilderExtensions.cs
@@ -8,6 +8,7 @@ using System.Threading;
 
 using arolariu.Backend.Common.Azure;
 using arolariu.Backend.Common.Configuration;
+using arolariu.Backend.Common.Http;
 using arolariu.Backend.Common.Options;
 using arolariu.Backend.Common.Telemetry.Logging;
 using arolariu.Backend.Common.Telemetry.Metering;
@@ -325,6 +326,9 @@ internal static class WebApplicationBuilderExtensions
     services.AddSwaggerGen(SwaggerConfigurationService.GetSwaggerGenOptions());
     services.AddHealthChecks();
     services.AddRateLimitingPolicies();
+
+    services.AddExceptionHandler<ExceptionMappingHandler>();
+    services.AddProblemDetails();
 
     builder.AddOTelLogging();
     builder.AddOTelMetering();

--- a/sites/api.arolariu.ro/src/Core/Domain/General/Extensions/WebApplicationExtensions.cs
+++ b/sites/api.arolariu.ro/src/Core/Domain/General/Extensions/WebApplicationExtensions.cs
@@ -106,6 +106,12 @@ internal static class WebApplicationExtensions
     var logger = app.Services.GetRequiredService<ILoggerFactory>().CreateLogger("arolariu.Backend.Core");
     logger.LogPipelineConfigurationStarted();
 
+    // UseExceptionHandler must be the FIRST middleware so it wraps everything downstream —
+    // routing, model binding, auth, endpoint handlers. Registered via AddExceptionHandler<ExceptionMappingHandler>
+    // in WebApplicationBuilderExtensions, it routes escapes through ExceptionToHttpResultMapper and
+    // writes an RFC 7807 ProblemDetails response. See RFC 2003.
+    app.UseExceptionHandler();
+
     app.UseHttpsRedirection();
     app.UseAuthServices();
 

--- a/sites/api.arolariu.ro/src/Invoices/DDD/AggregatorRoots/Invoices/Exceptions/Inner/InvoiceAlreadyExistsException.cs
+++ b/sites/api.arolariu.ro/src/Invoices/DDD/AggregatorRoots/Invoices/Exceptions/Inner/InvoiceAlreadyExistsException.cs
@@ -16,41 +16,41 @@ using arolariu.Backend.Common.Exceptions;
 [ExcludeFromCodeCoverage]
 public sealed class InvoiceAlreadyExistsException : Exception, IAlreadyExistsException
 {
-/// <summary>Initializes a new instance of the <see cref="InvoiceAlreadyExistsException"/> class.</summary>
-public InvoiceAlreadyExistsException() { }
+  /// <summary>Initializes a new instance of the <see cref="InvoiceAlreadyExistsException"/> class.</summary>
+  public InvoiceAlreadyExistsException() { }
 
-/// <summary>Initializes a new instance of the <see cref="InvoiceAlreadyExistsException"/> class with the specified invoice identifier.</summary>
-/// <param name="invoiceIdentifier">The identifier of the invoice that already exists.</param>
-public InvoiceAlreadyExistsException(Guid invoiceIdentifier)
-: base($"Invoice with identifier '{invoiceIdentifier}' already exists.")
-{
-InvoiceIdentifier = invoiceIdentifier;
-}
+  /// <summary>Initializes a new instance of the <see cref="InvoiceAlreadyExistsException"/> class with the specified invoice identifier.</summary>
+  /// <param name="invoiceIdentifier">The identifier of the invoice that already exists.</param>
+  public InvoiceAlreadyExistsException(Guid invoiceIdentifier)
+  : base($"Invoice with identifier '{invoiceIdentifier}' already exists.")
+  {
+    InvoiceIdentifier = invoiceIdentifier;
+  }
 
-/// <summary>Initializes a new instance of the <see cref="InvoiceAlreadyExistsException"/> class with the specified invoice identifier and inner exception.</summary>
-/// <param name="invoiceIdentifier">The identifier of the invoice that already exists.</param>
-/// <param name="innerException">The inner exception.</param>
-public InvoiceAlreadyExistsException(Guid invoiceIdentifier, Exception innerException)
-: base($"Invoice with identifier '{invoiceIdentifier}' already exists.", innerException)
-{
-InvoiceIdentifier = invoiceIdentifier;
-}
+  /// <summary>Initializes a new instance of the <see cref="InvoiceAlreadyExistsException"/> class with the specified invoice identifier and inner exception.</summary>
+  /// <param name="invoiceIdentifier">The identifier of the invoice that already exists.</param>
+  /// <param name="innerException">The inner exception.</param>
+  public InvoiceAlreadyExistsException(Guid invoiceIdentifier, Exception innerException)
+  : base($"Invoice with identifier '{invoiceIdentifier}' already exists.", innerException)
+  {
+    InvoiceIdentifier = invoiceIdentifier;
+  }
 
-/// <summary>Initializes a new instance of the <see cref="InvoiceAlreadyExistsException"/> class with a custom message.</summary>
-/// <param name="message">The exception message.</param>
-public InvoiceAlreadyExistsException(string message) : base(message) { }
+  /// <summary>Initializes a new instance of the <see cref="InvoiceAlreadyExistsException"/> class with a custom message.</summary>
+  /// <param name="message">The exception message.</param>
+  public InvoiceAlreadyExistsException(string message) : base(message) { }
 
-/// <summary>Initializes a new instance of the <see cref="InvoiceAlreadyExistsException"/> class with a custom message and inner exception.</summary>
-/// <param name="message">The exception message.</param>
-/// <param name="innerException">The inner exception.</param>
-public InvoiceAlreadyExistsException(string message, Exception innerException)
-: base(message, innerException) { }
+  /// <summary>Initializes a new instance of the <see cref="InvoiceAlreadyExistsException"/> class with a custom message and inner exception.</summary>
+  /// <param name="message">The exception message.</param>
+  /// <param name="innerException">The inner exception.</param>
+  public InvoiceAlreadyExistsException(string message, Exception innerException)
+  : base(message, innerException) { }
 
 #pragma warning disable SYSLIB0051
-private InvoiceAlreadyExistsException(SerializationInfo info, StreamingContext context)
-: base(info, context) { }
+  private InvoiceAlreadyExistsException(SerializationInfo info, StreamingContext context)
+  : base(info, context) { }
 #pragma warning restore SYSLIB0051
 
-/// <summary>Gets the identifier of the invoice that already exists.</summary>
-public Guid InvoiceIdentifier { get; }
+  /// <summary>Gets the identifier of the invoice that already exists.</summary>
+  public Guid InvoiceIdentifier { get; }
 }

--- a/sites/api.arolariu.ro/src/Invoices/DDD/AggregatorRoots/Invoices/Exceptions/Inner/InvoiceAlreadyExistsException.cs
+++ b/sites/api.arolariu.ro/src/Invoices/DDD/AggregatorRoots/Invoices/Exceptions/Inner/InvoiceAlreadyExistsException.cs
@@ -9,6 +9,9 @@ using arolariu.Backend.Common.Exceptions;
 /// <summary>
 /// Thrown when attempting to create an invoice with an identifier that already exists in the data store (Cosmos HTTP 409).
 /// </summary>
+/// <remarks>
+/// Implements <see cref="IAlreadyExistsException"/>; <c>ExceptionToHttpResultMapper</c> produces HTTP 409 Conflict when this exception is surfaced, whether unwrapped or wrapped by a higher-layer outer exception.
+/// </remarks>
 [Serializable]
 [ExcludeFromCodeCoverage]
 public sealed class InvoiceAlreadyExistsException : Exception, IAlreadyExistsException

--- a/sites/api.arolariu.ro/src/Invoices/DDD/AggregatorRoots/Invoices/Exceptions/Inner/InvoiceCosmosDbRateLimitException.cs
+++ b/sites/api.arolariu.ro/src/Invoices/DDD/AggregatorRoots/Invoices/Exceptions/Inner/InvoiceCosmosDbRateLimitException.cs
@@ -10,6 +10,9 @@ using arolariu.Backend.Common.Exceptions;
 /// Thrown when Cosmos DB returns HTTP 429 (request rate too large). Carries the
 /// recommended retry-after value so the mapper can surface it as a response hint.
 /// </summary>
+/// <remarks>
+/// Implements <see cref="IRateLimitedException"/>; <c>ExceptionToHttpResultMapper</c> produces HTTP 429 Too Many Requests and surfaces the <see cref="RetryAfter"/> value in the <c>retryAfterSeconds</c> ProblemDetails extension.
+/// </remarks>
 [Serializable]
 [ExcludeFromCodeCoverage]
 public sealed class InvoiceCosmosDbRateLimitException : Exception, IRateLimitedException

--- a/sites/api.arolariu.ro/src/Invoices/DDD/AggregatorRoots/Invoices/Exceptions/Inner/InvoiceCosmosDbRateLimitException.cs
+++ b/sites/api.arolariu.ro/src/Invoices/DDD/AggregatorRoots/Invoices/Exceptions/Inner/InvoiceCosmosDbRateLimitException.cs
@@ -17,33 +17,33 @@ using arolariu.Backend.Common.Exceptions;
 [ExcludeFromCodeCoverage]
 public sealed class InvoiceCosmosDbRateLimitException : Exception, IRateLimitedException
 {
-/// <summary>Initializes a new instance of the <see cref="InvoiceCosmosDbRateLimitException"/> class.</summary>
-public InvoiceCosmosDbRateLimitException() { }
+  /// <summary>Initializes a new instance of the <see cref="InvoiceCosmosDbRateLimitException"/> class.</summary>
+  public InvoiceCosmosDbRateLimitException() { }
 
-/// <summary>Initializes a new instance of the <see cref="InvoiceCosmosDbRateLimitException"/> class with retry-after metadata.</summary>
-/// <param name="retryAfter">The recommended retry-after duration from Cosmos DB.</param>
-/// <param name="innerException">The underlying Cosmos exception.</param>
-public InvoiceCosmosDbRateLimitException(TimeSpan retryAfter, Exception innerException)
-: base("Cosmos DB rate limit exceeded (HTTP 429).", innerException)
-{
-RetryAfter = retryAfter;
-}
+  /// <summary>Initializes a new instance of the <see cref="InvoiceCosmosDbRateLimitException"/> class with retry-after metadata.</summary>
+  /// <param name="retryAfter">The recommended retry-after duration from Cosmos DB.</param>
+  /// <param name="innerException">The underlying Cosmos exception.</param>
+  public InvoiceCosmosDbRateLimitException(TimeSpan retryAfter, Exception innerException)
+  : base("Cosmos DB rate limit exceeded (HTTP 429).", innerException)
+  {
+    RetryAfter = retryAfter;
+  }
 
-/// <summary>Initializes a new instance of the <see cref="InvoiceCosmosDbRateLimitException"/> class with a custom message.</summary>
-/// <param name="message">The exception message.</param>
-public InvoiceCosmosDbRateLimitException(string message) : base(message) { }
+  /// <summary>Initializes a new instance of the <see cref="InvoiceCosmosDbRateLimitException"/> class with a custom message.</summary>
+  /// <param name="message">The exception message.</param>
+  public InvoiceCosmosDbRateLimitException(string message) : base(message) { }
 
-/// <summary>Initializes a new instance of the <see cref="InvoiceCosmosDbRateLimitException"/> class with a custom message and inner exception.</summary>
-/// <param name="message">The exception message.</param>
-/// <param name="innerException">The inner exception.</param>
-public InvoiceCosmosDbRateLimitException(string message, Exception innerException)
-: base(message, innerException) { }
+  /// <summary>Initializes a new instance of the <see cref="InvoiceCosmosDbRateLimitException"/> class with a custom message and inner exception.</summary>
+  /// <param name="message">The exception message.</param>
+  /// <param name="innerException">The inner exception.</param>
+  public InvoiceCosmosDbRateLimitException(string message, Exception innerException)
+  : base(message, innerException) { }
 
 #pragma warning disable SYSLIB0051
-private InvoiceCosmosDbRateLimitException(SerializationInfo info, StreamingContext context)
-: base(info, context) { }
+  private InvoiceCosmosDbRateLimitException(SerializationInfo info, StreamingContext context)
+  : base(info, context) { }
 #pragma warning restore SYSLIB0051
 
-/// <summary>Gets the recommended retry-after duration from Cosmos DB.</summary>
-public TimeSpan RetryAfter { get; }
+  /// <summary>Gets the recommended retry-after duration from Cosmos DB.</summary>
+  public TimeSpan RetryAfter { get; }
 }

--- a/sites/api.arolariu.ro/src/Invoices/DDD/AggregatorRoots/Invoices/Exceptions/Inner/InvoiceFailedStorageException.cs
+++ b/sites/api.arolariu.ro/src/Invoices/DDD/AggregatorRoots/Invoices/Exceptions/Inner/InvoiceFailedStorageException.cs
@@ -12,21 +12,21 @@ using System.Runtime.Serialization;
 [ExcludeFromCodeCoverage]
 public sealed class InvoiceFailedStorageException : Exception
 {
-	/// <summary>Initializes a new instance of the <see cref="InvoiceFailedStorageException"/> class.</summary>
-	public InvoiceFailedStorageException() { }
+  /// <summary>Initializes a new instance of the <see cref="InvoiceFailedStorageException"/> class.</summary>
+  public InvoiceFailedStorageException() { }
 
-	/// <summary>Initializes a new instance of the <see cref="InvoiceFailedStorageException"/> class with a custom message.</summary>
-	/// <param name="message">The exception message.</param>
-	public InvoiceFailedStorageException(string message) : base(message) { }
+  /// <summary>Initializes a new instance of the <see cref="InvoiceFailedStorageException"/> class with a custom message.</summary>
+  /// <param name="message">The exception message.</param>
+  public InvoiceFailedStorageException(string message) : base(message) { }
 
-	/// <summary>Initializes a new instance of the <see cref="InvoiceFailedStorageException"/> class with a custom message and inner exception.</summary>
-	/// <param name="message">The exception message.</param>
-	/// <param name="innerException">The inner exception.</param>
-	public InvoiceFailedStorageException(string message, Exception innerException)
-		: base(message, innerException) { }
+  /// <summary>Initializes a new instance of the <see cref="InvoiceFailedStorageException"/> class with a custom message and inner exception.</summary>
+  /// <param name="message">The exception message.</param>
+  /// <param name="innerException">The inner exception.</param>
+  public InvoiceFailedStorageException(string message, Exception innerException)
+      : base(message, innerException) { }
 
 #pragma warning disable SYSLIB0051
-	private InvoiceFailedStorageException(SerializationInfo info, StreamingContext context)
-		: base(info, context) { }
+  private InvoiceFailedStorageException(SerializationInfo info, StreamingContext context)
+      : base(info, context) { }
 #pragma warning restore SYSLIB0051
 }

--- a/sites/api.arolariu.ro/src/Invoices/DDD/AggregatorRoots/Invoices/Exceptions/Inner/InvoiceForbiddenAccessException.cs
+++ b/sites/api.arolariu.ro/src/Invoices/DDD/AggregatorRoots/Invoices/Exceptions/Inner/InvoiceForbiddenAccessException.cs
@@ -10,6 +10,9 @@ using arolariu.Backend.Common.Exceptions;
 /// Thrown when the caller has authenticated but lacks permission for the requested
 /// invoice (e.g., cross-user access). Maps to HTTP 403 Forbidden.
 /// </summary>
+/// <remarks>
+/// Implements <see cref="IForbiddenException"/>; <c>ExceptionToHttpResultMapper</c> produces HTTP 403 Forbidden when this exception is surfaced, whether unwrapped or wrapped by a higher-layer outer exception.
+/// </remarks>
 [Serializable]
 [ExcludeFromCodeCoverage]
 public sealed class InvoiceForbiddenAccessException : Exception, IForbiddenException

--- a/sites/api.arolariu.ro/src/Invoices/DDD/AggregatorRoots/Invoices/Exceptions/Inner/InvoiceForbiddenAccessException.cs
+++ b/sites/api.arolariu.ro/src/Invoices/DDD/AggregatorRoots/Invoices/Exceptions/Inner/InvoiceForbiddenAccessException.cs
@@ -17,37 +17,37 @@ using arolariu.Backend.Common.Exceptions;
 [ExcludeFromCodeCoverage]
 public sealed class InvoiceForbiddenAccessException : Exception, IForbiddenException
 {
-/// <summary>Initializes a new instance of the <see cref="InvoiceForbiddenAccessException"/> class.</summary>
-public InvoiceForbiddenAccessException() { }
+  /// <summary>Initializes a new instance of the <see cref="InvoiceForbiddenAccessException"/> class.</summary>
+  public InvoiceForbiddenAccessException() { }
 
-/// <summary>Initializes a new instance of the <see cref="InvoiceForbiddenAccessException"/> class with invoice and user identifiers.</summary>
-/// <param name="invoiceIdentifier">The identifier of the invoice that the user is forbidden from accessing.</param>
-/// <param name="requestingUserIdentifier">The identifier of the user attempting to access the invoice.</param>
-public InvoiceForbiddenAccessException(Guid invoiceIdentifier, Guid requestingUserIdentifier)
-: base($"User '{requestingUserIdentifier}' is forbidden from accessing invoice '{invoiceIdentifier}'.")
-{
-InvoiceIdentifier = invoiceIdentifier;
-RequestingUserIdentifier = requestingUserIdentifier;
-}
+  /// <summary>Initializes a new instance of the <see cref="InvoiceForbiddenAccessException"/> class with invoice and user identifiers.</summary>
+  /// <param name="invoiceIdentifier">The identifier of the invoice that the user is forbidden from accessing.</param>
+  /// <param name="requestingUserIdentifier">The identifier of the user attempting to access the invoice.</param>
+  public InvoiceForbiddenAccessException(Guid invoiceIdentifier, Guid requestingUserIdentifier)
+  : base($"User '{requestingUserIdentifier}' is forbidden from accessing invoice '{invoiceIdentifier}'.")
+  {
+    InvoiceIdentifier = invoiceIdentifier;
+    RequestingUserIdentifier = requestingUserIdentifier;
+  }
 
-/// <summary>Initializes a new instance of the <see cref="InvoiceForbiddenAccessException"/> class with a custom message.</summary>
-/// <param name="message">The exception message.</param>
-public InvoiceForbiddenAccessException(string message) : base(message) { }
+  /// <summary>Initializes a new instance of the <see cref="InvoiceForbiddenAccessException"/> class with a custom message.</summary>
+  /// <param name="message">The exception message.</param>
+  public InvoiceForbiddenAccessException(string message) : base(message) { }
 
-/// <summary>Initializes a new instance of the <see cref="InvoiceForbiddenAccessException"/> class with a custom message and inner exception.</summary>
-/// <param name="message">The exception message.</param>
-/// <param name="innerException">The inner exception.</param>
-public InvoiceForbiddenAccessException(string message, Exception innerException)
-: base(message, innerException) { }
+  /// <summary>Initializes a new instance of the <see cref="InvoiceForbiddenAccessException"/> class with a custom message and inner exception.</summary>
+  /// <param name="message">The exception message.</param>
+  /// <param name="innerException">The inner exception.</param>
+  public InvoiceForbiddenAccessException(string message, Exception innerException)
+  : base(message, innerException) { }
 
 #pragma warning disable SYSLIB0051
-private InvoiceForbiddenAccessException(SerializationInfo info, StreamingContext context)
-: base(info, context) { }
+  private InvoiceForbiddenAccessException(SerializationInfo info, StreamingContext context)
+  : base(info, context) { }
 #pragma warning restore SYSLIB0051
 
-/// <summary>Gets the identifier of the invoice that the user is forbidden from accessing.</summary>
-public Guid InvoiceIdentifier { get; }
+  /// <summary>Gets the identifier of the invoice that the user is forbidden from accessing.</summary>
+  public Guid InvoiceIdentifier { get; }
 
-/// <summary>Gets the identifier of the user attempting to access the invoice.</summary>
-public Guid RequestingUserIdentifier { get; }
+  /// <summary>Gets the identifier of the user attempting to access the invoice.</summary>
+  public Guid RequestingUserIdentifier { get; }
 }

--- a/sites/api.arolariu.ro/src/Invoices/DDD/AggregatorRoots/Invoices/Exceptions/Inner/InvoiceLockedException.cs
+++ b/sites/api.arolariu.ro/src/Invoices/DDD/AggregatorRoots/Invoices/Exceptions/Inner/InvoiceLockedException.cs
@@ -16,32 +16,32 @@ using arolariu.Backend.Common.Exceptions;
 [ExcludeFromCodeCoverage]
 public sealed class InvoiceLockedException : Exception, ILockedException
 {
-/// <summary>Initializes a new instance of the <see cref="InvoiceLockedException"/> class.</summary>
-public InvoiceLockedException() { }
+  /// <summary>Initializes a new instance of the <see cref="InvoiceLockedException"/> class.</summary>
+  public InvoiceLockedException() { }
 
-/// <summary>Initializes a new instance of the <see cref="InvoiceLockedException"/> class with the specified invoice identifier.</summary>
-/// <param name="invoiceIdentifier">The identifier of the locked invoice.</param>
-public InvoiceLockedException(Guid invoiceIdentifier)
-: base($"Invoice with identifier '{invoiceIdentifier}' is locked (soft-deleted).")
-{
-InvoiceIdentifier = invoiceIdentifier;
-}
+  /// <summary>Initializes a new instance of the <see cref="InvoiceLockedException"/> class with the specified invoice identifier.</summary>
+  /// <param name="invoiceIdentifier">The identifier of the locked invoice.</param>
+  public InvoiceLockedException(Guid invoiceIdentifier)
+  : base($"Invoice with identifier '{invoiceIdentifier}' is locked (soft-deleted).")
+  {
+    InvoiceIdentifier = invoiceIdentifier;
+  }
 
-/// <summary>Initializes a new instance of the <see cref="InvoiceLockedException"/> class with a custom message.</summary>
-/// <param name="message">The exception message.</param>
-public InvoiceLockedException(string message) : base(message) { }
+  /// <summary>Initializes a new instance of the <see cref="InvoiceLockedException"/> class with a custom message.</summary>
+  /// <param name="message">The exception message.</param>
+  public InvoiceLockedException(string message) : base(message) { }
 
-/// <summary>Initializes a new instance of the <see cref="InvoiceLockedException"/> class with a custom message and inner exception.</summary>
-/// <param name="message">The exception message.</param>
-/// <param name="innerException">The inner exception.</param>
-public InvoiceLockedException(string message, Exception innerException)
-: base(message, innerException) { }
+  /// <summary>Initializes a new instance of the <see cref="InvoiceLockedException"/> class with a custom message and inner exception.</summary>
+  /// <param name="message">The exception message.</param>
+  /// <param name="innerException">The inner exception.</param>
+  public InvoiceLockedException(string message, Exception innerException)
+  : base(message, innerException) { }
 
 #pragma warning disable SYSLIB0051
-private InvoiceLockedException(SerializationInfo info, StreamingContext context)
-: base(info, context) { }
+  private InvoiceLockedException(SerializationInfo info, StreamingContext context)
+  : base(info, context) { }
 #pragma warning restore SYSLIB0051
 
-/// <summary>Gets the identifier of the locked invoice.</summary>
-public Guid InvoiceIdentifier { get; }
+  /// <summary>Gets the identifier of the locked invoice.</summary>
+  public Guid InvoiceIdentifier { get; }
 }

--- a/sites/api.arolariu.ro/src/Invoices/DDD/AggregatorRoots/Invoices/Exceptions/Inner/InvoiceLockedException.cs
+++ b/sites/api.arolariu.ro/src/Invoices/DDD/AggregatorRoots/Invoices/Exceptions/Inner/InvoiceLockedException.cs
@@ -9,6 +9,9 @@ using arolariu.Backend.Common.Exceptions;
 /// <summary>
 /// Thrown when an invoice is soft-deleted and cannot be mutated or read through the standard read path. Maps to HTTP 423 Locked.
 /// </summary>
+/// <remarks>
+/// Implements <see cref="ILockedException"/>; <c>ExceptionToHttpResultMapper</c> produces HTTP 423 Locked when this exception is surfaced, whether unwrapped or wrapped by a higher-layer outer exception.
+/// </remarks>
 [Serializable]
 [ExcludeFromCodeCoverage]
 public sealed class InvoiceLockedException : Exception, ILockedException

--- a/sites/api.arolariu.ro/src/Invoices/DDD/AggregatorRoots/Invoices/Exceptions/Inner/InvoiceNotFoundException.cs
+++ b/sites/api.arolariu.ro/src/Invoices/DDD/AggregatorRoots/Invoices/Exceptions/Inner/InvoiceNotFoundException.cs
@@ -9,6 +9,9 @@ using arolariu.Backend.Common.Exceptions;
 /// <summary>
 /// Thrown when an invoice lookup by identifier returns no result from the data store.
 /// </summary>
+/// <remarks>
+/// Implements <see cref="INotFoundException"/>; <c>ExceptionToHttpResultMapper</c> produces HTTP 404 Not Found when this exception is surfaced, whether unwrapped or wrapped by a Foundation/Orchestration/Processing outer exception.
+/// </remarks>
 [Serializable]
 [ExcludeFromCodeCoverage]
 public sealed class InvoiceNotFoundException : Exception, INotFoundException

--- a/sites/api.arolariu.ro/src/Invoices/DDD/AggregatorRoots/Invoices/Exceptions/Inner/InvoiceNotFoundException.cs
+++ b/sites/api.arolariu.ro/src/Invoices/DDD/AggregatorRoots/Invoices/Exceptions/Inner/InvoiceNotFoundException.cs
@@ -16,41 +16,41 @@ using arolariu.Backend.Common.Exceptions;
 [ExcludeFromCodeCoverage]
 public sealed class InvoiceNotFoundException : Exception, INotFoundException
 {
-/// <summary>Initializes a new instance of the <see cref="InvoiceNotFoundException"/> class.</summary>
-public InvoiceNotFoundException() { }
+  /// <summary>Initializes a new instance of the <see cref="InvoiceNotFoundException"/> class.</summary>
+  public InvoiceNotFoundException() { }
 
-/// <summary>Initializes a new instance of the <see cref="InvoiceNotFoundException"/> class with the specified invoice identifier.</summary>
-/// <param name="invoiceIdentifier">The identifier of the invoice that was not found.</param>
-public InvoiceNotFoundException(Guid invoiceIdentifier)
-: base($"Invoice with identifier '{invoiceIdentifier}' was not found.")
-{
-InvoiceIdentifier = invoiceIdentifier;
-}
+  /// <summary>Initializes a new instance of the <see cref="InvoiceNotFoundException"/> class with the specified invoice identifier.</summary>
+  /// <param name="invoiceIdentifier">The identifier of the invoice that was not found.</param>
+  public InvoiceNotFoundException(Guid invoiceIdentifier)
+  : base($"Invoice with identifier '{invoiceIdentifier}' was not found.")
+  {
+    InvoiceIdentifier = invoiceIdentifier;
+  }
 
-/// <summary>Initializes a new instance of the <see cref="InvoiceNotFoundException"/> class with the specified invoice identifier and inner exception.</summary>
-/// <param name="invoiceIdentifier">The identifier of the invoice that was not found.</param>
-/// <param name="innerException">The inner exception.</param>
-public InvoiceNotFoundException(Guid invoiceIdentifier, Exception innerException)
-: base($"Invoice with identifier '{invoiceIdentifier}' was not found.", innerException)
-{
-InvoiceIdentifier = invoiceIdentifier;
-}
+  /// <summary>Initializes a new instance of the <see cref="InvoiceNotFoundException"/> class with the specified invoice identifier and inner exception.</summary>
+  /// <param name="invoiceIdentifier">The identifier of the invoice that was not found.</param>
+  /// <param name="innerException">The inner exception.</param>
+  public InvoiceNotFoundException(Guid invoiceIdentifier, Exception innerException)
+  : base($"Invoice with identifier '{invoiceIdentifier}' was not found.", innerException)
+  {
+    InvoiceIdentifier = invoiceIdentifier;
+  }
 
-/// <summary>Initializes a new instance of the <see cref="InvoiceNotFoundException"/> class with a custom message.</summary>
-/// <param name="message">The exception message.</param>
-public InvoiceNotFoundException(string message) : base(message) { }
+  /// <summary>Initializes a new instance of the <see cref="InvoiceNotFoundException"/> class with a custom message.</summary>
+  /// <param name="message">The exception message.</param>
+  public InvoiceNotFoundException(string message) : base(message) { }
 
-/// <summary>Initializes a new instance of the <see cref="InvoiceNotFoundException"/> class with a custom message and inner exception.</summary>
-/// <param name="message">The exception message.</param>
-/// <param name="innerException">The inner exception.</param>
-public InvoiceNotFoundException(string message, Exception innerException)
-: base(message, innerException) { }
+  /// <summary>Initializes a new instance of the <see cref="InvoiceNotFoundException"/> class with a custom message and inner exception.</summary>
+  /// <param name="message">The exception message.</param>
+  /// <param name="innerException">The inner exception.</param>
+  public InvoiceNotFoundException(string message, Exception innerException)
+  : base(message, innerException) { }
 
 #pragma warning disable SYSLIB0051
-private InvoiceNotFoundException(SerializationInfo info, StreamingContext context)
-: base(info, context) { }
+  private InvoiceNotFoundException(SerializationInfo info, StreamingContext context)
+  : base(info, context) { }
 #pragma warning restore SYSLIB0051
 
-/// <summary>Gets the identifier of the invoice that was not found.</summary>
-public Guid InvoiceIdentifier { get; }
+  /// <summary>Gets the identifier of the invoice that was not found.</summary>
+  public Guid InvoiceIdentifier { get; }
 }

--- a/sites/api.arolariu.ro/src/Invoices/DDD/AggregatorRoots/Invoices/Exceptions/Inner/InvoiceUnauthorizedAccessException.cs
+++ b/sites/api.arolariu.ro/src/Invoices/DDD/AggregatorRoots/Invoices/Exceptions/Inner/InvoiceUnauthorizedAccessException.cs
@@ -9,6 +9,9 @@ using arolariu.Backend.Common.Exceptions;
 /// <summary>
 /// Thrown when the dependency rejects the request due to missing/invalid authentication (HTTP 401 at Cosmos or downstream boundary).
 /// </summary>
+/// <remarks>
+/// Implements <see cref="IUnauthorizedException"/>; <c>ExceptionToHttpResultMapper</c> produces HTTP 401 Unauthorized when this exception is surfaced, whether unwrapped or wrapped by a higher-layer outer exception.
+/// </remarks>
 [Serializable]
 [ExcludeFromCodeCoverage]
 public sealed class InvoiceUnauthorizedAccessException : Exception, IUnauthorizedException

--- a/sites/api.arolariu.ro/src/Invoices/DDD/AggregatorRoots/Invoices/Exceptions/Inner/InvoiceUnauthorizedAccessException.cs
+++ b/sites/api.arolariu.ro/src/Invoices/DDD/AggregatorRoots/Invoices/Exceptions/Inner/InvoiceUnauthorizedAccessException.cs
@@ -16,21 +16,21 @@ using arolariu.Backend.Common.Exceptions;
 [ExcludeFromCodeCoverage]
 public sealed class InvoiceUnauthorizedAccessException : Exception, IUnauthorizedException
 {
-/// <summary>Initializes a new instance of the <see cref="InvoiceUnauthorizedAccessException"/> class.</summary>
-public InvoiceUnauthorizedAccessException() { }
+  /// <summary>Initializes a new instance of the <see cref="InvoiceUnauthorizedAccessException"/> class.</summary>
+  public InvoiceUnauthorizedAccessException() { }
 
-/// <summary>Initializes a new instance of the <see cref="InvoiceUnauthorizedAccessException"/> class with a custom message.</summary>
-/// <param name="message">The exception message.</param>
-public InvoiceUnauthorizedAccessException(string message) : base(message) { }
+  /// <summary>Initializes a new instance of the <see cref="InvoiceUnauthorizedAccessException"/> class with a custom message.</summary>
+  /// <param name="message">The exception message.</param>
+  public InvoiceUnauthorizedAccessException(string message) : base(message) { }
 
-/// <summary>Initializes a new instance of the <see cref="InvoiceUnauthorizedAccessException"/> class with a custom message and inner exception.</summary>
-/// <param name="message">The exception message.</param>
-/// <param name="innerException">The inner exception.</param>
-public InvoiceUnauthorizedAccessException(string message, Exception innerException)
-: base(message, innerException) { }
+  /// <summary>Initializes a new instance of the <see cref="InvoiceUnauthorizedAccessException"/> class with a custom message and inner exception.</summary>
+  /// <param name="message">The exception message.</param>
+  /// <param name="innerException">The inner exception.</param>
+  public InvoiceUnauthorizedAccessException(string message, Exception innerException)
+  : base(message, innerException) { }
 
 #pragma warning disable SYSLIB0051
-private InvoiceUnauthorizedAccessException(SerializationInfo info, StreamingContext context)
-: base(info, context) { }
+  private InvoiceUnauthorizedAccessException(SerializationInfo info, StreamingContext context)
+  : base(info, context) { }
 #pragma warning restore SYSLIB0051
 }

--- a/sites/api.arolariu.ro/src/Invoices/DDD/Entities/Merchants/Exceptions/Inner/MerchantAlreadyExistsException.cs
+++ b/sites/api.arolariu.ro/src/Invoices/DDD/Entities/Merchants/Exceptions/Inner/MerchantAlreadyExistsException.cs
@@ -16,41 +16,41 @@ using arolariu.Backend.Common.Exceptions;
 [ExcludeFromCodeCoverage]
 public sealed class MerchantAlreadyExistsException : Exception, IAlreadyExistsException
 {
-/// <summary>Initializes a new instance of the <see cref="MerchantAlreadyExistsException"/> class.</summary>
-public MerchantAlreadyExistsException() { }
+  /// <summary>Initializes a new instance of the <see cref="MerchantAlreadyExistsException"/> class.</summary>
+  public MerchantAlreadyExistsException() { }
 
-/// <summary>Initializes a new instance of the <see cref="MerchantAlreadyExistsException"/> class with the specified merchant identifier.</summary>
-/// <param name="merchantIdentifier">The identifier of the merchant that already exists.</param>
-public MerchantAlreadyExistsException(Guid merchantIdentifier)
-: base($"Merchant with identifier '{merchantIdentifier}' already exists.")
-{
-MerchantIdentifier = merchantIdentifier;
-}
+  /// <summary>Initializes a new instance of the <see cref="MerchantAlreadyExistsException"/> class with the specified merchant identifier.</summary>
+  /// <param name="merchantIdentifier">The identifier of the merchant that already exists.</param>
+  public MerchantAlreadyExistsException(Guid merchantIdentifier)
+  : base($"Merchant with identifier '{merchantIdentifier}' already exists.")
+  {
+    MerchantIdentifier = merchantIdentifier;
+  }
 
-/// <summary>Initializes a new instance of the <see cref="MerchantAlreadyExistsException"/> class with the specified merchant identifier and inner exception.</summary>
-/// <param name="merchantIdentifier">The identifier of the merchant that already exists.</param>
-/// <param name="innerException">The inner exception.</param>
-public MerchantAlreadyExistsException(Guid merchantIdentifier, Exception innerException)
-: base($"Merchant with identifier '{merchantIdentifier}' already exists.", innerException)
-{
-MerchantIdentifier = merchantIdentifier;
-}
+  /// <summary>Initializes a new instance of the <see cref="MerchantAlreadyExistsException"/> class with the specified merchant identifier and inner exception.</summary>
+  /// <param name="merchantIdentifier">The identifier of the merchant that already exists.</param>
+  /// <param name="innerException">The inner exception.</param>
+  public MerchantAlreadyExistsException(Guid merchantIdentifier, Exception innerException)
+  : base($"Merchant with identifier '{merchantIdentifier}' already exists.", innerException)
+  {
+    MerchantIdentifier = merchantIdentifier;
+  }
 
-/// <summary>Initializes a new instance of the <see cref="MerchantAlreadyExistsException"/> class with a custom message.</summary>
-/// <param name="message">The exception message.</param>
-public MerchantAlreadyExistsException(string message) : base(message) { }
+  /// <summary>Initializes a new instance of the <see cref="MerchantAlreadyExistsException"/> class with a custom message.</summary>
+  /// <param name="message">The exception message.</param>
+  public MerchantAlreadyExistsException(string message) : base(message) { }
 
-/// <summary>Initializes a new instance of the <see cref="MerchantAlreadyExistsException"/> class with a custom message and inner exception.</summary>
-/// <param name="message">The exception message.</param>
-/// <param name="innerException">The inner exception.</param>
-public MerchantAlreadyExistsException(string message, Exception innerException)
-: base(message, innerException) { }
+  /// <summary>Initializes a new instance of the <see cref="MerchantAlreadyExistsException"/> class with a custom message and inner exception.</summary>
+  /// <param name="message">The exception message.</param>
+  /// <param name="innerException">The inner exception.</param>
+  public MerchantAlreadyExistsException(string message, Exception innerException)
+  : base(message, innerException) { }
 
 #pragma warning disable SYSLIB0051
-private MerchantAlreadyExistsException(SerializationInfo info, StreamingContext context)
-: base(info, context) { }
+  private MerchantAlreadyExistsException(SerializationInfo info, StreamingContext context)
+  : base(info, context) { }
 #pragma warning restore SYSLIB0051
 
-/// <summary>Gets the identifier of the merchant that already exists.</summary>
-public Guid MerchantIdentifier { get; }
+  /// <summary>Gets the identifier of the merchant that already exists.</summary>
+  public Guid MerchantIdentifier { get; }
 }

--- a/sites/api.arolariu.ro/src/Invoices/DDD/Entities/Merchants/Exceptions/Inner/MerchantAlreadyExistsException.cs
+++ b/sites/api.arolariu.ro/src/Invoices/DDD/Entities/Merchants/Exceptions/Inner/MerchantAlreadyExistsException.cs
@@ -9,6 +9,9 @@ using arolariu.Backend.Common.Exceptions;
 /// <summary>
 /// Thrown when attempting to create a merchant with an identifier that already exists in the data store (Cosmos HTTP 409).
 /// </summary>
+/// <remarks>
+/// Implements <see cref="IAlreadyExistsException"/>; <c>ExceptionToHttpResultMapper</c> produces HTTP 409 Conflict when this exception is surfaced, whether unwrapped or wrapped by a higher-layer outer exception.
+/// </remarks>
 [Serializable]
 [ExcludeFromCodeCoverage]
 public sealed class MerchantAlreadyExistsException : Exception, IAlreadyExistsException

--- a/sites/api.arolariu.ro/src/Invoices/DDD/Entities/Merchants/Exceptions/Inner/MerchantCosmosDbRateLimitException.cs
+++ b/sites/api.arolariu.ro/src/Invoices/DDD/Entities/Merchants/Exceptions/Inner/MerchantCosmosDbRateLimitException.cs
@@ -10,6 +10,9 @@ using arolariu.Backend.Common.Exceptions;
 /// Thrown when Cosmos DB returns HTTP 429 (request rate too large). Carries the
 /// recommended retry-after value so the mapper can surface it as a response hint.
 /// </summary>
+/// <remarks>
+/// Implements <see cref="IRateLimitedException"/>; <c>ExceptionToHttpResultMapper</c> produces HTTP 429 Too Many Requests and surfaces the <see cref="RetryAfter"/> value in the <c>retryAfterSeconds</c> ProblemDetails extension.
+/// </remarks>
 [Serializable]
 [ExcludeFromCodeCoverage]
 public sealed class MerchantCosmosDbRateLimitException : Exception, IRateLimitedException

--- a/sites/api.arolariu.ro/src/Invoices/DDD/Entities/Merchants/Exceptions/Inner/MerchantCosmosDbRateLimitException.cs
+++ b/sites/api.arolariu.ro/src/Invoices/DDD/Entities/Merchants/Exceptions/Inner/MerchantCosmosDbRateLimitException.cs
@@ -17,33 +17,33 @@ using arolariu.Backend.Common.Exceptions;
 [ExcludeFromCodeCoverage]
 public sealed class MerchantCosmosDbRateLimitException : Exception, IRateLimitedException
 {
-/// <summary>Initializes a new instance of the <see cref="MerchantCosmosDbRateLimitException"/> class.</summary>
-public MerchantCosmosDbRateLimitException() { }
+  /// <summary>Initializes a new instance of the <see cref="MerchantCosmosDbRateLimitException"/> class.</summary>
+  public MerchantCosmosDbRateLimitException() { }
 
-/// <summary>Initializes a new instance of the <see cref="MerchantCosmosDbRateLimitException"/> class with retry-after metadata.</summary>
-/// <param name="retryAfter">The recommended retry-after duration from Cosmos DB.</param>
-/// <param name="innerException">The underlying Cosmos exception.</param>
-public MerchantCosmosDbRateLimitException(TimeSpan retryAfter, Exception innerException)
-: base("Cosmos DB rate limit exceeded (HTTP 429).", innerException)
-{
-RetryAfter = retryAfter;
-}
+  /// <summary>Initializes a new instance of the <see cref="MerchantCosmosDbRateLimitException"/> class with retry-after metadata.</summary>
+  /// <param name="retryAfter">The recommended retry-after duration from Cosmos DB.</param>
+  /// <param name="innerException">The underlying Cosmos exception.</param>
+  public MerchantCosmosDbRateLimitException(TimeSpan retryAfter, Exception innerException)
+  : base("Cosmos DB rate limit exceeded (HTTP 429).", innerException)
+  {
+    RetryAfter = retryAfter;
+  }
 
-/// <summary>Initializes a new instance of the <see cref="MerchantCosmosDbRateLimitException"/> class with a custom message.</summary>
-/// <param name="message">The exception message.</param>
-public MerchantCosmosDbRateLimitException(string message) : base(message) { }
+  /// <summary>Initializes a new instance of the <see cref="MerchantCosmosDbRateLimitException"/> class with a custom message.</summary>
+  /// <param name="message">The exception message.</param>
+  public MerchantCosmosDbRateLimitException(string message) : base(message) { }
 
-/// <summary>Initializes a new instance of the <see cref="MerchantCosmosDbRateLimitException"/> class with a custom message and inner exception.</summary>
-/// <param name="message">The exception message.</param>
-/// <param name="innerException">The inner exception.</param>
-public MerchantCosmosDbRateLimitException(string message, Exception innerException)
-: base(message, innerException) { }
+  /// <summary>Initializes a new instance of the <see cref="MerchantCosmosDbRateLimitException"/> class with a custom message and inner exception.</summary>
+  /// <param name="message">The exception message.</param>
+  /// <param name="innerException">The inner exception.</param>
+  public MerchantCosmosDbRateLimitException(string message, Exception innerException)
+  : base(message, innerException) { }
 
 #pragma warning disable SYSLIB0051
-private MerchantCosmosDbRateLimitException(SerializationInfo info, StreamingContext context)
-: base(info, context) { }
+  private MerchantCosmosDbRateLimitException(SerializationInfo info, StreamingContext context)
+  : base(info, context) { }
 #pragma warning restore SYSLIB0051
 
-/// <summary>Gets the recommended retry-after duration from Cosmos DB.</summary>
-public TimeSpan RetryAfter { get; }
+  /// <summary>Gets the recommended retry-after duration from Cosmos DB.</summary>
+  public TimeSpan RetryAfter { get; }
 }

--- a/sites/api.arolariu.ro/src/Invoices/DDD/Entities/Merchants/Exceptions/Inner/MerchantFailedStorageException.cs
+++ b/sites/api.arolariu.ro/src/Invoices/DDD/Entities/Merchants/Exceptions/Inner/MerchantFailedStorageException.cs
@@ -12,21 +12,21 @@ using System.Runtime.Serialization;
 [ExcludeFromCodeCoverage]
 public sealed class MerchantFailedStorageException : Exception
 {
-	/// <summary>Initializes a new instance of the <see cref="MerchantFailedStorageException"/> class.</summary>
-	public MerchantFailedStorageException() { }
+  /// <summary>Initializes a new instance of the <see cref="MerchantFailedStorageException"/> class.</summary>
+  public MerchantFailedStorageException() { }
 
-	/// <summary>Initializes a new instance of the <see cref="MerchantFailedStorageException"/> class with a custom message.</summary>
-	/// <param name="message">The exception message.</param>
-	public MerchantFailedStorageException(string message) : base(message) { }
+  /// <summary>Initializes a new instance of the <see cref="MerchantFailedStorageException"/> class with a custom message.</summary>
+  /// <param name="message">The exception message.</param>
+  public MerchantFailedStorageException(string message) : base(message) { }
 
-	/// <summary>Initializes a new instance of the <see cref="MerchantFailedStorageException"/> class with a custom message and inner exception.</summary>
-	/// <param name="message">The exception message.</param>
-	/// <param name="innerException">The inner exception.</param>
-	public MerchantFailedStorageException(string message, Exception innerException)
-		: base(message, innerException) { }
+  /// <summary>Initializes a new instance of the <see cref="MerchantFailedStorageException"/> class with a custom message and inner exception.</summary>
+  /// <param name="message">The exception message.</param>
+  /// <param name="innerException">The inner exception.</param>
+  public MerchantFailedStorageException(string message, Exception innerException)
+      : base(message, innerException) { }
 
 #pragma warning disable SYSLIB0051
-	private MerchantFailedStorageException(SerializationInfo info, StreamingContext context)
-		: base(info, context) { }
+  private MerchantFailedStorageException(SerializationInfo info, StreamingContext context)
+      : base(info, context) { }
 #pragma warning restore SYSLIB0051
 }

--- a/sites/api.arolariu.ro/src/Invoices/DDD/Entities/Merchants/Exceptions/Inner/MerchantForbiddenAccessException.cs
+++ b/sites/api.arolariu.ro/src/Invoices/DDD/Entities/Merchants/Exceptions/Inner/MerchantForbiddenAccessException.cs
@@ -17,37 +17,37 @@ using arolariu.Backend.Common.Exceptions;
 [ExcludeFromCodeCoverage]
 public sealed class MerchantForbiddenAccessException : Exception, IForbiddenException
 {
-/// <summary>Initializes a new instance of the <see cref="MerchantForbiddenAccessException"/> class.</summary>
-public MerchantForbiddenAccessException() { }
+  /// <summary>Initializes a new instance of the <see cref="MerchantForbiddenAccessException"/> class.</summary>
+  public MerchantForbiddenAccessException() { }
 
-/// <summary>Initializes a new instance of the <see cref="MerchantForbiddenAccessException"/> class with merchant and user identifiers.</summary>
-/// <param name="merchantIdentifier">The identifier of the merchant that the user is forbidden from accessing.</param>
-/// <param name="requestingUserIdentifier">The identifier of the user attempting to access the merchant.</param>
-public MerchantForbiddenAccessException(Guid merchantIdentifier, Guid requestingUserIdentifier)
-: base($"User '{requestingUserIdentifier}' is forbidden from accessing merchant '{merchantIdentifier}'.")
-{
-MerchantIdentifier = merchantIdentifier;
-RequestingUserIdentifier = requestingUserIdentifier;
-}
+  /// <summary>Initializes a new instance of the <see cref="MerchantForbiddenAccessException"/> class with merchant and user identifiers.</summary>
+  /// <param name="merchantIdentifier">The identifier of the merchant that the user is forbidden from accessing.</param>
+  /// <param name="requestingUserIdentifier">The identifier of the user attempting to access the merchant.</param>
+  public MerchantForbiddenAccessException(Guid merchantIdentifier, Guid requestingUserIdentifier)
+  : base($"User '{requestingUserIdentifier}' is forbidden from accessing merchant '{merchantIdentifier}'.")
+  {
+    MerchantIdentifier = merchantIdentifier;
+    RequestingUserIdentifier = requestingUserIdentifier;
+  }
 
-/// <summary>Initializes a new instance of the <see cref="MerchantForbiddenAccessException"/> class with a custom message.</summary>
-/// <param name="message">The exception message.</param>
-public MerchantForbiddenAccessException(string message) : base(message) { }
+  /// <summary>Initializes a new instance of the <see cref="MerchantForbiddenAccessException"/> class with a custom message.</summary>
+  /// <param name="message">The exception message.</param>
+  public MerchantForbiddenAccessException(string message) : base(message) { }
 
-/// <summary>Initializes a new instance of the <see cref="MerchantForbiddenAccessException"/> class with a custom message and inner exception.</summary>
-/// <param name="message">The exception message.</param>
-/// <param name="innerException">The inner exception.</param>
-public MerchantForbiddenAccessException(string message, Exception innerException)
-: base(message, innerException) { }
+  /// <summary>Initializes a new instance of the <see cref="MerchantForbiddenAccessException"/> class with a custom message and inner exception.</summary>
+  /// <param name="message">The exception message.</param>
+  /// <param name="innerException">The inner exception.</param>
+  public MerchantForbiddenAccessException(string message, Exception innerException)
+  : base(message, innerException) { }
 
 #pragma warning disable SYSLIB0051
-private MerchantForbiddenAccessException(SerializationInfo info, StreamingContext context)
-: base(info, context) { }
+  private MerchantForbiddenAccessException(SerializationInfo info, StreamingContext context)
+  : base(info, context) { }
 #pragma warning restore SYSLIB0051
 
-/// <summary>Gets the identifier of the merchant that the user is forbidden from accessing.</summary>
-public Guid MerchantIdentifier { get; }
+  /// <summary>Gets the identifier of the merchant that the user is forbidden from accessing.</summary>
+  public Guid MerchantIdentifier { get; }
 
-/// <summary>Gets the identifier of the user attempting to access the merchant.</summary>
-public Guid RequestingUserIdentifier { get; }
+  /// <summary>Gets the identifier of the user attempting to access the merchant.</summary>
+  public Guid RequestingUserIdentifier { get; }
 }

--- a/sites/api.arolariu.ro/src/Invoices/DDD/Entities/Merchants/Exceptions/Inner/MerchantForbiddenAccessException.cs
+++ b/sites/api.arolariu.ro/src/Invoices/DDD/Entities/Merchants/Exceptions/Inner/MerchantForbiddenAccessException.cs
@@ -10,6 +10,9 @@ using arolariu.Backend.Common.Exceptions;
 /// Thrown when the caller has authenticated but lacks permission for the requested
 /// merchant (e.g., cross-user access). Maps to HTTP 403 Forbidden.
 /// </summary>
+/// <remarks>
+/// Implements <see cref="IForbiddenException"/>; <c>ExceptionToHttpResultMapper</c> produces HTTP 403 Forbidden when this exception is surfaced, whether unwrapped or wrapped by a higher-layer outer exception.
+/// </remarks>
 [Serializable]
 [ExcludeFromCodeCoverage]
 public sealed class MerchantForbiddenAccessException : Exception, IForbiddenException

--- a/sites/api.arolariu.ro/src/Invoices/DDD/Entities/Merchants/Exceptions/Inner/MerchantLockedException.cs
+++ b/sites/api.arolariu.ro/src/Invoices/DDD/Entities/Merchants/Exceptions/Inner/MerchantLockedException.cs
@@ -16,32 +16,32 @@ using arolariu.Backend.Common.Exceptions;
 [ExcludeFromCodeCoverage]
 public sealed class MerchantLockedException : Exception, ILockedException
 {
-/// <summary>Initializes a new instance of the <see cref="MerchantLockedException"/> class.</summary>
-public MerchantLockedException() { }
+  /// <summary>Initializes a new instance of the <see cref="MerchantLockedException"/> class.</summary>
+  public MerchantLockedException() { }
 
-/// <summary>Initializes a new instance of the <see cref="MerchantLockedException"/> class with the specified merchant identifier.</summary>
-/// <param name="merchantIdentifier">The identifier of the locked merchant.</param>
-public MerchantLockedException(Guid merchantIdentifier)
-: base($"Merchant with identifier '{merchantIdentifier}' is locked (soft-deleted).")
-{
-MerchantIdentifier = merchantIdentifier;
-}
+  /// <summary>Initializes a new instance of the <see cref="MerchantLockedException"/> class with the specified merchant identifier.</summary>
+  /// <param name="merchantIdentifier">The identifier of the locked merchant.</param>
+  public MerchantLockedException(Guid merchantIdentifier)
+  : base($"Merchant with identifier '{merchantIdentifier}' is locked (soft-deleted).")
+  {
+    MerchantIdentifier = merchantIdentifier;
+  }
 
-/// <summary>Initializes a new instance of the <see cref="MerchantLockedException"/> class with a custom message.</summary>
-/// <param name="message">The exception message.</param>
-public MerchantLockedException(string message) : base(message) { }
+  /// <summary>Initializes a new instance of the <see cref="MerchantLockedException"/> class with a custom message.</summary>
+  /// <param name="message">The exception message.</param>
+  public MerchantLockedException(string message) : base(message) { }
 
-/// <summary>Initializes a new instance of the <see cref="MerchantLockedException"/> class with a custom message and inner exception.</summary>
-/// <param name="message">The exception message.</param>
-/// <param name="innerException">The inner exception.</param>
-public MerchantLockedException(string message, Exception innerException)
-: base(message, innerException) { }
+  /// <summary>Initializes a new instance of the <see cref="MerchantLockedException"/> class with a custom message and inner exception.</summary>
+  /// <param name="message">The exception message.</param>
+  /// <param name="innerException">The inner exception.</param>
+  public MerchantLockedException(string message, Exception innerException)
+  : base(message, innerException) { }
 
 #pragma warning disable SYSLIB0051
-private MerchantLockedException(SerializationInfo info, StreamingContext context)
-: base(info, context) { }
+  private MerchantLockedException(SerializationInfo info, StreamingContext context)
+  : base(info, context) { }
 #pragma warning restore SYSLIB0051
 
-/// <summary>Gets the identifier of the locked merchant.</summary>
-public Guid MerchantIdentifier { get; }
+  /// <summary>Gets the identifier of the locked merchant.</summary>
+  public Guid MerchantIdentifier { get; }
 }

--- a/sites/api.arolariu.ro/src/Invoices/DDD/Entities/Merchants/Exceptions/Inner/MerchantLockedException.cs
+++ b/sites/api.arolariu.ro/src/Invoices/DDD/Entities/Merchants/Exceptions/Inner/MerchantLockedException.cs
@@ -9,6 +9,9 @@ using arolariu.Backend.Common.Exceptions;
 /// <summary>
 /// Thrown when a merchant is soft-deleted and cannot be mutated or read through the standard read path. Maps to HTTP 423 Locked.
 /// </summary>
+/// <remarks>
+/// Implements <see cref="ILockedException"/>; <c>ExceptionToHttpResultMapper</c> produces HTTP 423 Locked when this exception is surfaced, whether unwrapped or wrapped by a higher-layer outer exception.
+/// </remarks>
 [Serializable]
 [ExcludeFromCodeCoverage]
 public sealed class MerchantLockedException : Exception, ILockedException

--- a/sites/api.arolariu.ro/src/Invoices/DDD/Entities/Merchants/Exceptions/Inner/MerchantNotFoundException.cs
+++ b/sites/api.arolariu.ro/src/Invoices/DDD/Entities/Merchants/Exceptions/Inner/MerchantNotFoundException.cs
@@ -16,41 +16,41 @@ using arolariu.Backend.Common.Exceptions;
 [ExcludeFromCodeCoverage]
 public sealed class MerchantNotFoundException : Exception, INotFoundException
 {
-/// <summary>Initializes a new instance of the <see cref="MerchantNotFoundException"/> class.</summary>
-public MerchantNotFoundException() { }
+  /// <summary>Initializes a new instance of the <see cref="MerchantNotFoundException"/> class.</summary>
+  public MerchantNotFoundException() { }
 
-/// <summary>Initializes a new instance of the <see cref="MerchantNotFoundException"/> class with the specified merchant identifier.</summary>
-/// <param name="merchantIdentifier">The identifier of the merchant that was not found.</param>
-public MerchantNotFoundException(Guid merchantIdentifier)
-: base($"Merchant with identifier '{merchantIdentifier}' was not found.")
-{
-MerchantIdentifier = merchantIdentifier;
-}
+  /// <summary>Initializes a new instance of the <see cref="MerchantNotFoundException"/> class with the specified merchant identifier.</summary>
+  /// <param name="merchantIdentifier">The identifier of the merchant that was not found.</param>
+  public MerchantNotFoundException(Guid merchantIdentifier)
+  : base($"Merchant with identifier '{merchantIdentifier}' was not found.")
+  {
+    MerchantIdentifier = merchantIdentifier;
+  }
 
-/// <summary>Initializes a new instance of the <see cref="MerchantNotFoundException"/> class with the specified merchant identifier and inner exception.</summary>
-/// <param name="merchantIdentifier">The identifier of the merchant that was not found.</param>
-/// <param name="innerException">The inner exception.</param>
-public MerchantNotFoundException(Guid merchantIdentifier, Exception innerException)
-: base($"Merchant with identifier '{merchantIdentifier}' was not found.", innerException)
-{
-MerchantIdentifier = merchantIdentifier;
-}
+  /// <summary>Initializes a new instance of the <see cref="MerchantNotFoundException"/> class with the specified merchant identifier and inner exception.</summary>
+  /// <param name="merchantIdentifier">The identifier of the merchant that was not found.</param>
+  /// <param name="innerException">The inner exception.</param>
+  public MerchantNotFoundException(Guid merchantIdentifier, Exception innerException)
+  : base($"Merchant with identifier '{merchantIdentifier}' was not found.", innerException)
+  {
+    MerchantIdentifier = merchantIdentifier;
+  }
 
-/// <summary>Initializes a new instance of the <see cref="MerchantNotFoundException"/> class with a custom message.</summary>
-/// <param name="message">The exception message.</param>
-public MerchantNotFoundException(string message) : base(message) { }
+  /// <summary>Initializes a new instance of the <see cref="MerchantNotFoundException"/> class with a custom message.</summary>
+  /// <param name="message">The exception message.</param>
+  public MerchantNotFoundException(string message) : base(message) { }
 
-/// <summary>Initializes a new instance of the <see cref="MerchantNotFoundException"/> class with a custom message and inner exception.</summary>
-/// <param name="message">The exception message.</param>
-/// <param name="innerException">The inner exception.</param>
-public MerchantNotFoundException(string message, Exception innerException)
-: base(message, innerException) { }
+  /// <summary>Initializes a new instance of the <see cref="MerchantNotFoundException"/> class with a custom message and inner exception.</summary>
+  /// <param name="message">The exception message.</param>
+  /// <param name="innerException">The inner exception.</param>
+  public MerchantNotFoundException(string message, Exception innerException)
+  : base(message, innerException) { }
 
 #pragma warning disable SYSLIB0051
-private MerchantNotFoundException(SerializationInfo info, StreamingContext context)
-: base(info, context) { }
+  private MerchantNotFoundException(SerializationInfo info, StreamingContext context)
+  : base(info, context) { }
 #pragma warning restore SYSLIB0051
 
-/// <summary>Gets the identifier of the merchant that was not found.</summary>
-public Guid MerchantIdentifier { get; }
+  /// <summary>Gets the identifier of the merchant that was not found.</summary>
+  public Guid MerchantIdentifier { get; }
 }

--- a/sites/api.arolariu.ro/src/Invoices/DDD/Entities/Merchants/Exceptions/Inner/MerchantNotFoundException.cs
+++ b/sites/api.arolariu.ro/src/Invoices/DDD/Entities/Merchants/Exceptions/Inner/MerchantNotFoundException.cs
@@ -9,6 +9,9 @@ using arolariu.Backend.Common.Exceptions;
 /// <summary>
 /// Thrown when a merchant lookup by identifier returns no result from the data store.
 /// </summary>
+/// <remarks>
+/// Implements <see cref="INotFoundException"/>; <c>ExceptionToHttpResultMapper</c> produces HTTP 404 Not Found when this exception is surfaced, whether unwrapped or wrapped by a Foundation/Orchestration/Processing outer exception.
+/// </remarks>
 [Serializable]
 [ExcludeFromCodeCoverage]
 public sealed class MerchantNotFoundException : Exception, INotFoundException

--- a/sites/api.arolariu.ro/src/Invoices/DDD/Entities/Merchants/Exceptions/Inner/MerchantUnauthorizedAccessException.cs
+++ b/sites/api.arolariu.ro/src/Invoices/DDD/Entities/Merchants/Exceptions/Inner/MerchantUnauthorizedAccessException.cs
@@ -9,6 +9,9 @@ using arolariu.Backend.Common.Exceptions;
 /// <summary>
 /// Thrown when the dependency rejects the request due to missing/invalid authentication (HTTP 401 at Cosmos or downstream boundary).
 /// </summary>
+/// <remarks>
+/// Implements <see cref="IUnauthorizedException"/>; <c>ExceptionToHttpResultMapper</c> produces HTTP 401 Unauthorized when this exception is surfaced, whether unwrapped or wrapped by a higher-layer outer exception.
+/// </remarks>
 [Serializable]
 [ExcludeFromCodeCoverage]
 public sealed class MerchantUnauthorizedAccessException : Exception, IUnauthorizedException

--- a/sites/api.arolariu.ro/src/Invoices/DDD/Entities/Merchants/Exceptions/Inner/MerchantUnauthorizedAccessException.cs
+++ b/sites/api.arolariu.ro/src/Invoices/DDD/Entities/Merchants/Exceptions/Inner/MerchantUnauthorizedAccessException.cs
@@ -16,21 +16,21 @@ using arolariu.Backend.Common.Exceptions;
 [ExcludeFromCodeCoverage]
 public sealed class MerchantUnauthorizedAccessException : Exception, IUnauthorizedException
 {
-/// <summary>Initializes a new instance of the <see cref="MerchantUnauthorizedAccessException"/> class.</summary>
-public MerchantUnauthorizedAccessException() { }
+  /// <summary>Initializes a new instance of the <see cref="MerchantUnauthorizedAccessException"/> class.</summary>
+  public MerchantUnauthorizedAccessException() { }
 
-/// <summary>Initializes a new instance of the <see cref="MerchantUnauthorizedAccessException"/> class with a custom message.</summary>
-/// <param name="message">The exception message.</param>
-public MerchantUnauthorizedAccessException(string message) : base(message) { }
+  /// <summary>Initializes a new instance of the <see cref="MerchantUnauthorizedAccessException"/> class with a custom message.</summary>
+  /// <param name="message">The exception message.</param>
+  public MerchantUnauthorizedAccessException(string message) : base(message) { }
 
-/// <summary>Initializes a new instance of the <see cref="MerchantUnauthorizedAccessException"/> class with a custom message and inner exception.</summary>
-/// <param name="message">The exception message.</param>
-/// <param name="innerException">The inner exception.</param>
-public MerchantUnauthorizedAccessException(string message, Exception innerException)
-: base(message, innerException) { }
+  /// <summary>Initializes a new instance of the <see cref="MerchantUnauthorizedAccessException"/> class with a custom message and inner exception.</summary>
+  /// <param name="message">The exception message.</param>
+  /// <param name="innerException">The inner exception.</param>
+  public MerchantUnauthorizedAccessException(string message, Exception innerException)
+  : base(message, innerException) { }
 
 #pragma warning disable SYSLIB0051
-private MerchantUnauthorizedAccessException(SerializationInfo info, StreamingContext context)
-: base(info, context) { }
+  private MerchantUnauthorizedAccessException(SerializationInfo info, StreamingContext context)
+  : base(info, context) { }
 #pragma warning restore SYSLIB0051
 }

--- a/sites/api.arolariu.ro/src/Invoices/Services/Foundation/InvoiceAnalysis/InvoiceAnalysisFoundationService.Exceptions.cs
+++ b/sites/api.arolariu.ro/src/Invoices/Services/Foundation/InvoiceAnalysis/InvoiceAnalysisFoundationService.Exceptions.cs
@@ -30,7 +30,7 @@ public partial class InvoiceAnalysisFoundationService
       or InvoicePaymentInformationNotCorrectException
       or InvoiceTimeInformationNotCorrectException
       or InvoicePhotoLocationNotCorrectException
-      => CreateAndLogValidationException(exception),
+      => LogAndWrapValidation(exception),
 
     InvoiceNotFoundException
       or InvoiceAlreadyExistsException
@@ -38,16 +38,16 @@ public partial class InvoiceAnalysisFoundationService
       or InvoiceCosmosDbRateLimitException
       or InvoiceUnauthorizedAccessException
       or InvoiceForbiddenAccessException
-      => CreateAndLogDependencyValidationException(exception),
+      => LogAndWrapDependencyValidation(exception),
 
     InvoiceFailedStorageException
       or OperationCanceledException
-      => CreateAndLogDependencyException(exception),
+      => LogAndWrapDependency(exception),
 
-    _ => CreateAndLogServiceException(exception),
+    _ => LogAndWrapService(exception),
   };
 
-  private InvoiceFoundationValidationException CreateAndLogValidationException(Exception exception)
+  private InvoiceFoundationValidationException LogAndWrapValidation(Exception exception)
   {
     var invoiceFoundationValidationException = new InvoiceFoundationValidationException(exception);
     var exceptionMessage = invoiceFoundationValidationException.Message;
@@ -55,7 +55,7 @@ public partial class InvoiceAnalysisFoundationService
     return invoiceFoundationValidationException;
   }
 
-  private InvoiceFoundationDependencyException CreateAndLogDependencyException(Exception exception)
+  private InvoiceFoundationDependencyException LogAndWrapDependency(Exception exception)
   {
     var invoiceFoundationDependencyException = new InvoiceFoundationDependencyException(exception);
     var exceptionMessage = invoiceFoundationDependencyException.Message;
@@ -63,7 +63,7 @@ public partial class InvoiceAnalysisFoundationService
     return invoiceFoundationDependencyException;
   }
 
-  private InvoiceFoundationDependencyValidationException CreateAndLogDependencyValidationException(Exception exception)
+  private InvoiceFoundationDependencyValidationException LogAndWrapDependencyValidation(Exception exception)
   {
     var invoiceFoundationDependencyValidationException = new InvoiceFoundationDependencyValidationException(exception);
     var exceptionMessage = invoiceFoundationDependencyValidationException.Message;
@@ -71,7 +71,7 @@ public partial class InvoiceAnalysisFoundationService
     return invoiceFoundationDependencyValidationException;
   }
 
-  private InvoiceFoundationServiceException CreateAndLogServiceException(Exception exception)
+  private InvoiceFoundationServiceException LogAndWrapService(Exception exception)
   {
     var invoiceFoundationServiceException = new InvoiceFoundationServiceException(exception);
     var exceptionMessage = invoiceFoundationServiceException.Message;

--- a/sites/api.arolariu.ro/src/Invoices/Services/Foundation/InvoiceAnalysis/InvoiceAnalysisFoundationService.Exceptions.cs
+++ b/sites/api.arolariu.ro/src/Invoices/Services/Foundation/InvoiceAnalysis/InvoiceAnalysisFoundationService.Exceptions.cs
@@ -4,6 +4,7 @@ using System;
 using System.Threading.Tasks;
 
 using arolariu.Backend.Domain.Invoices.DDD.AggregatorRoots.Invoices;
+using arolariu.Backend.Domain.Invoices.DDD.AggregatorRoots.Invoices.Exceptions.Inner;
 using arolariu.Backend.Domain.Invoices.DDD.AggregatorRoots.Invoices.Exceptions.Outer.Foundation;
 
 public partial class InvoiceAnalysisFoundationService
@@ -18,9 +19,33 @@ public partial class InvoiceAnalysisFoundationService
     }
     catch (Exception exception)
     {
-      throw CreateAndLogServiceException(exception);
+      throw Classify(exception);
     }
   }
+
+  private Exception Classify(Exception exception) => exception switch
+  {
+    InvoiceIdNotSetException
+      or InvoiceDescriptionNotSetException
+      or InvoicePaymentInformationNotCorrectException
+      or InvoiceTimeInformationNotCorrectException
+      or InvoicePhotoLocationNotCorrectException
+      => CreateAndLogValidationException(exception),
+
+    InvoiceNotFoundException
+      or InvoiceAlreadyExistsException
+      or InvoiceLockedException
+      or InvoiceCosmosDbRateLimitException
+      or InvoiceUnauthorizedAccessException
+      or InvoiceForbiddenAccessException
+      => CreateAndLogDependencyValidationException(exception),
+
+    InvoiceFailedStorageException
+      or OperationCanceledException
+      => CreateAndLogDependencyException(exception),
+
+    _ => CreateAndLogServiceException(exception),
+  };
 
   private InvoiceFoundationValidationException CreateAndLogValidationException(Exception exception)
   {

--- a/sites/api.arolariu.ro/src/Invoices/Services/Foundation/InvoiceStorage/InvoiceStorageFoundationService.Exceptions.cs
+++ b/sites/api.arolariu.ro/src/Invoices/Services/Foundation/InvoiceStorage/InvoiceStorageFoundationService.Exceptions.cs
@@ -63,12 +63,12 @@ public partial class InvoiceStorageFoundationService
     InvoiceNotFoundException
       or InvoiceAlreadyExistsException
       or InvoiceLockedException
-      => LogAndWrapDependencyValidation(exception),
-
-    InvoiceCosmosDbRateLimitException
-      or InvoiceFailedStorageException
+      or InvoiceCosmosDbRateLimitException
       or InvoiceUnauthorizedAccessException
       or InvoiceForbiddenAccessException
+      => LogAndWrapDependencyValidation(exception),
+
+    InvoiceFailedStorageException
       or OperationCanceledException
       => LogAndWrapDependency(exception),
 

--- a/sites/api.arolariu.ro/src/Invoices/Services/Foundation/MerchantStorage/MerchantStorageFoundationService.Exceptions.cs
+++ b/sites/api.arolariu.ro/src/Invoices/Services/Foundation/MerchantStorage/MerchantStorageFoundationService.Exceptions.cs
@@ -59,12 +59,12 @@ public partial class MerchantStorageFoundationService
     MerchantNotFoundException
       or MerchantAlreadyExistsException
       or MerchantLockedException
-      => LogAndWrapDependencyValidation(exception),
-
-    MerchantCosmosDbRateLimitException
-      or MerchantFailedStorageException
+      or MerchantCosmosDbRateLimitException
       or MerchantUnauthorizedAccessException
       or MerchantForbiddenAccessException
+      => LogAndWrapDependencyValidation(exception),
+
+    MerchantFailedStorageException
       or OperationCanceledException
       => LogAndWrapDependency(exception),
 

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Http/ExceptionMappingHandlerTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Http/ExceptionMappingHandlerTests.cs
@@ -1,0 +1,79 @@
+namespace arolariu.Backend.Core.Tests.Common.Http;
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+using arolariu.Backend.Common.Exceptions;
+using arolariu.Backend.Common.Http;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+/// <summary>
+/// Tests for <see cref="ExceptionMappingHandler"/> covering exception routing through
+/// the static mapper, ProblemDetails response writing, and Activity telemetry recording.
+/// </summary>
+[TestClass]
+public sealed class ExceptionMappingHandlerTests
+{
+  private sealed class NotFoundEx : Exception, INotFoundException { public NotFoundEx(string m) : base(m) { } }
+
+  /// <summary>
+  /// Verifies that a classifiable exception (implementing a marker interface) is mapped
+  /// to the correct HTTP status code, written as ProblemDetails, and handler returns true.
+  /// </summary>
+  [TestMethod]
+  public async Task TryHandleAsync_ClassifiableException_WritesProblemDetailsAndReturnsTrue()
+  {
+    // Arrange
+    var handler = new ExceptionMappingHandler();
+    var services = new ServiceCollection()
+      .AddLogging()
+      .BuildServiceProvider();
+    var context = new DefaultHttpContext
+    {
+      Response = { Body = new MemoryStream() },
+      RequestServices = services
+    };
+    var exception = new NotFoundEx("Resource not found");
+
+    // Act
+    var handled = await handler.TryHandleAsync(context, exception, CancellationToken.None);
+
+    // Assert
+    Assert.IsTrue(handled);
+    Assert.AreEqual(404, context.Response.StatusCode);
+    Assert.AreEqual("application/problem+json", context.Response.ContentType);
+  }
+
+  /// <summary>
+  /// Verifies that an unclassifiable (plain) exception is mapped to HTTP 500 Internal Server Error,
+  /// written as ProblemDetails, and handler returns true.
+  /// </summary>
+  [TestMethod]
+  public async Task TryHandleAsync_UnclassifiableException_WritesInternalServerError()
+  {
+    // Arrange
+    var handler = new ExceptionMappingHandler();
+    var services = new ServiceCollection()
+      .AddLogging()
+      .BuildServiceProvider();
+    var context = new DefaultHttpContext
+    {
+      Response = { Body = new MemoryStream() },
+      RequestServices = services
+    };
+    var exception = new Exception("surprise");
+
+    // Act
+    var handled = await handler.TryHandleAsync(context, exception, CancellationToken.None);
+
+    // Assert
+    Assert.IsTrue(handled);
+    Assert.AreEqual(500, context.Response.StatusCode);
+  }
+}

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Http/ExceptionMappingHandlerTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Http/ExceptionMappingHandlerTests.cs
@@ -120,6 +120,20 @@ public sealed class ExceptionMappingHandlerTests
   }
 
   /// <summary>
+  /// Rewinds the response body stream to position 0 and reads the full content as a string.
+  /// This helper prevents silent empty reads when body position is not manually reset; all
+  /// body-reading tests should call this method rather than implementing inline rewind logic.
+  /// </summary>
+  /// <param name="context">The <see cref="HttpContext"/> whose response body will be read.</param>
+  /// <returns>The response body content as a string.</returns>
+  private static async Task<string> ReadResponseBodyAsync(HttpContext context)
+  {
+    context.Response.Body.Position = 0;
+    using var reader = new StreamReader(context.Response.Body, leaveOpen: true);
+    return await reader.ReadToEndAsync();
+  }
+
+  /// <summary>
   /// Verifies that when an ambient <see cref="Activity"/> is present, the emitted
   /// ProblemDetails body includes a <c>traceId</c> extension matching
   /// <c>Activity.Current.TraceId</c>. This is the correlation hook that lets clients
@@ -148,9 +162,7 @@ public sealed class ExceptionMappingHandlerTests
     await handler.TryHandleAsync(context, new NotFoundEx("nope"), CancellationToken.None);
 
     // Assert — read response body and confirm it carries the active trace identifier.
-    context.Response.Body.Position = 0;
-    using var reader = new StreamReader(context.Response.Body);
-    var body = await reader.ReadToEndAsync();
+    var body = await ReadResponseBodyAsync(context);
 
     var expectedTraceId = activity!.TraceId.ToString();
     Assert.IsTrue(

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Http/ExceptionMappingHandlerTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Http/ExceptionMappingHandlerTests.cs
@@ -76,7 +76,7 @@ public sealed class ExceptionMappingHandlerTests
     // Arrange
     var handler = new ExceptionMappingHandler();
     var context = CreateHttpContextWithLoggingServices();
-    var exception = new Exception("surprise");
+    var exception = new InvalidOperationException("surprise");
 
     // Act
     var handled = await handler.TryHandleAsync(context, exception, CancellationToken.None);
@@ -101,7 +101,7 @@ public sealed class ExceptionMappingHandlerTests
     var handler = new ExceptionMappingHandler();
 
     await Assert.ThrowsExactlyAsync<ArgumentNullException>(
-      () => handler.TryHandleAsync(httpContext: null!, exception: new Exception(), CancellationToken.None).AsTask());
+      () => handler.TryHandleAsync(httpContext: null!, exception: new InvalidOperationException(), CancellationToken.None).AsTask());
   }
 
   /// <summary>

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Http/ExceptionMappingHandlerTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Http/ExceptionMappingHandlerTests.cs
@@ -1,6 +1,7 @@
 namespace arolariu.Backend.Core.Tests.Common.Http;
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -23,6 +24,25 @@ public sealed class ExceptionMappingHandlerTests
   private sealed class NotFoundEx : Exception, INotFoundException { public NotFoundEx(string m) : base(m) { } }
 
   /// <summary>
+  /// Builds a <see cref="DefaultHttpContext"/> wired with a logging <see cref="IServiceProvider"/>
+  /// and an in-memory response body, suitable for exercising <see cref="ExceptionMappingHandler"/>
+  /// end-to-end (mapper dispatch + result execution).
+  /// </summary>
+  /// <returns>A fresh <see cref="HttpContext"/> per invocation — do not reuse between tests.</returns>
+  private static DefaultHttpContext CreateHttpContextWithLoggingServices()
+  {
+    var services = new ServiceCollection()
+      .AddLogging()
+      .BuildServiceProvider();
+
+    return new DefaultHttpContext
+    {
+      Response = { Body = new MemoryStream() },
+      RequestServices = services,
+    };
+  }
+
+  /// <summary>
   /// Verifies that a classifiable exception (implementing a marker interface) is mapped
   /// to the correct HTTP status code, written as ProblemDetails, and handler returns true.
   /// </summary>
@@ -31,14 +51,7 @@ public sealed class ExceptionMappingHandlerTests
   {
     // Arrange
     var handler = new ExceptionMappingHandler();
-    var services = new ServiceCollection()
-      .AddLogging()
-      .BuildServiceProvider();
-    var context = new DefaultHttpContext
-    {
-      Response = { Body = new MemoryStream() },
-      RequestServices = services
-    };
+    var context = CreateHttpContextWithLoggingServices();
     var exception = new NotFoundEx("Resource not found");
 
     // Act
@@ -47,7 +60,10 @@ public sealed class ExceptionMappingHandlerTests
     // Assert
     Assert.IsTrue(handled);
     Assert.AreEqual(404, context.Response.StatusCode);
-    Assert.AreEqual("application/problem+json", context.Response.ContentType);
+    Assert.IsNotNull(context.Response.ContentType);
+    Assert.IsTrue(
+      context.Response.ContentType!.Contains("application/problem+json", StringComparison.Ordinal),
+      $"Expected content-type to contain 'application/problem+json' but got '{context.Response.ContentType}'.");
   }
 
   /// <summary>
@@ -59,14 +75,7 @@ public sealed class ExceptionMappingHandlerTests
   {
     // Arrange
     var handler = new ExceptionMappingHandler();
-    var services = new ServiceCollection()
-      .AddLogging()
-      .BuildServiceProvider();
-    var context = new DefaultHttpContext
-    {
-      Response = { Body = new MemoryStream() },
-      RequestServices = services
-    };
+    var context = CreateHttpContextWithLoggingServices();
     var exception = new Exception("surprise");
 
     // Act
@@ -75,5 +84,77 @@ public sealed class ExceptionMappingHandlerTests
     // Assert
     Assert.IsTrue(handled);
     Assert.AreEqual(500, context.Response.StatusCode);
+    Assert.IsNotNull(context.Response.ContentType);
+    Assert.IsTrue(
+      context.Response.ContentType!.Contains("application/problem+json", StringComparison.Ordinal),
+      $"Expected content-type to contain 'application/problem+json' but got '{context.Response.ContentType}'.");
+  }
+
+  /// <summary>
+  /// Verifies that <see cref="ExceptionMappingHandler.TryHandleAsync"/> rejects a null
+  /// <see cref="HttpContext"/> with <see cref="ArgumentNullException"/> — the null guard
+  /// is the first statement in the method to fail fast before any mapper dispatch.
+  /// </summary>
+  [TestMethod]
+  public async Task TryHandleAsync_NullHttpContext_ThrowsArgumentNullException()
+  {
+    var handler = new ExceptionMappingHandler();
+
+    await Assert.ThrowsExactlyAsync<ArgumentNullException>(
+      () => handler.TryHandleAsync(httpContext: null!, exception: new Exception(), CancellationToken.None).AsTask());
+  }
+
+  /// <summary>
+  /// Verifies that <see cref="ExceptionMappingHandler.TryHandleAsync"/> rejects a null
+  /// <see cref="Exception"/> with <see cref="ArgumentNullException"/> — complements the
+  /// null-context guard to ensure the handler is defensive on both required inputs.
+  /// </summary>
+  [TestMethod]
+  public async Task TryHandleAsync_NullException_ThrowsArgumentNullException()
+  {
+    var handler = new ExceptionMappingHandler();
+    var context = CreateHttpContextWithLoggingServices();
+
+    await Assert.ThrowsExactlyAsync<ArgumentNullException>(
+      () => handler.TryHandleAsync(context, exception: null!, CancellationToken.None).AsTask());
+  }
+
+  /// <summary>
+  /// Verifies that when an ambient <see cref="Activity"/> is present, the emitted
+  /// ProblemDetails body includes a <c>traceId</c> extension matching
+  /// <c>Activity.Current.TraceId</c>. This is the correlation hook that lets clients
+  /// and SREs tie a 4xx/5xx response back to the originating distributed trace.
+  /// </summary>
+  [TestMethod]
+  public async Task TryHandleAsync_ClassifiableException_IncludesTraceIdWhenActivityPresent()
+  {
+    // Arrange — register a listener that samples EVERYTHING so StartActivity actually
+    // produces a non-null Activity (default sampling yields null outside a host).
+    using var listener = new ActivityListener
+    {
+      ShouldListenTo = _ => true,
+      Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+    };
+    ActivitySource.AddActivityListener(listener);
+
+    using var source = new ActivitySource("arolariu.tests.ExceptionMappingHandler");
+    using var activity = source.StartActivity("test-op");
+    Assert.IsNotNull(activity, "ActivityListener wiring failed; StartActivity returned null.");
+
+    var handler = new ExceptionMappingHandler();
+    var context = CreateHttpContextWithLoggingServices();
+
+    // Act
+    await handler.TryHandleAsync(context, new NotFoundEx("nope"), CancellationToken.None);
+
+    // Assert — read response body and confirm it carries the active trace identifier.
+    context.Response.Body.Position = 0;
+    using var reader = new StreamReader(context.Response.Body);
+    var body = await reader.ReadToEndAsync();
+
+    var expectedTraceId = activity!.TraceId.ToString();
+    Assert.IsTrue(
+      body.Contains(expectedTraceId, StringComparison.Ordinal),
+      $"Expected traceId '{expectedTraceId}' in ProblemDetails body but got: {body}");
   }
 }

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Http/ExceptionMappingHandlerTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Http/ExceptionMappingHandlerTests.cs
@@ -22,7 +22,12 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 [TestClass]
 public sealed class ExceptionMappingHandlerTests
 {
-  private sealed class NotFoundEx : Exception, INotFoundException { public NotFoundEx(string m) : base(m) { } }
+  private sealed class NotFoundEx : Exception, INotFoundException { public NotFoundEx(string m) : base(m) { }
+
+    public NotFoundEx()
+    {
+    }
+  }
 
   /// <summary>
   /// A minimal <see cref="IHttpResponseFeature"/> implementation that allows setting HasStarted.

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Http/ExceptionMappingHandlerTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Http/ExceptionMappingHandlerTests.cs
@@ -10,6 +10,7 @@ using arolariu.Backend.Common.Exceptions;
 using arolariu.Backend.Common.Http;
 
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -22,6 +23,21 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 public sealed class ExceptionMappingHandlerTests
 {
   private sealed class NotFoundEx : Exception, INotFoundException { public NotFoundEx(string m) : base(m) { } }
+
+  /// <summary>
+  /// A minimal <see cref="IHttpResponseFeature"/> implementation that allows setting HasStarted.
+  /// </summary>
+  private sealed class TestHttpResponseFeature : IHttpResponseFeature
+  {
+    public Stream Body { get; set; } = new MemoryStream();
+    public bool HasStarted { get; set; }
+    public IHeaderDictionary Headers { get; set; } = new HeaderDictionary();
+    public int StatusCode { get; set; } = 200;
+    public string? ReasonPhrase { get; set; }
+
+    public void OnCompleted(Func<object, Task> callback, object state) { }
+    public void OnStarting(Func<object, Task> callback, object state) { }
+  }
 
   /// <summary>
   /// Builds a <see cref="DefaultHttpContext"/> wired with a logging <see cref="IServiceProvider"/>
@@ -168,5 +184,38 @@ public sealed class ExceptionMappingHandlerTests
     Assert.IsTrue(
       body.Contains(expectedTraceId, StringComparison.Ordinal),
       $"Expected traceId '{expectedTraceId}' in ProblemDetails body but got: {body}");
+  }
+
+  /// <summary>
+  /// Verifies that <see cref="ExceptionMappingHandler.TryHandleAsync"/> returns <see langword="false"/>
+  /// when the response has already started writing (headers committed), without attempting to
+  /// overwrite the status code or write ProblemDetails. This guards against corrupted or
+  /// ill-formed responses when an exception escapes a streaming handler or middleware that
+  /// has already begun writing the response body.
+  /// </summary>
+  [TestMethod]
+  public async Task TryHandleAsync_WhenResponseHasStarted_ReturnsFalseWithoutWriting()
+  {
+    // Arrange — build a context with a response feature that reports HasStarted = true.
+    var handler = new ExceptionMappingHandler();
+    var services = new ServiceCollection()
+      .AddLogging()
+      .BuildServiceProvider();
+
+    var responseFeature = new TestHttpResponseFeature { HasStarted = true, StatusCode = 200 };
+
+    var context = new DefaultHttpContext();
+    context.Features.Set<IHttpResponseFeature>(responseFeature);
+    context.RequestServices = services;
+
+    // Act
+    var handled = await handler.TryHandleAsync(
+        context,
+        new InvalidOperationException("too late"),
+        CancellationToken.None);
+
+    // Assert — handler must return false, and the status code should remain unchanged.
+    Assert.IsFalse(handled, "TryHandleAsync should return false when response has already started.");
+    Assert.AreEqual(200, responseFeature.StatusCode, "Status code should remain unchanged when response has already started.");
   }
 }

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Http/ExceptionToHttpResultMapperTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Http/ExceptionToHttpResultMapperTests.cs
@@ -112,4 +112,17 @@ public sealed class ExceptionToHttpResultMapperTests
     var problem = (ProblemHttpResult)result;
     Assert.IsTrue(problem.ProblemDetails.Extensions.ContainsKey("retryAfterSeconds"));
   }
+
+  /// <summary>BadHttpRequestException propagates its StatusCode instead of defaulting to 500.</summary>
+  [TestMethod]
+  public void ToHttpResult_BadHttpRequestException_PropagatesItsStatusCode()
+  {
+    var exception = new Microsoft.AspNetCore.Http.BadHttpRequestException("bad body", statusCode: 400);
+
+    var result = ExceptionToHttpResultMapper.ToHttpResult(exception, activity: null);
+
+    Assert.IsInstanceOfType(result, typeof(ProblemHttpResult));
+    var problem = (ProblemHttpResult)result;
+    Assert.AreEqual(400, problem.StatusCode);
+  }
 }

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Http/ExceptionToHttpResultMapperTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Http/ExceptionToHttpResultMapperTests.cs
@@ -8,6 +8,7 @@ using arolariu.Backend.Common.Http;
 
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Diagnostics.CodeAnalysis;
 
 /// <summary>
 /// Tests for <see cref="ExceptionToHttpResultMapper"/> covering marker-to-status mapping,
@@ -17,13 +18,19 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 public sealed class ExceptionToHttpResultMapperTests
 {
 
+  [SuppressMessage("Performance", "CA1812", Justification = "Instantiated via Activator.CreateInstance in data-driven test")]
   private sealed class ValidationEx : Exception, IValidationException { public ValidationEx(string m) : base(m) { } }
   private sealed class NotFoundEx : Exception, INotFoundException { public NotFoundEx(string m) : base(m) { } }
+  [SuppressMessage("Performance", "CA1812", Justification = "Instantiated via Activator.CreateInstance in data-driven test")]
   private sealed class ConflictEx : Exception, IAlreadyExistsException { public ConflictEx(string m) : base(m) { } }
+  [SuppressMessage("Performance", "CA1812", Justification = "Instantiated via Activator.CreateInstance in data-driven test")]
   private sealed class LockedEx : Exception, ILockedException { public LockedEx(string m) : base(m) { } }
   private sealed class RateLimitEx : Exception, IRateLimitedException { public RateLimitEx(string m) : base(m) { } }
+  [SuppressMessage("Performance", "CA1812", Justification = "Instantiated via Activator.CreateInstance in data-driven test")]
   private sealed class UnauthorizedEx : Exception, IUnauthorizedException { public UnauthorizedEx(string m) : base(m) { } }
+  [SuppressMessage("Performance", "CA1812", Justification = "Instantiated via Activator.CreateInstance in data-driven test")]
   private sealed class ForbiddenEx : Exception, IForbiddenException { public ForbiddenEx(string m) : base(m) { } }
+  [SuppressMessage("Performance", "CA1812", Justification = "Instantiated via Activator.CreateInstance in data-driven test")]
   private sealed class DependencyEx : Exception, IDependencyException { public DependencyEx(string m) : base(m) { } }
   private sealed class ServiceEx : Exception, IServiceException { public ServiceEx(string m) : base(m) { } }
 
@@ -44,7 +51,7 @@ public sealed class ExceptionToHttpResultMapperTests
 
     var result = ExceptionToHttpResultMapper.ToHttpResult(ex, activity: null);
 
-    Assert.IsInstanceOfType(result, typeof(ProblemHttpResult));
+    Assert.IsInstanceOfType<ProblemHttpResult>(result);
     var problem = (ProblemHttpResult)result;
     Assert.AreEqual(expectedStatus, problem.StatusCode);
   }
@@ -53,9 +60,9 @@ public sealed class ExceptionToHttpResultMapperTests
   [TestMethod]
   public void ToHttpResult_UnknownException_MapsTo500()
   {
-    var result = ExceptionToHttpResultMapper.ToHttpResult(new Exception("boom"), activity: null);
+    var result = ExceptionToHttpResultMapper.ToHttpResult(new InvalidOperationException("boom"), activity: null);
 
-    Assert.IsInstanceOfType(result, typeof(ProblemHttpResult));
+    Assert.IsInstanceOfType<ProblemHttpResult>(result);
     var problem = (ProblemHttpResult)result;
     Assert.AreEqual(500, problem.StatusCode);
     Assert.AreEqual("An unexpected error occurred. Please try again later.", problem.ProblemDetails.Detail);
@@ -66,11 +73,11 @@ public sealed class ExceptionToHttpResultMapperTests
   public void ToHttpResult_InnerExceptionDrivesClassification()
   {
     var inner = new NotFoundEx("missing");
-    var outer = new Exception("outer", inner);
+    var outer = new InvalidOperationException("outer", inner);
 
     var result = ExceptionToHttpResultMapper.ToHttpResult(outer, activity: null);
 
-    Assert.IsInstanceOfType(result, typeof(ProblemHttpResult));
+    Assert.IsInstanceOfType<ProblemHttpResult>(result);
     var problem = (ProblemHttpResult)result;
     Assert.AreEqual(404, problem.StatusCode);
   }
@@ -83,7 +90,7 @@ public sealed class ExceptionToHttpResultMapperTests
 
     var result = ExceptionToHttpResultMapper.ToHttpResult(ex, activity: null);
 
-    Assert.IsInstanceOfType(result, typeof(ProblemHttpResult));
+    Assert.IsInstanceOfType<ProblemHttpResult>(result);
     var problem = (ProblemHttpResult)result;
     var detail = problem.ProblemDetails.Detail ?? string.Empty;
     Assert.IsFalse(detail.Contains("arolariu.Backend.Invoices", StringComparison.Ordinal));
@@ -93,11 +100,12 @@ public sealed class ExceptionToHttpResultMapperTests
   [TestMethod]
   public void ToHttpResult_IncludesTraceIdWhenActivityPresent()
   {
-    using var activity = new Activity("test").Start();
+    using var activity = new Activity("test");
+    activity.Start();
 
     var result = ExceptionToHttpResultMapper.ToHttpResult(new ServiceEx("boom"), activity);
 
-    Assert.IsInstanceOfType(result, typeof(ProblemHttpResult));
+    Assert.IsInstanceOfType<ProblemHttpResult>(result);
     var problem = (ProblemHttpResult)result;
     Assert.IsTrue(problem.ProblemDetails.Extensions.ContainsKey("traceId"));
   }
@@ -108,7 +116,7 @@ public sealed class ExceptionToHttpResultMapperTests
   {
     var result = ExceptionToHttpResultMapper.ToHttpResult(new RateLimitEx("throttled"), activity: null);
 
-    Assert.IsInstanceOfType(result, typeof(ProblemHttpResult));
+    Assert.IsInstanceOfType<ProblemHttpResult>(result);
     var problem = (ProblemHttpResult)result;
     Assert.IsTrue(problem.ProblemDetails.Extensions.ContainsKey("retryAfterSeconds"));
   }
@@ -121,7 +129,7 @@ public sealed class ExceptionToHttpResultMapperTests
 
     var result = ExceptionToHttpResultMapper.ToHttpResult(exception, activity: null);
 
-    Assert.IsInstanceOfType(result, typeof(ProblemHttpResult));
+    Assert.IsInstanceOfType<ProblemHttpResult>(result);
     var problem = (ProblemHttpResult)result;
     Assert.AreEqual(400, problem.StatusCode);
   }

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Http/ExceptionToHttpResultMapperTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Http/ExceptionToHttpResultMapperTests.cs
@@ -19,23 +19,68 @@ public sealed class ExceptionToHttpResultMapperTests
 {
 
   [SuppressMessage("Performance", "CA1812", Justification = "Instantiated via Activator.CreateInstance in data-driven test")]
-  private sealed class ValidationEx : Exception, IValidationException { public ValidationEx(string m) : base(m) { } }
-  private sealed class NotFoundEx : Exception, INotFoundException { public NotFoundEx(string m) : base(m) { } }
+  private sealed class ValidationEx : Exception, IValidationException { public ValidationEx(string m) : base(m) { }
+
+    public ValidationEx()
+    {
+    }
+  }
+  private sealed class NotFoundEx : Exception, INotFoundException { public NotFoundEx(string m) : base(m) { }
+
+    public NotFoundEx()
+    {
+    }
+  }
   [SuppressMessage("Performance", "CA1812", Justification = "Instantiated via Activator.CreateInstance in data-driven test")]
-  private sealed class ConflictEx : Exception, IAlreadyExistsException { public ConflictEx(string m) : base(m) { } }
+  private sealed class ConflictEx : Exception, IAlreadyExistsException { public ConflictEx(string m) : base(m) { }
+
+    public ConflictEx()
+    {
+    }
+  }
   [SuppressMessage("Performance", "CA1812", Justification = "Instantiated via Activator.CreateInstance in data-driven test")]
-  private sealed class LockedEx : Exception, ILockedException { public LockedEx(string m) : base(m) { } }
-  private sealed class RateLimitEx : Exception, IRateLimitedException { public RateLimitEx(string m) : base(m) { } }
+  private sealed class LockedEx : Exception, ILockedException { public LockedEx(string m) : base(m) { }
+
+    public LockedEx()
+    {
+    }
+  }
+  private sealed class RateLimitEx : Exception, IRateLimitedException { public RateLimitEx(string m) : base(m) { }
+
+    public RateLimitEx()
+    {
+    }
+  }
   [SuppressMessage("Performance", "CA1812", Justification = "Instantiated via Activator.CreateInstance in data-driven test")]
-  private sealed class UnauthorizedEx : Exception, IUnauthorizedException { public UnauthorizedEx(string m) : base(m) { } }
+  private sealed class UnauthorizedEx : Exception, IUnauthorizedException { public UnauthorizedEx(string m) : base(m) { }
+
+    public UnauthorizedEx()
+    {
+    }
+  }
   [SuppressMessage("Performance", "CA1812", Justification = "Instantiated via Activator.CreateInstance in data-driven test")]
-  private sealed class ForbiddenEx : Exception, IForbiddenException { public ForbiddenEx(string m) : base(m) { } }
+  private sealed class ForbiddenEx : Exception, IForbiddenException { public ForbiddenEx(string m) : base(m) { }
+
+    public ForbiddenEx()
+    {
+    }
+  }
   [SuppressMessage("Performance", "CA1812", Justification = "Instantiated via Activator.CreateInstance in data-driven test")]
-  private sealed class DependencyEx : Exception, IDependencyException { public DependencyEx(string m) : base(m) { } }
-  private sealed class ServiceEx : Exception, IServiceException { public ServiceEx(string m) : base(m) { } }
+  private sealed class DependencyEx : Exception, IDependencyException { public DependencyEx(string m) : base(m) { }
+
+    public DependencyEx()
+    {
+    }
+  }
+  private sealed class ServiceEx : Exception, IServiceException { public ServiceEx(string m) : base(m) { }
+
+    public ServiceEx()
+    {
+    }
+  }
 
   /// <summary>Ensures each marker interface maps to its canonical HTTP status.</summary>
-  [DataTestMethod]
+  [TestMethod]
   [DataRow(typeof(ValidationEx), 400)]
   [DataRow(typeof(NotFoundEx), 404)]
   [DataRow(typeof(ConflictEx), 409)]

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Integration/ExceptionHandlerPipelineTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Integration/ExceptionHandlerPipelineTests.cs
@@ -1,0 +1,143 @@
+namespace arolariu.Backend.Domain.Tests.Integration;
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+using arolariu.Backend.Common.Http;
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+using Xunit;
+
+/// <summary>
+/// Integration-style tests asserting that the ASP.NET Core pipeline wiring of
+/// <see cref="ExceptionMappingHandler"/> (via <c>AddExceptionHandler</c> + <c>AddProblemDetails</c>
+/// at composition, and <c>UseExceptionHandler()</c> as the first middleware) produces
+/// RFC 7807 ProblemDetails responses for exceptions that escape endpoint handlers —
+/// including pre-handler faults such as malformed JSON model binding.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why not <c>WebApplicationFactory&lt;Program&gt;</c>?</b> The production <c>Program.cs</c>
+/// boots Azure Key Vault, Cosmos DB, SQL Server, and Application Insights during startup,
+/// none of which are available in unit/CI environments. This fixture constructs a minimal
+/// <see cref="WebApplication"/> that mirrors just the exception-handler wiring from
+/// <c>WebApplicationBuilderExtensions</c> / <c>WebApplicationExtensions</c>, plus a single
+/// JSON-accepting endpoint, so the test verifies the middleware contract without dragging
+/// in infrastructure dependencies.
+/// </para>
+/// <para>
+/// <b>What this guards:</b> Regressions where the pipeline wiring is accidentally removed
+/// or reordered (e.g., <c>UseExceptionHandler</c> moved after model binding / auth), which
+/// would let binding faults bubble up as framework plain-text responses rather than the
+/// standardised ProblemDetails contract.
+/// </para>
+/// </remarks>
+public sealed class ExceptionHandlerPipelineTests
+{
+  /// <summary>
+  /// Builds a minimal in-test <see cref="WebApplication"/> that registers
+  /// <see cref="ExceptionMappingHandler"/> through <c>AddExceptionHandler</c>, enables
+  /// <c>AddProblemDetails</c>, installs <c>UseExceptionHandler()</c> as the first middleware,
+  /// and maps a single JSON-bound POST endpoint at <c>/rest/v1/invoices</c>. The app is hosted
+  /// in-memory via <see cref="TestServer"/> so the returned <see cref="HttpClient"/> exercises
+  /// the real middleware pipeline without Kestrel or infrastructure services.
+  /// </summary>
+  /// <returns>
+  /// Tuple of the running <see cref="IHost"/> (the caller disposes it) and an
+  /// <see cref="HttpClient"/> bound to the <see cref="TestServer"/>.
+  /// </returns>
+  private static async Task<(IHost Host, HttpClient Client)> CreateTestHostAsync()
+  {
+    var builder = WebApplication.CreateBuilder();
+    builder.WebHost.UseTestServer();
+
+    // Mirror the production wiring for the exception-handler pipeline — see
+    // WebApplicationBuilderExtensions.AddGeneralDomainConfiguration.
+    builder.Services.AddExceptionHandler<ExceptionMappingHandler>();
+    builder.Services.AddProblemDetails();
+
+    // Force Minimal API body-binding failures (malformed JSON) to throw
+    // BadHttpRequestException instead of writing a silent 400 — this is what causes
+    // the exception to escape into the middleware pipeline and hit UseExceptionHandler.
+    // Production code sees the equivalent behaviour because it throws from the
+    // invoice processing services; here we route the pre-handler fault through the
+    // same door to exercise the exact handler path.
+    builder.Services.Configure<Microsoft.AspNetCore.Routing.RouteHandlerOptions>(
+      opts => opts.ThrowOnBadRequest = true);
+
+    var app = builder.Build();
+
+    // UseExceptionHandler must be the first middleware — mirrors WebApplicationExtensions.
+    app.UseExceptionHandler();
+
+    // A minimal JSON-bound endpoint that exercises model binding. Malformed JSON throws
+    // a BadHttpRequestException during binding; the exception escapes into the pipeline,
+    // UseExceptionHandler routes it through ExceptionMappingHandler, and a ProblemDetails
+    // response is written back instead of a framework-default plain-text body.
+    app.MapPost("/rest/v1/invoices", (Payload _) => Results.Ok());
+
+    await app.StartAsync().ConfigureAwait(false);
+
+    var client = app.GetTestClient();
+    return (app, client);
+  }
+
+  /// <summary>
+  /// Minimal body record so the endpoint requires JSON model binding; the shape does not
+  /// matter because the test sends an intentionally malformed body and asserts the pre-handler
+  /// error path. The type is instantiated reflectively by the JSON model binder, so the
+  /// analyzer's "never instantiated" heuristic is a false positive here.
+  /// </summary>
+  [System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instantiated reflectively by the ASP.NET Core JSON model binder.")]
+  private sealed record Payload(string Name);
+
+  /// <summary>
+  /// Verifies that a malformed JSON body posted to a JSON-bound endpoint produces an
+  /// RFC 7807 ProblemDetails response (content-type <c>application/problem+json</c>),
+  /// not a framework plain-text fallback. This is the belt-and-suspenders contract the
+  /// pipeline wiring exists to guarantee — endpoint try/catch blocks cannot see these
+  /// faults because they occur before the handler runs.
+  /// </summary>
+  [Fact]
+  public async Task MalformedJsonBody_ReturnsProblemDetails_NotPlainText()
+  {
+    // Arrange
+    var (host, client) = await CreateTestHostAsync().ConfigureAwait(false);
+    using (host)
+    using (client)
+    {
+      using var malformed = new StringContent("{ invalid json", System.Text.Encoding.UTF8, "application/json");
+
+      // Act
+      using var response = await client.PostAsync(new Uri("/rest/v1/invoices", UriKind.Relative), malformed).ConfigureAwait(false);
+      var body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+      var contentTypeString = response.Content.Headers.ContentType?.ToString() ?? "(null)";
+
+      // Primary contract: ProblemDetails content-type (tolerate charset suffix).
+      Assert.Contains(
+        "application/problem+json",
+        contentTypeString,
+        StringComparison.Ordinal);
+
+      // Sanity — the body should be a JSON document (RFC 7807 shape), not plain text.
+      Assert.StartsWith("{", body.TrimStart(), StringComparison.Ordinal);
+
+      // Status is a 4xx or 5xx — the current mapper has no special case for
+      // BadHttpRequestException, so it lands on the 500 default. The key contract the
+      // pipeline guarantees is the ProblemDetails envelope; the specific code is a
+      // secondary signal the test pins to detect accidental success (2xx) regressions.
+      Assert.InRange((int)response.StatusCode, 400, 599);
+    }
+  }
+}

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Integration/ExceptionHandlerPipelineTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Integration/ExceptionHandlerPipelineTests.cs
@@ -138,9 +138,7 @@ public sealed class ExceptionHandlerPipelineTests
       // IProblemDetailsService does not emit.
       Assert.Contains("api.arolariu.ro/problems", body, StringComparison.Ordinal);
 
-      // TODO(follow-up): expect 400 once BadHttpRequestException is mapped to its StatusCode
-      //   in ExceptionToHttpResultMapper. Currently maps to 500 (default arm).
-      Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+      Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
   }
 }

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Integration/ExceptionHandlerPipelineTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Integration/ExceptionHandlerPipelineTests.cs
@@ -113,15 +113,15 @@ public sealed class ExceptionHandlerPipelineTests
   public async Task MalformedJsonBody_ReturnsProblemDetails_NotPlainText()
   {
     // Arrange
-    var (host, client) = await CreateTestHostAsync().ConfigureAwait(false);
+    var (host, client) = await CreateTestHostAsync();
     using (host)
     using (client)
     {
       using var malformed = new StringContent("{ invalid json", System.Text.Encoding.UTF8, "application/json");
 
       // Act
-      using var response = await client.PostAsync(new Uri("/rest/v1/invoices", UriKind.Relative), malformed).ConfigureAwait(false);
-      var body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+      using var response = await client.PostAsync(new Uri("/rest/v1/invoices", UriKind.Relative), malformed);
+      var body = await response.Content.ReadAsStringAsync();
       var contentTypeString = response.Content.Headers.ContentType?.ToString() ?? "(null)";
 
       // Primary contract: ProblemDetails content-type (tolerate charset suffix).

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Integration/ExceptionHandlerPipelineTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Integration/ExceptionHandlerPipelineTests.cs
@@ -133,11 +133,14 @@ public sealed class ExceptionHandlerPipelineTests
       // Sanity — the body should be a JSON document (RFC 7807 shape), not plain text.
       Assert.StartsWith("{", body.TrimStart(), StringComparison.Ordinal);
 
-      // Status is a 4xx or 5xx — the current mapper has no special case for
-      // BadHttpRequestException, so it lands on the 500 default. The key contract the
-      // pipeline guarantees is the ProblemDetails envelope; the specific code is a
-      // secondary signal the test pins to detect accidental success (2xx) regressions.
-      Assert.InRange((int)response.StatusCode, 400, 599);
+      // Prove the custom ExceptionMappingHandler (not the framework fallback) actually ran
+      // by asserting the body contains our custom ProblemTypeUris domain, which the default
+      // IProblemDetailsService does not emit.
+      Assert.Contains("api.arolariu.ro/problems", body, StringComparison.Ordinal);
+
+      // TODO(follow-up): expect 400 once BadHttpRequestException is mapped to its StatusCode
+      //   in ExceptionToHttpResultMapper. Currently maps to 500 (default arm).
+      Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
     }
   }
 }

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Integration/InvoiceEndpointsStatusCodeTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Integration/InvoiceEndpointsStatusCodeTests.cs
@@ -2,6 +2,7 @@ namespace arolariu.Backend.Domain.Tests.Integration;
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
@@ -81,6 +82,16 @@ public sealed class InvoiceEndpointsStatusCodeTests
   {
     public TestDependencyException(string message) : base(message) { }
   }
+
+  private sealed class TestUnauthorizedException : Exception, IUnauthorizedException
+  {
+    public TestUnauthorizedException(string message) : base(message) { }
+  }
+
+  private sealed class TestForbiddenException : Exception, IForbiddenException
+  {
+    public TestForbiddenException(string message) : base(message) { }
+  }
   #endregion
 
   #region Test utilities
@@ -102,6 +113,15 @@ public sealed class InvoiceEndpointsStatusCodeTests
     var mock = new Mock<IInvoiceProcessingService>(MockBehavior.Strict);
     mock
       .Setup(s => s.ReadInvoice(It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
+      .ThrowsAsync(exceptionToThrow);
+    return mock;
+  }
+
+  private static Mock<IInvoiceProcessingService> CreateServiceMockThatThrowsOnMerchantRead(Exception exceptionToThrow)
+  {
+    var mock = new Mock<IInvoiceProcessingService>(MockBehavior.Strict);
+    mock
+      .Setup(s => s.ReadMerchant(It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(exceptionToThrow);
     return mock;
   }
@@ -289,6 +309,237 @@ public sealed class InvoiceEndpointsStatusCodeTests
     // Assert
     Assert.Equal(StatusCodes.Status400BadRequest, GetStatusCode(result));
     mockService.VerifyNoOtherCalls();
+  }
+  #endregion
+
+  #region GET /rest/v1/invoices/{id} - 401/403 status code tests
+  /// <summary>
+  /// Verifies that an <see cref="IUnauthorizedException"/> thrown by the processing service
+  /// is mapped to a 401 Unauthorized <see cref="ProblemDetails"/> response by the endpoint.
+  /// </summary>
+  [Fact]
+  public async Task RetrieveSpecificInvoiceAsync_WhenServiceThrowsUnauthorized_Returns401()
+  {
+    var mockService = CreateServiceMockThatThrowsOnRead(new TestUnauthorizedException("authentication required"));
+    var accessor = CreateAuthenticatedContextAccessor();
+
+    var result = await InvoiceEndpoints
+      .RetrieveSpecificInvoiceAsync(mockService.Object, accessor, Guid.NewGuid())
+      .ConfigureAwait(false);
+
+    Assert.Equal(StatusCodes.Status401Unauthorized, GetStatusCode(result));
+    Assert.Equal(ProblemTypeUris.Unauthorized, GetProblemDetails(result).Type);
+  }
+
+  /// <summary>
+  /// Verifies that an <see cref="IForbiddenException"/> thrown by the processing service
+  /// is mapped to a 403 Forbidden <see cref="ProblemDetails"/> response by the endpoint.
+  /// </summary>
+  [Fact]
+  public async Task RetrieveSpecificInvoiceAsync_WhenServiceThrowsForbidden_Returns403()
+  {
+    var mockService = CreateServiceMockThatThrowsOnRead(new TestForbiddenException("access denied"));
+    var accessor = CreateAuthenticatedContextAccessor();
+
+    var result = await InvoiceEndpoints
+      .RetrieveSpecificInvoiceAsync(mockService.Object, accessor, Guid.NewGuid())
+      .ConfigureAwait(false);
+
+    Assert.Equal(StatusCodes.Status403Forbidden, GetStatusCode(result));
+    Assert.Equal(ProblemTypeUris.Forbidden, GetProblemDetails(result).Type);
+  }
+  #endregion
+
+  #region GET /rest/v1/merchants/{id} status code tests
+  // Mirrors the Invoice-endpoint coverage against the Merchant read handler
+  // (RetrieveSpecificMerchantAsync). Both handlers funnel exceptions through
+  // ExceptionToHttpResultMapper, so the contract under test is identical; only the
+  // handler signature and the service method being provoked (ReadMerchant vs ReadInvoice)
+  // differ.
+
+  /// <summary>
+  /// Verifies that an <see cref="INotFoundException"/> thrown from <c>ReadMerchant</c>
+  /// is mapped to a 404 Not Found <see cref="ProblemDetails"/> response by the endpoint.
+  /// </summary>
+  [Fact]
+  public async Task RetrieveSpecificMerchantAsync_WhenServiceThrowsNotFound_Returns404()
+  {
+    var mockService = CreateServiceMockThatThrowsOnMerchantRead(new TestNotFoundException("merchant not found"));
+    var accessor = CreateAuthenticatedContextAccessor();
+
+    var result = await InvoiceEndpoints
+      .RetrieveSpecificMerchantAsync(mockService.Object, accessor, Guid.NewGuid(), parentCompanyId: null)
+      .ConfigureAwait(false);
+
+    Assert.Equal(StatusCodes.Status404NotFound, GetStatusCode(result));
+    Assert.Equal(ProblemTypeUris.NotFound, GetProblemDetails(result).Type);
+  }
+
+  /// <summary>
+  /// Verifies that an <see cref="IAlreadyExistsException"/> thrown from <c>ReadMerchant</c>
+  /// is mapped to a 409 Conflict <see cref="ProblemDetails"/> response by the endpoint.
+  /// </summary>
+  [Fact]
+  public async Task RetrieveSpecificMerchantAsync_WhenServiceThrowsConflict_Returns409()
+  {
+    var mockService = CreateServiceMockThatThrowsOnMerchantRead(new TestConflictException("merchant already exists"));
+    var accessor = CreateAuthenticatedContextAccessor();
+
+    var result = await InvoiceEndpoints
+      .RetrieveSpecificMerchantAsync(mockService.Object, accessor, Guid.NewGuid(), parentCompanyId: null)
+      .ConfigureAwait(false);
+
+    Assert.Equal(StatusCodes.Status409Conflict, GetStatusCode(result));
+    Assert.Equal(ProblemTypeUris.Conflict, GetProblemDetails(result).Type);
+  }
+
+  /// <summary>
+  /// Verifies that an <see cref="ILockedException"/> thrown from <c>ReadMerchant</c>
+  /// is mapped to a 423 Locked <see cref="ProblemDetails"/> response by the endpoint.
+  /// </summary>
+  [Fact]
+  public async Task RetrieveSpecificMerchantAsync_WhenServiceThrowsLocked_Returns423()
+  {
+    var mockService = CreateServiceMockThatThrowsOnMerchantRead(new TestLockedException("merchant locked"));
+    var accessor = CreateAuthenticatedContextAccessor();
+
+    var result = await InvoiceEndpoints
+      .RetrieveSpecificMerchantAsync(mockService.Object, accessor, Guid.NewGuid(), parentCompanyId: null)
+      .ConfigureAwait(false);
+
+    Assert.Equal(StatusCodes.Status423Locked, GetStatusCode(result));
+    Assert.Equal(ProblemTypeUris.Locked, GetProblemDetails(result).Type);
+  }
+
+  /// <summary>
+  /// Verifies that an <see cref="IRateLimitedException"/> thrown from <c>ReadMerchant</c>
+  /// is mapped to a 429 Too Many Requests <see cref="ProblemDetails"/> response carrying
+  /// the retry hint on the <c>retryAfterSeconds</c> extension member.
+  /// </summary>
+  [Fact]
+  public async Task RetrieveSpecificMerchantAsync_WhenServiceThrowsRateLimit_Returns429WithRetryAfterSecondsExtension()
+  {
+    var retryAfter = TimeSpan.FromSeconds(17);
+    var mockService = CreateServiceMockThatThrowsOnMerchantRead(
+      new TestRateLimitedException("merchant reads throttled", retryAfter));
+    var accessor = CreateAuthenticatedContextAccessor();
+
+    var result = await InvoiceEndpoints
+      .RetrieveSpecificMerchantAsync(mockService.Object, accessor, Guid.NewGuid(), parentCompanyId: null)
+      .ConfigureAwait(false);
+
+    Assert.Equal(StatusCodes.Status429TooManyRequests, GetStatusCode(result));
+    var problem = GetProblemDetails(result);
+    Assert.Equal(ProblemTypeUris.RateLimited, problem.Type);
+
+    Assert.True(
+      problem.Extensions.TryGetValue("retryAfterSeconds", out var retryHint),
+      "Expected 'retryAfterSeconds' extension on 429 ProblemDetails body.");
+    Assert.Equal(17, Assert.IsType<int>(retryHint));
+  }
+
+  /// <summary>
+  /// Verifies that an <see cref="IUnauthorizedException"/> thrown from <c>ReadMerchant</c>
+  /// is mapped to a 401 Unauthorized <see cref="ProblemDetails"/> response by the endpoint.
+  /// </summary>
+  [Fact]
+  public async Task RetrieveSpecificMerchantAsync_WhenServiceThrowsUnauthorized_Returns401()
+  {
+    var mockService = CreateServiceMockThatThrowsOnMerchantRead(new TestUnauthorizedException("authentication required"));
+    var accessor = CreateAuthenticatedContextAccessor();
+
+    var result = await InvoiceEndpoints
+      .RetrieveSpecificMerchantAsync(mockService.Object, accessor, Guid.NewGuid(), parentCompanyId: null)
+      .ConfigureAwait(false);
+
+    Assert.Equal(StatusCodes.Status401Unauthorized, GetStatusCode(result));
+    Assert.Equal(ProblemTypeUris.Unauthorized, GetProblemDetails(result).Type);
+  }
+
+  /// <summary>
+  /// Verifies that an <see cref="IForbiddenException"/> thrown from <c>ReadMerchant</c>
+  /// is mapped to a 403 Forbidden <see cref="ProblemDetails"/> response by the endpoint.
+  /// </summary>
+  [Fact]
+  public async Task RetrieveSpecificMerchantAsync_WhenServiceThrowsForbidden_Returns403()
+  {
+    var mockService = CreateServiceMockThatThrowsOnMerchantRead(new TestForbiddenException("access denied"));
+    var accessor = CreateAuthenticatedContextAccessor();
+
+    var result = await InvoiceEndpoints
+      .RetrieveSpecificMerchantAsync(mockService.Object, accessor, Guid.NewGuid(), parentCompanyId: null)
+      .ConfigureAwait(false);
+
+    Assert.Equal(StatusCodes.Status403Forbidden, GetStatusCode(result));
+    Assert.Equal(ProblemTypeUris.Forbidden, GetProblemDetails(result).Type);
+  }
+
+  /// <summary>
+  /// Verifies that an <see cref="IDependencyException"/> thrown from <c>ReadMerchant</c>
+  /// is mapped to a 503 Service Unavailable <see cref="ProblemDetails"/> response by the endpoint.
+  /// </summary>
+  [Fact]
+  public async Task RetrieveSpecificMerchantAsync_WhenServiceThrowsDependencyFailure_Returns503()
+  {
+    var mockService = CreateServiceMockThatThrowsOnMerchantRead(
+      new TestDependencyException("upstream dependency failed"));
+    var accessor = CreateAuthenticatedContextAccessor();
+
+    var result = await InvoiceEndpoints
+      .RetrieveSpecificMerchantAsync(mockService.Object, accessor, Guid.NewGuid(), parentCompanyId: null)
+      .ConfigureAwait(false);
+
+    Assert.Equal(StatusCodes.Status503ServiceUnavailable, GetStatusCode(result));
+    Assert.Equal(ProblemTypeUris.ServiceUnavailable, GetProblemDetails(result).Type);
+  }
+  #endregion
+
+  #region ProblemDetails traceId extension tests
+  /// <summary>
+  /// Verifies that when an ambient <see cref="Activity"/> is active during handler execution,
+  /// the emitted <see cref="ProblemDetails"/> payload exposes a <c>traceId</c> extension equal to
+  /// <see cref="Activity.TraceId"/>. This is the correlation hook that ties a 4xx/5xx response
+  /// back to the originating distributed trace for client/SRE diagnostics.
+  /// </summary>
+  /// <remarks>
+  /// Registers an <see cref="ActivityListener"/> with <see cref="ActivitySamplingResult.AllData"/>
+  /// so <see cref="ActivitySource.StartActivity(string, ActivityKind)"/> actually produces a
+  /// non-null <see cref="Activity"/>; default sampling yields <c>null</c> outside a hosted app.
+  /// Mirrors the pattern used by <c>ExceptionMappingHandlerTests.TryHandleAsync_ClassifiableException_IncludesTraceIdWhenActivityPresent</c>.
+  /// </remarks>
+  [Fact]
+  public async Task RetrieveSpecificInvoiceAsync_WhenActivityActive_ProblemDetailsIncludesTraceId()
+  {
+    // Arrange - register a listener that samples EVERYTHING so StartActivity returns a real Activity.
+    using var listener = new ActivityListener
+    {
+      ShouldListenTo = _ => true,
+      Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+    };
+    ActivitySource.AddActivityListener(listener);
+
+    using var source = new ActivitySource("arolariu.tests.InvoiceEndpointsStatusCodeTests");
+    using var activity = source.StartActivity("test-op");
+    Assert.NotNull(activity);
+
+    var mockService = CreateServiceMockThatThrowsOnRead(new TestNotFoundException("invoice not found"));
+    var accessor = CreateAuthenticatedContextAccessor();
+
+    // Act
+    var result = await InvoiceEndpoints
+      .RetrieveSpecificInvoiceAsync(mockService.Object, accessor, Guid.NewGuid())
+      .ConfigureAwait(false);
+
+    // Assert
+    Assert.Equal(StatusCodes.Status404NotFound, GetStatusCode(result));
+    var problem = GetProblemDetails(result);
+
+    Assert.True(
+      problem.Extensions.TryGetValue("traceId", out var traceIdValue),
+      "Expected 'traceId' extension on ProblemDetails when an Activity is active.");
+
+    var expectedTraceId = Activity.Current!.TraceId.ToString();
+    Assert.Equal(expectedTraceId, Assert.IsType<string>(traceIdValue));
   }
   #endregion
 }

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Integration/InvoiceEndpointsStatusCodeTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Integration/InvoiceEndpointsStatusCodeTests.cs
@@ -56,16 +56,28 @@ public sealed class InvoiceEndpointsStatusCodeTests
   private sealed class TestNotFoundException : Exception, INotFoundException
   {
     public TestNotFoundException(string message) : base(message) { }
+
+    public TestNotFoundException()
+    {
+    }
   }
 
   private sealed class TestConflictException : Exception, IAlreadyExistsException
   {
     public TestConflictException(string message) : base(message) { }
+
+    public TestConflictException()
+    {
+    }
   }
 
   private sealed class TestLockedException : Exception, ILockedException
   {
     public TestLockedException(string message) : base(message) { }
+
+    public TestLockedException()
+    {
+    }
   }
 
   private sealed class TestRateLimitedException : Exception, IRateLimitedException
@@ -76,21 +88,37 @@ public sealed class InvoiceEndpointsStatusCodeTests
     }
 
     public TimeSpan RetryAfter { get; }
+
+    public TestRateLimitedException()
+    {
+    }
   }
 
   private sealed class TestDependencyException : Exception, IDependencyException
   {
     public TestDependencyException(string message) : base(message) { }
+
+    public TestDependencyException()
+    {
+    }
   }
 
   private sealed class TestUnauthorizedException : Exception, IUnauthorizedException
   {
     public TestUnauthorizedException(string message) : base(message) { }
+
+    public TestUnauthorizedException()
+    {
+    }
   }
 
   private sealed class TestForbiddenException : Exception, IForbiddenException
   {
     public TestForbiddenException(string message) : base(message) { }
+
+    public TestForbiddenException()
+    {
+    }
   }
   #endregion
 
@@ -158,7 +186,7 @@ public sealed class InvoiceEndpointsStatusCodeTests
     // Act
     var result = await InvoiceEndpoints
       .RetrieveSpecificInvoiceAsync(mockService.Object, accessor, Guid.NewGuid())
-      .ConfigureAwait(false);
+;
 
     // Assert
     Assert.Equal(StatusCodes.Status404NotFound, GetStatusCode(result));
@@ -178,7 +206,7 @@ public sealed class InvoiceEndpointsStatusCodeTests
 
     var result = await InvoiceEndpoints
       .RetrieveSpecificInvoiceAsync(mockService.Object, accessor, Guid.NewGuid())
-      .ConfigureAwait(false);
+;
 
     Assert.Equal(StatusCodes.Status409Conflict, GetStatusCode(result));
     Assert.Equal(ProblemTypeUris.Conflict, GetProblemDetails(result).Type);
@@ -196,7 +224,7 @@ public sealed class InvoiceEndpointsStatusCodeTests
 
     var result = await InvoiceEndpoints
       .RetrieveSpecificInvoiceAsync(mockService.Object, accessor, Guid.NewGuid())
-      .ConfigureAwait(false);
+;
 
     Assert.Equal(StatusCodes.Status423Locked, GetStatusCode(result));
     Assert.Equal(ProblemTypeUris.Locked, GetProblemDetails(result).Type);
@@ -219,7 +247,7 @@ public sealed class InvoiceEndpointsStatusCodeTests
     // Act
     var result = await InvoiceEndpoints
       .RetrieveSpecificInvoiceAsync(mockService.Object, accessor, Guid.NewGuid())
-      .ConfigureAwait(false);
+;
 
     // Assert
     Assert.Equal(StatusCodes.Status429TooManyRequests, GetStatusCode(result));
@@ -247,7 +275,7 @@ public sealed class InvoiceEndpointsStatusCodeTests
 
     var result = await InvoiceEndpoints
       .RetrieveSpecificInvoiceAsync(mockService.Object, accessor, Guid.NewGuid())
-      .ConfigureAwait(false);
+;
 
     Assert.Equal(StatusCodes.Status503ServiceUnavailable, GetStatusCode(result));
     Assert.Equal(ProblemTypeUris.ServiceUnavailable, GetProblemDetails(result).Type);
@@ -270,7 +298,7 @@ public sealed class InvoiceEndpointsStatusCodeTests
     // Act
     var result = await InvoiceEndpoints
       .RetrieveSpecificInvoiceAsync(mockService.Object, accessor, Guid.NewGuid())
-      .ConfigureAwait(false);
+;
 
     // Assert
     Assert.Equal(StatusCodes.Status500InternalServerError, GetStatusCode(result));
@@ -304,7 +332,7 @@ public sealed class InvoiceEndpointsStatusCodeTests
     // Act
     var result = await InvoiceEndpoints
       .CreateNewInvoiceAsync(mockService.Object, accessor, invalidDto)
-      .ConfigureAwait(false);
+;
 
     // Assert
     Assert.Equal(StatusCodes.Status400BadRequest, GetStatusCode(result));
@@ -325,7 +353,7 @@ public sealed class InvoiceEndpointsStatusCodeTests
 
     var result = await InvoiceEndpoints
       .RetrieveSpecificInvoiceAsync(mockService.Object, accessor, Guid.NewGuid())
-      .ConfigureAwait(false);
+;
 
     Assert.Equal(StatusCodes.Status401Unauthorized, GetStatusCode(result));
     Assert.Equal(ProblemTypeUris.Unauthorized, GetProblemDetails(result).Type);
@@ -343,7 +371,7 @@ public sealed class InvoiceEndpointsStatusCodeTests
 
     var result = await InvoiceEndpoints
       .RetrieveSpecificInvoiceAsync(mockService.Object, accessor, Guid.NewGuid())
-      .ConfigureAwait(false);
+;
 
     Assert.Equal(StatusCodes.Status403Forbidden, GetStatusCode(result));
     Assert.Equal(ProblemTypeUris.Forbidden, GetProblemDetails(result).Type);
@@ -369,7 +397,7 @@ public sealed class InvoiceEndpointsStatusCodeTests
 
     var result = await InvoiceEndpoints
       .RetrieveSpecificMerchantAsync(mockService.Object, accessor, Guid.NewGuid(), parentCompanyId: null)
-      .ConfigureAwait(false);
+;
 
     Assert.Equal(StatusCodes.Status404NotFound, GetStatusCode(result));
     Assert.Equal(ProblemTypeUris.NotFound, GetProblemDetails(result).Type);
@@ -387,7 +415,7 @@ public sealed class InvoiceEndpointsStatusCodeTests
 
     var result = await InvoiceEndpoints
       .RetrieveSpecificMerchantAsync(mockService.Object, accessor, Guid.NewGuid(), parentCompanyId: null)
-      .ConfigureAwait(false);
+;
 
     Assert.Equal(StatusCodes.Status409Conflict, GetStatusCode(result));
     Assert.Equal(ProblemTypeUris.Conflict, GetProblemDetails(result).Type);
@@ -405,7 +433,7 @@ public sealed class InvoiceEndpointsStatusCodeTests
 
     var result = await InvoiceEndpoints
       .RetrieveSpecificMerchantAsync(mockService.Object, accessor, Guid.NewGuid(), parentCompanyId: null)
-      .ConfigureAwait(false);
+;
 
     Assert.Equal(StatusCodes.Status423Locked, GetStatusCode(result));
     Assert.Equal(ProblemTypeUris.Locked, GetProblemDetails(result).Type);
@@ -426,7 +454,7 @@ public sealed class InvoiceEndpointsStatusCodeTests
 
     var result = await InvoiceEndpoints
       .RetrieveSpecificMerchantAsync(mockService.Object, accessor, Guid.NewGuid(), parentCompanyId: null)
-      .ConfigureAwait(false);
+;
 
     Assert.Equal(StatusCodes.Status429TooManyRequests, GetStatusCode(result));
     var problem = GetProblemDetails(result);
@@ -450,7 +478,7 @@ public sealed class InvoiceEndpointsStatusCodeTests
 
     var result = await InvoiceEndpoints
       .RetrieveSpecificMerchantAsync(mockService.Object, accessor, Guid.NewGuid(), parentCompanyId: null)
-      .ConfigureAwait(false);
+;
 
     Assert.Equal(StatusCodes.Status401Unauthorized, GetStatusCode(result));
     Assert.Equal(ProblemTypeUris.Unauthorized, GetProblemDetails(result).Type);
@@ -468,7 +496,7 @@ public sealed class InvoiceEndpointsStatusCodeTests
 
     var result = await InvoiceEndpoints
       .RetrieveSpecificMerchantAsync(mockService.Object, accessor, Guid.NewGuid(), parentCompanyId: null)
-      .ConfigureAwait(false);
+;
 
     Assert.Equal(StatusCodes.Status403Forbidden, GetStatusCode(result));
     Assert.Equal(ProblemTypeUris.Forbidden, GetProblemDetails(result).Type);
@@ -487,7 +515,7 @@ public sealed class InvoiceEndpointsStatusCodeTests
 
     var result = await InvoiceEndpoints
       .RetrieveSpecificMerchantAsync(mockService.Object, accessor, Guid.NewGuid(), parentCompanyId: null)
-      .ConfigureAwait(false);
+;
 
     Assert.Equal(StatusCodes.Status503ServiceUnavailable, GetStatusCode(result));
     Assert.Equal(ProblemTypeUris.ServiceUnavailable, GetProblemDetails(result).Type);
@@ -528,7 +556,7 @@ public sealed class InvoiceEndpointsStatusCodeTests
     // Act
     var result = await InvoiceEndpoints
       .RetrieveSpecificInvoiceAsync(mockService.Object, accessor, Guid.NewGuid())
-      .ConfigureAwait(false);
+;
 
     // Assert
     Assert.Equal(StatusCodes.Status404NotFound, GetStatusCode(result));

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Foundation/InvoiceAnalysisFoundationServiceExceptionsTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Foundation/InvoiceAnalysisFoundationServiceExceptionsTests.cs
@@ -1,0 +1,93 @@
+namespace arolariu.Backend.Domain.Tests.Invoices.Services.Foundation;
+
+using System;
+using System.Threading.Tasks;
+
+using arolariu.Backend.Domain.Invoices.Brokers.AnalysisBrokers.ClassifierBroker;
+using arolariu.Backend.Domain.Invoices.Brokers.AnalysisBrokers.IdentifierBroker;
+using arolariu.Backend.Domain.Invoices.DDD.AggregatorRoots.Invoices;
+using arolariu.Backend.Domain.Invoices.DDD.AggregatorRoots.Invoices.Exceptions.Inner;
+using arolariu.Backend.Domain.Invoices.DDD.AggregatorRoots.Invoices.Exceptions.Outer.Foundation;
+using arolariu.Backend.Domain.Invoices.DTOs;
+using arolariu.Backend.Domain.Invoices.Services.Foundation.InvoiceAnalysis;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Moq;
+
+using Xunit;
+
+/// <summary>
+/// Verifies that inner exceptions propagated from the analysis brokers (OCR + GPT) are
+/// classified into the correct Foundation-tier outer exceptions by the TryCatch boundary.
+/// Mirrors the tiering contract validated in <see cref="InvoiceStorageFoundationServiceExceptionsTests"/>.
+/// </summary>
+public class InvoiceAnalysisFoundationServiceExceptionsTests
+{
+  private readonly Mock<IClassifierBroker> _classifierBroker = new();
+  private readonly Mock<IFormRecognizerBroker> _formRecognizerBroker = new();
+  private readonly InvoiceAnalysisFoundationService _sut;
+
+  /// <summary>Initializes a new instance of the <see cref="InvoiceAnalysisFoundationServiceExceptionsTests"/> class.</summary>
+  public InvoiceAnalysisFoundationServiceExceptionsTests()
+  {
+    _sut = new InvoiceAnalysisFoundationService(
+      _classifierBroker.Object,
+      _formRecognizerBroker.Object,
+      NullLoggerFactory.Instance);
+  }
+
+  /// <summary>Verifies that an <see cref="InvoiceIdNotSetException"/> from the OCR broker is wrapped into an <see cref="InvoiceFoundationValidationException"/>.</summary>
+  [Fact]
+  public async Task AnalyzeInvoiceAsync_WhenBrokerThrowsIdNotSet_ThrowsFoundationValidationException()
+  {
+    _formRecognizerBroker
+      .Setup(b => b.PerformOcrAnalysisOnSingleInvoice(It.IsAny<Invoice>(), It.IsAny<AnalysisOptions>()))
+      .ThrowsAsync(new InvoiceIdNotSetException());
+
+    var ex = await Assert.ThrowsAsync<InvoiceFoundationValidationException>(
+      () => _sut.AnalyzeInvoiceAsync(AnalysisOptions.CompleteAnalysis, new Invoice { id = Guid.NewGuid(), UserIdentifier = Guid.NewGuid() }));
+
+    Assert.IsType<InvoiceIdNotSetException>(ex.InnerException);
+  }
+
+  /// <summary>Verifies that an <see cref="InvoiceCosmosDbRateLimitException"/> from the OCR broker is wrapped into an <see cref="InvoiceFoundationDependencyValidationException"/> (caller-correctable 429, not 500).</summary>
+  [Fact]
+  public async Task AnalyzeInvoiceAsync_WhenBrokerThrowsCosmosRateLimit_ThrowsFoundationDependencyValidationException()
+  {
+    _formRecognizerBroker
+      .Setup(b => b.PerformOcrAnalysisOnSingleInvoice(It.IsAny<Invoice>(), It.IsAny<AnalysisOptions>()))
+      .ThrowsAsync(new InvoiceCosmosDbRateLimitException(TimeSpan.FromSeconds(5), new Exception()));
+
+    var ex = await Assert.ThrowsAsync<InvoiceFoundationDependencyValidationException>(
+      () => _sut.AnalyzeInvoiceAsync(AnalysisOptions.CompleteAnalysis, new Invoice { id = Guid.NewGuid(), UserIdentifier = Guid.NewGuid() }));
+
+    Assert.IsType<InvoiceCosmosDbRateLimitException>(ex.InnerException);
+  }
+
+  /// <summary>Verifies that an <see cref="OperationCanceledException"/> from the OCR broker is wrapped into an <see cref="InvoiceFoundationDependencyException"/> (transient downstream cancellation, not a generic 500).</summary>
+  [Fact]
+  public async Task AnalyzeInvoiceAsync_WhenBrokerThrowsOperationCanceled_ThrowsFoundationDependencyException()
+  {
+    _formRecognizerBroker
+      .Setup(b => b.PerformOcrAnalysisOnSingleInvoice(It.IsAny<Invoice>(), It.IsAny<AnalysisOptions>()))
+      .ThrowsAsync(new OperationCanceledException());
+
+    await Assert.ThrowsAsync<InvoiceFoundationDependencyException>(
+      () => _sut.AnalyzeInvoiceAsync(AnalysisOptions.CompleteAnalysis, new Invoice { id = Guid.NewGuid(), UserIdentifier = Guid.NewGuid() }));
+  }
+
+  /// <summary>Verifies that an unclassified exception from the OCR broker is wrapped into an <see cref="InvoiceFoundationServiceException"/> (catch-all tier, 500).</summary>
+  [Fact]
+  public async Task AnalyzeInvoiceAsync_WhenBrokerThrowsUnknown_ThrowsFoundationServiceException()
+  {
+    _formRecognizerBroker
+      .Setup(b => b.PerformOcrAnalysisOnSingleInvoice(It.IsAny<Invoice>(), It.IsAny<AnalysisOptions>()))
+      .ThrowsAsync(new InvalidOperationException("ai model failure"));
+
+    var ex = await Assert.ThrowsAsync<InvoiceFoundationServiceException>(
+      () => _sut.AnalyzeInvoiceAsync(AnalysisOptions.CompleteAnalysis, new Invoice { id = Guid.NewGuid(), UserIdentifier = Guid.NewGuid() }));
+
+    Assert.IsType<InvalidOperationException>(ex.InnerException);
+  }
+}

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Foundation/InvoiceAnalysisFoundationServiceTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Foundation/InvoiceAnalysisFoundationServiceTests.cs
@@ -294,10 +294,12 @@ public sealed class InvoiceAnalysisFoundationServiceTests
   }
 
   /// <summary>
-  /// Validates OperationCanceledException is wrapped into foundation service exception.
+  /// Validates OperationCanceledException is wrapped into foundation dependency exception,
+  /// since downstream cancellation (e.g. timeout from the OCR broker) is a transient infrastructure
+  /// concern that should surface as a 503 rather than a generic 500 per RFC 2003.
   /// </summary>
   [Fact]
-  public async Task AnalyzeInvoiceAsync_OperationCanceledException_ThrowsFoundationServiceException()
+  public async Task AnalyzeInvoiceAsync_OperationCanceledException_ThrowsFoundationDependencyException()
   {
     // Arrange
     var options = AnalysisOptions.CompleteAnalysis;
@@ -308,7 +310,7 @@ public sealed class InvoiceAnalysisFoundationServiceTests
         .ThrowsAsync(new OperationCanceledException("Cancelled"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceFoundationServiceException>(() =>
+    await Assert.ThrowsAsync<InvoiceFoundationDependencyException>(() =>
         service.AnalyzeInvoiceAsync(options, invoice));
   }
 

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Foundation/InvoiceStorageFoundationServiceExceptionsTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Foundation/InvoiceStorageFoundationServiceExceptionsTests.cs
@@ -60,7 +60,7 @@ public class InvoiceStorageFoundationServiceExceptionsTests
 
   /// <summary>Verifies that an <see cref="InvoiceUnauthorizedAccessException"/> from the broker is wrapped into an <see cref="InvoiceFoundationDependencyValidationException"/> (caller-correctable 401, not 503).</summary>
   [Fact]
-  public async Task TryCatchAsync_UnauthorizedAccess_Wraps_As_DependencyValidation()
+  public async Task ReadInvoiceObject_WhenBrokerThrowsUnauthorized_ThrowsFoundationDependencyValidationException()
   {
     _broker.Setup(b => b.ReadInvoiceAsync(It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new InvoiceUnauthorizedAccessException("unauthorized"));
@@ -73,7 +73,7 @@ public class InvoiceStorageFoundationServiceExceptionsTests
 
   /// <summary>Verifies that an <see cref="InvoiceForbiddenAccessException"/> from the broker is wrapped into an <see cref="InvoiceFoundationDependencyValidationException"/> (caller-correctable 403, not 503).</summary>
   [Fact]
-  public async Task TryCatchAsync_ForbiddenAccess_Wraps_As_DependencyValidation()
+  public async Task ReadInvoiceObject_WhenBrokerThrowsForbidden_ThrowsFoundationDependencyValidationException()
   {
     _broker.Setup(b => b.ReadInvoiceAsync(It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new InvoiceForbiddenAccessException(Guid.NewGuid(), Guid.NewGuid()));
@@ -86,7 +86,7 @@ public class InvoiceStorageFoundationServiceExceptionsTests
 
   /// <summary>Verifies that an <see cref="InvoiceCosmosDbRateLimitException"/> from the broker is wrapped into an <see cref="InvoiceFoundationDependencyValidationException"/> (caller-correctable 429, not 503).</summary>
   [Fact]
-  public async Task TryCatchAsync_CosmosRateLimit_Wraps_As_DependencyValidation()
+  public async Task ReadInvoiceObject_WhenBrokerThrowsRateLimit_ThrowsFoundationDependencyValidationException()
   {
     _broker.Setup(b => b.ReadInvoiceAsync(It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new InvoiceCosmosDbRateLimitException(TimeSpan.FromSeconds(2), new Exception()));
@@ -99,7 +99,7 @@ public class InvoiceStorageFoundationServiceExceptionsTests
 
   /// <summary>Regression guard: <see cref="InvoiceFailedStorageException"/> must remain in the Dependency tier (downstream unreachable, 503).</summary>
   [Fact]
-  public async Task TryCatchAsync_FailedStorage_StaysIn_DependencyTier()
+  public async Task ReadInvoiceObject_WhenBrokerThrowsFailedStorage_ThrowsFoundationDependencyException()
   {
     _broker.Setup(b => b.ReadInvoiceAsync(It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new InvoiceFailedStorageException("down"));

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Foundation/InvoiceStorageFoundationServiceExceptionsTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Foundation/InvoiceStorageFoundationServiceExceptionsTests.cs
@@ -58,26 +58,56 @@ public class InvoiceStorageFoundationServiceExceptionsTests
     Assert.IsType<InvoiceAlreadyExistsException>(ex.InnerException);
   }
 
-  /// <summary>Verifies that an <see cref="InvoiceCosmosDbRateLimitException"/> from the broker is wrapped into an <see cref="InvoiceFoundationDependencyException"/>.</summary>
+  /// <summary>Verifies that an <see cref="InvoiceUnauthorizedAccessException"/> from the broker is wrapped into an <see cref="InvoiceFoundationDependencyValidationException"/> (caller-correctable 401, not 503).</summary>
   [Fact]
-  public async Task ReadInvoiceObject_WhenBrokerThrowsRateLimit_ThrowsFoundationDependencyException()
+  public async Task TryCatchAsync_UnauthorizedAccess_Wraps_As_DependencyValidation()
+  {
+    _broker.Setup(b => b.ReadInvoiceAsync(It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
+      .ThrowsAsync(new InvoiceUnauthorizedAccessException("unauthorized"));
+
+    var ex = await Assert.ThrowsAsync<InvoiceFoundationDependencyValidationException>(
+      () => _sut.ReadInvoiceObject(Guid.NewGuid(), Guid.NewGuid()));
+
+    Assert.IsType<InvoiceUnauthorizedAccessException>(ex.InnerException);
+  }
+
+  /// <summary>Verifies that an <see cref="InvoiceForbiddenAccessException"/> from the broker is wrapped into an <see cref="InvoiceFoundationDependencyValidationException"/> (caller-correctable 403, not 503).</summary>
+  [Fact]
+  public async Task TryCatchAsync_ForbiddenAccess_Wraps_As_DependencyValidation()
+  {
+    _broker.Setup(b => b.ReadInvoiceAsync(It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
+      .ThrowsAsync(new InvoiceForbiddenAccessException(Guid.NewGuid(), Guid.NewGuid()));
+
+    var ex = await Assert.ThrowsAsync<InvoiceFoundationDependencyValidationException>(
+      () => _sut.ReadInvoiceObject(Guid.NewGuid(), Guid.NewGuid()));
+
+    Assert.IsType<InvoiceForbiddenAccessException>(ex.InnerException);
+  }
+
+  /// <summary>Verifies that an <see cref="InvoiceCosmosDbRateLimitException"/> from the broker is wrapped into an <see cref="InvoiceFoundationDependencyValidationException"/> (caller-correctable 429, not 503).</summary>
+  [Fact]
+  public async Task TryCatchAsync_CosmosRateLimit_Wraps_As_DependencyValidation()
   {
     _broker.Setup(b => b.ReadInvoiceAsync(It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new InvoiceCosmosDbRateLimitException(TimeSpan.FromSeconds(2), new Exception()));
 
-    await Assert.ThrowsAsync<InvoiceFoundationDependencyException>(
+    var ex = await Assert.ThrowsAsync<InvoiceFoundationDependencyValidationException>(
       () => _sut.ReadInvoiceObject(Guid.NewGuid(), Guid.NewGuid()));
+
+    Assert.IsType<InvoiceCosmosDbRateLimitException>(ex.InnerException);
   }
 
-  /// <summary>Verifies that an <see cref="InvoiceFailedStorageException"/> from the broker is wrapped into an <see cref="InvoiceFoundationDependencyException"/>.</summary>
+  /// <summary>Regression guard: <see cref="InvoiceFailedStorageException"/> must remain in the Dependency tier (downstream unreachable, 503).</summary>
   [Fact]
-  public async Task ReadInvoiceObject_WhenBrokerThrowsFailedStorage_ThrowsFoundationDependencyException()
+  public async Task TryCatchAsync_FailedStorage_StaysIn_DependencyTier()
   {
     _broker.Setup(b => b.ReadInvoiceAsync(It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new InvoiceFailedStorageException("down"));
 
-    await Assert.ThrowsAsync<InvoiceFoundationDependencyException>(
+    var ex = await Assert.ThrowsAsync<InvoiceFoundationDependencyException>(
       () => _sut.ReadInvoiceObject(Guid.NewGuid(), Guid.NewGuid()));
+
+    Assert.IsType<InvoiceFailedStorageException>(ex.InnerException);
   }
 
   /// <summary>Verifies that an unclassified exception from the broker is wrapped into an <see cref="InvoiceFoundationServiceException"/>.</summary>

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Foundation/MerchantStorageFoundationServiceExceptionsTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Foundation/MerchantStorageFoundationServiceExceptionsTests.cs
@@ -58,26 +58,56 @@ public class MerchantStorageFoundationServiceExceptionsTests
     Assert.IsType<MerchantAlreadyExistsException>(ex.InnerException);
   }
 
-  /// <summary>Verifies that a <see cref="MerchantCosmosDbRateLimitException"/> from the broker is wrapped into a <see cref="MerchantFoundationServiceDependencyException"/>.</summary>
+  /// <summary>Verifies that a <see cref="MerchantUnauthorizedAccessException"/> from the broker is wrapped into a <see cref="MerchantFoundationServiceDependencyValidationException"/> (caller-correctable 401, not 503).</summary>
   [Fact]
-  public async Task ReadMerchantObject_WhenBrokerThrowsRateLimit_ThrowsFoundationDependencyException()
+  public async Task ReadMerchantObject_WhenBrokerThrowsUnauthorized_ThrowsFoundationDependencyValidationException()
+  {
+    _broker.Setup(b => b.ReadMerchantAsync(It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
+      .ThrowsAsync(new MerchantUnauthorizedAccessException("unauthorized"));
+
+    var ex = await Assert.ThrowsAsync<MerchantFoundationServiceDependencyValidationException>(
+      () => _sut.ReadMerchantObject(Guid.NewGuid(), Guid.NewGuid()));
+
+    Assert.IsType<MerchantUnauthorizedAccessException>(ex.InnerException);
+  }
+
+  /// <summary>Verifies that a <see cref="MerchantForbiddenAccessException"/> from the broker is wrapped into a <see cref="MerchantFoundationServiceDependencyValidationException"/> (caller-correctable 403, not 503).</summary>
+  [Fact]
+  public async Task ReadMerchantObject_WhenBrokerThrowsForbidden_ThrowsFoundationDependencyValidationException()
+  {
+    _broker.Setup(b => b.ReadMerchantAsync(It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
+      .ThrowsAsync(new MerchantForbiddenAccessException(Guid.NewGuid(), Guid.NewGuid()));
+
+    var ex = await Assert.ThrowsAsync<MerchantFoundationServiceDependencyValidationException>(
+      () => _sut.ReadMerchantObject(Guid.NewGuid(), Guid.NewGuid()));
+
+    Assert.IsType<MerchantForbiddenAccessException>(ex.InnerException);
+  }
+
+  /// <summary>Verifies that a <see cref="MerchantCosmosDbRateLimitException"/> from the broker is wrapped into a <see cref="MerchantFoundationServiceDependencyValidationException"/> (caller-correctable 429, not 503).</summary>
+  [Fact]
+  public async Task ReadMerchantObject_WhenBrokerThrowsRateLimit_ThrowsFoundationDependencyValidationException()
   {
     _broker.Setup(b => b.ReadMerchantAsync(It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new MerchantCosmosDbRateLimitException(TimeSpan.FromSeconds(2), new Exception()));
 
-    await Assert.ThrowsAsync<MerchantFoundationServiceDependencyException>(
+    var ex = await Assert.ThrowsAsync<MerchantFoundationServiceDependencyValidationException>(
       () => _sut.ReadMerchantObject(Guid.NewGuid(), Guid.NewGuid()));
+
+    Assert.IsType<MerchantCosmosDbRateLimitException>(ex.InnerException);
   }
 
-  /// <summary>Verifies that a <see cref="MerchantFailedStorageException"/> from the broker is wrapped into a <see cref="MerchantFoundationServiceDependencyException"/>.</summary>
+  /// <summary>Regression guard: <see cref="MerchantFailedStorageException"/> must remain in the Dependency tier (downstream unreachable, 503).</summary>
   [Fact]
   public async Task ReadMerchantObject_WhenBrokerThrowsFailedStorage_ThrowsFoundationDependencyException()
   {
     _broker.Setup(b => b.ReadMerchantAsync(It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new MerchantFailedStorageException("down"));
 
-    await Assert.ThrowsAsync<MerchantFoundationServiceDependencyException>(
+    var ex = await Assert.ThrowsAsync<MerchantFoundationServiceDependencyException>(
       () => _sut.ReadMerchantObject(Guid.NewGuid(), Guid.NewGuid()));
+
+    Assert.IsType<MerchantFailedStorageException>(ex.InnerException);
   }
 
   /// <summary>Verifies that an unclassified exception from the broker is wrapped into a <see cref="MerchantFoundationServiceException"/>.</summary>

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/arolariu.Backend.Domain.Tests.csproj
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/arolariu.Backend.Domain.Tests.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup Label="Test Packages">
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" />
     <PackageReference Include="Moq" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/packages.lock.json
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/packages.lock.json
@@ -8,6 +8,12 @@
         "resolved": "8.0.1",
         "contentHash": "heVQl5tKYnnIDYlR1QMVGueYH6iriZTcZB6AjDczQNwZzxkjDIt9C84Pt4cCiZYrbo7jkZOYGWbs6Lo9wAtVLg=="
       },
+      "Microsoft.AspNetCore.TestHost": {
+        "type": "Direct",
+        "requested": "[10.0.5, )",
+        "resolved": "10.0.5",
+        "contentHash": "PJEdrZnnhvxIEXzDdvdZ38GvpdaiUfKkZ99kudS8riJwhowFb/Qh26Wjk9smrCWcYdMFQmpN5epGiL4o1s8LYA=="
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.3.0, )",
@@ -62,23 +68,7 @@
       "Castle.Core": {
         "type": "Transitive",
         "resolved": "5.2.1",
-        "contentHash": "wHARzQA695jwwKreOzNsq54KiGqKP38tv8hi8e2FXDEC/sA6BtrX90tVPDkOfVu13PbEzr00TCV8coikl+D1Iw==",
-        "dependencies": {
-          "System.Diagnostics.EventLog": "6.0.0"
-        }
-      },
-      "Microsoft.AspNetCore.Cryptography.Internal": {
-        "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "kFUpNRYySfqNLuQKGMKZ2mK8b86R1zizlc9QB6R/Ess0rSkrA8pRNCMSFm+DqUnNfm5G3FWjsYIJOKYyhkHeig=="
-      },
-      "Microsoft.AspNetCore.Cryptography.KeyDerivation": {
-        "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "NkWUZYkL6wavYY2wMZgnODzsyTOZhcRxP/DJvZlBbWEJViukdyuIqtdTzltODyjsc3MjEvxmbPDDk2KgGv6tMA==",
-        "dependencies": {
-          "Microsoft.AspNetCore.Cryptography.Internal": "10.0.5"
-        }
+        "contentHash": "wHARzQA695jwwKreOzNsq54KiGqKP38tv8hi8e2FXDEC/sA6BtrX90tVPDkOfVu13PbEzr00TCV8coikl+D1Iw=="
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
@@ -109,7 +99,6 @@
           "Azure.Identity": "1.14.2",
           "Microsoft.Bcl.Cryptography": "9.0.4",
           "Microsoft.Data.SqlClient.SNI.runtime": "6.0.2",
-          "Microsoft.Extensions.Caching.Memory": "9.0.4",
           "Microsoft.IdentityModel.JsonWebTokens": "7.7.1",
           "Microsoft.IdentityModel.Protocols.OpenIdConnect": "7.7.1",
           "Microsoft.SqlServer.Server": "1.0.0",
@@ -135,157 +124,10 @@
         "resolved": "10.0.0",
         "contentHash": "NCWCGiwRwje8773yzPQhvucYnnfeR+ZoB1VRIrIMp4uaeUNw7jvEPHij3HIbwCDuNCrNcphA00KSAR9yD9qmbg=="
       },
-      "Microsoft.Extensions.Caching.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "k/QDdQ94/0Shi0KfU+e12m73jfQo+3JpErTtgpZfsCIqkvdEEO0XIx6R+iTbN55rNPaNhOqNY4/sB+jZ8XxVPw==",
-        "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.5"
-        }
-      },
-      "Microsoft.Extensions.Caching.Memory": {
-        "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "jUEXmkBUPdOS/MP9areK/sbKhdklq9+tEhvwfxGalZVnmyLUO5rrheNNutUBtvbZ7J8ECkG7/r2KXi/IFC06cA==",
-        "dependencies": {
-          "Microsoft.Extensions.Caching.Abstractions": "10.0.5",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Options": "10.0.5",
-          "Microsoft.Extensions.Primitives": "10.0.5"
-        }
-      },
-      "Microsoft.Extensions.Configuration": {
-        "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "8Rx5sqg04FttxrumyG6bmoRuFRgYzK6IVwF1i0/o0cXfKBdDeVpJejKHtJCMjyg9E/DNMVqpqOGe/tCT5gYvVA==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Primitives": "10.0.5"
-        }
-      },
-      "Microsoft.Extensions.Configuration.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "P09QpTHjqHmCLQOTC+WyLkoRNxek4NIvfWt+TnU0etoDUSRxcltyd6+j/ouRbMdLR0j44GqGO+lhI2M4fAHG4g==",
-        "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.5"
-        }
-      },
-      "Microsoft.Extensions.Configuration.Binder": {
-        "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "99Z4rjyXopb1MIazDSPcvwYCUdYNO01Cf1GUs2WUjIFAbkGmwzj2vPa2k+3pheJRV+YgNd2QqRKHAri0oBAU4Q==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.5",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5"
-        }
-      },
-      "Microsoft.Extensions.DependencyInjection": {
-        "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "v1SVsowG6YE1YnHVGmLWz57YTRCQRx9pH5ebIESXfm5isI9gA3QaMyg/oMTzPpXYZwSAVDzYItGJKfmV+pqXkQ==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
-        }
-      },
-      "Microsoft.Extensions.DependencyInjection.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "iVMtq9eRvzyhx8949EGT0OCYJfXi737SbRVzWXE5GrOgGj5AaZ9eUuxA/BSUfmOMALKn/g8KfFaNQw0eiB3lyA=="
-      },
       "Microsoft.Extensions.DependencyModel": {
         "type": "Transitive",
         "resolved": "10.0.5",
         "contentHash": "xA4kkL+QS6KCAOKz/O0oquHs44Ob8J7zpBCNt3wjkBWDg5aCqfwG8rWWLsg5V86AM0sB849g9JjPjIdksTCIKg=="
-      },
-      "Microsoft.Extensions.Diagnostics": {
-        "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "vAJHd4yOpmKoK+jBuYV7a3y+Ab9U4ARCc29b6qvMy276RgJFw9LFs0DdsPqOL3ahwzyrX7tM+i4cCxU/RX0qAg==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.5",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.5"
-        }
-      },
-      "Microsoft.Extensions.Diagnostics.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "/nYGrpa9/0BZofrVpBbbj+Ns8ZesiPE0V/KxsuHgDgHQopIzN54nRaQGSuvPw16/kI9sW1Zox5yyAPqvf0Jz6A==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Options": "10.0.5"
-        }
-      },
-      "Microsoft.Extensions.FileProviders.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "4TD9AXDRsipTmaemwnjt/DM5Ri0de2JzHQhvZ4woBTjUtL4XrPNsMrOk5oiLJAx1gTrE6pOIhxv+lEde5F6CZA==",
-        "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.3"
-        }
-      },
-      "Microsoft.Extensions.Hosting.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "GdMpC10Jf6poxSvUJ4lgYpJ5F/kJeaAoJmrPufjBoPYyCTKKY5Dyl0rZA+LBNvFqTq1cZa/lhlptlUhNvU6xrg==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.3",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.3",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.3",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.3"
-        }
-      },
-      "Microsoft.Extensions.Logging.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "9HOdqlDtPptVcmKAjsQ/Nr5Rxfq6FMYLdhvZh1lVmeKR738qeYecQD7+ldooXf+u2KzzR1kafSphWngIM3C6ug==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
-        }
-      },
-      "Microsoft.Extensions.Logging.Configuration": {
-        "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "j8zcwhS6bYB6FEfaY3nYSgHdpiL2T+/V3xjpHtslVAegyI1JUbB9yAt/BFdvZdsNbY0Udm4xFtvfT/hUwcOOOg==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Logging": "10.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Options": "10.0.0",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.0"
-        }
-      },
-      "Microsoft.Extensions.Options": {
-        "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "MDaQMdUplw0AIRhWWmbLA7yQEXaLIHb+9CTroTiNS8OlI0LMXS4LCxtopqauiqGCWlRgJ+xyraVD8t6veRAFbw==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Primitives": "10.0.5"
-        }
-      },
-      "Microsoft.Extensions.Options.ConfigurationExtensions": {
-        "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "BB9uUW3+6Rxu1R97OB1H/13lUF8P2+H1+eDhpZlK30kDh/6E4EKHBUqTp+ilXQmZLzsRErxON8aBSR6WpUKJdg==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.5",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Options": "10.0.5",
-          "Microsoft.Extensions.Primitives": "10.0.5"
-        }
-      },
-      "Microsoft.Extensions.Primitives": {
-        "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "/HUHJ0tw/LQvD0DZrz50eQy/3z7PfX7WWEaXnjKTV9/TNdcgFlNTZGo49QhS7PTmhDqMyHRMqAXSBxLh0vso4g=="
       },
       "Microsoft.Identity.Client": {
         "type": "Transitive",
@@ -379,7 +221,6 @@
         "resolved": "1.15.1",
         "contentHash": "aZedpOfXtHmVSWlebxJBeJg2DCdzds86mMowBTS6l+sjwV9LvQuZa0JDU9+S7FQvta4hnauxlCEYplbiDiYGeg==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
           "OpenTelemetry.Api": "1.15.1"
         }
       },
@@ -388,8 +229,6 @@
         "resolved": "1.15.0",
         "contentHash": "J0lI7lCngS4TJD4T7KNsAerOIjJHNV0T2MK0iuS2tK8wF7iqL1dp4MKW05FiyfvrIXkwsvFc1okKchxS8B0+SQ==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.0",
-          "Microsoft.Extensions.Options": "10.0.0",
           "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.15.0, 2.0.0)"
         }
       },
@@ -416,9 +255,6 @@
         "resolved": "1.10.0",
         "contentHash": "lBEWs54F5Y5pZ9hC+8z4S/X76957ex+DPk7WecRHlbIHtrPfbRMMlOgI3iDn4Jpb3bSxvBnKaaHoD59auFjlBA==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.3",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.3",
           "System.Memory.Data": "10.0.3"
         }
       },
@@ -427,14 +263,8 @@
         "resolved": "9.0.4",
         "contentHash": "dvjqKp+2LpGid6phzrdrS/2mmEPxFl3jE1+L7614q4ZChKbLJCpHXg6sBILlCCED1t//EE+un/UdAetzIMpqnw==",
         "dependencies": {
-          "System.Diagnostics.EventLog": "9.0.4",
           "System.Security.Cryptography.ProtectedData": "9.0.4"
         }
-      },
-      "System.Diagnostics.EventLog": {
-        "type": "Transitive",
-        "resolved": "9.0.4",
-        "contentHash": "getRQEXD8idlpb1KW56XuxImMy0FKp2WJPDf3Qr0kI/QKxxJSftqfDFVo0DZ3HCJRLU73qHSruv5q2l5O47jQQ=="
       },
       "System.IdentityModel.Tokens.Jwt": {
         "type": "Transitive",
@@ -613,8 +443,6 @@
         "contentHash": "yWOcmVL3SP5aVZqJ24V8IXdGRT6GW3/SD/al2w1Xe0MIcT8DuXpPOyKE9Pbk8/XxMtjHX14A82U6gwvDaU/GIw==",
         "dependencies": {
           "Azure.Core": "1.52.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.3",
           "Microsoft.Identity.Client": "4.83.1",
           "Microsoft.Identity.Client.Extensions.Msal": "4.83.1"
         }
@@ -686,8 +514,7 @@
         "resolved": "10.0.5",
         "contentHash": "oo1uauTwgcnhYgituZ2nI3wJ8XN9z76ggu2zkOJu1BCfOOsqr+g08Kr4MOiMuXEhwySkpIV+MVoC25hC1288NA==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.5",
-          "Microsoft.Extensions.Identity.Stores": "10.0.5"
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.5"
         }
       },
       "Microsoft.AspNetCore.OpenApi": {
@@ -718,9 +545,7 @@
         "contentHash": "9tNBmK3EpYVGRQLiqP+bqK2m+TD0Gv//4vCzR7ZOgl4FWzCFyOpYdIVka13M4kcBdPdSJcs3wbHr3rmzOqbIMA==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore.Abstractions": "10.0.5",
-          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.5",
-          "Microsoft.Extensions.Caching.Memory": "10.0.5",
-          "Microsoft.Extensions.Logging": "10.0.5"
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.5"
         }
       },
       "Microsoft.EntityFrameworkCore.Abstractions": {
@@ -743,8 +568,6 @@
         "dependencies": {
           "Microsoft.Azure.Cosmos": "3.51.0",
           "Microsoft.EntityFrameworkCore": "10.0.5",
-          "Microsoft.Extensions.Caching.Memory": "10.0.5",
-          "Microsoft.Extensions.Logging": "10.0.5",
           "Newtonsoft.Json": "13.0.3"
         }
       },
@@ -755,9 +578,7 @@
         "contentHash": "ADoXceIHRqoIWTTM8WKoCMkWRieq9qh9RLEgAj1AWYHyJu2Zn5M0a97k2gDHI9l+uXc+UxRd8e2TwmWe3Pyqhg==",
         "dependencies": {
           "Castle.Core": "5.2.1",
-          "Microsoft.EntityFrameworkCore": "10.0.5",
-          "Microsoft.Extensions.Caching.Memory": "10.0.5",
-          "Microsoft.Extensions.Logging": "10.0.5"
+          "Microsoft.EntityFrameworkCore": "10.0.5"
         }
       },
       "Microsoft.EntityFrameworkCore.Relational": {
@@ -766,10 +587,7 @@
         "resolved": "10.0.5",
         "contentHash": "uxmFjZEAB/KbsgWFSS4lLqkEHCfXxB2x0UcbiO4e5fCRpFFeTMSx/me6009nYJLu5IKlDwO1POh++P6RilFTDw==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "10.0.5",
-          "Microsoft.Extensions.Caching.Memory": "10.0.5",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Logging": "10.0.5"
+          "Microsoft.EntityFrameworkCore": "10.0.5"
         }
       },
       "Microsoft.EntityFrameworkCore.Sqlite.Core": {
@@ -780,10 +598,7 @@
         "dependencies": {
           "Microsoft.Data.Sqlite.Core": "10.0.5",
           "Microsoft.EntityFrameworkCore.Relational": "10.0.5",
-          "Microsoft.Extensions.Caching.Memory": "10.0.5",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
           "Microsoft.Extensions.DependencyModel": "10.0.5",
-          "Microsoft.Extensions.Logging": "10.0.5",
           "SQLitePCLRaw.core": "2.1.11"
         }
       },
@@ -794,10 +609,7 @@
         "contentHash": "/3Ault1Ay6OIEp3ZGGVem4mSWyEOX9e5leUMalGV9aFM57e0xFHAnlhmNaBHYtILkbtkaAErikQuaLqMQb4fww==",
         "dependencies": {
           "Microsoft.Data.SqlClient": "6.1.1",
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.5",
-          "Microsoft.Extensions.Caching.Memory": "10.0.5",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Logging": "10.0.5"
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.5"
         }
       },
       "Microsoft.Extensions.Azure": {
@@ -807,48 +619,7 @@
         "contentHash": "AIP7ud1rcQTRfzgne5Jw0P+zjx8ojGawwRuBVrYWgA/a+TKW3CaoQK/sYUcrbxYSVv6FT8rSwTlMecC0MwEbOQ==",
         "dependencies": {
           "Azure.Core": "1.50.0",
-          "Azure.Identity": "1.17.1",
-          "Microsoft.Extensions.Configuration": "8.0.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Configuration.Binder": "8.0.2",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
-          "Microsoft.Extensions.Logging": "8.0.1",
-          "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
-          "Microsoft.Extensions.Options": "8.0.2"
-        }
-      },
-      "Microsoft.Extensions.Identity.Core": {
-        "type": "CentralTransitive",
-        "requested": "[10.0.5, )",
-        "resolved": "10.0.5",
-        "contentHash": "ew2Xob+HFvJvM7BelIrUIbGeVMO2q1A6gsZEsI8N/v0ddSv7qbvvY68mH16XzvlsqydqD3ct5ioQHsiEUDSNkg==",
-        "dependencies": {
-          "Microsoft.AspNetCore.Cryptography.KeyDerivation": "10.0.5",
-          "Microsoft.Extensions.Diagnostics": "10.0.5",
-          "Microsoft.Extensions.Logging": "10.0.5",
-          "Microsoft.Extensions.Options": "10.0.5"
-        }
-      },
-      "Microsoft.Extensions.Identity.Stores": {
-        "type": "CentralTransitive",
-        "requested": "[10.0.5, )",
-        "resolved": "10.0.5",
-        "contentHash": "St8g+4xGLUhfSzTlHSLtCv7kh/tppvFab5x0kFIOsWryf1ffK2Ux+JIg01v5Yf27g2iQLCFEmW5hG5DDZL1HLA==",
-        "dependencies": {
-          "Microsoft.Extensions.Caching.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Identity.Core": "10.0.5",
-          "Microsoft.Extensions.Logging": "10.0.5"
-        }
-      },
-      "Microsoft.Extensions.Logging": {
-        "type": "CentralTransitive",
-        "requested": "[10.0.5, )",
-        "resolved": "10.0.5",
-        "contentHash": "+XTMKQyDWg4ODoNHU/BN3BaI1jhGO7VCS+BnzT/4IauiG6y2iPAte7MyD7rHKS+hNP0TkFkjrae8DFjDUxtcxg==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection": "10.0.5",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Options": "10.0.5"
+          "Azure.Identity": "1.17.1"
         }
       },
       "Microsoft.IdentityModel.JsonWebTokens": {
@@ -866,8 +637,6 @@
         "resolved": "1.15.1",
         "contentHash": "oJCqFTS/9S70TGPoamdGJRvw5hLOn6I/XC4X0npDErl2sHDlAg030ArJkIHIuLFCTO5GWqj1uDhsZNjO36xMxg==",
         "dependencies": {
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Logging.Configuration": "10.0.0",
           "OpenTelemetry.Api.ProviderBuilderExtensions": "1.15.1"
         }
       },
@@ -892,7 +661,6 @@
         "resolved": "1.15.1",
         "contentHash": "/mN9I16P8miDSHogFC0OFyPzUvYXibk/rLFLXW3Io50IN+XEQx7E6dSyUdMRdY+NKmOCo/oS5ICXkjdoFrwq2A==",
         "dependencies": {
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
           "OpenTelemetry": "1.15.1"
         }
       },
@@ -911,8 +679,6 @@
         "resolved": "1.15.0-beta.1",
         "contentHash": "N01GzP+r8lpSBiqjRX0/WjSp17r+zk6dKvGKthiASyFzF44lrJo8cA3ihXnw3p4Rnqg1mVjOYy19R6iJ84NTpg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.0",
-          "Microsoft.Extensions.Options": "10.0.0",
           "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.15.0, 2.0.0)"
         }
       },
@@ -922,8 +688,6 @@
         "resolved": "1.15.0",
         "contentHash": "uToc7bUp8IEdb0ny9mKsL6FrrYelINPzxxiSShJgOf4XmQc4Azww6S5RjRj24YhsOn2a1MABOrxfVTZXtDk4Eg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.0",
-          "Microsoft.Extensions.Options": "10.0.0",
           "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.15.0, 2.0.0)"
         }
       },


### PR DESCRIPTION
## Summary

Completes the exception-boundary hardening work started in commit `33cdc475` (which added refinement markers to 12 inner exceptions and converted `ExceptionToHttpResultMapper` to static). This PR lands the five remaining phases of the plan at `docs/superpowers/plans/2026-04-17-exception-boundary-hardening.md`.

- **Foundation tier correctness:** Invoice + Merchant + Analysis Foundation services now route auth / rate-limit failures through `DependencyValidation` (log level Error, HTTP 401/403/429 via inner marker) instead of the `Dependency` arm (503, Critical). Analysis service gains the full four-tier `Classify()` it was missing.
- **Defense-in-depth handler:** New `ExceptionMappingHandler : IExceptionHandler` wired as the first middleware — catches exceptions escaping endpoint handlers (middleware faults, model binding) and still produces RFC 7807 ProblemDetails via the static mapper.
- **Integration coverage:** 10 new tests in `InvoiceEndpointsStatusCodeTests.cs` close the 401/403 gap on Invoice, the entire Merchant matrix (401/403/404/409/423/429/503), and add a `traceId`-in-ProblemDetails assertion. The pipeline integration test asserts `api.arolariu.ro/problems` in the body to prove the custom handler ran (not ASP.NET's default).
- **Docs alignment:** RFC 2003 purged of "future enhancement" language and stale `IExceptionToHttpResultMapper` references; 12 inner-exception classes gained `<remarks>` blocks documenting their refinement marker and HTTP status.

**Tests:** 1145/1145 pass (74 Core + 1071 Domain). `TreatWarningsAsErrors` build clean: 0 warnings, 0 errors.

## Commit trail (9 commits)

| SHA | Subject |
|---|---|
| `af8d6040` | refactor(foundation/invoice): reclassify auth and rate-limit as DependencyValidation |
| `87235178` | refactor(foundation/merchant): reclassify auth and rate-limit as DependencyValidation |
| `11da89e0` | refactor(foundation/analysis): classify inner exceptions across all four tiers |
| `276eaa35` | feat(common/http): add IExceptionHandler that routes escapes through the mapper |
| `9833d00c` | feat(core/pipeline): wire ExceptionMappingHandler into the ASP.NET pipeline |
| `992b0ed1` | test(common/http): tighten ExceptionMappingHandler pipeline assertions |
| `8985836c` | test(endpoints): close endpoint status-code coverage gaps (401/403, Merchant, traceId) |
| `a630eb28` | docs(rfc/2003): align exception boundary section with shipped implementation |
| `15f43a7f` | docs(invoices/exceptions): document HTTP mapping via refinement marker on inner exceptions |

## Known non-blocking follow-ups (tracked in commits + RFC, not in this PR)

1. **`BadHttpRequestException` → 500.** Should propagate `ex.StatusCode` (typically 400). Currently pinned at 500 with a TODO in `ExceptionHandlerPipelineTests.cs:141` and documented as a known gap in RFC 2003.
2. **Test-file CA warnings** (`CA1812` / `CA2201` / `CA2263` / `CA2000`) in the two new Core test files — cosmetic; suppressible with `internal sealed` fixture types and the generic `Assert.IsInstanceOfType<T>` overload.
3. **Helper-naming drift.** `InvoiceAnalysisFoundationService` uses `CreateAndLogXException`; the two Storage services use `LogAndWrapX`. Semantically identical, visually inconsistent.
4. **Optional consolidation** of the three near-identical `Classify()` switches once the pattern is confirmed across all three services.

## Test plan

- [x] `dotnet build sites/api.arolariu.ro/src/Core` — 0 warnings, 0 errors
- [x] `dotnet test sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests` — 74/74 pass
- [x] `dotnet test sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests` — 1071/1071 pass
- [ ] Deep code review on the full branch diff
- [ ] Spot-check that each Phase's intent matches the corresponding commit
- [ ] Verify `BadHttpRequestException → 500` gap is acceptable for this PR (vs. gated on a fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)