### PR TITLE
Restore internal accessibility on invoice endpoint handlers

### DIFF
--- a/sites/api.arolariu.ro/src/Invoices/AssemblyInfo.cs
+++ b/sites/api.arolariu.ro/src/Invoices/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+using System.Runtime.CompilerServices;
+
+// Allow the domain test project to exercise internal endpoint handlers (e.g.,
+// RetrieveSpecificInvoiceAsync, CreateNewInvoiceAsync) directly from integration-style
+// tests that validate exception-to-HTTP-status wiring without standing up a full
+// WebApplication host.
+[assembly: InternalsVisibleTo("arolariu.Backend.Domain.Tests")]

--- a/sites/api.arolariu.ro/src/Invoices/Endpoints/InvoiceEndpoints.Handlers.cs
+++ b/sites/api.arolariu.ro/src/Invoices/Endpoints/InvoiceEndpoints.Handlers.cs
@@ -21,7 +21,7 @@ using static arolariu.Backend.Common.Telemetry.Tracing.ActivityGenerators;
 public static partial class InvoiceEndpoints
 {
   #region CRUD operations for the Invoice Standard Endpoints
-  public static async partial Task<IResult> CreateNewInvoiceAsync(
+  internal static async partial Task<IResult> CreateNewInvoiceAsync(
     IInvoiceProcessingService invoiceProcessingService,
     IHttpContextAccessor httpContext,
     CreateInvoiceRequestDto invoiceDto)
@@ -62,7 +62,7 @@ public static partial class InvoiceEndpoints
     }
   }
 
-  public static async partial Task<IResult> RetrieveSpecificInvoiceAsync(
+  internal static async partial Task<IResult> RetrieveSpecificInvoiceAsync(
     IInvoiceProcessingService invoiceProcessingService,
     IHttpContextAccessor httpContext,
     Guid id)
@@ -142,7 +142,7 @@ public static partial class InvoiceEndpoints
     }
   }
 
-  public static async partial Task<IResult> RetrieveAllInvoicesAsync(
+  internal static async partial Task<IResult> RetrieveAllInvoicesAsync(
     IInvoiceProcessingService invoiceProcessingService,
     IHttpContextAccessor httpContext
     )
@@ -174,7 +174,7 @@ public static partial class InvoiceEndpoints
     }
   }
 
-  public static async partial Task<IResult> DeleteInvoicesAsync(
+  internal static async partial Task<IResult> DeleteInvoicesAsync(
     IInvoiceProcessingService invoiceProcessingService,
     IHttpContextAccessor httpContext
     )
@@ -206,7 +206,7 @@ public static partial class InvoiceEndpoints
     }
   }
 
-  public static async partial Task<IResult> UpdateSpecificInvoiceAsync(
+  internal static async partial Task<IResult> UpdateSpecificInvoiceAsync(
     IInvoiceProcessingService invoiceProcessingService,
     IHttpContextAccessor httpContext,
     Guid id,
@@ -256,7 +256,7 @@ public static partial class InvoiceEndpoints
     }
   }
 
-  public static async partial Task<IResult> PatchSpecificInvoiceAsync(
+  internal static async partial Task<IResult> PatchSpecificInvoiceAsync(
     IInvoiceProcessingService invoiceProcessingService,
     IHttpContextAccessor httpContext,
     Guid id,
@@ -321,7 +321,7 @@ public static partial class InvoiceEndpoints
     }
   }
 
-  public static async partial Task<IResult> DeleteInvoiceAsync(
+  internal static async partial Task<IResult> DeleteInvoiceAsync(
     IInvoiceProcessingService invoiceProcessingService,
     IHttpContextAccessor httpContext,
     Guid id)
@@ -362,7 +362,7 @@ public static partial class InvoiceEndpoints
     }
   }
 
-  public static async partial Task<IResult> AddProductToInvoiceAsync(
+  internal static async partial Task<IResult> AddProductToInvoiceAsync(
     IInvoiceProcessingService invoiceProcessingService,
     IHttpContextAccessor httpContext,
     Guid id,
@@ -407,7 +407,7 @@ public static partial class InvoiceEndpoints
     }
   }
 
-  public static async partial Task<IResult> RetrieveProductsFromInvoiceAsync(
+  internal static async partial Task<IResult> RetrieveProductsFromInvoiceAsync(
     IInvoiceProcessingService invoiceProcessingService,
     IHttpContextAccessor httpContext,
     Guid id)
@@ -446,7 +446,7 @@ public static partial class InvoiceEndpoints
     }
   }
 
-  public static async partial Task<IResult> RemoveProductFromInvoiceAsync(
+  internal static async partial Task<IResult> RemoveProductFromInvoiceAsync(
     IInvoiceProcessingService invoiceProcessingService,
     IHttpContextAccessor httpContext,
     Guid id,
@@ -489,7 +489,7 @@ public static partial class InvoiceEndpoints
     }
   }
 
-  public static async partial Task<IResult> UpdateProductInInvoiceAsync(
+  internal static async partial Task<IResult> UpdateProductInInvoiceAsync(
     IInvoiceProcessingService invoiceProcessingService,
     IHttpContextAccessor httpContext,
     Guid id,
@@ -548,7 +548,7 @@ public static partial class InvoiceEndpoints
     }
   }
 
-  public static async partial Task<IResult> RetrieveMerchantFromInvoiceAsync(
+  internal static async partial Task<IResult> RetrieveMerchantFromInvoiceAsync(
     IInvoiceProcessingService invoiceProcessingService,
     IHttpContextAccessor httpContext,
     Guid id)
@@ -603,7 +603,7 @@ public static partial class InvoiceEndpoints
     }
   }
 
-  public static async partial Task<IResult> AddMerchantToInvoiceAsync(
+  internal static async partial Task<IResult> AddMerchantToInvoiceAsync(
     IInvoiceProcessingService invoiceProcessingService,
     IHttpContextAccessor httpContext,
     Guid id,
@@ -664,7 +664,7 @@ public static partial class InvoiceEndpoints
     }
   }
 
-  public static async partial Task<IResult> RemoveMerchantFromInvoiceAsync(
+  internal static async partial Task<IResult> RemoveMerchantFromInvoiceAsync(
     IInvoiceProcessingService invoiceProcessingService,
     IHttpContextAccessor httpContext,
     Guid id)
@@ -729,7 +729,7 @@ public static partial class InvoiceEndpoints
     }
   }
 
-  public static async partial Task<IResult> CreateInvoiceScanAsync(
+  internal static async partial Task<IResult> CreateInvoiceScanAsync(
     IInvoiceProcessingService invoiceProcessingService,
     IHttpContextAccessor httpContext,
     Guid id,
@@ -776,7 +776,7 @@ public static partial class InvoiceEndpoints
     }
   }
 
-  public static async partial Task<IResult> RetrieveInvoiceScansAsync(
+  internal static async partial Task<IResult> RetrieveInvoiceScansAsync(
     IInvoiceProcessingService invoiceProcessingService,
     IHttpContextAccessor httpContext,
     Guid id)
@@ -815,7 +815,7 @@ public static partial class InvoiceEndpoints
     }
   }
 
-  public static async partial Task<IResult> DeleteInvoiceScanAsync(
+  internal static async partial Task<IResult> DeleteInvoiceScanAsync(
     IInvoiceProcessingService invoiceProcessingService,
     IHttpContextAccessor httpContext,
     Guid id,
@@ -870,7 +870,7 @@ public static partial class InvoiceEndpoints
     }
   }
 
-  public static async partial Task<IResult> RetrieveInvoiceMetadataAsync(
+  internal static async partial Task<IResult> RetrieveInvoiceMetadataAsync(
     IInvoiceProcessingService invoiceProcessingService,
     IHttpContextAccessor httpContext,
     Guid id)
@@ -909,7 +909,7 @@ public static partial class InvoiceEndpoints
     }
   }
 
-  public static async partial Task<IResult> PatchInvoiceMetadataAsync(
+  internal static async partial Task<IResult> PatchInvoiceMetadataAsync(
     IInvoiceProcessingService invoiceProcessingService,
     IHttpContextAccessor httpContext,
     Guid id,
@@ -954,7 +954,7 @@ public static partial class InvoiceEndpoints
     }
   }
 
-  public static async partial Task<IResult> DeleteInvoiceMetadataAsync(
+  internal static async partial Task<IResult> DeleteInvoiceMetadataAsync(
     IInvoiceProcessingService invoiceProcessingService,
     IHttpContextAccessor httpContext,
     Guid id,
@@ -1005,7 +1005,7 @@ public static partial class InvoiceEndpoints
   #endregion
 
   #region CRUD operations for the Merchant Standard Endpoints
-  public static async partial Task<IResult> CreateNewMerchantAsync(
+  internal static async partial Task<IResult> CreateNewMerchantAsync(
     IInvoiceProcessingService invoiceProcessingService,
     IHttpContextAccessor httpContext,
     CreateMerchantRequestDto merchantDto)
@@ -1040,7 +1040,7 @@ public static partial class InvoiceEndpoints
     }
   }
 
-  public static async partial Task<IResult> RetrieveAllMerchantsAsync(
+  internal static async partial Task<IResult> RetrieveAllMerchantsAsync(
     IInvoiceProcessingService invoiceProcessingService,
     IHttpContextAccessor httpContext,
     Guid parentCompanyId)
@@ -1075,7 +1075,7 @@ public static partial class InvoiceEndpoints
     }
   }
 
-  public static async partial Task<IResult> RetrieveSpecificMerchantAsync(
+  internal static async partial Task<IResult> RetrieveSpecificMerchantAsync(
     IInvoiceProcessingService invoiceProcessingService,
     IHttpContextAccessor httpContext,
     Guid id,
@@ -1119,7 +1119,7 @@ public static partial class InvoiceEndpoints
     }
   }
 
-  public static async partial Task<IResult> UpdateSpecificMerchantAsync(
+  internal static async partial Task<IResult> UpdateSpecificMerchantAsync(
     IInvoiceProcessingService invoiceProcessingService,
     IHttpContextAccessor httpContext,
     Guid id,
@@ -1164,7 +1164,7 @@ public static partial class InvoiceEndpoints
     }
   }
 
-  public static async partial Task<IResult> DeleteMerchantAsync(
+  internal static async partial Task<IResult> DeleteMerchantAsync(
     IInvoiceProcessingService invoiceProcessingService,
     IHttpContextAccessor httpContext,
     Guid id,
@@ -1224,7 +1224,7 @@ public static partial class InvoiceEndpoints
     }
   }
 
-  public static async partial Task<IResult> RetrieveInvoicesFromMerchantAsync(
+  internal static async partial Task<IResult> RetrieveInvoicesFromMerchantAsync(
     IInvoiceProcessingService invoiceProcessingService,
     IHttpContextAccessor httpContext,
     Guid id)
@@ -1279,7 +1279,7 @@ public static partial class InvoiceEndpoints
     }
   }
 
-  public static async partial Task<IResult> AddInvoiceToMerchantAsync(
+  internal static async partial Task<IResult> AddInvoiceToMerchantAsync(
     IInvoiceProcessingService invoiceProcessingService,
     IHttpContextAccessor httpContext,
     Guid id,
@@ -1342,7 +1342,7 @@ public static partial class InvoiceEndpoints
     }
   }
 
-  public static async partial Task<IResult> RemoveInvoiceFromMerchantAsync(
+  internal static async partial Task<IResult> RemoveInvoiceFromMerchantAsync(
     IInvoiceProcessingService invoiceProcessingService,
     IHttpContextAccessor httpContext,
     Guid id,
@@ -1407,7 +1407,7 @@ public static partial class InvoiceEndpoints
     }
   }
 
-  public static async partial Task<IResult> RetrieveProductsFromMerchantAsync(
+  internal static async partial Task<IResult> RetrieveProductsFromMerchantAsync(
     IInvoiceProcessingService invoiceProcessingService,
     IHttpContextAccessor httpContext,
     Guid id)
@@ -1467,7 +1467,7 @@ public static partial class InvoiceEndpoints
   #endregion
 
   #region Analysis operations
-  public static async partial Task<IResult> AnalyzeInvoiceAsync(
+  internal static async partial Task<IResult> AnalyzeInvoiceAsync(
     IInvoiceProcessingService invoiceProcessingService,
     IHttpContextAccessor httpContext,
     Guid id,

--- a/sites/api.arolariu.ro/src/Invoices/Endpoints/InvoiceEndpoints.Metadata.cs
+++ b/sites/api.arolariu.ro/src/Invoices/Endpoints/InvoiceEndpoints.Metadata.cs
@@ -48,7 +48,7 @@ public static partial class InvoiceEndpoints
   [SwaggerResponse(StatusCodes.Status500InternalServerError, "An internal server error occurred while processing the request.", typeof(ProblemDetails))]
   [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "General exception types represent unexpected errors.")]
   [Authorize]
-  public static partial Task<IResult> CreateNewInvoiceAsync(
+  internal static partial Task<IResult> CreateNewInvoiceAsync(
     [FromServices] IInvoiceProcessingService invoiceProcessingService,
     [FromServices] IHttpContextAccessor httpContext,
     [FromBody, SwaggerRequestBody("The invoice DTO containing the details for the new invoice.", Required = true)] CreateInvoiceRequestDto invoiceDto);
@@ -78,7 +78,7 @@ public static partial class InvoiceEndpoints
   [SwaggerResponse(StatusCodes.Status500InternalServerError, "An internal server error occurred while processing the request.", typeof(ProblemDetails))]
   [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "General exception types represent unexpected errors.")]
   [Authorize]
-  public static partial Task<IResult> RetrieveSpecificInvoiceAsync(
+  internal static partial Task<IResult> RetrieveSpecificInvoiceAsync(
     [FromServices] IInvoiceProcessingService invoiceProcessingService,
     [FromServices] IHttpContextAccessor httpContext,
     [FromRoute, SwaggerParameter("The unique identifier of the invoice to retrieve.", Required = true)] Guid id);
@@ -106,7 +106,7 @@ public static partial class InvoiceEndpoints
   [SwaggerResponse(StatusCodes.Status500InternalServerError, "The invoices could not be retrieved due to an internal service error.", typeof(ProblemDetails))]
   [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "General exception types represent unexpected errors.")]
   [Authorize]
-  public static partial Task<IResult> RetrieveAllInvoicesAsync(
+  internal static partial Task<IResult> RetrieveAllInvoicesAsync(
     [FromServices] IInvoiceProcessingService invoiceProcessingService,
     [FromServices] IHttpContextAccessor httpContext
     );
@@ -137,7 +137,7 @@ public static partial class InvoiceEndpoints
   [SwaggerResponse(StatusCodes.Status500InternalServerError, "An internal server error occurred while processing the request.", typeof(ProblemDetails))]
   [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "General exception types represent unexpected errors.")]
   [Authorize]
-  public static partial Task<IResult> UpdateSpecificInvoiceAsync(
+  internal static partial Task<IResult> UpdateSpecificInvoiceAsync(
     [FromServices] IInvoiceProcessingService invoiceProcessingService,
     [FromServices] IHttpContextAccessor httpContext,
     [FromRoute, SwaggerParameter("The unique identifier of the invoice to update.", Required = true)] Guid id,
@@ -169,7 +169,7 @@ public static partial class InvoiceEndpoints
   [SwaggerResponse(StatusCodes.Status500InternalServerError, "An internal server error occurred while processing the request.", typeof(ProblemDetails))]
   [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "General exception types represent unexpected errors.")]
   [Authorize]
-  public static partial Task<IResult> PatchSpecificInvoiceAsync(
+  internal static partial Task<IResult> PatchSpecificInvoiceAsync(
     [FromServices] IInvoiceProcessingService invoiceProcessingService,
     [FromServices] IHttpContextAccessor httpContext,
     [FromRoute, SwaggerParameter("The unique identifier of the invoice to patch.", Required = true)] Guid id,
@@ -200,7 +200,7 @@ public static partial class InvoiceEndpoints
   [SwaggerResponse(StatusCodes.Status500InternalServerError, "An internal server error occurred while processing the request.", typeof(ProblemDetails))]
   [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "General exception types represent unexpected errors.")]
   [Authorize]
-  public static partial Task<IResult> DeleteInvoiceAsync(
+  internal static partial Task<IResult> DeleteInvoiceAsync(
     [FromServices] IInvoiceProcessingService invoiceProcessingService,
     [FromServices] IHttpContextAccessor httpContext,
     [FromRoute, SwaggerParameter("The unique identifier of the invoice to delete.", Required = true)] Guid id);
@@ -229,7 +229,7 @@ public static partial class InvoiceEndpoints
   [SwaggerResponse(StatusCodes.Status500InternalServerError, "An internal server error occurred while processing the request.", typeof(ProblemDetails))]
   [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "General exception types represent unexpected errors.")]
   [Authorize]
-  public static partial Task<IResult> DeleteInvoicesAsync(
+  internal static partial Task<IResult> DeleteInvoicesAsync(
     [FromServices] IInvoiceProcessingService invoiceProcessingService,
     [FromServices] IHttpContextAccessor httpContext
     );
@@ -262,7 +262,7 @@ public static partial class InvoiceEndpoints
   [SwaggerResponse(StatusCodes.Status500InternalServerError, "An internal server error occurred while processing the request.", typeof(ProblemDetails))]
   [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "General exception types represent unexpected errors.")]
   [Authorize]
-  public static partial Task<IResult> AddProductToInvoiceAsync(
+  internal static partial Task<IResult> AddProductToInvoiceAsync(
     [FromServices] IInvoiceProcessingService invoiceProcessingService,
     [FromServices] IHttpContextAccessor httpContext,
     [FromRoute, SwaggerParameter("The unique identifier of the invoice.", Required = true)] Guid id,
@@ -293,7 +293,7 @@ public static partial class InvoiceEndpoints
   [SwaggerResponse(StatusCodes.Status500InternalServerError, "An internal server error occurred while processing the request.", typeof(ProblemDetails))]
   [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "General exception types represent unexpected errors.")]
   [Authorize]
-  public static partial Task<IResult> RetrieveProductsFromInvoiceAsync(
+  internal static partial Task<IResult> RetrieveProductsFromInvoiceAsync(
     [FromServices] IInvoiceProcessingService invoiceProcessingService,
     [FromServices] IHttpContextAccessor httpContext,
     [FromRoute, SwaggerParameter("The unique identifier of the invoice.", Required = true)] Guid id);
@@ -326,7 +326,7 @@ public static partial class InvoiceEndpoints
   [SwaggerResponse(StatusCodes.Status500InternalServerError, "An internal server error occurred while processing the request.", typeof(ProblemDetails))]
   [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "General exception types represent unexpected errors.")]
   [Authorize]
-  public static partial Task<IResult> RemoveProductFromInvoiceAsync(
+  internal static partial Task<IResult> RemoveProductFromInvoiceAsync(
     [FromServices] IInvoiceProcessingService invoiceProcessingService,
     [FromServices] IHttpContextAccessor httpContext,
     [FromRoute, SwaggerParameter("The unique identifier of the invoice.", Required = true)] Guid id,
@@ -360,7 +360,7 @@ public static partial class InvoiceEndpoints
   [SwaggerResponse(StatusCodes.Status500InternalServerError, "An internal server error occurred while processing the request.", typeof(ProblemDetails))]
   [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "General exception types represent unexpected errors.")]
   [Authorize]
-  public static partial Task<IResult> UpdateProductInInvoiceAsync(
+  internal static partial Task<IResult> UpdateProductInInvoiceAsync(
     [FromServices] IInvoiceProcessingService invoiceProcessingService,
     [FromServices] IHttpContextAccessor httpContext,
     [FromRoute, SwaggerParameter("The unique identifier of the invoice.", Required = true)] Guid id,
@@ -391,7 +391,7 @@ public static partial class InvoiceEndpoints
   [SwaggerResponse(StatusCodes.Status500InternalServerError, "An internal server error occurred while processing the request.", typeof(ProblemDetails))]
   [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "General exception types represent unexpected errors.")]
   [Authorize]
-  public static partial Task<IResult> RetrieveMerchantFromInvoiceAsync(
+  internal static partial Task<IResult> RetrieveMerchantFromInvoiceAsync(
     [FromServices] IInvoiceProcessingService invoiceProcessingService,
     [FromServices] IHttpContextAccessor httpContext,
     [FromRoute, SwaggerParameter("The unique identifier of the invoice.", Required = true)] Guid id);
@@ -424,7 +424,7 @@ public static partial class InvoiceEndpoints
   [SwaggerResponse(StatusCodes.Status500InternalServerError, "An internal server error occurred while processing the request.", typeof(ProblemDetails))]
   [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "General exception types represent unexpected errors.")]
   [Authorize]
-  public static partial Task<IResult> AddMerchantToInvoiceAsync(
+  internal static partial Task<IResult> AddMerchantToInvoiceAsync(
     [FromServices] IInvoiceProcessingService invoiceProcessingService,
     [FromServices] IHttpContextAccessor httpContext,
     [FromRoute, SwaggerParameter("The unique identifier of the invoice.", Required = true)] Guid id,
@@ -457,7 +457,7 @@ public static partial class InvoiceEndpoints
   [SwaggerResponse(StatusCodes.Status500InternalServerError, "An internal server error occurred while processing the request.", typeof(ProblemDetails))]
   [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "General exception types represent unexpected errors.")]
   [Authorize]
-  public static partial Task<IResult> RemoveMerchantFromInvoiceAsync(
+  internal static partial Task<IResult> RemoveMerchantFromInvoiceAsync(
     [FromServices] IInvoiceProcessingService invoiceProcessingService,
     [FromServices] IHttpContextAccessor httpContext,
     [FromRoute, SwaggerParameter("The unique identifier of the invoice.", Required = true)] Guid id);
@@ -489,7 +489,7 @@ public static partial class InvoiceEndpoints
   [SwaggerResponse(StatusCodes.Status500InternalServerError, "An internal server error occurred while processing the request.", typeof(ProblemDetails))]
   [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "General exception types represent unexpected errors.")]
   [Authorize]
-  public static partial Task<IResult> CreateInvoiceScanAsync(
+  internal static partial Task<IResult> CreateInvoiceScanAsync(
     [FromServices] IInvoiceProcessingService invoiceProcessingService,
     [FromServices] IHttpContextAccessor httpContext,
     [FromRoute, SwaggerParameter("The unique identifier of the invoice.", Required = true)] Guid id,
@@ -520,7 +520,7 @@ public static partial class InvoiceEndpoints
   [SwaggerResponse(StatusCodes.Status500InternalServerError, "An internal server error occurred while processing the request.", typeof(ProblemDetails))]
   [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "General exception types represent unexpected errors.")]
   [Authorize]
-  public static partial Task<IResult> RetrieveInvoiceScansAsync(
+  internal static partial Task<IResult> RetrieveInvoiceScansAsync(
     [FromServices] IInvoiceProcessingService invoiceProcessingService,
     [FromServices] IHttpContextAccessor httpContext,
     [FromRoute, SwaggerParameter("The unique identifier of the invoice.", Required = true)] Guid id);
@@ -551,7 +551,7 @@ public static partial class InvoiceEndpoints
   [SwaggerResponse(StatusCodes.Status500InternalServerError, "An internal server error occurred while processing the request.", typeof(ProblemDetails))]
   [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "General exception types represent unexpected errors.")]
   [Authorize]
-  public static partial Task<IResult> DeleteInvoiceScanAsync(
+  internal static partial Task<IResult> DeleteInvoiceScanAsync(
     [FromServices] IInvoiceProcessingService invoiceProcessingService,
     [FromServices] IHttpContextAccessor httpContext,
     [FromRoute, SwaggerParameter("The unique identifier of the invoice.", Required = true)] Guid id,
@@ -582,7 +582,7 @@ public static partial class InvoiceEndpoints
   [SwaggerResponse(StatusCodes.Status500InternalServerError, "An internal server error occurred while processing the request.", typeof(ProblemDetails))]
   [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "General exception types represent unexpected errors.")]
   [Authorize]
-  public static partial Task<IResult> RetrieveInvoiceMetadataAsync(
+  internal static partial Task<IResult> RetrieveInvoiceMetadataAsync(
     [FromServices] IInvoiceProcessingService invoiceProcessingService,
     [FromServices] IHttpContextAccessor httpContext,
     [FromRoute, SwaggerParameter("The unique identifier of the invoice.", Required = true)] Guid id);
@@ -613,7 +613,7 @@ public static partial class InvoiceEndpoints
   [SwaggerResponse(StatusCodes.Status500InternalServerError, "An internal server error occurred while processing the request.", typeof(ProblemDetails))]
   [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "General exception types represent unexpected errors.")]
   [Authorize]
-  public static partial Task<IResult> PatchInvoiceMetadataAsync(
+  internal static partial Task<IResult> PatchInvoiceMetadataAsync(
     [FromServices] IInvoiceProcessingService invoiceProcessingService,
     [FromServices] IHttpContextAccessor httpContext,
     [FromRoute, SwaggerParameter("The unique identifier of the invoice.", Required = true)] Guid id,
@@ -645,7 +645,7 @@ public static partial class InvoiceEndpoints
   [SwaggerResponse(StatusCodes.Status500InternalServerError, "An internal server error occurred while processing the request.", typeof(ProblemDetails))]
   [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "General exception types represent unexpected errors.")]
   [Authorize]
-  public static partial Task<IResult> DeleteInvoiceMetadataAsync(
+  internal static partial Task<IResult> DeleteInvoiceMetadataAsync(
     [FromServices] IInvoiceProcessingService invoiceProcessingService,
     [FromServices] IHttpContextAccessor httpContext,
     [FromRoute, SwaggerParameter("The unique identifier of the invoice.", Required = true)] Guid id,
@@ -679,7 +679,7 @@ public static partial class InvoiceEndpoints
   [SwaggerResponse(StatusCodes.Status500InternalServerError, "An internal server error occurred while processing the request.", typeof(ProblemDetails))]
   [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "General exception types represent unexpected errors.")]
   [Authorize]
-  public static partial Task<IResult> CreateNewMerchantAsync(
+  internal static partial Task<IResult> CreateNewMerchantAsync(
     [FromServices] IInvoiceProcessingService invoiceProcessingService,
     [FromServices] IHttpContextAccessor httpContext,
     [FromBody, SwaggerRequestBody("The merchant data transfer object.", Required = true)] CreateMerchantRequestDto merchantDto);
@@ -707,7 +707,7 @@ public static partial class InvoiceEndpoints
   [SwaggerResponse(StatusCodes.Status500InternalServerError, "An internal server error occurred while processing the request.", typeof(ProblemDetails))]
   [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "General exception types represent unexpected errors.")]
   [Authorize]
-  public static partial Task<IResult> RetrieveAllMerchantsAsync(
+  internal static partial Task<IResult> RetrieveAllMerchantsAsync(
     [FromServices] IInvoiceProcessingService invoiceProcessingService,
     [FromServices] IHttpContextAccessor httpContext,
     [FromQuery, SwaggerParameter("The parent company identifier used as a filter.", Required = true)] Guid parentCompanyId);
@@ -738,7 +738,7 @@ public static partial class InvoiceEndpoints
   [SwaggerResponse(StatusCodes.Status500InternalServerError, "An internal server error occurred while processing the request.", typeof(ProblemDetails))]
   [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "General exception types represent unexpected errors.")]
   [Authorize]
-  public static partial Task<IResult> RetrieveSpecificMerchantAsync(
+  internal static partial Task<IResult> RetrieveSpecificMerchantAsync(
     [FromServices] IInvoiceProcessingService invoiceProcessingService,
     [FromServices] IHttpContextAccessor httpContext,
     [FromRoute, SwaggerParameter("The unique identifier of the merchant.", Required = true)] Guid id,
@@ -770,7 +770,7 @@ public static partial class InvoiceEndpoints
   [SwaggerResponse(StatusCodes.Status500InternalServerError, "An internal server error occurred while processing the request.", typeof(ProblemDetails))]
   [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "General exception types represent unexpected errors.")]
   [Authorize]
-  public static partial Task<IResult> UpdateSpecificMerchantAsync(
+  internal static partial Task<IResult> UpdateSpecificMerchantAsync(
     [FromServices] IInvoiceProcessingService invoiceProcessingService,
     [FromServices] IHttpContextAccessor httpContext,
     [FromRoute, SwaggerParameter("The unique identifier of the merchant.", Required = true)] Guid id,
@@ -802,7 +802,7 @@ public static partial class InvoiceEndpoints
   [SwaggerResponse(StatusCodes.Status500InternalServerError, "An internal server error occurred while processing the request.", typeof(ProblemDetails))]
   [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "General exception types represent unexpected errors.")]
   [Authorize]
-  public static partial Task<IResult> DeleteMerchantAsync(
+  internal static partial Task<IResult> DeleteMerchantAsync(
     [FromServices] IInvoiceProcessingService invoiceProcessingService,
     [FromServices] IHttpContextAccessor httpContext,
     [FromRoute, SwaggerParameter("The unique identifier of the merchant.", Required = true)] Guid id,
@@ -833,7 +833,7 @@ public static partial class InvoiceEndpoints
   [SwaggerResponse(StatusCodes.Status500InternalServerError, "An internal server error occurred while processing the request.", typeof(ProblemDetails))]
   [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "General exception types represent unexpected errors.")]
   [Authorize]
-  public static partial Task<IResult> RetrieveInvoicesFromMerchantAsync(
+  internal static partial Task<IResult> RetrieveInvoicesFromMerchantAsync(
     [FromServices] IInvoiceProcessingService invoiceProcessingService,
     [FromServices] IHttpContextAccessor httpContext,
     [FromRoute, SwaggerParameter("The unique identifier of the merchant.", Required = true)] Guid id);
@@ -866,7 +866,7 @@ public static partial class InvoiceEndpoints
   [SwaggerResponse(StatusCodes.Status500InternalServerError, "An internal server error occurred while processing the request.", typeof(ProblemDetails))]
   [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "General exception types represent unexpected errors.")]
   [Authorize]
-  public static partial Task<IResult> AddInvoiceToMerchantAsync(
+  internal static partial Task<IResult> AddInvoiceToMerchantAsync(
     [FromServices] IInvoiceProcessingService invoiceProcessingService,
     [FromServices] IHttpContextAccessor httpContext,
     [FromRoute, SwaggerParameter("The unique identifier of the merchant.", Required = true)] Guid id,
@@ -900,7 +900,7 @@ public static partial class InvoiceEndpoints
   [SwaggerResponse(StatusCodes.Status500InternalServerError, "An internal server error occurred while processing the request.", typeof(ProblemDetails))]
   [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "General exception types represent unexpected errors.")]
   [Authorize]
-  public static partial Task<IResult> RemoveInvoiceFromMerchantAsync(
+  internal static partial Task<IResult> RemoveInvoiceFromMerchantAsync(
     [FromServices] IInvoiceProcessingService invoiceProcessingService,
     [FromServices] IHttpContextAccessor httpContext,
     [FromRoute, SwaggerParameter("The unique identifier of the merchant.", Required = true)] Guid id,
@@ -931,7 +931,7 @@ public static partial class InvoiceEndpoints
   [SwaggerResponse(StatusCodes.Status500InternalServerError, "An internal server error occurred while processing the request.", typeof(ProblemDetails))]
   [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "General exception types represent unexpected errors.")]
   [Authorize]
-  public static partial Task<IResult> RetrieveProductsFromMerchantAsync(
+  internal static partial Task<IResult> RetrieveProductsFromMerchantAsync(
     [FromServices] IInvoiceProcessingService invoiceProcessingService,
     [FromServices] IHttpContextAccessor httpContext,
     [FromRoute, SwaggerParameter("The unique identifier of the merchant.", Required = true)] Guid id);
@@ -963,7 +963,7 @@ public static partial class InvoiceEndpoints
   [SwaggerResponse(StatusCodes.Status500InternalServerError, "An internal server error occurred while processing the request.", typeof(ProblemDetails))]
   [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "General exception types represent unexpected errors.")]
   [Authorize]
-  public static partial Task<IResult> AnalyzeInvoiceAsync(
+  internal static partial Task<IResult> AnalyzeInvoiceAsync(
     [FromServices] IInvoiceProcessingService invoiceProcessingService,
     [FromServices] IHttpContextAccessor httpContext,
     [FromRoute, SwaggerParameter("The unique identifier of the invoice.", Required = true)] Guid id,


### PR DESCRIPTION
This pull request makes the internal API endpoint handlers for invoices and merchants accessible to the test project, enabling more thorough integration-style testing without exposing these handlers publicly. The change is primarily about reducing the visibility of endpoint handler methods from `public` to `internal` and explicitly allowing the test assembly to access them.

The most important changes are:

**Endpoint Handler Visibility Restriction:**
* Changed all endpoint handler methods in `InvoiceEndpoints.Handlers.cs` and `InvoiceEndpoints.Metadata.cs` from `public` to `internal`, limiting their direct usage to within the assembly and designated friends. This helps encapsulate internal logic and prevents unintended external usage. [[1]](diffhunk://#diff-5e3e85cc4cdfcfa89fc89c4fc5f755bba4c98631fb6f3ac4bd30ab57031fab1eL24-R24) [[2]](diffhunk://#diff-5e3e85cc4cdfcfa89fc89c4fc5f755bba4c98631fb6f3ac4bd30ab57031fab1eL65-R65) [[3]](diffhunk://#diff-5e3e85cc4cdfcfa89fc89c4fc5f755bba4c98631fb6f3ac4bd30ab57031fab1eL145-R145) [[4]](diffhunk://#diff-5e3e85cc4cdfcfa89fc89c4fc5f755bba4c98631fb6f3ac4bd30ab57031fab1eL177-R177) [[5]](diffhunk://#diff-5e3e85cc4cdfcfa89fc89c4fc5f755bba4c98631fb6f3ac4bd30ab57031fab1eL209-R209) [[6]](diffhunk://#diff-5e3e85cc4cdfcfa89fc89c4fc5f755bba4c98631fb6f3ac4bd30ab57031fab1eL259-R259) [[7]](diffhunk://#diff-5e3e85cc4cdfcfa89fc89c4fc5f755bba4c98631fb6f3ac4bd30ab57031fab1eL324-R324) [[8]](diffhunk://#diff-5e3e85cc4cdfcfa89fc89c4fc5f755bba4c98631fb6f3ac4bd30ab57031fab1eL365-R365) [[9]](diffhunk://#diff-5e3e85cc4cdfcfa89fc89c4fc5f755bba4c98631fb6f3ac4bd30ab57031fab1eL410-R410) [[10]](diffhunk://#diff-5e3e85cc4cdfcfa89fc89c4fc5f755bba4c98631fb6f3ac4bd30ab57031fab1eL449-R449) [[11]](diffhunk://#diff-5e3e85cc4cdfcfa89fc89c4fc5f755bba4c98631fb6f3ac4bd30ab57031fab1eL492-R492) [[12]](diffhunk://#diff-5e3e85cc4cdfcfa89fc89c4fc5f755bba4c98631fb6f3ac4bd30ab57031fab1eL551-R551) [[13]](diffhunk://#diff-5e3e85cc4cdfcfa89fc89c4fc5f755bba4c98631fb6f3ac4bd30ab57031fab1eL606-R606) [[14]](diffhunk://#diff-5e3e85cc4cdfcfa89fc89c4fc5f755bba4c98631fb6f3ac4bd30ab57031fab1eL667-R667) [[15]](diffhunk://#diff-5e3e85cc4cdfcfa89fc89c4fc5f755bba4c98631fb6f3ac4bd30ab57031fab1eL732-R732) [[16]](diffhunk://#diff-5e3e85cc4cdfcfa89fc89c4fc5f755bba4c98631fb6f3ac4bd30ab57031fab1eL779-R779) [[17]](diffhunk://#diff-5e3e85cc4cdfcfa89fc89c4fc5f755bba4c98631fb6f3ac4bd30ab57031fab1eL818-R818) [[18]](diffhunk://#diff-5e3e85cc4cdfcfa89fc89c4fc5f755bba4c98631fb6f3ac4bd30ab57031fab1eL873-R873) [[19]](diffhunk://#diff-5e3e85cc4cdfcfa89fc89c4fc5f755bba4c98631fb6f3ac4bd30ab57031fab1eL912-R912) [[20]](diffhunk://#diff-5e3e85cc4cdfcfa89fc89c4fc5f755bba4c98631fb6f3ac4bd30ab57031fab1eL957-R957) [[21]](diffhunk://#diff-5e3e85cc4cdfcfa89fc89c4fc5f755bba4c98631fb6f3ac4bd30ab57031fab1eL1008-R1008) [[22]](diffhunk://#diff-5e3e85cc4cdfcfa89fc89c4fc5f755bba4c98631fb6f3ac4bd30ab57031fab1eL1043-R1043) [[23]](diffhunk://#diff-5e3e85cc4cdfcfa89fc89c4fc5f755bba4c98631fb6f3ac4bd30ab57031fab1eL1078-R1078) [[24]](diffhunk://#diff-5e3e85cc4cdfcfa89fc89c4fc5f755bba4c98631fb6f3ac4bd30ab57031fab1eL1122-R1122) [[25]](diffhunk://#diff-5e3e85cc4cdfcfa89fc89c4fc5f755bba4c98631fb6f3ac4bd30ab57031fab1eL1167-R1167) [[26]](diffhunk://#diff-5e3e85cc4cdfcfa89fc89c4fc5f755bba4c98631fb6f3ac4bd30ab57031fab1eL1227-R1227) [[27]](diffhunk://#diff-5e3e85cc4cdfcfa89fc89c4fc5f755bba4c98631fb6f3ac4bd30ab57031fab1eL1282-R1282) [[28]](diffhunk://#diff-5e3e85cc4cdfcfa89fc89c4fc5f755bba4c98631fb6f3ac4bd30ab57031fab1eL1345-R1345) [[29]](diffhunk://#diff-5e3e85cc4cdfcfa89fc89c4fc5f755bba4c98631fb6f3ac4bd30ab57031fab1eL1410-R1410) [[30]](diffhunk://#diff-5e3e85cc4cdfcfa89fc89c4fc5f755bba4c98631fb6f3ac4bd30ab57031fab1eL1470-R1470) [[31]](diffhunk://#diff-8b690a4856eb7e0065c1d268b2f49b645f1296a362a1444976c8effd60cd8404L51-R51) [[32]](diffhunk://#diff-8b690a4856eb7e0065c1d268b2f49b645f1296a362a1444976c8effd60cd8404L81-R81)

**Testability Enhancements:**
* Added an `[assembly: InternalsVisibleTo("arolariu.Backend.Domain.Tests")]` attribute in `AssemblyInfo.cs`, allowing the domain test project to access internal endpoint handlers for integration-style tests. This supports validating exception-to-HTTP-status mapping and other behaviors without needing to spin up the full web application.

These changes improve encapsulation while still supporting robust automated testing.