### PR TITLE
fix(docs): spawn defaultdocumentation in lowercase — Linux CI case-sensitivity

### DIFF
--- a/scripts/docs-assemble.ts
+++ b/scripts/docs-assemble.ts
@@ -273,12 +273,16 @@ async function runDotnetInternals(): Promise<string> {
     const outDir = join(DOTNET_INTERNALS_DIR, proj.assemblyName);
     mkdirSync(outDir, {recursive: true});
     const dll = join(API_ROOT, proj.binRelative, `${proj.assemblyName}.dll`);
-    // DefaultDocumentation is installed globally (via `dotnet tool install
-    // --global`) — see sites/docs.arolariu.ro/README.md for the one-time
-    // local setup command. Invoking the executable directly (instead of
-    // `dotnet tool run`) removes the need for a repo-level tool manifest.
+    // DefaultDocumentation.Console is installed globally (via `dotnet tool
+    // install --global`) — see sites/docs.arolariu.ro/README.md for the
+    // one-time local setup command. The invocable name is LOWERCASE
+    // (`defaultdocumentation`) — NuGet registers tool commands in lower
+    // case regardless of the package name's casing, and Linux file
+    // systems enforce that strictly. Windows' case-insensitive file
+    // system masks a PascalCase call here, so a mixed-case spelling
+    // silently works locally and only breaks on Linux CI.
     log += await runCommand(
-      'DefaultDocumentation',
+      'defaultdocumentation',
       ['--AssemblyFilePath', dll,
        '--OutputDirectoryPath', outDir,
        '--FileNameFactory', 'Name',

--- a/sites/docs.arolariu.ro/README.md
+++ b/sites/docs.arolariu.ro/README.md
@@ -82,10 +82,14 @@ python -m pip install -r sites/exp.arolariu.ro/requirements-dev.txt
 dotnet tool install --global DefaultDocumentation.Console --version 1.2.4
 ```
 
-After the global install, verify `DefaultDocumentation` is on your
-`PATH` (the dotnet CLI places global tools at `~/.dotnet/tools` on
-Unix and `%USERPROFILE%\.dotnet\tools` on Windows — add that
-directory to PATH if it isn't already).
+After the global install, verify `defaultdocumentation` (lowercase —
+that's the invocable command NuGet registers regardless of the
+`DefaultDocumentation.Console` package casing) is on your `PATH`. The
+dotnet CLI places global tools at `~/.dotnet/tools` on Unix and
+`%USERPROFILE%\.dotnet\tools` on Windows — add that directory to PATH
+if it isn't already. The orchestrator spawns the lowercase name
+because Linux file systems are case-sensitive; a PascalCase spelling
+silently works on Windows and then breaks in CI.
 
 **Everyday commands** (from the repo root):
 


### PR DESCRIPTION
## Summary

Fixes the blocked docs deploy on preview: [workflow run 24879154580](https://github.com/arolariu/arolariu.ro/actions/runs/24879154580/job/72842949420) failed at the `docs:assemble` step with `Error: spawn DefaultDocumentation ENOENT`.

Root cause: NuGet installs the `DefaultDocumentation.Console` global tool as a lowercase command — the install step itself confirms this:
```
You can invoke the tool using the following command: defaultdocumentation
Tool 'defaultdocumentation.console' (version '1.2.4') was successfully installed.
```
The orchestrator spawned `DefaultDocumentation` (PascalCase). Windows' case-insensitive NTFS resolves PascalCase to the lowercase `defaultdocumentation.exe` on disk, so every local build on Windows and macOS (HFS+/APFS default insensitive) succeeded. Ubuntu CI enforces case sensitivity and fails with ENOENT.

## Changes

- `scripts/docs-assemble.ts` — spawn `defaultdocumentation` (lowercase). Comment above the call now explains the hazard so the next contributor doesn't accidentally re-PascalCase it via autocomplete.
- `sites/docs.arolariu.ro/README.md` — local-setup section calls out the lowercase invocable command and the Linux/Windows divergence.

## Test plan

- [x] `npm run docs:assemble` on Windows — 1227 markdown files emitted (57 in `dotnet-internals`, same as before).
- [x] `npx vitest run scripts/docs-assemble` — 37/37 green.
- [ ] First CI run on this branch validates the Linux path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>