### PR TITLE
Fix per-sample latencies, probe cadence, and svelte-check errors

### DIFF
--- a/.github/workflows/official-status-probe.yml
+++ b/.github/workflows/official-status-probe.yml
@@ -23,7 +23,9 @@ jobs:
     if: github.repository == 'arolariu/arolariu.ro'
     name: 📡 Probe services and publish status data
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    # Budget: ~3 min probe + ~1–2 min setup + aggregate + push. 10 min ceiling
+    # catches genuine hangs without tripping on a transient cold-cache npm ci.
+    timeout-minutes: 10
     # Setting git identity via env vars once at the job level — every git
     # subcommand in the job inherits these, so we avoid repeating
     # `git config user.name/email` across steps. Runners do not auto-assign.

--- a/sites/status.arolariu.ro/scripts/aggregate.test.ts
+++ b/sites/status.arolariu.ro/scripts/aggregate.test.ts
@@ -171,6 +171,74 @@ describe("rebuildFine", () => {
     expect(bucket.latency.p99).toBeDefined();
   });
 
+  it("fans out sampleLatenciesMs into bucket percentiles so p50/p75/p95/p99 differ for a single probe run", () => {
+    // This is the direct regression test for the all-percentiles-equal bug:
+    // ONE probe run in the bucket, but it persists a distribution of 10 per-sample
+    // latencies. Without the fan-out, `acc.latencies.length === 1` and every
+    // percentile collapses to the median. With the fan-out, p50 ≠ p95 ≠ p99.
+    const probes: ProbeResult[] = [
+      {
+        service: "arolariu.ro",
+        timestamp: "2026-04-19T14:00:00Z",
+        latencyMs: 55, // median of the array below
+        httpStatus: 200,
+        overall: "Healthy",
+        sampleCount: 10,
+        sampleLatenciesMs: [10, 20, 30, 40, 50, 60, 70, 80, 90, 100],
+      },
+    ];
+    const agg = rebuildFine(probes, new Date("2026-04-19T15:00:00Z"));
+    const {p50, p75, p95, p99} = agg.services[0]!.buckets[0]!.latency;
+    expect(p50).toBe(55);
+    expect(p75).toBe(78);
+    expect(p95).toBe(95);
+    expect(p99).toBe(99);
+    // Counts in the bucket still reflect probe-run cardinality, not sample cardinality.
+    expect(agg.services[0]!.buckets[0]!.probes).toEqual({healthy: 10, total: 10});
+  });
+
+  it("falls back to latencyMs when a legacy probe row has no sampleLatenciesMs", () => {
+    // Legacy rows (pre-schema-change) had only `latencyMs`. They should still
+    // aggregate, and — when only one such row is in the bucket — the percentile
+    // collapse is expected: that row predates the fix by design.
+    const probes: ProbeResult[] = [mkProbe("arolariu.ro", "2026-04-19T14:00:00Z", "Healthy", 200)];
+    const agg = rebuildFine(probes, new Date("2026-04-19T15:00:00Z"));
+    const {p50, p75, p95, p99} = agg.services[0]!.buckets[0]!.latency;
+    expect(p50).toBe(200);
+    expect(p99).toBe(200);
+    expect(p75).toBe(200);
+    expect(p95).toBe(200);
+  });
+
+  it("fans out sub-check sampleDurationsMs so sub-series percentiles differ within one probe run", () => {
+    const probes: ProbeResult[] = [
+      {
+        service: "api.arolariu.ro",
+        timestamp: "2026-04-19T14:00:00Z",
+        latencyMs: 55,
+        httpStatus: 200,
+        overall: "Healthy",
+        sampleCount: 10,
+        sampleLatenciesMs: [10, 20, 30, 40, 50, 60, 70, 80, 90, 100],
+        subChecks: [
+          {
+            name: "mssql",
+            status: "Healthy",
+            durationMs: 55,
+            sampleDurationsMs: [10, 20, 30, 40, 50, 60, 70, 80, 90, 100],
+          },
+        ],
+      },
+    ];
+    const agg = rebuildFine(probes, new Date("2026-04-19T15:00:00Z"));
+    const api = agg.services.find((s) => s.service === "api.arolariu.ro")!;
+    const mssqlBucket = api.subSeries!["mssql"]![0]!;
+    expect(mssqlBucket.latency.p50).toBe(55);
+    expect(mssqlBucket.latency.p75).toBe(78);
+    expect(mssqlBucket.latency.p95).toBe(95);
+    expect(mssqlBucket.latency.p99).toBe(99);
+  });
+
   it("computes expected 4 percentiles for a known input sequence", () => {
     // latencies = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
     // linear interpolation between ranks (note: floating-point arithmetic

--- a/sites/status.arolariu.ro/scripts/aggregateServices.ts
+++ b/sites/status.arolariu.ro/scripts/aggregateServices.ts
@@ -19,7 +19,15 @@ export function groupProbes(
     if (!acc) {acc = {statuses: [], latencies: [], httpStatuses: [], sampleCount: 0, healthySamples: 0}; perService.set(bucket, acc);}
     const samples = p.sampleCount ?? 1;
     acc.statuses.push(p.overall);
-    acc.latencies.push(p.latencyMs);
+    // Fan out per-sample latencies when the probe persisted them; fall back to
+    // the single aggregated median for legacy rows pre-dating `sampleLatenciesMs`.
+    // This is what keeps bucket-level p50/p75/p95/p99 distinct — one latency
+    // per bucket collapses every percentile to the same number.
+    if (p.sampleLatenciesMs !== undefined && p.sampleLatenciesMs.length > 0) {
+      for (const l of p.sampleLatenciesMs) acc.latencies.push(l);
+    } else {
+      acc.latencies.push(p.latencyMs);
+    }
     acc.httpStatuses.push(p.httpStatus);
     acc.sampleCount += samples;
     if (p.overall === "Healthy") acc.healthySamples += samples;

--- a/sites/status.arolariu.ro/scripts/aggregateSubChecks.ts
+++ b/sites/status.arolariu.ro/scripts/aggregateSubChecks.ts
@@ -23,7 +23,14 @@ export function groupSubChecks(
       let acc = perSub.get(bucket);
       if (!acc) {acc = {statuses: [], latencies: [], httpStatuses: [], sampleCount: 0, healthySamples: 0}; perSub.set(bucket, acc);}
       acc.statuses.push(sc.status);
-      acc.latencies.push(sc.durationMs);
+      // Mirror the main-service fan-out: if the probe captured per-sample
+      // sub-check durations, feed all of them into the percentile calc. Legacy
+      // rows without `sampleDurationsMs` still contribute a single data point.
+      if (sc.sampleDurationsMs !== undefined && sc.sampleDurationsMs.length > 0) {
+        for (const d of sc.sampleDurationsMs) acc.latencies.push(d);
+      } else {
+        acc.latencies.push(sc.durationMs);
+      }
       acc.sampleCount += samples;
       if (sc.status === "Healthy") acc.healthySamples += samples;
     }

--- a/sites/status.arolariu.ro/scripts/probe.test.ts
+++ b/sites/status.arolariu.ro/scripts/probe.test.ts
@@ -147,6 +147,78 @@ describe("runProbe", () => {
     expect(results.every((r) => typeof r.latencyMs === "number" && r.latencyMs >= 0)).toBe(true);
   });
 
+  it("emits sampleLatenciesMs with one entry per sample so percentile math gets a real distribution", async () => {
+    globalThis.fetch = vi.fn(async () => new Response(JSON.stringify({status: "Healthy"}), {status: 200})) as typeof fetch;
+
+    const delays = [0, 0, 0, 0, 0];
+    const results = await runProbe({dataDir, now: new Date("2026-04-19T14:00:00Z"), sampleDelaysMs: delays});
+
+    for (const r of results) {
+      expect(r.sampleLatenciesMs).toBeDefined();
+      expect(r.sampleLatenciesMs).toHaveLength(delays.length);
+      expect(r.sampleLatenciesMs!.every((l) => typeof l === "number" && l >= 0)).toBe(true);
+      expect(r.sampleCount).toBe(delays.length);
+    }
+  });
+
+  it("skips samples without subChecks when enriching sampleDurationsMs (partial-response continue branch)", async () => {
+    // Worst sample MUST carry subChecks (otherwise the enrichment block is
+    // skipped entirely). Mid-run, emit one response whose body lacks the
+    // `entries` dictionary so the parser returns a subChecks-less ProbeResult —
+    // exercises the `if (s.subChecks === undefined) continue;` true branch.
+    let call = 0;
+    globalThis.fetch = vi.fn(async (url: string | URL) => {
+      const u = String(url);
+      if (u.includes("api.arolariu.ro/health")) {
+        const i = call++;
+        // sample 0: Healthy w/ subChecks; sample 1: Healthy, NO entries (no subChecks);
+        // sample 2: Degraded w/ subChecks (this is `worst` and has subChecks).
+        if (i === 1) return new Response(JSON.stringify({status: "Healthy"}), {status: 200});
+        const body =
+          i === 2
+            ? {status: "Degraded", entries: {mssql: {status: "Degraded", duration: "00:00:00.300"}}}
+            : {status: "Healthy", entries: {mssql: {status: "Healthy", duration: "00:00:00.100"}}};
+        return new Response(JSON.stringify(body), {status: 200});
+      }
+      return new Response(JSON.stringify({status: "Healthy"}), {status: 200});
+    }) as typeof fetch;
+
+    const results = await runProbe({dataDir, now: new Date("2026-04-19T14:00:00Z"), sampleDelaysMs: [0, 0, 0]});
+    const api = results.find((r) => r.service === "api.arolariu.ro")!;
+    expect(api.overall).toBe("Degraded");
+    const mssql = api.subChecks?.find((sc) => sc.name === "mssql");
+    expect(mssql).toBeDefined();
+    // Only 2 of 3 samples contributed mssql durations; the middle sample was skipped.
+    expect(mssql!.sampleDurationsMs).toEqual([100, 300]);
+  });
+
+  it("populates sampleDurationsMs on each sub-check with per-sample durations across the run", async () => {
+    // Return a different mssql duration on each call so we can assert the
+    // aggregated sub-check preserves all four distinct values, not just one.
+    let call = 0;
+    const apiDurations = ["00:00:00.100", "00:00:00.200", "00:00:00.300", "00:00:00.400"];
+    globalThis.fetch = vi.fn(async (url: string | URL) => {
+      const u = String(url);
+      if (u.includes("api.arolariu.ro/health")) {
+        const duration = apiDurations[call++ % apiDurations.length];
+        return new Response(
+          JSON.stringify({status: "Healthy", entries: {mssql: {status: "Healthy", duration}}}),
+          {status: 200},
+        );
+      }
+      return new Response(JSON.stringify({status: "Healthy"}), {status: 200});
+    }) as typeof fetch;
+
+    const results = await runProbe({dataDir, now: new Date("2026-04-19T14:00:00Z"), sampleDelaysMs: [0, 0, 0, 0]});
+    const api = results.find((r) => r.service === "api.arolariu.ro")!;
+    const mssql = api.subChecks?.find((sc) => sc.name === "mssql");
+    expect(mssql).toBeDefined();
+    expect(mssql!.sampleDurationsMs).toBeDefined();
+    expect(mssql!.sampleDurationsMs).toHaveLength(4);
+    // Four samples with four distinct durations ⇒ the sub-check must carry all four.
+    expect(new Set(mssql!.sampleDurationsMs)).toEqual(new Set([100, 200, 300, 400]));
+  });
+
   it("waits sampleDelaysMs between samples (using non-zero delays)", async () => {
     globalThis.fetch = vi.fn(async () => new Response(JSON.stringify({status: "Healthy"}), {status: 200})) as typeof fetch;
 

--- a/sites/status.arolariu.ro/scripts/probe.ts
+++ b/sites/status.arolariu.ro/scripts/probe.ts
@@ -26,16 +26,19 @@ import {parseExpArolariuRo} from "./parsers/expArolariuRo";
 const PROBE_TIMEOUT_MS = 10_000;
 
 /**
- * Delay BEFORE each sample fetch. Ten samples per service per 30-min cron,
- * spread over 3 minutes (immediate, +20s, +40s, …, +180s). The longer
- * window smooths out per-sample noise so bucket-level p95/p99 signal
- * becomes meaningful at the 30-minute fine tier.
+ * Delay BEFORE each sample fetch (inter-sample delta, NOT an absolute offset
+ * from probe start — see `probeOne`). Ten samples at a constant 20 s cadence:
+ * the first fires immediately, each subsequent sample waits 20 s after the
+ * previous one returns. Total sleep = 9 × 20 s = 180 s → the full run lasts
+ * ≈ 3 minutes + fetch time (≈190s worst case with PROBE_TIMEOUT_MS=10s on
+ * the final sample). Well under the 30-min cron cadence.
  *
- * Total wall-clock per service ≤ 180s + fetch time (≈190s worst case with
- * PROBE_TIMEOUT_MS=10s on the final sample). Still well under the 30-min
- * cron interval. Overridable in tests via `RunProbeOptions.sampleDelaysMs`.
+ * The 3-minute window is a deliberate trade-off: long enough to smooth out
+ * per-sample noise so bucket-level p95/p99 carry real signal, short enough
+ * to leave plenty of headroom on each cron tick. Overridable in tests via
+ * `RunProbeOptions.sampleDelaysMs`.
  */
-const DEFAULT_SAMPLE_DELAYS_MS: readonly number[] = [0, 20_000, 40_000, 60_000, 80_000, 100_000, 120_000, 140_000, 160_000, 180_000];
+const DEFAULT_SAMPLE_DELAYS_MS: readonly number[] = [0, 20_000, 20_000, 20_000, 20_000, 20_000, 20_000, 20_000, 20_000, 20_000];
 
 /** Severity ranking used when picking the "worst" sample across the batch. */
 const STATUS_ORDER: Record<HealthStatus, number> = {Healthy: 0, Degraded: 1, Unhealthy: 2};

--- a/sites/status.arolariu.ro/scripts/probe.ts
+++ b/sites/status.arolariu.ro/scripts/probe.ts
@@ -11,7 +11,7 @@ import {appendFileSync, existsSync, mkdirSync, readFileSync} from "node:fs";
 import {join} from "node:path";
 import {performance} from "node:perf_hooks";
 import {setTimeout as sleep} from "node:timers/promises";
-import type {HealthStatus, ProbeResult, ServiceId} from "../src/lib/types/status";
+import type {HealthStatus, ProbeResult, ServiceId, SubCheck} from "../src/lib/types/status";
 import {parseApiArolariuRo} from "./parsers/apiArolariuRo";
 import type {ProbeContext, RawResponse} from "./parsers/arolariuRo";
 import {parseArolariuRo} from "./parsers/arolariuRo";
@@ -118,6 +118,11 @@ async function singleFetch(cfg: ServiceConfig, nowIso: string): Promise<ProbeRes
  *     sample (preserves the most informative sub-check state + error text).
  *   - `latencyMs` is the median of the samples (noise-resistant; a single
  *     bad sample does not dominate).
+ *   - `sampleLatenciesMs` preserves the raw per-sample latencies so bucket
+ *     percentile math downstream has a real distribution, not a 1-element
+ *     array that collapses every percentile to the median.
+ *   - Each sub-check on the result carries `sampleDurationsMs` with its
+ *     per-sample durations across the run, for the same reason.
  *   - `timestamp` is the first sample's timestamp, so every service's
  *     aggregate aligns to the same 30-min bucket regardless of which
  *     sample was fastest/slowest.
@@ -127,9 +132,40 @@ function aggregateSamples(samples: readonly ProbeResult[]): ProbeResult {
   /* v8 ignore next */
   if (first === undefined) throw new Error("aggregateSamples requires at least one sample");
   const worst = samples.reduce<ProbeResult>((w, s) => (STATUS_ORDER[s.overall] > STATUS_ORDER[w.overall] ? s : w), first);
-  const sortedLatencies = [...samples.map((s) => s.latencyMs)].sort((a, b) => a - b);
+  const sampleLatenciesMs = samples.map((s) => s.latencyMs);
+  const sortedLatencies = [...sampleLatenciesMs].sort((a, b) => a - b);
   /* v8 ignore next */
   const median = sortedLatencies[Math.floor(samples.length / 2)] ?? first.latencyMs;
+
+  // Collect per-sample sub-check durations keyed by sub-check name. We preserve
+  // the worst sample's sub-check array as the output skeleton (status + error
+  // description semantics match `overall`), then enrich each entry with the
+  // full array of durations seen across ALL samples under that name.
+  let enrichedSubChecks: readonly SubCheck[] | undefined;
+  if (worst.subChecks !== undefined) {
+    const durationsByName = new Map<string, number[]>();
+    for (const s of samples) {
+      if (s.subChecks === undefined) continue;
+      for (const sc of s.subChecks) {
+        let arr = durationsByName.get(sc.name);
+        /* v8 ignore next */
+        if (arr === undefined) {arr = []; durationsByName.set(sc.name, arr);}
+        arr.push(sc.durationMs);
+      }
+    }
+    enrichedSubChecks = worst.subChecks.map((sc) => {
+      const durations = durationsByName.get(sc.name);
+      // `durations` is always defined + non-empty here: `worst` is one of the
+      // samples we iterated above, so its sub-check names are guaranteed keys
+      // in `durationsByName`. The fallback exists only to keep the type
+      // checker happy.
+      /* v8 ignore next 3 */
+      return durations !== undefined && durations.length > 0
+        ? {...sc, sampleDurationsMs: durations}
+        : sc;
+    });
+  }
+
   const base: ProbeResult = {
     service: worst.service,
     timestamp: first.timestamp,
@@ -137,11 +173,11 @@ function aggregateSamples(samples: readonly ProbeResult[]): ProbeResult {
     httpStatus: worst.httpStatus,
     overall: worst.overall,
     sampleCount: samples.length,
+    sampleLatenciesMs,
   };
   return {
     ...base,
-    /* v8 ignore next */
-    ...(worst.subChecks !== undefined && {subChecks: worst.subChecks}),
+    ...(enrichedSubChecks !== undefined && {subChecks: enrichedSubChecks}),
     /* v8 ignore next */
     ...(worst.error !== undefined && {error: worst.error}),
   };

--- a/sites/status.arolariu.ro/src/app.d.ts
+++ b/sites/status.arolariu.ro/src/app.d.ts
@@ -1,3 +1,11 @@
+/// <reference types="@sveltejs/kit" />
+
+// Side-effect CSS imports (e.g. `import "../app.css";` in +layout.svelte)
+// need a module declaration to satisfy `noUncheckedSideEffectImports` from
+// the monorepo-root tsconfig. Vite/SvelteKit handle the actual loading —
+// this file only tells TypeScript the module is a known extension.
+declare module "*.css";
+
 declare global {
   namespace App {
     interface Error {}

--- a/sites/status.arolariu.ro/src/lib/api/mockData.test.ts
+++ b/sites/status.arolariu.ro/src/lib/api/mockData.test.ts
@@ -154,7 +154,12 @@ describe("generateMockIncidents", () => {
     const result = generateMockIncidents();
     for (const incident of result.incidents) {
       if (incident.status === "open") {
-        expect(incident.resolvedAt).toBeUndefined();
+        // The `open` variant of the Incident union doesn't declare `resolvedAt`,
+        // so TS narrows the property away. This assertion exists to verify the
+        // *runtime* shape matches that type-level invariant — widen the view
+        // just for the read.
+        const maybeResolved = (incident as {resolvedAt?: string}).resolvedAt;
+        expect(maybeResolved).toBeUndefined();
       }
     }
   });

--- a/sites/status.arolariu.ro/src/lib/hooks/useCountTween.svelte.test.ts
+++ b/sites/status.arolariu.ro/src/lib/hooks/useCountTween.svelte.test.ts
@@ -127,10 +127,10 @@ describe("useCountTween", () => {
   });
 
   it("cleanup effect cancels pending RAF on scope teardown", () => {
-    let cancelId: number | null = null;
-    vi.stubGlobal("cancelAnimationFrame", (id: number) => {
-      cancelId = id;
-    });
+    // Stub `cancelAnimationFrame` with a no-op so teardown does not hit the
+    // real browser API (jsdom). We don't assert on the captured id — the
+    // test's only guarantee is that teardown doesn't throw.
+    vi.stubGlobal("cancelAnimationFrame", () => {});
 
     const root = $effect.root(() => {
       let target = $state(0);

--- a/sites/status.arolariu.ro/src/lib/routes/pageLogic.test.ts
+++ b/sites/status.arolariu.ro/src/lib/routes/pageLogic.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it} from "vitest";
-import type {AggregateFile, ServiceSeries} from "../types/status";
+import type {AggregateFile, ServiceId, ServiceSeries} from "../types/status";
 import {BUCKET_SIZE_TO_MS} from "../types/status";
 import {shouldIgnoreKeydown} from "./keyboardShortcuts";
 import {SERVICE_DISPLAY_ORDER, bucketDurationMsFor, orderedServices, showWeekdayChart} from "./pageLogic";

--- a/sites/status.arolariu.ro/src/lib/types/guards.test.ts
+++ b/sites/status.arolariu.ro/src/lib/types/guards.test.ts
@@ -37,6 +37,18 @@ describe("isSubCheck", () => {
   it("rejects wrong types", () => {
     expect(isSubCheck({name: "mssql", status: "bad", durationMs: 12})).toBe(false);
   });
+  it("accepts valid sampleDurationsMs array", () => {
+    expect(isSubCheck({name: "mssql", status: "Healthy", durationMs: 12, sampleDurationsMs: [10, 11, 12, 13]})).toBe(true);
+  });
+  it("accepts empty sampleDurationsMs array", () => {
+    expect(isSubCheck({name: "mssql", status: "Healthy", durationMs: 12, sampleDurationsMs: []})).toBe(true);
+  });
+  it("rejects non-array sampleDurationsMs", () => {
+    expect(isSubCheck({name: "mssql", status: "Healthy", durationMs: 12, sampleDurationsMs: 12})).toBe(false);
+  });
+  it("rejects negative values inside sampleDurationsMs", () => {
+    expect(isSubCheck({name: "mssql", status: "Healthy", durationMs: 12, sampleDurationsMs: [10, -1, 12]})).toBe(false);
+  });
 });
 
 describe("isProbeResult", () => {
@@ -59,6 +71,15 @@ describe("isProbeResult", () => {
   });
   it("rejects sampleCount < 1", () => {
     expect(isProbeResult({...valid, sampleCount: 0})).toBe(false);
+  });
+  it("accepts valid sampleLatenciesMs array", () => {
+    expect(isProbeResult({...valid, sampleLatenciesMs: [100, 120, 140]})).toBe(true);
+  });
+  it("rejects non-array sampleLatenciesMs", () => {
+    expect(isProbeResult({...valid, sampleLatenciesMs: 120})).toBe(false);
+  });
+  it("rejects negative values inside sampleLatenciesMs", () => {
+    expect(isProbeResult({...valid, sampleLatenciesMs: [100, -1, 140]})).toBe(false);
   });
 });
 

--- a/sites/status.arolariu.ro/src/lib/types/guards.ts
+++ b/sites/status.arolariu.ro/src/lib/types/guards.ts
@@ -38,13 +38,18 @@ export function isServiceId(v: unknown): v is ServiceId {
   return typeof v === "string" && (SERVICE_IDS as readonly string[]).includes(v);
 }
 
-/** Validates a sub-check shape: required name/status/durationMs, optional description. */
+/** Validates a sub-check shape: required name/status/durationMs, optional description/sampleDurationsMs. */
 export function isSubCheck(v: unknown): v is SubCheck {
   if (!isObject(v)) return false;
   if (typeof v["name"] !== "string") return false;
   if (!isHealthStatus(v["status"])) return false;
   if (!isNonNegativeNumber(v["durationMs"])) return false;
   if (v["description"] !== undefined && typeof v["description"] !== "string") return false;
+  const sampleDurations = v["sampleDurationsMs"];
+  if (sampleDurations !== undefined) {
+    if (!Array.isArray(sampleDurations)) return false;
+    if (!sampleDurations.every(isNonNegativeNumber)) return false;
+  }
   return true;
 }
 
@@ -68,6 +73,11 @@ export function isProbeResult(v: unknown): v is ProbeResult {
   }
   if (v["sampleCount"] !== undefined) {
     if (typeof v["sampleCount"] !== "number" || !Number.isFinite(v["sampleCount"]) || v["sampleCount"] < 1) return false;
+  }
+  const sampleLatencies = v["sampleLatenciesMs"];
+  if (sampleLatencies !== undefined) {
+    if (!Array.isArray(sampleLatencies)) return false;
+    if (!sampleLatencies.every(isNonNegativeNumber)) return false;
   }
   return true;
 }

--- a/sites/status.arolariu.ro/src/lib/types/status.ts
+++ b/sites/status.arolariu.ro/src/lib/types/status.ts
@@ -55,10 +55,23 @@ export interface SubCheck {
   readonly name: string;
   /** Sub-check health status contributing to the service overall status. */
   readonly status: HealthStatus;
-  /** Sub-check execution time in milliseconds. */
+  /**
+   * Representative sub-check execution time in milliseconds. When
+   * `sampleDurationsMs` is populated this is the worst sample's duration
+   * (aligned with how `overall` picks worst-sample status); when absent
+   * (legacy single-sample probes) it is simply the probe's only measurement.
+   */
   readonly durationMs: number;
   /** Optional human-readable message when degraded or unhealthy. */
   readonly description?: string;
+  /**
+   * Per-sample sub-check durations in milliseconds for this probe run.
+   * Present when the probe took multiple samples (current 10-sample-per-cron
+   * regime). Bucket-level percentile math MUST prefer this over `durationMs`
+   * when available — one `durationMs` per bucket collapses p50/p75/p95/p99
+   * to the same value.
+   */
+  readonly sampleDurationsMs?: readonly number[];
 }
 
 /**
@@ -82,6 +95,14 @@ export interface ProbeResult {
   readonly error?: string;
   /** Number of HTTP samples aggregated into this result. Defaults to 1 when absent (legacy). */
   readonly sampleCount?: number;
+  /**
+   * Raw per-sample latencies in milliseconds (one entry per HTTP sample
+   * taken in this cron run), preserved so bucket-level percentile math has
+   * a real distribution to work on instead of a single median. Absent on
+   * legacy single-sample rows. Consumers computing percentiles MUST prefer
+   * this when present and fall back to `[latencyMs]` otherwise.
+   */
+  readonly sampleLatenciesMs?: readonly number[];
 }
 
 /**

--- a/sites/status.arolariu.ro/src/routes/+error.svelte
+++ b/sites/status.arolariu.ro/src/routes/+error.svelte
@@ -6,10 +6,13 @@
    * throws — shows the status code + message in a minimal layout. No
    * retry affordance; SvelteKit's built-in navigation reloads the app.
    */
-  import {page} from "$app/stores";
+  // `$app/state` (rune-based) is the Kit-2.12+ replacement for the
+  // deprecated `$app/stores`. `page` is already reactive — no `$` prefix
+  // needed at the template site.
+  import {page} from "$app/state";
 </script>
 
 <main class="p-8">
-  <h1 class="text-xl font-semibold">Error {$page.status}</h1>
-  <p class="mt-2 opacity-60">{$page.error?.message ?? "Something went wrong."}</p>
+  <h1 class="text-xl font-semibold">Error {page.status}</h1>
+  <p class="mt-2 opacity-60">{page.error?.message ?? "Something went wrong."}</p>
 </main>

--- a/sites/status.arolariu.ro/src/routes/+layout.svelte
+++ b/sites/status.arolariu.ro/src/routes/+layout.svelte
@@ -7,7 +7,12 @@
    * No persistent chrome lives here — the page itself owns its masthead,
    * footer, and overlays.
    */
-  import "@/app.css";
+  // Relative import avoids the `@/*` alias, which svelte-check cannot resolve
+  // for side-effect CSS imports (the alias is defined in svelte.config.js +
+  // the generated .svelte-kit/tsconfig.json, but side-effect CSS resolution
+  // still needs a filesystem-relative path here). Runtime behaviour is
+  // identical; Vite resolves either form.
+  import "../app.css";
 
   /** Root layout props — only the Svelte-provided children snippet. */
   interface Props {


### PR DESCRIPTION
This pull request introduces significant improvements to the status probe system, focusing on capturing and preserving per-sample latency and sub-check duration data for more accurate percentile calculations in service health reporting. It also includes comprehensive updates to the aggregation, validation, and testing logic to support these enhancements.

**Probe Data Model and Aggregation Enhancements:**

- The probe now records `sampleLatenciesMs` (per-sample latencies) and, for sub-checks, `sampleDurationsMs` (per-sample durations), enabling accurate percentile (p50, p75, p95, p99) calculations downstream. Aggregation logic has been updated to fan out these arrays so that even a single probe run with multiple samples yields distinct percentile values, rather than collapsing all percentiles to the median. [[1]](diffhunk://#diff-4beedc89cf797bf0363dcbfc8e31f4561356af113a536ddb6ced556eff07aadaL130-R183) [[2]](diffhunk://#diff-e2e8744b41e62bcd6678ac5fd844fab14a1d5e004359a834cdb7dc84cb1b138cR22-R30) [[3]](diffhunk://#diff-bc36a82a5cf19f78f62883f19defcc0659aa20458b25ecf2e38313d42958ee33R26-R33)

**Test Coverage Improvements:**

- Extensive new tests verify that the system correctly handles per-sample latency and sub-check duration data, including edge cases such as legacy probe rows (without per-sample arrays), missing sub-checks, and validation of the new array fields. [[1]](diffhunk://#diff-5f90c1497908a86665b8e1099149bc7f412c43e1db0d9de867ec698402533adeR174-R241) [[2]](diffhunk://#diff-bc984f7b5037234de17d7d9789c990a5126eb766653fe65d1bc0acd46e099755R150-R221) [[3]](diffhunk://#diff-f11b584d537232f79e14f5cf434bd16ccdbafb60a010a1f21f6d8b30b76b6d0bR40-R51) [[4]](diffhunk://#diff-f11b584d537232f79e14f5cf434bd16ccdbafb60a010a1f21f6d8b30b76b6d0bR75-R83)

**Validation and Type Guard Updates:**

- The type guards for `ProbeResult` and `SubCheck` now validate the new `sampleLatenciesMs` and `sampleDurationsMs` fields, ensuring they are arrays of non-negative numbers when present. [[1]](diffhunk://#diff-e1c60f03e3119bb2cc4e43b428d65a4d56725032464884750cc953786899114bL41-R52) [[2]](diffhunk://#diff-e1c60f03e3119bb2cc4e43b428d65a4d56725032464884750cc953786899114bR77-R81)

**Probe Execution and Timing Adjustment:**

- The default probe sampling cadence is now a fixed 20-second delay between samples, simplifying timing and ensuring consistent probe durations. Documentation has been updated to reflect this change.

**Other Minor Improvements:**

- The workflow timeout for the status probe job has been reduced to 10 minutes to better catch genuine hangs without being triggered by transient setup delays.
- Minor test and import improvements for clarity and correctness. [[1]](diffhunk://#diff-7712445be11d924055862655f123b762bc6e28930795a0bb61542c29edce040bL2-R2) [[2]](diffhunk://#diff-c99cc0afcc1bd15b646e2e16412c9573b3ebfa109ab9fd101972c362d380d607L157-R162) [[3]](diffhunk://#diff-4101fa70a2194601211b647f6233219e6ae83102ae2a5659bc355e6dbc630cd0L130-R133)

**References:**

- Probe data model and aggregation: [[1]](diffhunk://#diff-4beedc89cf797bf0363dcbfc8e31f4561356af113a536ddb6ced556eff07aadaL130-R183) [[2]](diffhunk://#diff-e2e8744b41e62bcd6678ac5fd844fab14a1d5e004359a834cdb7dc84cb1b138cR22-R30) [[3]](diffhunk://#diff-bc36a82a5cf19f78f62883f19defcc0659aa20458b25ecf2e38313d42958ee33R26-R33)
- Test coverage: [[1]](diffhunk://#diff-5f90c1497908a86665b8e1099149bc7f412c43e1db0d9de867ec698402533adeR174-R241) [[2]](diffhunk://#diff-bc984f7b5037234de17d7d9789c990a5126eb766653fe65d1bc0acd46e099755R150-R221) [[3]](diffhunk://#diff-f11b584d537232f79e14f5cf434bd16ccdbafb60a010a1f21f6d8b30b76b6d0bR40-R51) [[4]](diffhunk://#diff-f11b584d537232f79e14f5cf434bd16ccdbafb60a010a1f21f6d8b30b76b6d0bR75-R83)
- Validation/type guards: [[1]](diffhunk://#diff-e1c60f03e3119bb2cc4e43b428d65a4d56725032464884750cc953786899114bL41-R52) [[2]](diffhunk://#diff-e1c60f03e3119bb2cc4e43b428d65a4d56725032464884750cc953786899114bR77-R81)
- Probe timing:
- Workflow timeout: