### PR TITLE
Adjust probe cron schedule for improved GHA reliability

### DIFF
--- a/.github/workflows/official-status-probe.yml
+++ b/.github/workflows/official-status-probe.yml
@@ -8,7 +8,14 @@ name: "official-status-probe"
 
 on:
   schedule:
-    - cron: "*/30 * * * *"
+    # Fire at :09 and :39 instead of the usual :00 / :30. GitHub Actions'
+    # shared scheduler load-sheds the heavily-subscribed round-minute slots
+    # (top-of-hour and :30 are the most-requested cron times across the
+    # platform), so a meaningful fraction of our scheduled runs were being
+    # dropped or delayed 10+ minutes. Odd-minute slots face far less
+    # contention and historically land closer to on-time. Cadence is
+    # unchanged — still two runs per hour, 30 min apart.
+    - cron: "9,39 * * * *"
   workflow_dispatch: {}
 
 permissions:


### PR DESCRIPTION
This pull request updates the schedule for the `official-status-probe` GitHub Actions workflow to improve reliability. The workflow now runs at :09 and :39 each hour instead of the more common :00 and :30 slots, which helps avoid delays caused by heavy load on GitHub's shared scheduler.

Scheduling improvements:

* [`.github/workflows/official-status-probe.yml`](diffhunk://#diff-70de70849756c644552c852fb3218c419124ad4c4992963096171d479820e4c8L11-R18): Changed the cron schedule to run at "9,39 * * * *" instead of "*/30 * * * *", reducing the likelihood of dropped or delayed runs by avoiding high-traffic times.