### PR TITLE
refactor(backend): polish exception boundary after code review

### DIFF
--- a/sites/api.arolariu.ro/src/Common/Exceptions/IRateLimitedException.cs
+++ b/sites/api.arolariu.ro/src/Common/Exceptions/IRateLimitedException.cs
@@ -1,13 +1,17 @@
 namespace arolariu.Backend.Common.Exceptions;
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 
 /// <summary>
 /// Refinement marker indicating the exception represents a "rate limited"
-/// dependency outcome. Mapper emits HTTP 429 Too Many Requests (a `retryAfterSeconds` extension in the RFC 7807 ProblemDetails body).
+/// dependency outcome. Mapper emits HTTP 429 Too Many Requests and surfaces the
+/// <see cref="RetryAfter"/> value in the <c>retryAfterSeconds</c> ProblemDetails extension.
 /// </summary>
-[SuppressMessage("Design", "CA1040:Avoid empty interfaces", Justification = "Marker interfaces used for exception classification and HTTP status mapping")]
 [SuppressMessage("Naming", "CA1711:Identifiers should not have incorrect suffix", Justification = "Exception suffix is intentional for exception marker interfaces")]
 public interface IRateLimitedException : IDependencyException
 {
+  /// <summary>Gets the recommended retry-after duration surfaced via the ProblemDetails response.</summary>
+  /// <remarks>Implementations return <see cref="TimeSpan.Zero"/> when no concrete retry hint is available; the mapper will apply a sensible default.</remarks>
+  TimeSpan RetryAfter { get; }
 }

--- a/sites/api.arolariu.ro/src/Common/Http/ExceptionMappingHandler.cs
+++ b/sites/api.arolariu.ro/src/Common/Http/ExceptionMappingHandler.cs
@@ -55,6 +55,9 @@ public sealed class ExceptionMappingHandler : IExceptionHandler
 
     httpContext.Response.Clear();
 
+    // cancellationToken is intentionally not propagated: IResult.ExecuteAsync(HttpContext) has no
+    // CancellationToken overload, and HttpContext.RequestAborted already carries the request-abort
+    // signal to downstream writers. Kestrel will abort the response write if the client has gone away.
     Activity.Current?.RecordException(exception);
     Activity.Current?.SetStatus(ActivityStatusCode.Error, exception.GetType().Name);
 

--- a/sites/api.arolariu.ro/src/Common/Http/ExceptionToHttpResultMapper.cs
+++ b/sites/api.arolariu.ro/src/Common/Http/ExceptionToHttpResultMapper.cs
@@ -30,9 +30,11 @@ public static class ExceptionToHttpResultMapper
       extensions["traceId"] = traceId;
     }
 
-    if (root is IRateLimitedException)
+    if (root is IRateLimitedException rateLimited)
     {
-      var retryAfter = TryGetRetryAfter(root);
+      var retryAfter = rateLimited.RetryAfter > TimeSpan.Zero
+        ? rateLimited.RetryAfter
+        : TimeSpan.FromSeconds(1);
       extensions["retryAfterSeconds"] = (int)Math.Ceiling(retryAfter.TotalSeconds);
     }
 
@@ -86,16 +88,6 @@ public static class ExceptionToHttpResultMapper
     IServiceException => (500, "Internal server error", ProblemTypeUris.InternalServerError),
     _ => (500, "Internal server error", ProblemTypeUris.InternalServerError),
   };
-
-  private static TimeSpan TryGetRetryAfter(Exception ex)
-  {
-    var prop = ex.GetType().GetProperty("RetryAfter", typeof(TimeSpan));
-    if (prop?.GetValue(ex) is TimeSpan span && span > TimeSpan.Zero)
-    {
-      return span;
-    }
-    return TimeSpan.FromSeconds(1);
-  }
 
   private static string BuildSafeDetail(Exception ex, int status)
   {

--- a/sites/api.arolariu.ro/src/Invoices/Brokers/DatabaseBroker/InvoiceNoSqlBroker.Invoices.cs
+++ b/sites/api.arolariu.ro/src/Invoices/Brokers/DatabaseBroker/InvoiceNoSqlBroker.Invoices.cs
@@ -378,7 +378,7 @@ public partial class InvoiceNoSqlBroker
         "Cosmos DB returned HTTP 401 Unauthorized while accessing invoice data.", cosmosException),
       HttpStatusCode.Forbidden => new InvoiceForbiddenAccessException(
         "Cosmos DB returned HTTP 403 Forbidden while accessing invoice data.", cosmosException),
-      (HttpStatusCode)429 => new InvoiceCosmosDbRateLimitException(
+      HttpStatusCode.TooManyRequests => new InvoiceCosmosDbRateLimitException(
         cosmosException.RetryAfter ?? TimeSpan.FromSeconds(1), cosmosException),
       HttpStatusCode.ServiceUnavailable
         or HttpStatusCode.InternalServerError

--- a/sites/api.arolariu.ro/src/Invoices/Brokers/DatabaseBroker/InvoiceNoSqlBroker.Merchants.cs
+++ b/sites/api.arolariu.ro/src/Invoices/Brokers/DatabaseBroker/InvoiceNoSqlBroker.Merchants.cs
@@ -300,7 +300,7 @@ public partial class InvoiceNoSqlBroker
         "Cosmos DB rejected the request as unauthorized.", cosmosException),
       HttpStatusCode.Forbidden => new MerchantForbiddenAccessException(
         "Cosmos DB forbade the requested merchant operation.", cosmosException),
-      (HttpStatusCode)429 => new MerchantCosmosDbRateLimitException(
+      HttpStatusCode.TooManyRequests => new MerchantCosmosDbRateLimitException(
         cosmosException.RetryAfter ?? TimeSpan.FromSeconds(1), cosmosException),
       HttpStatusCode.ServiceUnavailable
         or HttpStatusCode.InternalServerError

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Http/ExceptionToHttpResultMapperTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Http/ExceptionToHttpResultMapperTests.cs
@@ -50,6 +50,8 @@ public sealed class ExceptionToHttpResultMapperTests
     public RateLimitEx()
     {
     }
+
+    public TimeSpan RetryAfter { get; } = TimeSpan.Zero;
   }
   [SuppressMessage("Performance", "CA1812", Justification = "Instantiated via Activator.CreateInstance in data-driven test")]
   private sealed class UnauthorizedEx : Exception, IUnauthorizedException { public UnauthorizedEx(string m) : base(m) { }


### PR DESCRIPTION
## Summary

Three minor polish items flagged during the self code review of PR #648. All disjoint changes, no behavior change, one commit (`ac3b7d53`).

| # | Fix | Rationale |
|---|---|---|
| 1 | `(HttpStatusCode)429` → `HttpStatusCode.TooManyRequests` in both Cosmos broker translations (`InvoiceNoSqlBroker.Invoices.cs:381`, `.Merchants.cs:303`) | The enum value has existed since .NET Core 2.1; using it is more idiomatic than the numeric cast |
| 2 | Add `TimeSpan RetryAfter { get; }` to `IRateLimitedException`; drop the reflection-based `TryGetRetryAfter` helper in the mapper | Formalizes the contract: any `IRateLimitedException` impl must expose `RetryAfter`. No more reflection on a hot path, no more implicit duck-typing. |
| 3 | Document why `cancellationToken` is not propagated in `ExceptionMappingHandler.TryHandleAsync` | `IResult.ExecuteAsync(HttpContext)` has no CT overload; `HttpContext.RequestAborted` already carries the abort signal downstream. One-line comment captures this for future readers. |

### Independence from PR #650

This PR touches disjoint files from PR #650 (which is also against `preview`) — no merge conflict in either direction. Either PR can land first.

### Verification

- **Build:** 0 errors, 0 new warnings (`TreatWarningsAsErrors` enabled).
- **Tests:** 1147/1147 pass (76 Core + 1071 Domain) — identical baseline count, behavior unchanged.
- **Residual checks:**
  - `rg "TryGetRetryAfter"` → 0 matches
  - `rg "\(HttpStatusCode\)429"` → 0 matches

### Interface-contract impact

Adding `RetryAfter` to `IRateLimitedException` is a source-breaking change for any *external* implementer. Inside this repo there are only 3 implementations:
- `InvoiceCosmosDbRateLimitException` — already exposes `public TimeSpan RetryAfter { get; }` (satisfies via implicit interface implementation, no change)
- `MerchantCosmosDbRateLimitException` — same
- `RateLimitEx` test fixture in `ExceptionToHttpResultMapperTests.cs` — gained `public TimeSpan RetryAfter { get; } = TimeSpan.Zero;` (mapper falls back to 1-second default when zero)

No external consumers of the interface exist today.

## Test plan

- [x] `dotnet build sites/api.arolariu.ro/src/Core` — 0 warnings, 0 errors
- [x] `dotnet test sites/api.arolariu.ro/tests` — 1147/1147 pass
- [x] `rg TryGetRetryAfter sites/api.arolariu.ro` — no matches
- [ ] Quick smoke verification once merged into preview alongside PR #650

🤖 Generated with [Claude Code](https://claude.com/claude-code)