### PR TITLE
feat(docs): give docs.arolariu.ro its own console-aesthetic identity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,8 @@
         "@easyops-cn/docusaurus-search-local": "0.52.1",
         "@eslint/js": "9.39.2",
         "@faker-js/faker": "10.4.0",
+        "@fontsource/ibm-plex-mono": "5.2.7",
+        "@fontsource/ibm-plex-sans": "5.2.7",
         "@mdx-js/react": "3.1.1",
         "@microsoft/api-extractor": "7.58.7",
         "@next/bundle-analyzer": "16.2.4",
@@ -6681,6 +6683,24 @@
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@fontsource/ibm-plex-mono": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@fontsource/ibm-plex-mono/-/ibm-plex-mono-5.2.7.tgz",
+      "integrity": "sha512-MKAb8qV+CaiMQn2B0dIi1OV3565NYzp3WN5b4oT6LTkk+F0jR6j0ZN+5BKJiIhffDC3rtBULsYZE65+0018z9w==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/ibm-plex-sans": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@fontsource/ibm-plex-sans/-/ibm-plex-sans-5.2.7.tgz",
+      "integrity": "sha512-EDF1AwYRq4M3qnGLNoysqrVWtmoCep4knA8IsVOxZ9FDiiVPVTqM91E38dSyxiFbPxUiX6y1JiyiOsFojEB/8A==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
     },
     "node_modules/@formatjs/fast-memoize": {
       "version": "3.1.2",
@@ -13373,381 +13393,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
-      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
-      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
-      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
-      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
-      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
-      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
-      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
-      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
-      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
-      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
-      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
-      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
-      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
-      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
-      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
-      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
-      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
-      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
-      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
-      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
-      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
-      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
-      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
-      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
-      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true
-    },
     "node_modules/@rsbuild/core": {
       "version": "1.7.5",
       "resolved": "https://registry.npmjs.org/@rsbuild/core/-/core-1.7.5.tgz",
@@ -13880,86 +13525,6 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@rslib/core/node_modules/@module-federation/error-codes": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-2.3.3.tgz",
-      "integrity": "sha512-UVtKBoKnRDcHgByIDvPRZSxQqjqbNH7NvJm1KHLoce33+EDiIdZYs0HvvUQv43RgESpB9s7HjrqFlq3bEcAgfQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@rslib/core/node_modules/@module-federation/runtime": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-2.3.3.tgz",
-      "integrity": "sha512-JYJ3qv9V85DtBtT/ppDuJNwBTUrYqqZDYcyiTzwY5+44dC5QPvgJ//F+BOhAhZ02WkZV0b4jsKTyLOC3vXKGqQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@module-federation/error-codes": "2.3.3",
-        "@module-federation/runtime-core": "2.3.3",
-        "@module-federation/sdk": "2.3.3"
-      }
-    },
-    "node_modules/@rslib/core/node_modules/@module-federation/runtime-core": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-2.3.3.tgz",
-      "integrity": "sha512-B07LDH9KxhBO3GbULGW64mQFVQBtrEd3PoaCBm7XR1IbU8rMQUJQjDNVZgXYcyhRPBVP+3KWZuiaKFRiNb6PQw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@module-federation/error-codes": "2.3.3",
-        "@module-federation/sdk": "2.3.3"
-      }
-    },
-    "node_modules/@rslib/core/node_modules/@module-federation/runtime-tools": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-2.3.3.tgz",
-      "integrity": "sha512-XODzyLbBYcy4wnYBXKIBqaHPVfBx1HshGdjZmSctDDnx9/VYgdx9DShb6UI+WuQBKJgPzTcx4xbvbCM4SdMilQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@module-federation/runtime": "2.3.3",
-        "@module-federation/webpack-bundler-runtime": "2.3.3"
-      }
-    },
-    "node_modules/@rslib/core/node_modules/@module-federation/sdk": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.3.3.tgz",
-      "integrity": "sha512-mwCS+LQdqiSc6fM5iz/S60ibaFNSH6kNqlZkCRIuS4yjdZ+jgnihz+6xp1QzppvfFgKLhEHBiXOmcYOdk3Ckew==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "peerDependencies": {
-        "node-fetch": "^3.3.2"
-      },
-      "peerDependenciesMeta": {
-        "node-fetch": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@rslib/core/node_modules/@module-federation/webpack-bundler-runtime": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-2.3.3.tgz",
-      "integrity": "sha512-W+P6ZF9J3gwnQuoF07YV0OiR1D6sI/uErUu4+c3QXxka3orANUHujkddNSsDxL1obAGoJa7Da99crZKf7u2j/w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@module-federation/error-codes": "2.3.3",
-        "@module-federation/runtime": "2.3.3",
-        "@module-federation/sdk": "2.3.3"
       }
     },
     "node_modules/@rslib/core/node_modules/@napi-rs/wasm-runtime": {
@@ -39009,53 +38574,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/rollup": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
-      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/estree": "1.0.8"
-      },
-      "bin": {
-        "rollup": "dist/bin/rollup"
-      },
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
-      },
-      "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.2",
-        "@rollup/rollup-android-arm64": "4.60.2",
-        "@rollup/rollup-darwin-arm64": "4.60.2",
-        "@rollup/rollup-darwin-x64": "4.60.2",
-        "@rollup/rollup-freebsd-arm64": "4.60.2",
-        "@rollup/rollup-freebsd-x64": "4.60.2",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
-        "@rollup/rollup-linux-arm64-musl": "4.60.2",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
-        "@rollup/rollup-linux-loong64-musl": "4.60.2",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
-        "@rollup/rollup-linux-x64-gnu": "4.60.2",
-        "@rollup/rollup-linux-x64-musl": "4.60.2",
-        "@rollup/rollup-openbsd-x64": "4.60.2",
-        "@rollup/rollup-openharmony-arm64": "4.60.2",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
-        "@rollup/rollup-win32-x64-gnu": "4.60.2",
-        "@rollup/rollup-win32-x64-msvc": "4.60.2",
-        "fsevents": "~2.3.2"
-      }
-    },
     "node_modules/rsbuild-plugin-dts": {
       "version": "0.21.2",
       "resolved": "https://registry.npmjs.org/rsbuild-plugin-dts/-/rsbuild-plugin-dts-0.21.2.tgz",
@@ -40611,83 +40129,6 @@
         "is-generator-function": "^1.0.7",
         "is-typed-array": "^1.1.3",
         "which-typed-array": "^1.1.2"
-      }
-    },
-    "node_modules/storybook-builder-rsbuild/node_modules/vite": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
-      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "esbuild": "^0.27.0",
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.6",
-        "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.15"
-      },
-      "bin": {
-        "vite": "bin/vite.js"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "funding": {
-        "url": "https://github.com/vitejs/vite?sponsor=1"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      },
-      "peerDependencies": {
-        "@types/node": "^20.19.0 || >=22.12.0",
-        "jiti": ">=1.21.0",
-        "less": "^4.0.0",
-        "lightningcss": "^1.21.0",
-        "sass": "^1.70.0",
-        "sass-embedded": "^1.70.0",
-        "stylus": ">=0.54.8",
-        "sugarss": "^5.0.0",
-        "terser": "^5.16.0",
-        "tsx": "^4.8.1",
-        "yaml": "^2.4.2"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "jiti": {
-          "optional": true
-        },
-        "less": {
-          "optional": true
-        },
-        "lightningcss": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        },
-        "sass-embedded": {
-          "optional": true
-        },
-        "stylus": {
-          "optional": true
-        },
-        "sugarss": {
-          "optional": true
-        },
-        "terser": {
-          "optional": true
-        },
-        "tsx": {
-          "optional": true
-        },
-        "yaml": {
-          "optional": true
-        }
       }
     },
     "node_modules/storybook-react-rsbuild": {
@@ -44841,6 +44282,8 @@
         "@docusaurus/preset-classic": "*",
         "@docusaurus/theme-classic": "*",
         "@easyops-cn/docusaurus-search-local": "*",
+        "@fontsource/ibm-plex-mono": "*",
+        "@fontsource/ibm-plex-sans": "*",
         "@mdx-js/react": "*",
         "clsx": "*",
         "docusaurus-plugin-openapi-docs": "*",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,8 @@
     "@docusaurus/tsconfig": "3.10.0",
     "@docusaurus/types": "3.10.0",
     "@easyops-cn/docusaurus-search-local": "0.52.1",
+    "@fontsource/ibm-plex-mono": "5.2.7",
+    "@fontsource/ibm-plex-sans": "5.2.7",
     "@mdx-js/react": "3.1.1",
     "@azure/identity": "4.13.1",
     "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.32",

--- a/sites/docs.arolariu.ro-v2/docs/intro.md
+++ b/sites/docs.arolariu.ro-v2/docs/intro.md
@@ -1,11 +1,15 @@
 ---
 sidebar_position: 1
-slug: /
+slug: /intro
+title: Introduction
 ---
 
-# arolariu.ro documentation
+# Introduction
 
-Unified portal covering:
-- **.NET API** (`api.arolariu.ro`) — HTTP contract and internals
-- **TypeScript** (`arolariu.ro`, `@arolariu/components`) — types, hooks, UI components
-- **Python experimental** (`exp.arolariu.ro`) — config proxy service internals
+Welcome to the unified reference for `arolariu.ro`. The sidebar and navbar cover the three service-level surfaces:
+
+- **.NET API** (`api.arolariu.ro`) — HTTP contract plus internal types, services, and brokers.
+- **TypeScript** (`arolariu.ro`, `@arolariu/components`) — component library, hooks, shared types.
+- **Python experimental** (`exp.arolariu.ro`) — config proxy service internals.
+
+Prose lives under `/monorepo/` — engineering guides and RFCs mirrored from the repo's `/docs/` folder.

--- a/sites/docs.arolariu.ro-v2/package.json
+++ b/sites/docs.arolariu.ro-v2/package.json
@@ -19,6 +19,8 @@
     "@docusaurus/preset-classic": "*",
     "@docusaurus/theme-classic": "*",
     "@easyops-cn/docusaurus-search-local": "*",
+    "@fontsource/ibm-plex-mono": "*",
+    "@fontsource/ibm-plex-sans": "*",
     "@mdx-js/react": "*",
     "clsx": "*",
     "docusaurus-plugin-openapi-docs": "*",

--- a/sites/docs.arolariu.ro-v2/src/css/custom.css
+++ b/sites/docs.arolariu.ro-v2/src/css/custom.css
@@ -1,21 +1,17 @@
-:root {
-  --ifm-color-primary: #003f7d;
-  --ifm-color-primary-dark: #003871;
-  --ifm-color-primary-darker: #00356b;
-  --ifm-color-primary-darkest: #002c58;
-  --ifm-color-primary-light: #004689;
-  --ifm-color-primary-lighter: #00498f;
-  --ifm-color-primary-lightest: #00529f;
-  --ifm-code-font-size: 95%;
-  --ifm-font-family-base: system-ui, -apple-system, 'Segoe UI', sans-serif;
-}
-[data-theme='dark'] {
-  --ifm-color-primary: #4aa3ff;
-  --ifm-color-primary-dark: #2d94ff;
-  --ifm-color-primary-darker: #1e8cff;
-  --ifm-color-primary-darkest: #006dd9;
-  --ifm-color-primary-light: #67b2ff;
-  --ifm-color-primary-lighter: #76baff;
-  --ifm-color-primary-lightest: #a1cfff;
-  --ifm-background-color: #0e1422;
-}
+/*
+ * docs.arolariu.ro — single entry point for custom styling.
+ *
+ * Loads the fonts first, then the layered theme files.
+ * Docusaurus picks up this file via `themeConfig.customCss`.
+ */
+
+@import "@fontsource/ibm-plex-mono/400.css";
+@import "@fontsource/ibm-plex-mono/500.css";
+@import "@fontsource/ibm-plex-mono/600.css";
+@import "@fontsource/ibm-plex-sans/400.css";
+@import "@fontsource/ibm-plex-sans/500.css";
+@import "@fontsource/ibm-plex-sans/600.css";
+
+@import "./theme-tokens.css";
+@import "./theme-docusaurus.css";
+@import "./theme-motion.css";

--- a/sites/docs.arolariu.ro-v2/src/css/theme-docusaurus.css
+++ b/sites/docs.arolariu.ro-v2/src/css/theme-docusaurus.css
@@ -1,0 +1,676 @@
+/*
+ * Docusaurus (Infima) variable overrides. We remap Infima's tokens onto
+ * the carbon/copper palette defined in theme-tokens.css so every built-in
+ * Docusaurus component inherits the identity without per-component edits.
+ */
+
+:root,
+:root[data-theme='dark'],
+:root[data-theme='light'] {
+  /* Primary accent → oxidized copper */
+  --ifm-color-primary: var(--accent);
+  --ifm-color-primary-dark: var(--accent);
+  --ifm-color-primary-darker: var(--accent);
+  --ifm-color-primary-darkest: var(--accent);
+  --ifm-color-primary-light: var(--accent-dim);
+  --ifm-color-primary-lighter: var(--accent-dim);
+  --ifm-color-primary-lightest: var(--accent-faint);
+
+  /* Surfaces */
+  --ifm-background-color: var(--bg);
+  --ifm-background-surface-color: var(--bg);
+  --ifm-card-background-color: var(--surface);
+  --ifm-hover-overlay: var(--surface-hover);
+
+  /* Text */
+  --ifm-color-content: var(--text);
+  --ifm-color-content-secondary: var(--text-muted);
+  --ifm-font-color-base: var(--text);
+  --ifm-heading-color: var(--text);
+
+  /* Borders */
+  --ifm-color-emphasis-100: var(--surface);
+  --ifm-color-emphasis-200: var(--surface-hover);
+  --ifm-color-emphasis-300: var(--border);
+  --ifm-color-emphasis-500: var(--border-strong);
+  --ifm-color-emphasis-700: var(--text-muted);
+  --ifm-toc-border-color: var(--border);
+  --ifm-hr-border-color: var(--border);
+  --ifm-table-border-color: var(--border);
+
+  /* Typography */
+  --ifm-font-family-base: var(--font-sans);
+  --ifm-font-family-monospace: var(--font-mono);
+  --ifm-heading-font-family: var(--font-mono);
+  --ifm-font-weight-semibold: 500;
+  --ifm-heading-font-weight: 500;
+  --ifm-font-size-base: 16px;
+  --ifm-code-font-size: 0.875em;
+  --ifm-line-height-base: 1.65;
+  --ifm-h1-font-size: var(--fs-h1);
+  --ifm-h2-font-size: var(--fs-h2);
+  --ifm-h3-font-size: var(--fs-h3);
+
+  /* Geometry — rectilinear */
+  --ifm-global-radius: 0;
+  --ifm-button-border-radius: 0;
+  --ifm-code-border-radius: 0;
+  --ifm-alert-border-radius: 0;
+  --ifm-card-border-radius: 0;
+  --ifm-pagination-nav-border-radius: 0;
+  --ifm-badge-border-radius: 0;
+  --ifm-avatar-border-radius: 0;
+
+  /* Shadows — suppressed; docs don't need lift */
+  --ifm-global-shadow-lw: none;
+  --ifm-global-shadow-md: none;
+  --ifm-global-shadow-tl: var(--shadow-raised);
+
+  /* Navbar */
+  --ifm-navbar-background-color: var(--bg);
+  --ifm-navbar-link-color: var(--text-muted);
+  --ifm-navbar-link-hover-color: var(--accent);
+  --ifm-navbar-height: 3.25rem;
+  --ifm-navbar-padding-vertical: 0.5rem;
+  --ifm-navbar-shadow: none;
+
+  /* Footer */
+  --ifm-footer-background-color: var(--bg);
+  --ifm-footer-color: var(--text-muted);
+  --ifm-footer-link-color: var(--text-muted);
+  --ifm-footer-title-color: var(--text);
+  --ifm-footer-padding-vertical: 1.5rem;
+
+  /* Sidebar (menu) */
+  --ifm-menu-color: var(--text-muted);
+  --ifm-menu-color-background-active: transparent;
+  --ifm-menu-color-background-hover: var(--surface-hover);
+  --ifm-menu-color-active: var(--accent);
+  --ifm-menu-link-sublist-icon-filter: invert(55%) sepia(59%) saturate(452%) hue-rotate(340deg) brightness(95%);
+
+  /* Table of contents (right rail) */
+  --ifm-toc-link-color: var(--text-muted);
+
+  /* Code block */
+  --ifm-code-background: var(--surface);
+  --ifm-pre-background: var(--surface);
+  --docusaurus-highlighted-code-line-bg: rgba(232, 122, 62, 0.12);
+
+  /* Breadcrumb */
+  --ifm-breadcrumb-color-active: var(--accent);
+  --ifm-breadcrumb-item-background-active: transparent;
+
+  /* Pagination */
+  --ifm-pagination-nav-color-hover: var(--accent);
+
+  /* Button */
+  --ifm-button-color: var(--text);
+  --ifm-button-background-color: transparent;
+
+  /* Spacing */
+  --ifm-container-width: 1280px;
+  --ifm-spacing-horizontal: var(--sp-md);
+}
+
+/* ---------------------------------------------------------------- *
+ *  Global chrome — scanlines (dark) / graph paper (light)          *
+ * ---------------------------------------------------------------- */
+
+html,
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-sans);
+  font-feature-settings: "ss03", "ss04";
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
+body {
+  position: relative;
+  min-height: 100vh;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.35;
+  z-index: 0;
+  background-image: repeating-linear-gradient(
+    to bottom,
+    transparent 0,
+    transparent 2px,
+    rgba(255, 255, 255, 0.012) 2px,
+    rgba(255, 255, 255, 0.012) 3px
+  );
+}
+
+:root[data-theme='light'] body::before {
+  opacity: 1;
+  background-image:
+    repeating-linear-gradient(
+      to bottom,
+      transparent 0,
+      transparent 2px,
+      rgba(21, 16, 10, 0.025) 2px,
+      rgba(21, 16, 10, 0.025) 3px
+    ),
+    repeating-linear-gradient(
+      to right,
+      transparent 0,
+      transparent 48px,
+      rgba(21, 16, 10, 0.03) 48px,
+      rgba(21, 16, 10, 0.03) 49px
+    );
+}
+
+#__docusaurus {
+  position: relative;
+  z-index: 1;
+}
+
+/* Selection — signature copper */
+::selection {
+  background: var(--accent);
+  color: var(--bg);
+}
+
+/* Focus rings — single-pixel copper, no halo */
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+/* ---------------------------------------------------------------- *
+ *  Headings — mono + #/##/### prefixes in copper                   *
+ * ---------------------------------------------------------------- */
+
+.markdown h1,
+.markdown h2,
+.markdown h3,
+.markdown h4 {
+  font-family: var(--font-mono);
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  color: var(--text);
+  margin-top: 2.4em;
+  margin-bottom: 0.6em;
+  scroll-margin-top: calc(var(--ifm-navbar-height) + 1rem);
+}
+
+.markdown h1 {
+  margin-top: 0.2em;
+  padding-bottom: 0.4em;
+  border-bottom: 1px solid var(--accent-faint);
+  font-size: var(--fs-h1);
+}
+.markdown h1::before {
+  content: "# ";
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.markdown h2 {
+  font-size: var(--fs-h2);
+}
+.markdown h2::before {
+  content: "## ";
+  color: var(--accent-dim);
+}
+
+.markdown h3 {
+  font-size: var(--fs-h3);
+}
+.markdown h3::before {
+  content: "### ";
+  color: var(--accent-dim);
+}
+
+.markdown h4 {
+  font-size: var(--fs-lg);
+  color: var(--text-muted);
+}
+.markdown h4::before {
+  content: "#### ";
+  color: var(--text-faint);
+}
+
+/* Anchor hover — the copper hash sign also acts as the anchor link */
+.markdown h1:hover::before,
+.markdown h2:hover::before,
+.markdown h3:hover::before {
+  text-decoration: underline;
+  text-decoration-color: var(--accent);
+}
+
+/* Anchor-link icon Docusaurus injects (#) is redundant with our ::before */
+.markdown .hash-link {
+  display: none;
+}
+
+/* ---------------------------------------------------------------- *
+ *  Body prose                                                       *
+ * ---------------------------------------------------------------- */
+
+.markdown {
+  font-family: var(--font-sans);
+  font-size: var(--fs-body);
+  line-height: 1.65;
+  color: var(--text);
+}
+
+.markdown p,
+.markdown li {
+  color: var(--text);
+}
+
+.markdown strong {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.markdown em {
+  color: var(--text);
+}
+
+.markdown a {
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 1px solid var(--accent-faint);
+  transition: border-color 0.12s ease, color 0.12s ease;
+}
+.markdown a:hover {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+.markdown blockquote {
+  border-left: 2px solid var(--accent);
+  background: var(--surface);
+  padding: var(--sp-sm) var(--sp-md);
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+/* Inline code */
+.markdown code {
+  font-family: var(--font-mono);
+  font-size: 0.875em;
+  padding: 1px 6px;
+  background: var(--surface-hover);
+  border: 1px solid var(--border);
+  color: var(--accent);
+}
+
+/* ---------------------------------------------------------------- *
+ *  Code blocks — hairline frame, uppercase copper language chip     *
+ * ---------------------------------------------------------------- */
+
+.markdown pre,
+.theme-code-block {
+  border: 1px solid var(--border-strong);
+  background: var(--surface) !important;
+  font-family: var(--font-mono) !important;
+  font-size: var(--fs-sm) !important;
+  line-height: 1.55 !important;
+}
+
+.markdown pre code,
+.theme-code-block code {
+  background: transparent !important;
+  border: none !important;
+  color: var(--text) !important;
+  padding: 0 !important;
+}
+
+/* Code block title (filename chip) */
+.theme-code-block .theme-code-block-title,
+.codeBlockTitle_node_modules-\@docusaurus-theme-classic-lib-theme-CodeBlock-Container-styles-module {
+  background: var(--surface-hover) !important;
+  border-bottom: 1px solid var(--border) !important;
+  color: var(--accent) !important;
+  font-family: var(--font-mono) !important;
+  font-size: var(--fs-xs) !important;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 6px 12px !important;
+}
+
+/* Copy button: "copy ›" text, no icon flourish */
+.clean-btn {
+  border-radius: 0 !important;
+  background: var(--surface-hover) !important;
+  color: var(--text-muted) !important;
+  border: 1px solid var(--border) !important;
+  font-family: var(--font-mono) !important;
+}
+.clean-btn:hover {
+  color: var(--accent) !important;
+  border-color: var(--accent) !important;
+  background: var(--surface-raised) !important;
+}
+
+/* ---------------------------------------------------------------- *
+ *  Admonitions — text-first, icon-suppressed, [label] frames        *
+ * ---------------------------------------------------------------- */
+
+.theme-admonition,
+.alert {
+  border: none !important;
+  border-left: 3px solid var(--doc-note) !important;
+  border-radius: 0 !important;
+  background: var(--doc-note-bg) !important;
+  padding: var(--sp-sm) var(--sp-md) !important;
+  font-family: var(--font-sans);
+  color: var(--text);
+}
+
+.theme-admonition--note,
+.alert--secondary,
+.alert--info { border-left-color: var(--doc-note) !important; background: var(--doc-note-bg) !important; }
+.theme-admonition--tip,
+.alert--success { border-left-color: var(--doc-tip) !important; background: var(--doc-tip-bg) !important; }
+.theme-admonition--warning,
+.alert--warning { border-left-color: var(--doc-warning) !important; background: var(--doc-warning-bg) !important; }
+.theme-admonition--danger,
+.alert--danger { border-left-color: var(--doc-danger) !important; background: var(--doc-danger-bg) !important; }
+
+.theme-admonition .admonitionHeading_node_modules-\@docusaurus-theme-classic-lib-theme-Admonition-Layout-styles-module,
+.theme-admonition [class*="admonitionHeading"] {
+  font-family: var(--font-mono) !important;
+  font-size: var(--fs-xs) !important;
+  text-transform: lowercase;
+  letter-spacing: 0.06em;
+  color: var(--doc-note);
+  margin-bottom: var(--sp-xs);
+}
+
+/* Replace the default icon+name with bracketed label */
+.theme-admonition [class*="admonitionHeading"] > span:first-child {
+  display: none;
+}
+.theme-admonition [class*="admonitionHeading"] > span:last-child::before {
+  content: "[";
+  color: var(--text-muted);
+}
+.theme-admonition [class*="admonitionHeading"] > span:last-child::after {
+  content: "]";
+  color: var(--text-muted);
+}
+
+.theme-admonition--tip [class*="admonitionHeading"] { color: var(--doc-tip); }
+.theme-admonition--warning [class*="admonitionHeading"] { color: var(--doc-warning); }
+.theme-admonition--danger [class*="admonitionHeading"] { color: var(--doc-danger); }
+
+/* ---------------------------------------------------------------- *
+ *  Tables — mono, tabular-nums, hairline rows                       *
+ * ---------------------------------------------------------------- */
+
+.markdown table {
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  font-variant-numeric: tabular-nums;
+  border: 1px solid var(--border);
+  border-collapse: collapse;
+  width: 100%;
+  display: table;
+  margin: var(--sp-md) 0;
+}
+
+.markdown table thead {
+  background: transparent;
+}
+
+.markdown table th {
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: var(--fs-xs);
+  font-weight: 600;
+  color: var(--accent);
+  border-bottom: 1px solid var(--accent-faint);
+  padding: var(--sp-xs) var(--sp-sm);
+  text-align: left;
+}
+
+.markdown table td {
+  border-top: 1px solid var(--border);
+  padding: var(--sp-xs) var(--sp-sm);
+  color: var(--text);
+}
+
+.markdown table tbody tr:hover {
+  background: var(--surface-hover);
+}
+
+/* ---------------------------------------------------------------- *
+ *  Navbar                                                           *
+ * ---------------------------------------------------------------- */
+
+.navbar {
+  border-bottom: 1px solid var(--border);
+  backdrop-filter: blur(8px);
+  background: color-mix(in srgb, var(--bg) 85%, transparent);
+}
+
+.navbar__brand,
+.navbar__title {
+  font-family: var(--font-mono);
+  font-weight: 600;
+  color: var(--text);
+  letter-spacing: -0.01em;
+}
+
+.navbar__items .navbar__link {
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  text-transform: lowercase;
+  letter-spacing: 0.04em;
+  padding: 6px 10px;
+  border: 1px solid transparent;
+  color: var(--text-muted);
+  transition: color 0.12s ease, border-color 0.12s ease;
+}
+
+.navbar__items .navbar__link:hover {
+  color: var(--accent);
+  background: transparent;
+}
+
+.navbar__items .navbar__link--active {
+  color: var(--accent);
+  border-bottom: 2px solid var(--accent);
+  padding-bottom: 4px;
+}
+
+/* GitHub link — prepend a terminal glyph, strip default icon if any */
+.navbar__items--right .navbar__link[href*="github.com"]::before {
+  content: "⎘ ";
+  color: var(--accent);
+  margin-right: 2px;
+}
+
+/* Search trigger */
+.DocSearch-Button,
+[class*="searchBox"] button {
+  background: var(--surface-hover) !important;
+  border: 1px solid var(--border) !important;
+  border-radius: 0 !important;
+  font-family: var(--font-mono) !important;
+  color: var(--text-muted) !important;
+}
+.DocSearch-Button:hover {
+  color: var(--accent) !important;
+  border-color: var(--accent) !important;
+}
+
+/* ---------------------------------------------------------------- *
+ *  Sidebar                                                          *
+ * ---------------------------------------------------------------- */
+
+.theme-doc-sidebar-container {
+  border-right: 1px solid var(--border);
+  background: transparent;
+}
+
+.menu {
+  background: transparent;
+  font-family: var(--font-mono);
+  padding: var(--sp-sm);
+}
+
+.menu__list {
+  font-size: var(--fs-sm);
+}
+
+.menu__link {
+  border-radius: 0;
+  padding: 4px 10px;
+  color: var(--text-muted);
+  transition: color 0.08s ease, background 0.08s ease;
+  border-left: 2px solid transparent;
+  line-height: 1.5;
+}
+
+.menu__link:hover {
+  color: var(--text);
+  background: var(--surface-hover);
+}
+
+.menu__link--active {
+  color: var(--accent);
+  background: transparent;
+  border-left-color: var(--accent);
+  font-weight: 500;
+}
+
+.menu__link--sublist-caret::after,
+.menu__caret::before {
+  filter: brightness(0.7);
+}
+
+.menu__list-item-collapsible:hover {
+  background: var(--surface-hover);
+}
+
+.menu__list-item-collapsible--active {
+  background: transparent;
+}
+
+/* Section labels in sidebar — category headers */
+.menu__list-item--collapsed > .menu__list-item-collapsible > .menu__link,
+.menu__list-item-collapsible > .menu__link {
+  color: var(--text);
+  font-weight: 500;
+  text-transform: none;
+}
+
+/* ---------------------------------------------------------------- *
+ *  Right-rail TOC                                                   *
+ * ---------------------------------------------------------------- */
+
+.table-of-contents {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  border-left: 1px solid var(--border);
+}
+
+.table-of-contents__link {
+  color: var(--text-muted);
+}
+
+.table-of-contents__link--active,
+.table-of-contents__link:hover {
+  color: var(--accent);
+}
+
+/* ---------------------------------------------------------------- *
+ *  Pagination (prev/next)                                           *
+ * ---------------------------------------------------------------- */
+
+.pagination-nav__link {
+  border: 1px solid var(--border);
+  border-radius: 0;
+  background: var(--surface);
+  transition: border-color 0.12s ease;
+}
+.pagination-nav__link:hover {
+  border-color: var(--accent);
+}
+.pagination-nav__sublabel {
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+  font-size: var(--fs-xs);
+  text-transform: lowercase;
+  letter-spacing: 0.06em;
+}
+.pagination-nav__label {
+  font-family: var(--font-mono);
+  color: var(--text);
+}
+
+/* ---------------------------------------------------------------- *
+ *  Breadcrumb                                                       *
+ * ---------------------------------------------------------------- */
+
+.breadcrumbs {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: lowercase;
+  letter-spacing: 0.04em;
+}
+
+.breadcrumbs__item--active .breadcrumbs__link {
+  background: transparent;
+  color: var(--accent);
+}
+
+/* ---------------------------------------------------------------- *
+ *  Footer                                                           *
+ * ---------------------------------------------------------------- */
+
+.footer {
+  border-top: 1px solid var(--border);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  color: var(--text-muted);
+}
+
+.footer__copyright {
+  color: var(--text-muted);
+}
+
+.footer__copyright::before {
+  content: "// ";
+  color: var(--accent-dim);
+}
+
+/* ---------------------------------------------------------------- *
+ *  Search modal (Ctrl+K)                                            *
+ * ---------------------------------------------------------------- */
+
+.DocSearch-Modal,
+[class*="SearchModal"] {
+  background: var(--bg) !important;
+  border: 1px solid var(--border-strong) !important;
+  border-radius: 0 !important;
+  box-shadow: var(--shadow-raised) !important;
+  font-family: var(--font-mono) !important;
+}
+
+.DocSearch-SearchBar,
+.DocSearch-Input {
+  font-family: var(--font-mono) !important;
+}
+
+/* ---------------------------------------------------------------- *
+ *  HR — hairline, copper-tinted                                     *
+ * ---------------------------------------------------------------- */
+
+.markdown hr {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: var(--sp-lg) 0;
+}

--- a/sites/docs.arolariu.ro-v2/src/css/theme-docusaurus.css
+++ b/sites/docs.arolariu.ro-v2/src/css/theme-docusaurus.css
@@ -527,11 +527,49 @@ body::before {
 
 .menu__link {
   border-radius: 0;
-  padding: 4px 10px;
+  padding: 4px 10px 4px 6px;
   color: var(--text-muted);
   transition: color 0.08s ease, background 0.08s ease;
   border-left: 2px solid transparent;
   line-height: 1.5;
+  position: relative;
+}
+
+/* Tree connector — the signature sidebar treatment.
+ * Every leaf link gets a "└─" prefix; the collapsible category header
+ * separately gets a "▸" caret (via .menu__caret, Docusaurus default).
+ * The deeply-nested rules re-draw the connector per depth level so
+ * branches look like tree(1) output.
+ */
+.menu__link::before {
+  content: "└─";
+  display: inline-block;
+  margin-right: 0.5ch;
+  color: var(--text-faint);
+  font-family: var(--font-mono);
+  letter-spacing: -0.1em;
+  transition: color 0.08s ease;
+}
+
+.menu__list-item:not(:last-child) > .menu__link::before,
+.menu__list-item:not(:last-child) > .menu__list-item-collapsible > .menu__link::before {
+  content: "├─";
+}
+
+.menu__list-item-collapsible > .menu__link::before {
+  content: "├─";
+}
+
+.menu__list .menu__list .menu__link::before {
+  color: var(--text-faint);
+  opacity: 0.85;
+}
+
+.menu__link:hover::before {
+  color: var(--accent-dim);
+}
+.menu__link--active::before {
+  color: var(--accent);
 }
 
 .menu__link:hover {

--- a/sites/docs.arolariu.ro-v2/src/css/theme-motion.css
+++ b/sites/docs.arolariu.ro-v2/src/css/theme-motion.css
@@ -1,0 +1,47 @@
+/*
+ * Motion — restrained. Docs are reference material, not a dashboard;
+ * motion should never distract from reading. We use exactly two
+ * ingredients: a one-shot consolePrint reveal on the initial heading,
+ * and a steady caret blink on the hero.
+ */
+
+@keyframes consolePrint {
+  from { opacity: 0; transform: translateX(-4px); }
+  to   { opacity: 1; transform: none; }
+}
+
+@keyframes blink {
+  0%, 49%   { opacity: 1; }
+  50%, 100% { opacity: 0.15; }
+}
+
+/* Primary article title reveals as if line-printed */
+.markdown > h1:first-child {
+  animation: consolePrint 0.25s ease-out both;
+}
+
+/* Reusable helper classes */
+.console-print {
+  animation: consolePrint 0.3s ease-out both;
+}
+
+.blinking-caret {
+  display: inline-block;
+  width: 0.55em;
+  height: 1em;
+  vertical-align: -0.12em;
+  margin-left: 0.1em;
+  background: var(--accent);
+  animation: blink 1.05s steps(2, end) infinite;
+}
+
+/* Respect the platform preference */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/sites/docs.arolariu.ro-v2/src/css/theme-tokens.css
+++ b/sites/docs.arolariu.ro-v2/src/css/theme-tokens.css
@@ -1,0 +1,105 @@
+/*
+ * Design tokens for docs.arolariu.ro — carbon + oxidized copper.
+ *
+ * Ported from sites/status.arolariu.ro/src/app.css. The two surfaces
+ * share a palette, typography, rectilinear geometry, and console
+ * typography prefixes. They diverge in motion and layout density.
+ *
+ * This file declares every custom property. Docusaurus-specific
+ * overrides (Infima variables) live in theme-docusaurus.css so the
+ * raw palette stays decoupled from the shell.
+ */
+
+:root {
+  /* Surfaces */
+  --bg: #0a0b0d;
+  --surface: rgba(255, 255, 255, 0.02);
+  --surface-hover: rgba(255, 255, 255, 0.04);
+  --surface-raised: rgba(255, 255, 255, 0.07);
+  --border: rgba(255, 255, 255, 0.08);
+  --border-strong: rgba(255, 255, 255, 0.16);
+
+  /* Text */
+  --text: #c9cdd2;
+  --text-muted: #6b7179;
+  --text-faint: rgba(201, 205, 210, 0.38);
+
+  /* Signature accent — oxidized copper */
+  --accent: #e87a3e;
+  --accent-dim: rgba(232, 122, 62, 0.65);
+  --accent-faint: rgba(232, 122, 62, 0.18);
+
+  /* Semantic palette (admonitions) — matches status.arolariu.ro */
+  --doc-note: var(--accent);
+  --doc-note-bg: rgba(232, 122, 62, 0.08);
+  --doc-tip: #56d364;
+  --doc-tip-bg: rgba(86, 211, 100, 0.08);
+  --doc-warning: #e0b24e;
+  --doc-warning-bg: rgba(224, 178, 78, 0.08);
+  --doc-danger: #ff6b5b;
+  --doc-danger-bg: rgba(255, 107, 91, 0.09);
+  --doc-info: #7aa7d9;
+  --doc-info-bg: rgba(122, 167, 217, 0.08);
+
+  /* Typography stacks */
+  --font-mono: "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  --font-sans: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+
+  /* Fluid type scale — reference-density, denser than Docusaurus default */
+  --fs-xs: clamp(0.6875rem, 0.66rem + 0.15vw, 0.75rem);
+  --fs-sm: clamp(0.75rem, 0.72rem + 0.15vw, 0.8125rem);
+  --fs-body: clamp(0.875rem, 0.83rem + 0.22vw, 1rem);
+  --fs-lg: clamp(1rem, 0.94rem + 0.3vw, 1.125rem);
+  --fs-h3: clamp(1.0625rem, 0.98rem + 0.4vw, 1.25rem);
+  --fs-h2: clamp(1.1875rem, 1.05rem + 0.6vw, 1.5rem);
+  --fs-h1: clamp(1.625rem, 1.2rem + 1.6vw, 2.25rem);
+  --fs-hero: clamp(1.875rem, 1.2rem + 3vw, 3.25rem);
+
+  /* Fluid spacing */
+  --sp-2xs: clamp(2px, 0.15vw + 1px, 4px);
+  --sp-xs: clamp(6px, 0.4vw + 4px, 10px);
+  --sp-sm: clamp(10px, 0.6vw + 6px, 14px);
+  --sp-md: clamp(14px, 0.9vw + 8px, 20px);
+  --sp-lg: clamp(20px, 1.5vw + 12px, 32px);
+  --sp-xl: clamp(28px, 2vw + 16px, 48px);
+
+  /* Console aesthetic: no rounded corners anywhere */
+  --radius: 0;
+
+  /* Shadow vocabulary — used sparingly; docs don't need lift */
+  --shadow-raised: 0 10px 32px rgba(0, 0, 0, 0.55), 0 0 0 1px rgba(255, 255, 255, 0.06);
+}
+
+/*
+ * Light mode — cream paper with deep-ink text. Strictly mirrors
+ * the status-page light palette so brand continuity is preserved.
+ */
+:root[data-theme='light'] {
+  --bg: #f2e9d8;
+  --surface: rgba(21, 16, 10, 0.025);
+  --surface-hover: rgba(21, 16, 10, 0.05);
+  --surface-raised: #fbf5e6;
+  --border: rgba(21, 16, 10, 0.12);
+  --border-strong: rgba(21, 16, 10, 0.28);
+
+  --text: #15100a;
+  --text-muted: #6b5f4f;
+  --text-faint: rgba(21, 16, 10, 0.48);
+
+  --accent: #c44419;
+  --accent-dim: rgba(196, 68, 25, 0.65);
+  --accent-faint: rgba(196, 68, 25, 0.14);
+
+  --doc-note: var(--accent);
+  --doc-note-bg: rgba(196, 68, 25, 0.08);
+  --doc-tip: #1f5e1a;
+  --doc-tip-bg: rgba(31, 94, 26, 0.08);
+  --doc-warning: #9a5a11;
+  --doc-warning-bg: rgba(154, 90, 17, 0.08);
+  --doc-danger: #a72418;
+  --doc-danger-bg: rgba(167, 36, 24, 0.09);
+  --doc-info: #2a5788;
+  --doc-info-bg: rgba(42, 87, 136, 0.08);
+
+  --shadow-raised: 0 10px 32px rgba(21, 16, 10, 0.16), 0 0 0 1px rgba(21, 16, 10, 0.06);
+}

--- a/sites/docs.arolariu.ro-v2/src/pages/index.module.css
+++ b/sites/docs.arolariu.ro-v2/src/pages/index.module.css
@@ -1,0 +1,218 @@
+.page {
+  position: relative;
+  max-width: 980px;
+  margin: 0 auto;
+  padding: clamp(2.5rem, 5vw, 5rem) clamp(1rem, 3vw, 2.5rem) clamp(3rem, 6vw, 6rem);
+  font-family: var(--font-mono);
+  color: var(--text);
+}
+
+.hero {
+  margin-bottom: clamp(2rem, 4vw, 3rem);
+  animation: consolePrint 0.35s ease-out both;
+}
+
+.wordmark {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-weight: 600;
+  font-size: var(--fs-hero);
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0;
+}
+
+.prefix {
+  color: var(--text);
+}
+
+.slash {
+  color: var(--text-faint);
+  margin: 0 0.1em;
+}
+
+.accent {
+  color: var(--accent);
+}
+
+.tagline {
+  margin-top: clamp(0.75rem, 1.5vw, 1.25rem);
+  margin-bottom: 0;
+  font-size: var(--fs-lg);
+  color: var(--text-muted);
+  line-height: 1.5;
+  letter-spacing: -0.01em;
+}
+
+.comment {
+  color: var(--accent-dim);
+  margin-right: 0.5ch;
+}
+
+.caret {
+  display: inline-block;
+  width: 0.55em;
+  height: 1em;
+  vertical-align: -0.12em;
+  margin-left: 0.3em;
+  background: var(--accent);
+  animation: blink 1.05s steps(2, end) infinite;
+}
+
+.section {
+  margin-top: clamp(1.75rem, 3vw, 2.5rem);
+}
+
+.sectionTitle {
+  margin: 0 0 0.75rem;
+  font-family: var(--font-mono);
+  font-weight: 500;
+  font-size: var(--fs-lg);
+  color: var(--text);
+  letter-spacing: -0.01em;
+  animation: consolePrint 0.3s ease-out both;
+  animation-delay: 40ms;
+}
+
+.sectionTitle::before {
+  content: none;
+}
+
+.chevron {
+  color: var(--accent);
+  font-weight: 600;
+  margin-right: 0.4ch;
+}
+
+.rows {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  row-gap: 2px;
+  font-size: var(--fs-body);
+}
+
+.row {
+  display: grid;
+  grid-template-columns: auto auto 1fr auto auto;
+  align-items: baseline;
+  column-gap: 0.6ch;
+  padding: 6px 8px;
+  border-left: 2px solid transparent;
+  transition: background-color 0.12s ease, border-left-color 0.12s ease;
+  animation: consolePrint 0.3s ease-out both;
+}
+
+.row:hover {
+  background: var(--surface-hover);
+  border-left-color: var(--accent);
+}
+
+.row:has(.rowLabel[data-active='true']) {
+  background: var(--surface-hover);
+  border-left-color: var(--accent);
+}
+
+.tree {
+  color: var(--text-faint);
+  font-family: var(--font-mono);
+  letter-spacing: -0.1em;
+}
+
+.pointer {
+  color: var(--text-faint);
+  font-weight: 600;
+  width: 1ch;
+  text-align: center;
+  transition: color 0.12s ease;
+}
+
+.pointer[data-active='true'] {
+  color: var(--accent);
+}
+
+.rowLabel {
+  color: var(--text);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: color 0.12s ease, border-color 0.12s ease;
+  white-space: nowrap;
+}
+
+.rowLabel:hover,
+.rowLabel[data-active='true'] {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+.rowArrow {
+  color: var(--text-faint);
+  padding: 0 0.4ch;
+}
+
+.rowPath {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  color: var(--text-muted);
+  background: transparent;
+  border: none;
+  padding: 0;
+  white-space: nowrap;
+}
+
+.footer {
+  margin-top: clamp(2.5rem, 5vw, 4rem);
+  padding-top: 1rem;
+  border-top: 1px solid var(--border);
+  font-size: var(--fs-xs);
+  color: var(--text-muted);
+}
+
+.kbd {
+  display: inline-block;
+  min-width: 1.6em;
+  padding: 1px 6px;
+  margin: 0 0.15em;
+  font-family: var(--font-mono);
+  font-size: 0.9em;
+  background: var(--surface-hover);
+  border: 1px solid var(--border-strong);
+  color: var(--text);
+}
+
+@media (max-width: 720px) {
+  .row {
+    grid-template-columns: auto auto 1fr;
+  }
+  .rowArrow,
+  .rowPath {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .caret {
+    animation: none;
+    opacity: 1;
+  }
+  .hero,
+  .sectionTitle,
+  .row {
+    animation: none;
+  }
+}
+
+@keyframes consolePrint {
+  from { opacity: 0; transform: translateX(-4px); }
+  to   { opacity: 1; transform: none; }
+}
+
+@keyframes blink {
+  0%, 49%   { opacity: 1; }
+  50%, 100% { opacity: 0.15; }
+}

--- a/sites/docs.arolariu.ro-v2/src/pages/index.tsx
+++ b/sites/docs.arolariu.ro-v2/src/pages/index.tsx
@@ -1,0 +1,117 @@
+import React, {useEffect, useState} from 'react';
+import Layout from '@theme/Layout';
+import Link from '@docusaurus/Link';
+import styles from './index.module.css';
+
+type Row = {readonly label: string; readonly href: string};
+
+const START_HERE: readonly Row[] = [
+  {label: 'monorepo overview', href: '/monorepo/'},
+  {label: '.net internals', href: '/internals/dotnet/'},
+  {label: 'typescript reference', href: '/reference/typescript/'},
+  {label: 'experimental (python)', href: '/internals/experimental/'},
+];
+
+const RESOURCES: readonly Row[] = [
+  {label: 'rfcs', href: '/monorepo/rfc/'},
+  {label: 'backend guides', href: '/monorepo/backend/'},
+  {label: 'frontend guides', href: '/monorepo/frontend/'},
+];
+
+const ALL_ROWS: readonly Row[] = [...START_HERE, ...RESOURCES];
+
+function connector(index: number, total: number): string {
+  return index === total - 1 ? '└─' : '├─';
+}
+
+export default function Home(): React.ReactNode {
+  const [cursor, setCursor] = useState<number | null>(null);
+
+  useEffect(() => {
+    function handleKey(event: KeyboardEvent): void {
+      if (event.key === 'ArrowDown' || event.key === 'j') {
+        event.preventDefault();
+        setCursor((value) => (value === null ? 0 : Math.min(value + 1, ALL_ROWS.length - 1)));
+      } else if (event.key === 'ArrowUp' || event.key === 'k') {
+        event.preventDefault();
+        setCursor((value) => (value === null || value <= 0 ? 0 : value - 1));
+      } else if (event.key === 'Enter' && cursor !== null) {
+        event.preventDefault();
+        window.location.href = ALL_ROWS[cursor]!.href;
+      } else if (event.key === 'Escape') {
+        setCursor(null);
+      }
+    }
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [cursor]);
+
+  return (
+    <Layout title="docs" description="Unified reference for arolariu.ro">
+      <main className={styles.page}>
+        <section className={styles.hero}>
+          <h1 className={styles.wordmark}>
+            <span className={styles.prefix}>arolariu.ro</span>
+            <span className={styles.slash}>/</span>
+            <span className={styles.accent}>docs</span>
+          </h1>
+          <p className={styles.tagline}>
+            <span className={styles.comment}>//</span> unified reference for three services
+            <span className={styles.caret} aria-hidden="true" />
+          </p>
+        </section>
+
+        <Section title="start here" rows={START_HERE} cursor={cursor} cursorOffset={0} />
+        <Section title="resources" rows={RESOURCES} cursor={cursor} cursorOffset={START_HERE.length} />
+
+        <footer className={styles.footer}>
+          <span className={styles.comment}>//</span> use <kbd className={styles.kbd}>↑</kbd>{' '}
+          <kbd className={styles.kbd}>↓</kbd> to navigate, <kbd className={styles.kbd}>↵</kbd> to open
+        </footer>
+      </main>
+    </Layout>
+  );
+}
+
+function Section({
+  title,
+  rows,
+  cursor,
+  cursorOffset,
+}: {
+  readonly title: string;
+  readonly rows: readonly Row[];
+  readonly cursor: number | null;
+  readonly cursorOffset: number;
+}): React.ReactNode {
+  return (
+    <section className={styles.section}>
+      <h2 className={styles.sectionTitle}>
+        <span className={styles.chevron}>&gt;</span> {title}
+      </h2>
+      <ul className={styles.rows}>
+        {rows.map((row, i) => {
+          const globalIndex = cursorOffset + i;
+          const isActive = cursor === globalIndex;
+          return (
+            <li key={row.href} className={styles.row} style={{animationDelay: `${60 + globalIndex * 35}ms`}}>
+              <span className={styles.tree} aria-hidden="true">
+                {connector(i, rows.length)}
+              </span>
+              <span className={styles.pointer} aria-hidden="true" data-active={isActive}>
+                {isActive ? '▸' : '·'}
+              </span>
+              <Link to={row.href} className={styles.rowLabel} data-active={isActive}>
+                {row.label}
+              </Link>
+              <span className={styles.rowArrow} aria-hidden="true">
+                →
+              </span>
+              <code className={styles.rowPath}>{row.href}</code>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

Replaces the generic Docusaurus 3.10 default look with a distinctive **"developer console"** aesthetic. Extends the same carbon + oxidized-copper palette, IBM Plex Mono typography, rectilinear geometry, and console typography prefixes already used by `status.arolariu.ro` — giving the three developer-facing surfaces a unified visual family.

Four layers, one PR:

1. **Tokens + typography** (`bed51acf`) — carbon/copper palette ported from status.arolariu.ro, IBM Plex Mono + IBM Plex Sans, fluid type scale, rectilinear `border-radius: 0` across all Infima components.
2. **Component chrome** (`9a7daaea`, in the same commit as sidebar) — navbar, code blocks, admonitions, tables, breadcrumb, pagination, search modal, footer, right-rail TOC.
3. **Sidebar tree connectors** (`9a7daaea`) — the signature move: every sidebar link gets a `├─` / `└─` prefix in muted copper, turning the sidebar into something that looks like `tree(1)` output. Pure CSS, no swizzle.
4. **Landing hero + motion** (`a03a8c40`) — custom `src/pages/index.tsx` replaces the default landing. Terminal-styled wordmark `arolariu.ro/docs` with a blinking copper caret, two sections (`> start here`, `> resources`) listed with tree connectors, keyboard navigation (↑/↓/Enter). `consolePrint` stagger on initial paint. `prefers-reduced-motion` honored throughout.

Design plan lives at `docs/superpowers/specs/2026-04-22-docs-frontend-identity-design.md` (local-only per repo convention).

### Palette summary
- **Dark (default):** carbon `#0a0b0d` + oxidized copper `#e87a3e`, subtle scanline overlay.
- **Light:** cream paper `#f2e9d8` + deep ink + deeper copper `#c44419`, graph-paper grid overlay.
- OS theme preference respected (no hard default).

### Headings + admonitions
- Every heading gets a `#` / `##` / `###` / `####` prefix in copper.
- Admonitions are text-first: `[note]`, `[tip]`, `[warning]`, `[danger]` in their semantic accent color, left-border only, no pastel background tint.

## Test plan

- [x] `npm run docs:assemble && npx docusaurus build` — green
- [x] HTTP smoke across all 6 major routes (/, /intro/, /internals/dotnet/, /reference/typescript/, /internals/experimental/, /monorepo/rfc/...) — 200
- [x] Fonts load via `@fontsource/ibm-plex-mono` + `@fontsource/ibm-plex-sans` (npm, offline-friendly)
- [x] Landing page contains `wordmark` class + "unified reference" copy
- [x] Visual review in browser (Playwright unavailable during work session)
- [ ] Staging deploy visual check after merge

## Notes

- **No breaking changes** to the extractor pipeline or the four `_generated/` subtrees — this PR is purely presentational.
- **Changes one MD frontmatter:** `docs/intro.md` lost `slug: /` because that route is now owned by the new `src/pages/index.tsx` hero.
- **Three new root deps:** `@fontsource/ibm-plex-mono@5.2.7`, `@fontsource/ibm-plex-sans@5.2.7`. Both are font-subset npm packages; no external CDN.
- **Pages:** `/` → new hero · `/intro/` → former landing content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>