### PR TITLE
fix(backend): address PR #648 review comments (round 2)

### DIFF
--- a/.github/instructions/backend.instructions.md
+++ b/.github/instructions/backend.instructions.md
@@ -17,7 +17,7 @@ Applies to backend .NET architecture and implementation changes under `sites/api
 - Use The Standard layer boundaries and Florance dependency limits.
 - Consult RFC 2001-2004 for architecture, observability, and XML docs before significant design changes.
 - Require XML documentation and `.ConfigureAwait(false)` where mandated by current backend standards.
-- Classify exceptions with markers from `arolariu.Backend.Common.Exceptions` and map to HTTP responses through `IExceptionToHttpResultMapper` — do not hand-roll status codes or Problem Details in endpoint handlers (see RFC 2003 §Exception → HTTP Status Mapping Contract).
+- Classify exceptions with markers from `arolariu.Backend.Common.Exceptions`; endpoints call the static `ExceptionToHttpResultMapper.ToHttpResult(ex, Activity.Current)` directly, and the global `ExceptionMappingHandler` (`IExceptionHandler`) catches escapes — do not hand-roll status codes or Problem Details in endpoint handlers (see RFC 2003 §Exception → HTTP Status Mapping Contract).
 
 ### Prohibited Actions
 - Do not move business logic into Brokers.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -244,7 +244,7 @@ sites/cv.arolariu.ro (SvelteKit — standalone)
 - Handle loading, error, and empty states in UI
 - Use `next-intl` for all user-facing strings
 - Run `npm run lint` and `npm run format` before committing
-- Classify exceptions with marker interfaces and route endpoint responses through `IExceptionToHttpResultMapper` (see RFC 2003)
+- Classify exceptions with marker interfaces; endpoints map to HTTP via the static `ExceptionToHttpResultMapper`, with `ExceptionMappingHandler` (`IExceptionHandler`) as defense-in-depth for pipeline escapes (see RFC 2003)
 
 ### Ask First
 - Adding new npm or NuGet dependencies

--- a/sites/api.arolariu.ro/src/Invoices/DDD/AggregatorRoots/Invoices/Exceptions/Inner/InvoiceFailedStorageException.cs
+++ b/sites/api.arolariu.ro/src/Invoices/DDD/AggregatorRoots/Invoices/Exceptions/Inner/InvoiceFailedStorageException.cs
@@ -4,13 +4,20 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
 
+using arolariu.Backend.Common.Exceptions;
+
 /// <summary>
 /// Thrown when the Cosmos DB storage layer is unavailable or returns an unexpected
 /// server-side error (HTTP 500, 503, or connection failure). Maps to HTTP 503.
 /// </summary>
+/// <remarks>
+/// Implements <see cref="IDependencyException"/>; <c>ExceptionToHttpResultMapper</c>
+/// produces HTTP 503 Service Unavailable when this exception is surfaced, whether
+/// unwrapped or wrapped by a higher-layer outer exception.
+/// </remarks>
 [Serializable]
 [ExcludeFromCodeCoverage]
-public sealed class InvoiceFailedStorageException : Exception
+public sealed class InvoiceFailedStorageException : Exception, IDependencyException
 {
   /// <summary>Initializes a new instance of the <see cref="InvoiceFailedStorageException"/> class.</summary>
   public InvoiceFailedStorageException() { }

--- a/sites/api.arolariu.ro/src/Invoices/DDD/Entities/Merchants/Exceptions/Inner/MerchantFailedStorageException.cs
+++ b/sites/api.arolariu.ro/src/Invoices/DDD/Entities/Merchants/Exceptions/Inner/MerchantFailedStorageException.cs
@@ -4,13 +4,20 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
 
+using arolariu.Backend.Common.Exceptions;
+
 /// <summary>
 /// Thrown when the Cosmos DB storage layer is unavailable or returns an unexpected
 /// server-side error (HTTP 500, 503, or connection failure). Maps to HTTP 503.
 /// </summary>
+/// <remarks>
+/// Implements <see cref="IDependencyException"/>; <c>ExceptionToHttpResultMapper</c>
+/// produces HTTP 503 Service Unavailable when this exception is surfaced, whether
+/// unwrapped or wrapped by a higher-layer outer exception.
+/// </remarks>
 [Serializable]
 [ExcludeFromCodeCoverage]
-public sealed class MerchantFailedStorageException : Exception
+public sealed class MerchantFailedStorageException : Exception, IDependencyException
 {
   /// <summary>Initializes a new instance of the <see cref="MerchantFailedStorageException"/> class.</summary>
   public MerchantFailedStorageException() { }

--- a/sites/api.arolariu.ro/src/Invoices/Services/Processing/InvoiceProcessingService.Exceptions.cs
+++ b/sites/api.arolariu.ro/src/Invoices/Services/Processing/InvoiceProcessingService.Exceptions.cs
@@ -51,21 +51,21 @@ public partial class InvoiceProcessingService
   private Exception Classify(Exception exception) => exception switch
   {
     InvoiceOrchestrationValidationException invoiceValidation
-      => CreateAndLogValidationException(invoiceValidation.InnerException!),
+      => CreateAndLogValidationException(invoiceValidation.InnerException ?? invoiceValidation),
     InvoiceOrchestrationDependencyValidationException invoiceDependencyValidation
-      => CreateAndLogDependencyValidationException(invoiceDependencyValidation.InnerException!),
+      => CreateAndLogDependencyValidationException(invoiceDependencyValidation.InnerException ?? invoiceDependencyValidation),
     InvoiceOrchestrationDependencyException invoiceDependency
-      => CreateAndLogDependencyException(invoiceDependency.InnerException!),
+      => CreateAndLogDependencyException(invoiceDependency.InnerException ?? invoiceDependency),
     InvoiceOrchestrationServiceException invoiceService
-      => CreateAndLogServiceException(invoiceService.InnerException!),
+      => CreateAndLogServiceException(invoiceService.InnerException ?? invoiceService),
     MerchantOrchestrationServiceValidationException merchantValidation
-      => CreateAndLogDependencyValidationException(merchantValidation.InnerException!),
+      => CreateAndLogDependencyValidationException(merchantValidation.InnerException ?? merchantValidation),
     MerchantOrchestrationServiceDependencyValidationException merchantDependencyValidation
-      => CreateAndLogDependencyValidationException(merchantDependencyValidation.InnerException!),
+      => CreateAndLogDependencyValidationException(merchantDependencyValidation.InnerException ?? merchantDependencyValidation),
     MerchantOrchestrationServiceDependencyException merchantDependency
-      => CreateAndLogDependencyException(merchantDependency.InnerException!),
+      => CreateAndLogDependencyException(merchantDependency.InnerException ?? merchantDependency),
     MerchantOrchestrationServiceException merchantService
-      => CreateAndLogServiceException(merchantService.InnerException!),
+      => CreateAndLogServiceException(merchantService.InnerException ?? merchantService),
     _ => CreateAndLogServiceException(exception),
   };
   #endregion


### PR DESCRIPTION
## Summary

Addresses the 4 still-open items from Copilot's PR #648 review that weren't already fixed by the PR #649 merge. One commit, three mechanical changes:

| Review comment | Fix |
|---|---|
| #15 — `Classify()` uses `.InnerException!` (NRE risk if outer has parameterless ctor) | 8 arms in `InvoiceProcessingService.Exceptions.cs:54-68` now use `.InnerException ?? <outer>` — preserves diagnostics and prevents NREs in the exception boundary |
| #12, #16 — `MerchantFailedStorageException` + `InvoiceFailedStorageException` claim "Maps to 503" but lack any marker interface | Both now implement `IDependencyException`; class-level `<remarks>` documents the 503 mapping via `ExceptionToHttpResultMapper` |
| #13, #14 — `AGENTS.md:247` and `.github/instructions/backend.instructions.md:20` reference the deleted `IExceptionToHttpResultMapper` interface | Both lines now point at the actual code path: static `ExceptionToHttpResultMapper` for endpoint catches, `ExceptionMappingHandler` (`IExceptionHandler`) for pipeline escapes |

**Tests:** 1147/1147 pass (76 Core + 1071 Domain). Build 0 warnings, 0 errors. `rg IExceptionToHttpResultMapper --type md --type cs` returns no matches.

The other 12 Copilot/reviewer comments on PR #648 were already resolved by commits merged via PR #649 (the static-mapper conversion, inner-exception markers, Cosmos translation chaining, etc.) — inline replies posted on #648 cite the specific commits.

## Test plan

- [x] `dotnet build sites/api.arolariu.ro/src/Core` — 0 warnings, 0 errors
- [x] `dotnet test sites/api.arolariu.ro/tests` — 1147/1147 pass
- [x] `rg IExceptionToHttpResultMapper` — no matches in md/cs files
- [ ] Deep code review over the full preview→main delta before PR #648 merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)