### PR TITLE
fix(status): move probe cron to :09 and :39 for better GHA scheduler …

### DIFF
--- a/.github/workflows/official-status-probe.yml
+++ b/.github/workflows/official-status-probe.yml
@@ -8,7 +8,14 @@ name: "official-status-probe"
 
 on:
   schedule:
-    - cron: "*/30 * * * *"
+    # Fire at :09 and :39 instead of the usual :00 / :30. GitHub Actions'
+    # shared scheduler load-sheds the heavily-subscribed round-minute slots
+    # (top-of-hour and :30 are the most-requested cron times across the
+    # platform), so a meaningful fraction of our scheduled runs were being
+    # dropped or delayed 10+ minutes. Odd-minute slots face far less
+    # contention and historically land closer to on-time. Cadence is
+    # unchanged — still two runs per hour, 30 min apart.
+    - cron: "9,39 * * * *"
   workflow_dispatch: {}
 
 permissions:


### PR DESCRIPTION
…reliability

GitHub Actions' shared scheduler explicitly load-sheds during high-load windows, and the start of every hour plus the :30 mark are by far the most heavily-subscribed cron slots across the platform — most workflows use `0 * * * *` or `*/30 * * * *`. Observed behaviour on this workflow matched the pattern exactly: :00 ticks fired 7-14 min late, :30 ticks were silently dropped outright, giving an effective ~2-hour cadence instead of 30 min.

Shift to :09 and :39. Same 30-min cadence, same two runs per hour, but the slots are off the scheduler's congested paths and typically fire on time.

# [PR number] - [Short Description of Change]

---

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Chore (refactoring, build process, CI, etc.)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Ran unit tests
- [ ] Ran integration tests
- [ ] Ran end-to-end tests
- [ ] Manually tested the changes
- [ ] Other (please specify)
- [ ] Not applicable (e.g., documentation changes)

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please add screenshots to help explain your problem or showcase your feature.

| Before                               | After                              |
| ------------------------------------ | ---------------------------------- |
| ![Before](link_to_before_screenshot) | ![After](link_to_after_screenshot) |

## Additional context

Add any other context about the problem here.
