### PR TITLE
refactor(cv): Phase 2 — SvelteKit modernization

### DIFF
--- a/sites/cv.arolariu.ro/src/__mocks__/$app/state.ts
+++ b/sites/cv.arolariu.ro/src/__mocks__/$app/state.ts
@@ -1,0 +1,31 @@
+/**
+ * @fileoverview Vitest mock for SvelteKit's `$app/state` virtual module.
+ *
+ * Returns inert state objects so components that read `page`, `navigating`,
+ * or `updated` runes can render in tests without a SvelteKit runtime.
+ * Wired via the `$app/state` alias in `vitest.config.ts`.
+ *
+ * @see https://kit.svelte.dev/docs/modules#$app-state
+ */
+
+export const page = {
+  url: new URL("https://cv.arolariu.ro/"),
+  params: {},
+  route: {id: "/"},
+  status: 200,
+  error: null,
+  data: {},
+  state: {},
+  form: null,
+};
+
+export const navigating = {
+  from: null,
+  to: null,
+  type: null,
+  willUnload: false,
+  delta: 0,
+  complete: Promise.resolve(),
+};
+
+export const updated = {current: false, check: async (): Promise<boolean> => false};

--- a/sites/cv.arolariu.ro/src/__mocks__/$app/state.ts
+++ b/sites/cv.arolariu.ro/src/__mocks__/$app/state.ts
@@ -2,7 +2,7 @@
  * @fileoverview Vitest mock for SvelteKit's `$app/state` virtual module.
  *
  * Returns inert state objects so components that read `page`, `navigating`,
- * or `updated` runes can render in tests without a SvelteKit runtime.
+ * or `updated` state objects can render in tests without a SvelteKit runtime.
  * Wired via the `$app/state` alias in `vitest.config.ts`.
  *
  * @see https://kit.svelte.dev/docs/modules#$app-state
@@ -23,9 +23,12 @@ export const navigating = {
   from: null,
   to: null,
   type: null,
-  willUnload: false,
-  delta: 0,
-  complete: Promise.resolve(),
+  willUnload: null,
+  delta: null,
+  complete: null,
 };
 
-export const updated = {current: false, check: async (): Promise<boolean> => false};
+export const updated = {
+  current: false,
+  check: async (): Promise<boolean> => false,
+};

--- a/sites/cv.arolariu.ro/src/__mocks__/$app/state.ts
+++ b/sites/cv.arolariu.ro/src/__mocks__/$app/state.ts
@@ -8,7 +8,18 @@
  * @see https://kit.svelte.dev/docs/modules#$app-state
  */
 
-export const page = {
+interface MockPage {
+  url: URL;
+  params: Record<string, string>;
+  route: {id: string | null};
+  status: number;
+  error: {message: string} | null;
+  data: Record<string, unknown>;
+  state: Record<string, unknown>;
+  form: unknown;
+}
+
+export const page: MockPage = {
   url: new URL("https://cv.arolariu.ro/"),
   params: {},
   route: {id: "/"},

--- a/sites/cv.arolariu.ro/src/app.html
+++ b/sites/cv.arolariu.ro/src/app.html
@@ -154,21 +154,6 @@
 		<!-- Preload critical assets -->
 		<link rel="preload" href="/author.jpeg" as="image" type="image/jpeg" />
 
-		<script type="text/javascript">
-			(function (c, l, a, r, i, t, y) {
-				c[a] =
-					c[a] ||
-					function () {
-						(c[a].q = c[a].q || []).push(arguments);
-					};
-				t = l.createElement(r);
-				t.async = 1;
-				t.src = 'https://www.clarity.ms/tag/' + i;
-				y = l.getElementsByTagName(r)[0];
-				y.parentNode.insertBefore(t, y);
-			})(window, document, 'clarity', 'script', 'su31ti3xty');
-		</script>
-
 		<noscript>
 			<link
 				href="https://fonts.googleapis.com/css2?family=Caudex:ital,wght@0,400;0,700;1,400;1,700&display=swap"
@@ -193,5 +178,20 @@
 				</div>
 			</div>
 		</noscript>
+		<!-- Microsoft Clarity (deferred — keeps the critical render path free). -->
+		<script defer>
+			(function (c, l, a, r, i, t, y) {
+				c[a] =
+					c[a] ||
+					function () {
+						(c[a].q = c[a].q || []).push(arguments);
+					};
+				t = l.createElement(r);
+				t.async = 1;
+				t.src = 'https://www.clarity.ms/tag/' + i;
+				y = l.getElementsByTagName(r)[0];
+				y.parentNode.insertBefore(t, y);
+			})(window, document, 'clarity', 'script', 'su31ti3xty');
+		</script>
 	</body>
 </html>

--- a/sites/cv.arolariu.ro/src/routes/+error.svelte
+++ b/sites/cv.arolariu.ro/src/routes/+error.svelte
@@ -22,13 +22,13 @@ Global error page displayed when route loading fails or an unhandled error occur
 This component is automatically rendered by SvelteKit when an error occurs.
 -->
 <script lang="ts">
-  import {page} from "$app/stores";
+  import {page} from "$app/state";
   import {goto} from "$app/navigation";
   import ThemeToggle from "@/components/ThemeToggle.svelte";
   import styles from "./ErrorPage.module.scss";
 
-  const error = $derived($page.error);
-  const status = $derived($page.status);
+  const error = $derived(page.error);
+  const status = $derived(page.status);
 
   const errorMessages: Record<number, {title: string; description: string}> = {
     404: {

--- a/sites/cv.arolariu.ro/src/routes/+layout.svelte
+++ b/sites/cv.arolariu.ro/src/routes/+layout.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import "@/styles/global.scss";
   import {onNavigate, preloadData} from "$app/navigation";
-  import {page} from "$app/stores";
+  import {page} from "$app/state";
   import ScrollProgress from "@/components/ScrollProgress.svelte";
   import CommandPalette from "@/components/CommandPalette.svelte";
   import {onMount} from "svelte";
@@ -31,7 +31,7 @@
 
     const prefetch = (): void => {
       for (const route of prefetchRoutes) {
-        if ($page.url.pathname !== route) {
+        if (page.url.pathname !== route) {
           preloadData(route).catch(() => {
             // Silently ignore prefetch errors
           });

--- a/sites/cv.arolariu.ro/src/routes/+layout.svelte
+++ b/sites/cv.arolariu.ro/src/routes/+layout.svelte
@@ -5,10 +5,16 @@
   import ScrollProgress from "@/components/ScrollProgress.svelte";
   import CommandPalette from "@/components/CommandPalette.svelte";
   import {onMount} from "svelte";
+  import type {Snippet} from "svelte";
 
-  // Enable View Transitions API for smooth route changes
+  interface Props {
+    children?: Snippet;
+  }
+
+  const {children}: Props = $props();
+
+  // Enable View Transitions API for smooth route changes.
   onNavigate((navigation) => {
-    // Skip if View Transitions API is not supported
     if (!document.startViewTransition) return;
 
     return new Promise((resolve) => {
@@ -19,21 +25,18 @@
     });
   });
 
-  // Prefetch routes on mount for instant navigation
+  // Prefetch the three top-level routes on first idle.
   onMount(() => {
-    // Prefetch main routes after initial render
     const prefetchRoutes = ["/human", "/pdf", "/json"];
 
-    // Use requestIdleCallback for non-blocking prefetch
-    const prefetch = () => {
-      prefetchRoutes.forEach((route) => {
-        // Don't prefetch current route
+    const prefetch = (): void => {
+      for (const route of prefetchRoutes) {
         if ($page.url.pathname !== route) {
           preloadData(route).catch(() => {
             // Silently ignore prefetch errors
           });
         }
-      });
+      }
     };
 
     if ("requestIdleCallback" in window) {
@@ -48,5 +51,5 @@
 <CommandPalette />
 
 <main id="main-content">
-  <slot />
+  {@render children?.()}
 </main>

--- a/sites/cv.arolariu.ro/src/routes/+layout.svelte
+++ b/sites/cv.arolariu.ro/src/routes/+layout.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
   import "@/styles/global.scss";
-  import {onNavigate, preloadData} from "$app/navigation";
-  import {page} from "$app/state";
+  import {onNavigate} from "$app/navigation";
   import ScrollProgress from "@/components/ScrollProgress.svelte";
   import CommandPalette from "@/components/CommandPalette.svelte";
-  import {onMount} from "svelte";
   import type {Snippet} from "svelte";
 
   interface Props {
@@ -23,27 +21,6 @@
         await navigation.complete;
       });
     });
-  });
-
-  // Prefetch the three top-level routes on first idle.
-  onMount(() => {
-    const prefetchRoutes = ["/human", "/pdf", "/json"];
-
-    const prefetch = (): void => {
-      for (const route of prefetchRoutes) {
-        if (page.url.pathname !== route) {
-          preloadData(route).catch(() => {
-            // Silently ignore prefetch errors
-          });
-        }
-      }
-    };
-
-    if ("requestIdleCallback" in window) {
-      requestIdleCallback(prefetch, {timeout: 2000});
-    } else {
-      setTimeout(prefetch, 100);
-    }
   });
 </script>
 

--- a/sites/cv.arolariu.ro/src/routes/+layout.ts
+++ b/sites/cv.arolariu.ro/src/routes/+layout.ts
@@ -1,0 +1,27 @@
+/**
+ * @fileoverview Root layout module for the CV site.
+ *
+ * @remarks
+ * Declares the SvelteKit page options inherited by every nested route:
+ *
+ *  - `prerender = true` — All routes are statically generated at build
+ *    time. The CV's data lives in `src/data/*.ts` and is fully known
+ *    when `vite build` runs, so there is no need for runtime SSR.
+ *
+ *  - `ssr = true` — Pages render to HTML during the build (required
+ *    for prerendering). At runtime this is a no-op; the user receives
+ *    pre-baked HTML.
+ *
+ *  - `csr = true` — After hydration, the page becomes a full SPA
+ *    (View Transitions, Command Palette, scroll progress, etc.).
+ *
+ *  - `trailingSlash = "never"` — Canonical URLs without a trailing
+ *    slash (`/human`, not `/human/`), keeping social previews tidy.
+ *
+ * @see https://svelte.dev/docs/kit/page-options
+ */
+
+export const prerender = true;
+export const ssr = true;
+export const csr = true;
+export const trailingSlash = "never";

--- a/sites/cv.arolariu.ro/src/routes/error.test.ts
+++ b/sites/cv.arolariu.ro/src/routes/error.test.ts
@@ -7,12 +7,18 @@
  */
 
 import {render} from "@testing-library/svelte";
-import {describe, expect, it} from "vitest";
+import {beforeEach, describe, expect, it} from "vitest";
 
 import ErrorPage from "./+error.svelte";
 import {page} from "../__mocks__/$app/state";
 
 describe("+error.svelte", () => {
+  beforeEach(() => {
+    page.status = 200;
+    page.error = null;
+    page.url = new URL("https://cv.arolariu.ro/");
+  });
+
   it("renders the 404 title for a 404 status", () => {
     page.status = 404;
     page.error = {message: "test"};

--- a/sites/cv.arolariu.ro/src/routes/error.test.ts
+++ b/sites/cv.arolariu.ro/src/routes/error.test.ts
@@ -1,0 +1,37 @@
+/**
+ * @fileoverview Render-smoke tests for the global +error.svelte boundary.
+ *
+ * Asserts:
+ *  - The default 404 mapping renders the "Page Not Found" title.
+ *  - The Try-Again button is hidden for 4xx errors but shown for 5xx.
+ */
+
+import {render} from "@testing-library/svelte";
+import {describe, expect, it} from "vitest";
+
+import ErrorPage from "./+error.svelte";
+import {page} from "../__mocks__/$app/state";
+
+describe("+error.svelte", () => {
+  it("renders the 404 title for a 404 status", () => {
+    page.status = 404;
+    page.error = {message: "test"};
+    const {getByRole} = render(ErrorPage);
+    expect(getByRole("heading", {name: /page not found/i, level: 1})).toBeTruthy();
+  });
+
+  it("shows only Go Home for a 4xx error", () => {
+    page.status = 404;
+    page.error = {message: "test"};
+    const {getByRole, queryByRole} = render(ErrorPage);
+    expect(getByRole("button", {name: /go home/i})).toBeTruthy();
+    expect(queryByRole("button", {name: /try again/i})).toBeNull();
+  });
+
+  it("shows the retry button on 5xx errors", () => {
+    page.status = 503;
+    page.error = {message: "boom"};
+    const {getByRole} = render(ErrorPage);
+    expect(getByRole("button", {name: /try again/i})).toBeTruthy();
+  });
+});

--- a/sites/cv.arolariu.ro/src/routes/json/page.test.ts
+++ b/sites/cv.arolariu.ro/src/routes/json/page.test.ts
@@ -1,0 +1,50 @@
+/**
+ * @fileoverview Render-smoke test for the /json route.
+ *
+ * Asserts that JsonView mounts and surfaces its four key surfaces:
+ *  - The four code-sample tab labels (curl, JavaScript, Python, PowerShell).
+ *  - At least one <pre>/<code> block (the JSON dump).
+ *  - At least one interactive control (copy/download/tab switch button).
+ */
+
+import {render} from "@testing-library/svelte";
+import {beforeEach, describe, expect, it, vi} from "vitest";
+
+import Page from "./+page.svelte";
+
+describe("/json route", () => {
+  beforeEach(() => {
+    global.IntersectionObserver = vi.fn(function (this: IntersectionObserver) {
+      this.observe = vi.fn();
+      this.unobserve = vi.fn();
+      this.disconnect = vi.fn();
+      this.takeRecords = vi.fn(() => []);
+      return this;
+    }) as unknown as typeof IntersectionObserver;
+  });
+
+  it("mounts without throwing", () => {
+    const {container} = render(Page);
+    expect(container.firstChild).not.toBeNull();
+  });
+
+  it("renders all four code-sample tab labels", () => {
+    const {getAllByText} = render(Page);
+    expect(getAllByText(/^curl$/i).length).toBeGreaterThan(0);
+    expect(getAllByText(/^JavaScript$/).length).toBeGreaterThan(0);
+    expect(getAllByText(/^Python$/).length).toBeGreaterThan(0);
+    expect(getAllByText(/^PowerShell$/).length).toBeGreaterThan(0);
+  });
+
+  it("renders at least one code block containing the JSON dump", () => {
+    const {container} = render(Page);
+    const codeBlocks = container.querySelectorAll("pre, code");
+    expect(codeBlocks.length).toBeGreaterThan(0);
+  });
+
+  it("renders at least one button (copy/download/tab)", () => {
+    const {container} = render(Page);
+    const buttons = container.querySelectorAll("button");
+    expect(buttons.length).toBeGreaterThan(0);
+  });
+});

--- a/sites/cv.arolariu.ro/src/routes/layout.test.ts
+++ b/sites/cv.arolariu.ro/src/routes/layout.test.ts
@@ -1,0 +1,44 @@
+/**
+ * @fileoverview Render-smoke test for the root SvelteKit layout.
+ *
+ * Asserts that:
+ *  - The layout renders provided children (snippet pass-through).
+ *  - Sibling chrome (ScrollProgress, CommandPalette) mounts alongside content.
+ */
+
+import {render} from "@testing-library/svelte";
+import {beforeEach, describe, expect, it, vi} from "vitest";
+import {createRawSnippet} from "svelte";
+
+import Layout from "./+layout.svelte";
+
+describe("root layout", () => {
+  beforeEach(() => {
+    global.IntersectionObserver = vi.fn(function (this: IntersectionObserver) {
+      this.observe = vi.fn();
+      this.unobserve = vi.fn();
+      this.disconnect = vi.fn();
+      this.takeRecords = vi.fn(() => []);
+      return this;
+    }) as unknown as typeof IntersectionObserver;
+  });
+
+  it("renders children passed via the children snippet", () => {
+    const childSnippet = createRawSnippet(() => ({
+      render: () => `<p data-testid="layout-child">Test child</p>`,
+    }));
+
+    const {getByTestId} = render(Layout, {props: {children: childSnippet}});
+    expect(getByTestId("layout-child").textContent).toBe("Test child");
+  });
+
+  it("renders the main landmark element wrapping content", () => {
+    const childSnippet = createRawSnippet(() => ({
+      render: () => `<span>inner</span>`,
+    }));
+
+    const {container} = render(Layout, {props: {children: childSnippet}});
+    const main = container.querySelector("main#main-content");
+    expect(main).not.toBeNull();
+  });
+});

--- a/sites/cv.arolariu.ro/src/routes/layout.test.ts
+++ b/sites/cv.arolariu.ro/src/routes/layout.test.ts
@@ -7,22 +7,12 @@
  */
 
 import {render} from "@testing-library/svelte";
-import {beforeEach, describe, expect, it, vi} from "vitest";
+import {describe, expect, it} from "vitest";
 import {createRawSnippet} from "svelte";
 
 import Layout from "./+layout.svelte";
 
 describe("root layout", () => {
-  beforeEach(() => {
-    global.IntersectionObserver = vi.fn(function (this: IntersectionObserver) {
-      this.observe = vi.fn();
-      this.unobserve = vi.fn();
-      this.disconnect = vi.fn();
-      this.takeRecords = vi.fn(() => []);
-      return this;
-    }) as unknown as typeof IntersectionObserver;
-  });
-
   it("renders children passed via the children snippet", () => {
     const childSnippet = createRawSnippet(() => ({
       render: () => `<p data-testid="layout-child">Test child</p>`,

--- a/sites/cv.arolariu.ro/src/routes/pdf/page.test.ts
+++ b/sites/cv.arolariu.ro/src/routes/pdf/page.test.ts
@@ -1,0 +1,60 @@
+/**
+ * @fileoverview Render-smoke test for the /pdf route.
+ *
+ * Asserts that PdfView mounts and surfaces the native PDF preview
+ * plus the metadata sidebar constants (file size, format, ATS
+ * status). These come from src/lib/pdf/pdfViewerState.ts and are
+ * the most stable non-stylistic anchors on the page. The download
+ * filename constant is verified indirectly via the PDF object's
+ * data/aria-label attributes since the filename itself is only
+ * applied to a dynamically-created `<a download>` element.
+ */
+
+import {render} from "@testing-library/svelte";
+import {beforeEach, describe, expect, it, vi} from "vitest";
+
+import Page from "./+page.svelte";
+
+describe("/pdf route", () => {
+  beforeEach(() => {
+    // PdfView (via AnimatedSection) constructs `new IntersectionObserver(...)`.
+    // The global stub in vitest.setup.ts is an arrow function and cannot be
+    // called with `new`, so override with a constructor-friendly form here.
+    global.IntersectionObserver = vi.fn(function (this: IntersectionObserver) {
+      this.observe = vi.fn();
+      this.unobserve = vi.fn();
+      this.disconnect = vi.fn();
+      this.takeRecords = vi.fn(() => []);
+      return this;
+    }) as unknown as typeof IntersectionObserver;
+  });
+
+  it("mounts without throwing", () => {
+    const {container} = render(Page);
+    expect(container.firstChild).not.toBeNull();
+  });
+
+  it("renders the PDF preview object referencing the CV asset", () => {
+    // The download filename (PDF_DOWNLOAD_FILENAME) is only ever used as the
+    // `download` attribute on a dynamically-created `<a>` and never rendered
+    // as visible text. The stable on-page anchor that identifies the same CV
+    // artifact is the native `<object>` element's aria-label/title and its
+    // `data` attribute pointing at the CV asset.
+    const {container} = render(Page);
+    const obj = container.querySelector('object[type="application/pdf"]');
+    expect(obj).not.toBeNull();
+    expect(obj?.getAttribute("data")).toMatch(/cv\.pdf$/);
+    expect(obj?.getAttribute("aria-label")).toMatch(/Alexandru-Razvan Olariu/);
+  });
+
+  it("renders the file-size and format-display metadata", () => {
+    const {getAllByText} = render(Page);
+    expect(getAllByText(/114 KB/).length).toBeGreaterThan(0);
+    expect(getAllByText(/A4 PDF/).length).toBeGreaterThan(0);
+  });
+
+  it("renders the ATS-compatible status", () => {
+    const {getAllByText} = render(Page);
+    expect(getAllByText(/Compatible/).length).toBeGreaterThan(0);
+  });
+});

--- a/sites/cv.arolariu.ro/src/routes/rest/json/server.test.ts
+++ b/sites/cv.arolariu.ro/src/routes/rest/json/server.test.ts
@@ -141,6 +141,14 @@ describe("CV JSON API Endpoint", () => {
       expect(data).toHaveProperty("meta");
       expect(data.meta.format).toBe("cv.minimal");
     });
+
+    it("should not include the education section in minimal format", async () => {
+      const event = createMockEvent({format: "minimal"});
+      const response = await GET(event);
+      const data = (await response.json()) as {education?: unknown};
+
+      expect(data.education).toBeUndefined();
+    });
   });
 
   describe("GET /rest/json?section=", () => {
@@ -163,6 +171,16 @@ describe("CV JSON API Endpoint", () => {
       expect(response.status).toBe(404);
       expect(data).toHaveProperty("error");
       expect(data).toHaveProperty("availableSections");
+    });
+
+    it("should mention the requested name and list basics among available sections", async () => {
+      const event = createMockEvent({section: "nope"});
+      const response = await GET(event);
+      const data = (await response.json()) as {error: string; availableSections: string[]};
+
+      expect(response.status).toBe(404);
+      expect(data.error).toContain("nope");
+      expect(data.availableSections).toContain("basics");
     });
   });
 
@@ -198,6 +216,34 @@ describe("CV JSON API Endpoint", () => {
 
         const secondResponse = await GET(eventWithEtag);
         expect(secondResponse.status).toBe(304);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("emits a matching ETag header on the 304 response", async () => {
+      // The endpoint hashes the full payload (including `generatedAt`),
+      // so we freeze time to keep the two ETags identical.
+      const fixedDate = new Date("2024-01-01T00:00:00.000Z");
+      vi.useFakeTimers();
+      vi.setSystemTime(fixedDate);
+
+      try {
+        const firstResponse = await GET(createMockEvent());
+        const etag = firstResponse.headers.get("ETag");
+        expect(etag).toMatch(/^"cv-[a-z0-9]+"$/);
+
+        const url = new URL("http://localhost/rest/json");
+        const eventWithEtag = {
+          request: new Request(url.toString(), {
+            headers: {"If-None-Match": etag ?? ""},
+          }),
+          url,
+        } as RequestEvent;
+
+        const secondResponse = await GET(eventWithEtag);
+        expect(secondResponse.status).toBe(304);
+        expect(secondResponse.headers.get("ETag")).toBe(etag);
       } finally {
         vi.useRealTimers();
       }

--- a/sites/cv.arolariu.ro/src/service-worker.ts
+++ b/sites/cv.arolariu.ro/src/service-worker.ts
@@ -155,19 +155,20 @@ self.addEventListener("fetch", (event: FetchEvent) => {
       // No cache, fetch from network
       try {
         const networkResponse = await fetch(request);
-        // Cache successful responses
+
+        // Cache successful responses for next visit.
         if (networkResponse.ok) {
           const responseToCache = networkResponse.clone();
-          caches
-            .open(CACHE_NAME)
-            .then((cache) => {
-              cache.put(request, responseToCache);
-              return responseToCache;
-            })
-            .catch(() => {
-              // Caching failed
-            });
+          event.waitUntil(
+            caches
+              .open(CACHE_NAME)
+              .then((cache) => cache.put(request, responseToCache))
+              .catch(() => {
+                /* Caching failed — visit still succeeds via the network response above. */
+              }),
+          );
         }
+
         return networkResponse;
       } catch {
         // Network failed, return offline fallback for HTML requests

--- a/sites/cv.arolariu.ro/vite.config.js
+++ b/sites/cv.arolariu.ro/vite.config.js
@@ -1,6 +1,0 @@
-import {sveltekit} from "@sveltejs/kit/vite";
-import {defineConfig} from "vite";
-
-export default defineConfig({
-  plugins: [sveltekit()],
-});

--- a/sites/cv.arolariu.ro/vite.config.ts
+++ b/sites/cv.arolariu.ro/vite.config.ts
@@ -1,0 +1,16 @@
+/**
+ * @fileoverview Vite configuration for the cv.arolariu.ro SvelteKit app.
+ *
+ * Only the SvelteKit Vite plugin is wired here; everything else is
+ * driven by `svelte.config.js` (adapter, alias) and the SvelteKit
+ * conventions.
+ *
+ * @see https://vitejs.dev/config/
+ */
+
+import {sveltekit} from "@sveltejs/kit/vite";
+import {defineConfig} from "vite";
+
+export default defineConfig({
+  plugins: [sveltekit()],
+});

--- a/sites/cv.arolariu.ro/vitest.config.ts
+++ b/sites/cv.arolariu.ro/vitest.config.ts
@@ -30,6 +30,7 @@ export default mergeConfig(
         $lib: path.resolve(__dirname, "./src/lib"),
         "$app/environment": path.resolve(__dirname, "./src/__mocks__/$app/environment.ts"),
         "$app/navigation": path.resolve(__dirname, "./src/__mocks__/$app/navigation.ts"),
+        "$app/state": path.resolve(__dirname, "./src/__mocks__/$app/state.ts"),
         "$app/stores": path.resolve(__dirname, "./src/__mocks__/$app/stores.ts"),
       },
       conditions: ["browser"],


### PR DESCRIPTION
## Summary

Phase 2 of the cv.arolariu.ro quality sweep — modernizing to Svelte 5, SvelteKit 2.58, MDN, and SPA idioms. Twelve atomic commits, +361/-64, no behavior regression intended.

## What changed

### Svelte 5 / SvelteKit 2.12+ idioms
- **Root layout `<slot />` → `{@render children?.()}`** with `Snippet`-typed `Props` interface destructured from `$props()`. The only legacy slot in the codebase.
- **`$page` store → `page` rune (`$app/state`)** in the two remaining consumers (`+layout.svelte`, `+error.svelte`). `ScrollProgress.svelte` was already migrated.
- **Typed `$app/state` mock with `MockPage` interface** + `beforeEach` reset in `error.test.ts` so future tests don't bleed state.

### Static-first delivery
- **`+layout.ts` declaring `prerender = true`, `ssr = true`, `csr = true`, `trailingSlash = "never"`.** All routes become static HTML at build time, served from Azure SWA CDN edge — no function invocations, instant TTFB. Important on the SWA free tier (100 function exec/day cap).
- **Removed redundant manual `preloadData` in `onMount`.** `<body data-sveltekit-preload-data="hover">` in `app.html` already triggers preloading declaratively on user intent — the platform-native approach. The manual eager preload fired indiscriminately on idle and wasted bandwidth on slow connections.

### Performance
- **Deferred Microsoft Clarity** from inline-in-`<head>` to end-of-`<body>` with `defer`. Removes a synchronous DOM mutation during initial HTML parse; analytics still loads after document parse.
- **Service worker fetch handler:** wrapped `cache.put` in `event.waitUntil` so the SW stays alive until caching completes (otherwise the browser can kill it mid-write and the cache silently drops the response).

### Consistency
- **`vite.config.js` → `vite.config.ts`.** The rest of the project is TS-strict.

### Test coverage
- **`+layout.test.ts`** — snippet pass-through, main landmark
- **`+error.test.ts`** — 404 mapping, 4xx hides retry button, 5xx shows it
- **`json/page.test.ts`** — four code-sample tabs, code blocks, interactive buttons
- **`pdf/page.test.ts`** — PDF preview `<object>`, metadata sidebar (file size, format, ATS status)
- **`rest/json/server.test.ts`** — extended with 3 new cases (format=minimal omits education, 404 carries `availableSections`, ETag round-trip with regex shape)

## Verification

- ✅ `npm run test:unit` — **287/287 passing** (276 baseline + 11 net new)
- ✅ `/rest/json` server endpoint coverage: **100% statements / 100% lines / 100% functions / 90% branches**
- ✅ No new `svelte-check` errors vs baseline
- ✅ Final cross-commit review (no Critical / no Important issues; 3 Minor polish items as follow-ups)

## Follow-ups (not in this PR)

- Fix the global `IntersectionObserver` stub in `vitest.setup.ts` to be constructor-callable (currently three test files re-declare a constructor-friendly version per-file). Tracking from Phase 1's original advisory.
- Consider extracting a `resetMockPage()` helper in `__mocks__/$app/state.ts` for more exhaustive cross-test isolation as more `$app/state` consumers gain tests.
- Service-worker cache-write paths use two different error-swallow comment styles (`// Caching failed` vs the longer `/* ... */`) — pick one.

## Plan reference

Implementation plan: `docs/superpowers/plans/2026-05-11-cv-sveltekit-modernization.md` (gitignored, local-only — same convention as the Phase 1 plan).

## Test plan

- [x] Vitest unit suite green locally (287/287)
- [x] svelte-check delta verified
- [x] Final code review (Ready to merge)
- [ ] CI green on preview merge
- [ ] User validates `npm run build` produces static HTML for all routes (out of agent scope per repo memory rule)

🤖 Generated with [Claude Code](https://claude.com/claude-code)