### PR TITLE
Refactor and modernize CV components for Svelte 5 and SvelteKit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,11 +61,6 @@ nul
 **/.python_packages/
 
 
-# Local performance measurement artifacts (Phase 4 cv quality sweep):
-**/.perf-*.json
-**/.perf-*.txt
-**/.perf-*.md
-
 # arolariu.ro specific:
 sites/arolariu.ro/certificates
 sites/arolariu.ro/messages/*.d.json.ts

--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,11 @@ nul
 **/.python_packages/
 
 
+# Local performance measurement artifacts (Phase 4 cv quality sweep):
+**/.perf-*.json
+**/.perf-*.txt
+**/.perf-*.md
+
 # arolariu.ro specific:
 sites/arolariu.ro/certificates
 sites/arolariu.ro/messages/*.d.json.ts

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -433,7 +433,7 @@
     "*.cs": "$(capture).*.cs",
     "*.ts": "$(capture).*.ts",
     "*.tsx": "$(capture).*.tsx, $(capture).*.scss, $(capture).*.css",
-    "*.svelte": "$(capture).module.scss, $(capture).test.ts, $(capture).module.test.ts"
+    "*.svelte": "$(capture).*.scss, $(capture).*.ts"
   },
   "explorer.incrementalNaming": "smart",
   "explorer.openEditors.minVisible": 0,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -432,7 +432,8 @@
     "*.py": "$(capture).*.py",
     "*.cs": "$(capture).*.cs",
     "*.ts": "$(capture).*.ts",
-    "*.tsx": "$(capture).*.tsx, $(capture).*.scss, $(capture).*.css"
+    "*.tsx": "$(capture).*.tsx, $(capture).*.scss, $(capture).*.css",
+    "*.svelte": "$(capture).module.scss, $(capture).test.ts, $(capture).module.test.ts"
   },
   "explorer.incrementalNaming": "smart",
   "explorer.openEditors.minVisible": 0,

--- a/sites/cv.arolariu.ro/src/__mocks__/$app/state.ts
+++ b/sites/cv.arolariu.ro/src/__mocks__/$app/state.ts
@@ -1,0 +1,31 @@
+/**
+ * @fileoverview Vitest mock for SvelteKit's `$app/state` virtual module.
+ *
+ * Returns inert state objects so components that read `page`, `navigating`,
+ * or `updated` runes can render in tests without a SvelteKit runtime.
+ * Wired via the `$app/state` alias in `vitest.config.ts`.
+ *
+ * @see https://kit.svelte.dev/docs/modules#$app-state
+ */
+
+export const page = {
+  url: new URL("https://cv.arolariu.ro/"),
+  params: {},
+  route: {id: "/"},
+  status: 200,
+  error: null,
+  data: {},
+  state: {},
+  form: null,
+};
+
+export const navigating = {
+  from: null,
+  to: null,
+  type: null,
+  willUnload: false,
+  delta: 0,
+  complete: Promise.resolve(),
+};
+
+export const updated = {current: false, check: async (): Promise<boolean> => false};

--- a/sites/cv.arolariu.ro/src/__mocks__/$app/state.ts
+++ b/sites/cv.arolariu.ro/src/__mocks__/$app/state.ts
@@ -2,7 +2,7 @@
  * @fileoverview Vitest mock for SvelteKit's `$app/state` virtual module.
  *
  * Returns inert state objects so components that read `page`, `navigating`,
- * or `updated` runes can render in tests without a SvelteKit runtime.
+ * or `updated` state objects can render in tests without a SvelteKit runtime.
  * Wired via the `$app/state` alias in `vitest.config.ts`.
  *
  * @see https://kit.svelte.dev/docs/modules#$app-state
@@ -23,9 +23,12 @@ export const navigating = {
   from: null,
   to: null,
   type: null,
-  willUnload: false,
-  delta: 0,
-  complete: Promise.resolve(),
+  willUnload: null,
+  delta: null,
+  complete: null,
 };
 
-export const updated = {current: false, check: async (): Promise<boolean> => false};
+export const updated = {
+  current: false,
+  check: async (): Promise<boolean> => false,
+};

--- a/sites/cv.arolariu.ro/src/__mocks__/$app/state.ts
+++ b/sites/cv.arolariu.ro/src/__mocks__/$app/state.ts
@@ -8,7 +8,18 @@
  * @see https://kit.svelte.dev/docs/modules#$app-state
  */
 
-export const page = {
+interface MockPage {
+  url: URL;
+  params: Record<string, string>;
+  route: {id: string | null};
+  status: number;
+  error: {message: string} | null;
+  data: Record<string, unknown>;
+  state: Record<string, unknown>;
+  form: unknown;
+}
+
+export const page: MockPage = {
   url: new URL("https://cv.arolariu.ro/"),
   params: {},
   route: {id: "/"},

--- a/sites/cv.arolariu.ro/src/app.html
+++ b/sites/cv.arolariu.ro/src/app.html
@@ -178,8 +178,11 @@
 				</div>
 			</div>
 		</noscript>
-		<!-- Microsoft Clarity (deferred — keeps the critical render path free). -->
-		<script defer>
+		<!-- Microsoft Clarity — placed at end of <body> so it runs after the
+		     primary HTML parse, not in the critical render path. The `defer`
+		     attribute is ignored on inline scripts, so position-in-document
+		     is the actual deferral mechanism here. -->
+		<script>
 			(function (c, l, a, r, i, t, y) {
 				c[a] =
 					c[a] ||

--- a/sites/cv.arolariu.ro/src/app.html
+++ b/sites/cv.arolariu.ro/src/app.html
@@ -154,21 +154,6 @@
 		<!-- Preload critical assets -->
 		<link rel="preload" href="/author.jpeg" as="image" type="image/jpeg" />
 
-		<script type="text/javascript">
-			(function (c, l, a, r, i, t, y) {
-				c[a] =
-					c[a] ||
-					function () {
-						(c[a].q = c[a].q || []).push(arguments);
-					};
-				t = l.createElement(r);
-				t.async = 1;
-				t.src = 'https://www.clarity.ms/tag/' + i;
-				y = l.getElementsByTagName(r)[0];
-				y.parentNode.insertBefore(t, y);
-			})(window, document, 'clarity', 'script', 'su31ti3xty');
-		</script>
-
 		<noscript>
 			<link
 				href="https://fonts.googleapis.com/css2?family=Caudex:ital,wght@0,400;0,700;1,400;1,700&display=swap"
@@ -193,5 +178,20 @@
 				</div>
 			</div>
 		</noscript>
+		<!-- Microsoft Clarity (deferred — keeps the critical render path free). -->
+		<script defer>
+			(function (c, l, a, r, i, t, y) {
+				c[a] =
+					c[a] ||
+					function () {
+						(c[a].q = c[a].q || []).push(arguments);
+					};
+				t = l.createElement(r);
+				t.async = 1;
+				t.src = 'https://www.clarity.ms/tag/' + i;
+				y = l.getElementsByTagName(r)[0];
+				y.parentNode.insertBefore(t, y);
+			})(window, document, 'clarity', 'script', 'su31ti3xty');
+		</script>
 	</body>
 </html>

--- a/sites/cv.arolariu.ro/src/components/CommandPalette.module.scss
+++ b/sites/cv.arolariu.ro/src/components/CommandPalette.module.scss
@@ -1,15 +1,5 @@
 @use "../styles/breakpoints";
 
-.backdrop {
-  position: fixed;
-  inset: 0;
-  z-index: 50;
-  cursor: pointer;
-  background: rgb(0 0 0 / 0.5);
-  backdrop-filter: blur(4px);
-  animation: fade-in 150ms ease-out;
-}
-
 .modal {
   position: fixed;
   top: 20%;
@@ -326,8 +316,35 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .backdrop,
   .modal {
     animation: none;
+  }
+}
+
+/* Backdrop styling for the native <dialog>. The browser draws ::backdrop
+   only when the dialog is opened via showModal(). */
+dialog.modal::backdrop {
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
+}
+
+/* The native <dialog> defaults to fixed inset:auto + width:fit-content,
+   so neutralise the user-agent box and let our existing .modal rule
+   handle positioning/sizing. */
+dialog.modal {
+  padding: 0;
+  border: none;
+  background: transparent;
+  max-width: min(32rem, calc(100vw - 2rem));
+}
+
+dialog.modal:not([open]) {
+  display: none;
+}
+
+/* Reduced motion: skip the backdrop blur (cheap on modern GPUs but not free). */
+@media (prefers-reduced-motion: reduce) {
+  dialog.modal::backdrop {
+    backdrop-filter: none;
   }
 }

--- a/sites/cv.arolariu.ro/src/components/CommandPalette.svelte
+++ b/sites/cv.arolariu.ro/src/components/CommandPalette.svelte
@@ -383,16 +383,17 @@
 
       <!-- Command list -->
       <div class={styles.commandList}>
-        {#each Object.entries(groupedCommands) as [category, cmds]}
+        {#each Object.entries(groupedCommands) as [category, cmds] (category)}
           {#if cmds.length > 0}
             <div class={styles.commandGroup}>
               <div class={styles.categoryLabel}>
                 {categoryLabels[category] ?? category}
               </div>
-              {#each cmds as cmd}
+              {#each cmds as cmd (cmd.id)}
                 {@const globalIndex = flatCommands.indexOf(cmd)}
                 {@const isSelected = globalIndex === selectedIndex}
                 <button
+                  id="cmd-{cmd.id}"
                   onclick={() => cmd.action()}
                   onmouseenter={() => (selectedIndex = globalIndex)}
                   class={cx(styles.commandItem, isSelected ? styles.commandItemSelected : styles.commandItemIdle)}>

--- a/sites/cv.arolariu.ro/src/components/CommandPalette.svelte
+++ b/sites/cv.arolariu.ro/src/components/CommandPalette.svelte
@@ -1,4 +1,10 @@
 <script lang="ts">
+  // CommandPalette is a layout singleton: it's mounted exactly once
+  // from +layout.svelte and attaches a document-level keydown listener
+  // in onMount (for the Cmd/Ctrl+K shortcut + arrow navigation). Do
+  // NOT mount this component inside a route page or anywhere else —
+  // each mount would attach another listener, leaking memory and
+  // double-firing the global shortcut.
   import {goto} from "$app/navigation";
   import {cx} from "@/lib/utils";
   import {useTheme} from "@/hooks/useTheme.svelte";

--- a/sites/cv.arolariu.ro/src/components/CommandPalette.svelte
+++ b/sites/cv.arolariu.ro/src/components/CommandPalette.svelte
@@ -22,6 +22,7 @@
   let searchQuery = $state("");
   let selectedIndex = $state(0);
   let inputRef = $state<HTMLInputElement | null>(null);
+  let dialogRef = $state<HTMLDialogElement | null>(null);
 
   // Define all available commands
   const commands = $derived.by((): CommandAction[] => [
@@ -244,13 +245,15 @@
     isOpen = true;
     searchQuery = "";
     selectedIndex = 0;
-    setTimeout(() => inputRef?.focus(), 50);
+    if (!dialogRef?.open) dialogRef?.showModal();
+    queueMicrotask(() => inputRef?.focus());
   }
 
   function close() {
     isOpen = false;
     searchQuery = "";
     selectedIndex = 0;
+    dialogRef?.close();
   }
 
   function handleKeydown(e: KeyboardEvent) {
@@ -339,24 +342,22 @@
   };
 </script>
 
-{#if isOpen}
-  <!-- Backdrop -->
-  <div
-    class={styles.backdrop}
-    onclick={close}
-    onkeydown={(e) => e.key === "Escape" && close()}
-    role="button"
-    tabindex="-1"
-    aria-label="Close command palette">
-  </div>
-
-  <!-- Command Palette Modal -->
-  <div
-    class={styles.modal}
-    role="dialog"
-    aria-modal="true"
-    aria-label="Command palette">
-    <div class={styles.panel}>
+<!-- Command Palette Modal (native <dialog> handles focus-trap, ESC, backdrop, inert) -->
+<dialog
+  bind:this={dialogRef}
+  class={styles.modal}
+  aria-label="Command palette"
+  onclose={() => {
+    isOpen = false;
+    searchQuery = "";
+    selectedIndex = 0;
+  }}
+  onclick={(e) => {
+    // Close when the user clicks the backdrop (i.e. the dialog element itself,
+    // not any of its descendants).
+    if (e.target === dialogRef) close();
+  }}>
+  <div class={styles.panel}>
       <!-- Search input -->
       <div class={styles.searchRow}>
         <svg
@@ -450,8 +451,7 @@
         </div>
       </div>
     </div>
-  </div>
-{/if}
+</dialog>
 
 <!-- Keyboard shortcut hint (always visible) -->
 <button

--- a/sites/cv.arolariu.ro/src/components/CommandPalette.svelte
+++ b/sites/cv.arolariu.ro/src/components/CommandPalette.svelte
@@ -24,7 +24,7 @@
   let inputRef = $state<HTMLInputElement | null>(null);
 
   // Define all available commands
-  const commands = $derived((): CommandAction[] => [
+  const commands = $derived.by((): CommandAction[] => [
     // Navigation
     {
       id: "nav-home",
@@ -208,12 +208,11 @@
   ]);
 
   // Filter commands based on search query
-  const filteredCommands = $derived(() => {
-    const allCommands = commands();
-    if (!searchQuery.trim()) return allCommands;
+  const filteredCommands = $derived.by(() => {
+    if (!searchQuery.trim()) return commands;
 
     const query = searchQuery.toLowerCase();
-    return allCommands.filter((cmd) => {
+    return commands.filter((cmd) => {
       const labelMatch = cmd.label.toLowerCase().includes(query);
       const descMatch = cmd.description?.toLowerCase().includes(query);
       const keywordMatch = cmd.keywords?.some((k) => k.includes(query));
@@ -222,15 +221,14 @@
   });
 
   // Group commands by category
-  const groupedCommands = $derived(() => {
-    const filtered = filteredCommands();
+  const groupedCommands = $derived.by(() => {
     const groups = {
       navigation: [] as CommandAction[],
       action: [] as CommandAction[],
       contact: [] as CommandAction[],
     };
 
-    filtered.forEach((cmd) => {
+    filteredCommands.forEach((cmd) => {
       groups[cmd.category].push(cmd);
     });
 
@@ -238,9 +236,8 @@
   });
 
   // Get flat list for keyboard navigation
-  const flatCommands = $derived(() => {
-    const groups = groupedCommands();
-    return [...groups.navigation, ...groups.action, ...groups.contact];
+  const flatCommands = $derived.by(() => {
+    return [...groupedCommands.navigation, ...groupedCommands.action, ...groupedCommands.contact];
   });
 
   function open() {
@@ -270,7 +267,7 @@
 
     if (!isOpen) return;
 
-    const cmds = flatCommands();
+    const cmds = flatCommands;
 
     switch (e.key) {
       case "Escape":
@@ -299,7 +296,8 @@
 
   // Reset selected index when filtered results change
   $effect(() => {
-    flatCommands();
+    // Reference the derived value so the effect re-runs when it updates.
+    flatCommands;
     selectedIndex = 0;
   });
 
@@ -384,14 +382,14 @@
 
       <!-- Command list -->
       <div class={styles.commandList}>
-        {#each Object.entries(groupedCommands()) as [category, cmds]}
+        {#each Object.entries(groupedCommands) as [category, cmds]}
           {#if cmds.length > 0}
             <div class={styles.commandGroup}>
               <div class={styles.categoryLabel}>
                 {categoryLabels[category] ?? category}
               </div>
               {#each cmds as cmd}
-                {@const globalIndex = flatCommands().indexOf(cmd)}
+                {@const globalIndex = flatCommands.indexOf(cmd)}
                 {@const isSelected = globalIndex === selectedIndex}
                 <button
                   onclick={() => cmd.action()}
@@ -423,7 +421,7 @@
           {/if}
         {/each}
 
-        {#if flatCommands().length === 0}
+        {#if flatCommands.length === 0}
           <div class={styles.emptyState}>
             <p>No commands found for "{searchQuery}"</p>
           </div>

--- a/sites/cv.arolariu.ro/src/components/CommandPalette.test.ts
+++ b/sites/cv.arolariu.ro/src/components/CommandPalette.test.ts
@@ -1,0 +1,35 @@
+/**
+ * @fileoverview Render tests for the CommandPalette component.
+ *
+ * Asserts the migration to the native <dialog> element:
+ *  - The element is `<dialog>`, not `<div role="dialog">`.
+ *  - It carries an accessible name (aria-label or aria-labelledby).
+ *  - Initially closed (no `open` attribute) so it does not steal focus on mount.
+ */
+
+import {render} from "@testing-library/svelte";
+import {describe, expect, it} from "vitest";
+
+import CommandPalette from "./CommandPalette.svelte";
+
+describe("CommandPalette", () => {
+  it("uses the native <dialog> element", () => {
+    const {container} = render(CommandPalette);
+    const dialog = container.querySelector("dialog");
+    expect(dialog).not.toBeNull();
+  });
+
+  it("dialog has an accessible name", () => {
+    const {container} = render(CommandPalette);
+    const dialog = container.querySelector("dialog");
+    const ariaLabel = dialog?.getAttribute("aria-label");
+    const labelledBy = dialog?.getAttribute("aria-labelledby");
+    expect(ariaLabel ?? labelledBy).toBeTruthy();
+  });
+
+  it("dialog starts closed", () => {
+    const {container} = render(CommandPalette);
+    const dialog = container.querySelector("dialog");
+    expect(dialog?.hasAttribute("open")).toBe(false);
+  });
+});

--- a/sites/cv.arolariu.ro/src/components/CommandPalette.test.ts
+++ b/sites/cv.arolariu.ro/src/components/CommandPalette.test.ts
@@ -32,4 +32,18 @@ describe("CommandPalette", () => {
     const dialog = container.querySelector("dialog");
     expect(dialog?.hasAttribute("open")).toBe(false);
   });
+
+  it("renders each command button with a stable id attribute (keyed each blocks)", () => {
+    const {container} = render(CommandPalette);
+    const buttons = container.querySelectorAll("dialog button[id^='cmd-']");
+    // Sanity: at least one filtered command button should be rendered on mount
+    // (the palette renders the full command list when searchQuery is empty).
+    expect(buttons.length).toBeGreaterThan(0);
+
+    // Every button must have a unique id; this is the signal that the
+    // {#each ... (cmd.id)} key is in effect, because the template binds
+    // id="cmd-{cmd.id}".
+    const ids = Array.from(buttons, (b) => b.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
 });

--- a/sites/cv.arolariu.ro/src/components/HelpDialog.module.scss
+++ b/sites/cv.arolariu.ro/src/components/HelpDialog.module.scss
@@ -1,18 +1,5 @@
 @use "../styles/breakpoints";
 
-.overlay {
-  position: fixed;
-  inset: 0;
-  z-index: 50;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 1rem;
-  background: rgb(0 0 0 / 0.5);
-  backdrop-filter: blur(4px);
-  animation: fade-in 200ms ease-out;
-}
-
 .panel {
   width: 100%;
   max-width: 48rem;
@@ -670,8 +657,41 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .overlay,
   .panel {
     animation: none;
+  }
+}
+
+/* Backdrop styling for the native <dialog>. The browser draws ::backdrop
+   only when the dialog is opened via showModal(). */
+dialog.panel::backdrop {
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
+}
+
+/* The native <dialog> defaults to fixed inset:auto + width:fit-content
+   and ships its own padding/border/background. Neutralise the user-agent
+   box so our existing .panel rule controls the visual chrome. */
+dialog.panel {
+  padding: 0;
+  border: 1px solid var(--cv-color-gray-200);
+  background: var(--cv-color-white);
+  max-width: min(48rem, calc(100vw - 2rem));
+  margin: auto;
+}
+
+:global(.dark) dialog.panel {
+  border-color: var(--cv-color-gray-700);
+  background: var(--cv-color-gray-900);
+}
+
+dialog.panel:not([open]) {
+  display: none;
+}
+
+/* Reduced motion: skip the backdrop blur. */
+@media (prefers-reduced-motion: reduce) {
+  dialog.panel::backdrop {
+    backdrop-filter: none;
   }
 }

--- a/sites/cv.arolariu.ro/src/components/HelpDialog.svelte
+++ b/sites/cv.arolariu.ro/src/components/HelpDialog.svelte
@@ -6,76 +6,29 @@
   // Bindable open flag; parent can bind:open, and we set open=false to close
   let {open = $bindable(false)} = $props();
 
-  let container: HTMLDivElement | null = $state(null);
-  let panel: HTMLDivElement | null = $state(null);
+  let dialogRef = $state<HTMLDialogElement | null>(null);
   let closeBtn: HTMLButtonElement | null = $state(null);
-  let previouslyFocused: HTMLElement | null = null;
   let activeTab = $state<"info" | "shortcuts" | "features">("info");
 
-  function focusFirstElement() {
-    if (!panel) return;
-    const focusable = panel.querySelectorAll<HTMLElement>(
-      'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])',
-    );
-    const first = focusable[0];
-    (first ?? closeBtn ?? panel).focus();
+  function close() {
+    open = false;
+    dialogRef?.close();
   }
 
-  function trapTab(e: KeyboardEvent) {
-    if (!open || !panel) return;
-    if (e.key !== "Tab") return;
-    const focusable = panel.querySelectorAll<HTMLElement>(
-      'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])',
-    );
-    if (focusable.length === 0) return;
-    const first = focusable[0];
-    const last = focusable[focusable.length - 1];
-    if (!first || !last) return;
-    const active = document.activeElement as HTMLElement | null;
-
-    if (e.shiftKey) {
-      if (active === first || !panel.contains(active)) {
-        last.focus();
-        e.preventDefault();
-      }
-    } else {
-      if (active === last) {
-        first.focus();
-        e.preventDefault();
-      }
-    }
-  }
-
-  function handleKeydown(e: KeyboardEvent) {
-    if (!open) return;
-    if (e.key === "Escape") {
-      e.stopPropagation();
-      e.preventDefault();
-      open = false;
-    } else if (e.key === "Tab") {
-      trapTab(e);
-    }
-  }
-
-  function handleOverlayClick(e: MouseEvent) {
-    if (!open) return;
-    if (e.target === container) {
-      open = false;
-    }
-  }
-
+  // Sync the bindable `open` prop into the native <dialog> imperative API.
+  // The browser handles focus-trap, ESC, backdrop, and inert siblings.
   $effect(() => {
-    if (!open) {
-      previouslyFocused?.focus?.();
-      return;
+    if (!dialogRef) return;
+    if (open && !dialogRef.open) {
+      dialogRef.showModal();
+      // Defer focus until after the browser opens the dialog. The native
+      // <dialog> would auto-focus the first focusable descendant, but we
+      // explicitly steer focus to the close button for parity with the
+      // previous behaviour.
+      queueMicrotask(() => closeBtn?.focus());
+    } else if (!open && dialogRef.open) {
+      dialogRef.close();
     }
-    previouslyFocused = document.activeElement as HTMLElement | null;
-    const prevOverflow = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-    requestAnimationFrame(() => focusFirstElement());
-    return () => {
-      document.body.style.overflow = prevOverflow;
-    };
   });
 
   // Keyboard shortcuts data
@@ -137,24 +90,20 @@
   }
 </script>
 
-{#if open}
-  <!-- Overlay -->
-  <div
-    bind:this={container}
-    class={styles.overlay}
-    role="presentation"
-    onclick={handleOverlayClick}
-    onkeydown={handleKeydown}>
-    <!-- Dialog panel -->
-    <div
-      bind:this={panel}
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="help-dialog-title"
-      aria-describedby="help-dialog-description"
-      class={styles.panel}
-      tabindex="-1"
-      onkeydown={handleKeydown}>
+<!-- Help dialog (native <dialog> handles focus-trap, ESC, backdrop, inert) -->
+<dialog
+  bind:this={dialogRef}
+  class={styles.panel}
+  aria-labelledby="help-dialog-title"
+  aria-describedby="help-dialog-description"
+  onclose={() => {
+    open = false;
+  }}
+  onclick={(e) => {
+    // Close when the user clicks the backdrop (i.e. the dialog element itself,
+    // not any of its descendants).
+    if (e.target === dialogRef) close();
+  }}>
       <!-- Header -->
       <header class={styles.header}>
         <div class={styles.headerTitleGroup}>
@@ -182,7 +131,7 @@
         </div>
         <button
           bind:this={closeBtn}
-          onclick={() => (open = false)}
+          onclick={close}
           class={styles.closeButton}
           aria-label={ui.buttons.close}>
           <svg
@@ -407,12 +356,10 @@
         <div class={styles.footerContent}>
           <p class={styles.footerText}> Built with care using modern web technologies </p>
           <button
-            onclick={() => (open = false)}
+            onclick={close}
             class={styles.footerButton}>
             {ui.buttons.close}
           </button>
         </div>
       </footer>
-    </div>
-  </div>
-{/if}
+</dialog>

--- a/sites/cv.arolariu.ro/src/components/HelpDialog.test.ts
+++ b/sites/cv.arolariu.ro/src/components/HelpDialog.test.ts
@@ -1,0 +1,35 @@
+/**
+ * @fileoverview Render tests for the HelpDialog component.
+ *
+ * Asserts the migration to the native <dialog> element:
+ *  - The element is `<dialog>`, not `<div role="dialog">`.
+ *  - It carries an accessible name.
+ *  - Initially closed.
+ */
+
+import {render} from "@testing-library/svelte";
+import {describe, expect, it} from "vitest";
+
+import HelpDialog from "./HelpDialog.svelte";
+
+describe("HelpDialog", () => {
+  it("uses the native <dialog> element", () => {
+    const {container} = render(HelpDialog);
+    const dialog = container.querySelector("dialog");
+    expect(dialog).not.toBeNull();
+  });
+
+  it("dialog has an accessible name", () => {
+    const {container} = render(HelpDialog);
+    const dialog = container.querySelector("dialog");
+    const ariaLabel = dialog?.getAttribute("aria-label");
+    const labelledBy = dialog?.getAttribute("aria-labelledby");
+    expect(ariaLabel ?? labelledBy).toBeTruthy();
+  });
+
+  it("dialog starts closed", () => {
+    const {container} = render(HelpDialog);
+    const dialog = container.querySelector("dialog");
+    expect(dialog?.hasAttribute("open")).toBe(false);
+  });
+});

--- a/sites/cv.arolariu.ro/src/components/ScrollProgress.module.scss
+++ b/sites/cv.arolariu.ro/src/components/ScrollProgress.module.scss
@@ -12,29 +12,13 @@
 .bar {
   width: 100%;
   height: 100%;
-  transform: scaleX(0);
+  transform: scaleX(var(--scroll-progress, 0));
   transform-origin: left;
   background: linear-gradient(90deg, var(--cv-color-blue-500) 0%, var(--cv-color-purple-500) 50%, var(--cv-color-pink-500) 100%);
-  animation: scroll-progress linear;
-  animation-timeline: scroll(root);
-}
-
-@keyframes scroll-progress {
-  to {
-    transform: scaleX(1);
-  }
-}
-
-@supports not (animation-timeline: scroll()) {
-  .bar {
-    display: none;
-  }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .bar {
-    transform: scaleX(1);
     opacity: 0.3;
-    animation: none;
   }
 }

--- a/sites/cv.arolariu.ro/src/components/ScrollProgress.svelte
+++ b/sites/cv.arolariu.ro/src/components/ScrollProgress.svelte
@@ -1,9 +1,32 @@
 <script lang="ts">
   import {page} from "$app/state";
+  import {onMount} from "svelte";
   import styles from "./ScrollProgress.module.scss";
 
-  // Only show scroll progress on /human route (main CV view)
+  // Only show scroll progress on /human route (main CV view).
   const showProgress = $derived(page.url.pathname === "/human");
+
+  let scrollPercent = $state<number>(0);
+
+  function computeScrollPercent(): number {
+    const scrollTop = window.scrollY || document.documentElement.scrollTop;
+    const scrollHeight = document.documentElement.scrollHeight - document.documentElement.clientHeight;
+    if (scrollHeight <= 0) return 0;
+    return Math.min(100, Math.max(0, Math.round((scrollTop / scrollHeight) * 100)));
+  }
+
+  onMount(() => {
+    const handler = (): void => {
+      scrollPercent = computeScrollPercent();
+    };
+    handler(); // initial value
+    window.addEventListener("scroll", handler, {passive: true});
+    window.addEventListener("resize", handler, {passive: true});
+    return () => {
+      window.removeEventListener("scroll", handler);
+      window.removeEventListener("resize", handler);
+    };
+  });
 </script>
 
 {#if showProgress}
@@ -12,7 +35,9 @@
     role="progressbar"
     aria-label="Page scroll progress"
     aria-valuemin={0}
-    aria-valuemax={100}>
+    aria-valuemax={100}
+    aria-valuenow={scrollPercent}
+    style="--scroll-progress: {scrollPercent / 100};">
     <div class={styles.bar}></div>
   </div>
 {/if}

--- a/sites/cv.arolariu.ro/src/components/ScrollProgress.svelte
+++ b/sites/cv.arolariu.ro/src/components/ScrollProgress.svelte
@@ -3,7 +3,7 @@
   import styles from "./ScrollProgress.module.scss";
 
   // Only show scroll progress on /human route (main CV view)
-  let showProgress = $derived(page.url.pathname === "/human");
+  const showProgress = $derived(page.url.pathname === "/human");
 </script>
 
 {#if showProgress}

--- a/sites/cv.arolariu.ro/src/components/ScrollProgress.test.ts
+++ b/sites/cv.arolariu.ro/src/components/ScrollProgress.test.ts
@@ -1,0 +1,45 @@
+/**
+ * @fileoverview Render test for ScrollProgress (route-gated visibility).
+ *
+ * Asserts:
+ *  - On routes other than /human, ScrollProgress renders nothing.
+ *  - On /human, ScrollProgress renders a <div role="progressbar"> with
+ *    ARIA value-min/max set to 0/100.
+ *
+ * Setup: mutate the $app/state mock's `page.url` before render. The
+ * mock exports a mutable `page` object (per Phase 2 follow-up typing).
+ */
+
+import {render} from "@testing-library/svelte";
+import {beforeEach, describe, expect, it} from "vitest";
+
+import {page} from "../__mocks__/$app/state";
+import ScrollProgress from "./ScrollProgress.svelte";
+
+describe("ScrollProgress", () => {
+  beforeEach(() => {
+    page.url = new URL("https://cv.arolariu.ro/");
+  });
+
+  it("renders nothing on routes other than /human", () => {
+    page.url = new URL("https://cv.arolariu.ro/");
+    const {container} = render(ScrollProgress);
+    expect(container.querySelector("div[role='progressbar']")).toBeNull();
+  });
+
+  it("renders nothing on /json", () => {
+    page.url = new URL("https://cv.arolariu.ro/json");
+    const {container} = render(ScrollProgress);
+    expect(container.querySelector("div[role='progressbar']")).toBeNull();
+  });
+
+  it("renders a progressbar with ARIA bounds on /human", () => {
+    page.url = new URL("https://cv.arolariu.ro/human");
+    const {container} = render(ScrollProgress);
+    const bar = container.querySelector("div[role='progressbar']");
+    expect(bar).not.toBeNull();
+    expect(bar?.getAttribute("aria-label")).toBe("Page scroll progress");
+    expect(bar?.getAttribute("aria-valuemin")).toBe("0");
+    expect(bar?.getAttribute("aria-valuemax")).toBe("100");
+  });
+});

--- a/sites/cv.arolariu.ro/src/components/ScrollProgress.test.ts
+++ b/sites/cv.arolariu.ro/src/components/ScrollProgress.test.ts
@@ -12,8 +12,8 @@
 
 import {render} from "@testing-library/svelte";
 import {beforeEach, describe, expect, it} from "vitest";
+import {page} from "$app/state";
 
-import {page} from "../__mocks__/$app/state";
 import ScrollProgress from "./ScrollProgress.svelte";
 
 describe("ScrollProgress", () => {

--- a/sites/cv.arolariu.ro/src/components/ScrollProgress.test.ts
+++ b/sites/cv.arolariu.ro/src/components/ScrollProgress.test.ts
@@ -41,5 +41,6 @@ describe("ScrollProgress", () => {
     expect(bar?.getAttribute("aria-label")).toBe("Page scroll progress");
     expect(bar?.getAttribute("aria-valuemin")).toBe("0");
     expect(bar?.getAttribute("aria-valuemax")).toBe("100");
+    expect(bar?.getAttribute("aria-valuenow")).not.toBeNull();
   });
 });

--- a/sites/cv.arolariu.ro/src/components/ThemeToggle.test.ts
+++ b/sites/cv.arolariu.ro/src/components/ThemeToggle.test.ts
@@ -1,0 +1,46 @@
+/**
+ * @fileoverview Behaviour test for the ThemeToggle component.
+ *
+ * Asserts:
+ *  - Renders a single <button> with the accessible-name "Toggle theme".
+ *  - Clicking the button flips `useTheme().current` to the opposite value.
+ *
+ * Notes:
+ *  - useTheme is a Svelte 5 runes-class singleton. The first test to
+ *    run will see whatever value localStorage's mock returns; we
+ *    explicitly set the theme before each assertion to avoid order
+ *    dependence with other tests in the suite.
+ */
+
+import {render, fireEvent} from "@testing-library/svelte";
+import {beforeEach, describe, expect, it} from "vitest";
+
+import {useTheme} from "@/hooks/useTheme.svelte";
+import ThemeToggle from "./ThemeToggle.svelte";
+
+describe("ThemeToggle", () => {
+  beforeEach(() => {
+    // Pin theme to "dark" so the click-to-toggle assertion is deterministic.
+    useTheme().set("dark");
+  });
+
+  it("renders a Toggle Theme button", () => {
+    const {getByRole} = render(ThemeToggle);
+    const button = getByRole("button", {name: /toggle theme/i});
+    expect(button).toBeTruthy();
+  });
+
+  it("clicking the button toggles the theme from dark to light", async () => {
+    expect(useTheme().current).toBe("dark");
+    const {getByRole} = render(ThemeToggle);
+    await fireEvent.click(getByRole("button", {name: /toggle theme/i}));
+    expect(useTheme().current).toBe("light");
+  });
+
+  it("a second click toggles back from light to dark", async () => {
+    useTheme().set("light");
+    const {getByRole} = render(ThemeToggle);
+    await fireEvent.click(getByRole("button", {name: /toggle theme/i}));
+    expect(useTheme().current).toBe("dark");
+  });
+});

--- a/sites/cv.arolariu.ro/src/components/motion/AnimatedSection.svelte
+++ b/sites/cv.arolariu.ro/src/components/motion/AnimatedSection.svelte
@@ -9,9 +9,8 @@
   type Props = {
     children?: Snippet;
     class?: string;
-    // Delay before the animation starts. Accepts milliseconds.
-    // Backwards-compat: if value <= 10, it's treated as seconds.
-    delay?: number; // ms (or seconds when <= 10)
+    // Delay before the animation starts, in milliseconds.
+    delay?: number;
     duration?: number; // seconds
     id?: string;
     animation?: AnimationType;
@@ -47,13 +46,7 @@
     hasAnimated = true;
     const reduce = prefersReducedMotion.current;
     const ms = reduce ? 0 : Math.max(0, duration) * 1000;
-    // Support both ms and s: treat small values (<=10) as seconds, otherwise ms
-    const dl = reduce
-      ? 0
-      : (() => {
-          const val = Math.max(0, delay);
-          return val <= 10 ? val * 1000 : val;
-        })();
+    const dl = reduce ? 0 : Math.max(0, delay);
     x.set(0, {duration: ms, delay: dl});
     y.set(0, {duration: ms, delay: dl});
     scale.set(1, {duration: ms, delay: dl});

--- a/sites/cv.arolariu.ro/src/components/motion/AnimatedSection.svelte
+++ b/sites/cv.arolariu.ro/src/components/motion/AnimatedSection.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import type {Snippet} from "svelte";
   import {onMount, untrack} from "svelte";
   import {Tween, prefersReducedMotion} from "svelte/motion";
   import {intersect} from "./intersection";
@@ -6,7 +7,7 @@
   type AnimationType = "fade-up" | "fade-down" | "fade-left" | "fade-right" | "fade-in" | "scale-up";
 
   type Props = {
-    children?: any;
+    children?: Snippet;
     class?: string;
     // Delay before the animation starts. Accepts milliseconds.
     // Backwards-compat: if value <= 10, it's treated as seconds.

--- a/sites/cv.arolariu.ro/src/components/motion/AnimatedSection.test.ts
+++ b/sites/cv.arolariu.ro/src/components/motion/AnimatedSection.test.ts
@@ -1,0 +1,71 @@
+/**
+ * @fileoverview Render-smoke test for AnimatedSection.
+ *
+ * Asserts:
+ *  - Renders a <section> element.
+ *  - Children passed via the children snippet appear inside the section.
+ *  - The id and class props are forwarded to the rendered element.
+ *  - aria-label is built from the id ("Section: {id}") or falls back
+ *    to a default when no id is given.
+ *
+ * Notes:
+ *  - vitest.setup.ts installs a non-constructor IntersectionObserver
+ *    stub. AnimatedSection's transitive import uses `new` on it, so
+ *    we install a constructor-friendly override in beforeEach (same
+ *    pattern as the human-view section tests).
+ */
+
+import {render} from "@testing-library/svelte";
+import {beforeEach, describe, expect, it, vi} from "vitest";
+import {createRawSnippet} from "svelte";
+
+import AnimatedSection from "./AnimatedSection.svelte";
+
+describe("AnimatedSection", () => {
+  beforeEach(() => {
+    global.IntersectionObserver = vi.fn(function (this: IntersectionObserver) {
+      this.observe = vi.fn();
+      this.unobserve = vi.fn();
+      this.disconnect = vi.fn();
+      this.takeRecords = vi.fn(() => []);
+      return this;
+    }) as unknown as typeof IntersectionObserver;
+  });
+
+  it("renders a <section> wrapping the children snippet", () => {
+    const childSnippet = createRawSnippet(() => ({
+      render: () => `<span data-testid="child">inside</span>`,
+    }));
+    const {container, getByTestId} = render(AnimatedSection, {props: {children: childSnippet}});
+    expect(container.querySelector("section")).not.toBeNull();
+    expect(getByTestId("child").textContent).toBe("inside");
+  });
+
+  it("forwards the id prop to the <section>", () => {
+    const childSnippet = createRawSnippet(() => ({render: () => `<span>x</span>`}));
+    const {container} = render(AnimatedSection, {props: {children: childSnippet, id: "about"}});
+    expect(container.querySelector("section")?.getAttribute("id")).toBe("about");
+  });
+
+  it("forwards the class prop to the <section>", () => {
+    const childSnippet = createRawSnippet(() => ({render: () => `<span>x</span>`}));
+    const {container} = render(AnimatedSection, {
+      props: {children: childSnippet, class: "custom-class"},
+    });
+    expect(container.querySelector("section")?.className).toContain("custom-class");
+  });
+
+  it("derives aria-label from the id prop when present", () => {
+    const childSnippet = createRawSnippet(() => ({render: () => `<span>x</span>`}));
+    const {container} = render(AnimatedSection, {
+      props: {children: childSnippet, id: "experience"},
+    });
+    expect(container.querySelector("section")?.getAttribute("aria-label")).toBe("Section: experience");
+  });
+
+  it("uses a generic aria-label when no id is provided", () => {
+    const childSnippet = createRawSnippet(() => ({render: () => `<span>x</span>`}));
+    const {container} = render(AnimatedSection, {props: {children: childSnippet}});
+    expect(container.querySelector("section")?.getAttribute("aria-label")).toBe("Content section");
+  });
+});

--- a/sites/cv.arolariu.ro/src/lib/views/HumanView.svelte
+++ b/sites/cv.arolariu.ro/src/lib/views/HumanView.svelte
@@ -52,9 +52,7 @@ Full keyboard navigation supported.
   import styles from "./HumanView.module.scss";
 </script>
 
-<main
-  id="main"
-  class={styles.shell}>
+<section class={styles.shell}>
   <Header />
   <Hero />
   <About />
@@ -65,4 +63,4 @@ Full keyboard navigation supported.
   <Testimonials />
   <Contact />
   <Footer />
-</main>
+</section>

--- a/sites/cv.arolariu.ro/src/lib/views/JsonView.module.scss
+++ b/sites/cv.arolariu.ro/src/lib/views/JsonView.module.scss
@@ -474,34 +474,12 @@
   color: var(--cv-color-gray-400);
 }
 
-.highlightToggle {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  color: var(--cv-color-gray-600);
-  font-size: 0.78rem;
-  cursor: pointer;
-  user-select: none;
-}
-
-:global(.dark) .highlightToggle {
-  color: var(--cv-color-gray-400);
-}
-
-.highlightCheckbox {
-  width: 0.95rem;
-  height: 0.95rem;
-  cursor: pointer;
-  accent-color: var(--cv-accent-primary);
-}
-
 .jsonContainer {
   max-height: 60vh;
   overflow: auto;
   padding: 1rem 1.15rem;
 }
 
-.pre,
 .prePlain {
   margin: 0;
   font-family: ui-monospace, "JetBrains Mono", monospace;
@@ -509,54 +487,11 @@
   line-height: 1.55;
   white-space: pre-wrap;
   overflow-wrap: break-word;
-}
-
-.prePlain {
   color: var(--cv-color-gray-900);
 }
 
 :global(.dark) .prePlain {
   color: var(--cv-color-gray-100);
-}
-
-.jsonContainer :global(.json-key) {
-  color: var(--cv-accent-primary);
-}
-
-.jsonContainer :global(.json-string) {
-  color: var(--cv-accent-success);
-}
-
-.jsonContainer :global(.json-number) {
-  color: var(--cv-accent-primary);
-}
-
-.jsonContainer :global(.json-boolean) {
-  color: var(--cv-color-gray-500);
-}
-
-.jsonContainer :global(.json-null) {
-  color: var(--cv-color-gray-500);
-}
-
-:global(.dark) .jsonContainer :global(.json-key) {
-  color: var(--cv-color-blue-300);
-}
-
-:global(.dark) .jsonContainer :global(.json-string) {
-  color: var(--cv-color-green-400);
-}
-
-:global(.dark) .jsonContainer :global(.json-number) {
-  color: var(--cv-color-blue-300);
-}
-
-:global(.dark) .jsonContainer :global(.json-boolean) {
-  color: var(--cv-color-gray-400);
-}
-
-:global(.dark) .jsonContainer :global(.json-null) {
-  color: var(--cv-color-gray-400);
 }
 
 /* ===== Schema footer ===== */

--- a/sites/cv.arolariu.ro/src/lib/views/JsonView.svelte
+++ b/sites/cv.arolariu.ro/src/lib/views/JsonView.svelte
@@ -149,9 +149,7 @@ $cv.work | Select-Object position, name`,
   showNavLinks={false}
   {actionsConfig} />
 
-<main
-  id="main-content"
-  class={styles.main}>
+<section class={styles.main}>
   <div class={styles.container}>
     <!-- Editorial hero -->
     <AnimatedSection
@@ -354,4 +352,4 @@ $cv.work | Select-Object position, name`,
       </section>
     </AnimatedSection>
   </div>
-</main>
+</section>

--- a/sites/cv.arolariu.ro/src/lib/views/JsonView.svelte
+++ b/sites/cv.arolariu.ro/src/lib/views/JsonView.svelte
@@ -17,7 +17,6 @@ code panel, schema footer.
 
   let copySuccess = $state<boolean>(false);
   let activeTab = $state<"formatted" | "raw">("formatted");
-  let showHighlighting = $state<boolean>(true);
 
   let activeCodeTab = $state<CodeSampleId>("curl");
   let copiedSample = $state<CodeSampleId | null>(null);
@@ -65,17 +64,6 @@ $cv = Invoke-RestMethod -Uri "https://cv.arolariu.ro/rest/json"
 # List all positions held
 $cv.work | Select-Object position, name`,
   };
-
-  function highlightJSON(jsonStr: string): string {
-    return jsonStr
-      .replace(/"([^"]+)":/g, '<span class="json-key">"$1"</span>:')
-      .replace(/: "([^"]*)"/g, ': <span class="json-string">"$1"</span>')
-      .replace(/: (\d+\.?\d*)/g, ': <span class="json-number">$1</span>')
-      .replace(/: (true|false)/g, ': <span class="json-boolean">$1</span>')
-      .replace(/: (null)/g, ': <span class="json-null">$1</span>');
-  }
-
-  const highlightedJSON = $derived(showHighlighting ? highlightJSON(formattedJSON) : formattedJSON);
 
   async function copyToClipboard(): Promise<void> {
     const textToCopy = activeTab === "raw" ? rawJSON : formattedJSON;
@@ -305,15 +293,6 @@ $cv.work | Select-Object position, name`,
                 {opt.label}
               </button>
             {/each}
-            {#if activeTab === "formatted"}
-              <label class={styles.highlightToggle}>
-                <input
-                  type="checkbox"
-                  bind:checked={showHighlighting}
-                  class={styles.highlightCheckbox} />
-                <span>Highlight</span>
-              </label>
-            {/if}
           </div>
         </div>
         <div
@@ -321,11 +300,7 @@ $cv.work | Select-Object position, name`,
           class={styles.jsonContainer}
           role="tabpanel"
           aria-labelledby="json-format-tab-{activeTab}">
-          {#if activeTab === "formatted" && showHighlighting}
-            <pre class={styles.pre}>{@html highlightedJSON}</pre>
-          {:else}
-            <pre class={styles.prePlain}>{activeTab === "formatted" ? formattedJSON : rawJSON}</pre>
-          {/if}
+          <pre class={styles.prePlain}>{activeTab === "formatted" ? formattedJSON : rawJSON}</pre>
         </div>
       </section>
     </AnimatedSection>

--- a/sites/cv.arolariu.ro/src/lib/views/MainView.svelte
+++ b/sites/cv.arolariu.ro/src/lib/views/MainView.svelte
@@ -43,10 +43,18 @@ to choose their preferred CV format (Human-readable, PDF, or JSON).
   // chunk out of the landing page's critical path.
   let HelpDialog = $state<Component | null>(null);
 
+  /** Transient flag covering the dynamic-import round-trip for HelpDialog. */
+  let isLoadingHelp = $state<boolean>(false);
+
   async function loadHelpDialog(): Promise<void> {
-    if (HelpDialog !== null) return;
-    const mod = await import("@/components/HelpDialog.svelte");
-    HelpDialog = mod.default;
+    if (HelpDialog !== null || isLoadingHelp) return;
+    isLoadingHelp = true;
+    try {
+      const mod = await import("@/components/HelpDialog.svelte");
+      HelpDialog = mod.default;
+    } finally {
+      isLoadingHelp = false;
+    }
   }
 
   /**
@@ -143,6 +151,7 @@ to choose their preferred CV format (Human-readable, PDF, or JSON).
           class={styles.panelCard}
           style="--panel-delay: {i * 100}ms;"
           aria-label={panel.title}
+          aria-busy={panel.id === "help" ? isLoadingHelp : undefined}
           onclick={panel.action}
           data-panel={panel.id}>
           <div class={cx(styles.panelGradientOverlay, gradientClasses[panel.gradient])}></div>

--- a/sites/cv.arolariu.ro/src/lib/views/MainView.svelte
+++ b/sites/cv.arolariu.ro/src/lib/views/MainView.svelte
@@ -28,15 +28,26 @@ to choose their preferred CV format (Human-readable, PDF, or JSON).
 <script lang="ts">
   import {landing} from "@/data";
   import ThemeToggle from "@/components/ThemeToggle.svelte";
-  import HelpDialog from "@/components/HelpDialog.svelte";
   import {goto} from "$app/navigation";
   import {cx} from "@/lib/utils";
   import Icon, {type IconName} from "@/presentation/Icon.svelte";
   import Footer from "@/presentation/Footer.svelte";
+  import type {Component} from "svelte";
   import styles from "./MainView.module.scss";
 
   /** Controls visibility of the help dialog modal. */
   let showHelpDialog = $state<boolean>(false);
+
+  // HelpDialog is dynamically imported the first time the user opens it.
+  // Most visitors never use the keyboard-shortcuts help, so we keep its
+  // chunk out of the landing page's critical path.
+  let HelpDialog = $state<Component | null>(null);
+
+  async function loadHelpDialog(): Promise<void> {
+    if (HelpDialog !== null) return;
+    const mod = await import("@/components/HelpDialog.svelte");
+    HelpDialog = mod.default;
+  }
 
   /**
    * Panel configuration for the landing page grid.
@@ -73,7 +84,10 @@ to choose their preferred CV format (Human-readable, PDF, or JSON).
       description: landing.panels.help.description,
       gradient: "purplePink",
       icon: "help" satisfies IconName,
-      action: () => (showHelpDialog = true),
+      action: async () => {
+        await loadHelpDialog();
+        showHelpDialog = true;
+      },
     },
   ] as const;
 
@@ -164,5 +178,8 @@ to choose their preferred CV format (Human-readable, PDF, or JSON).
     <Footer />
   </div>
 
-  <HelpDialog bind:open={showHelpDialog} />
+  {#if HelpDialog && showHelpDialog}
+    {@const HelpDialogComponent = HelpDialog}
+    <HelpDialogComponent bind:open={showHelpDialog} />
+  {/if}
 </div>

--- a/sites/cv.arolariu.ro/src/lib/views/MainView.test.ts
+++ b/sites/cv.arolariu.ro/src/lib/views/MainView.test.ts
@@ -1,0 +1,30 @@
+/**
+ * @fileoverview Render-smoke test for MainView (the / route's body).
+ *
+ * Asserts:
+ *  - MainView mounts without throwing.
+ *  - The HelpDialog is NOT in the initial render tree (it lazy-loads
+ *    only after the user opens it).
+ */
+
+import {render} from "@testing-library/svelte";
+import {describe, expect, it} from "vitest";
+
+import MainView from "./MainView.svelte";
+
+describe("MainView", () => {
+  it("mounts without throwing", () => {
+    const {container} = render(MainView);
+    expect(container.firstChild).not.toBeNull();
+  });
+
+  it("does not render HelpDialog before it is opened", () => {
+    const {container} = render(MainView);
+    // HelpDialog's <dialog> renders with aria-labelledby="help-dialog-title"
+    // (per Phase 3 migration). If the dialog is in the initial render tree,
+    // that element will be present even when closed. Lazy-loading should
+    // keep it out of the DOM entirely until first open.
+    const dialog = container.querySelector("dialog[aria-labelledby='help-dialog-title']");
+    expect(dialog).toBeNull();
+  });
+});

--- a/sites/cv.arolariu.ro/src/lib/views/PdfView.svelte
+++ b/sites/cv.arolariu.ro/src/lib/views/PdfView.svelte
@@ -38,7 +38,7 @@ metadata sidebar (file size, page count, format, last-updated, ATS status).
   let isMobile = $state(false);
   let surfaceStatus = $state<PdfSurfaceStatus>("loading");
   let nativeFrameKey = $state(0);
-  let assistanceTimer: ReturnType<typeof window.setTimeout> | undefined;
+  let assistanceTimer: number | undefined;
 
   const showAssistance = $derived(shouldShowPdfAssistance(surfaceStatus));
   const statusMessage = $derived(

--- a/sites/cv.arolariu.ro/src/lib/views/PdfView.svelte
+++ b/sites/cv.arolariu.ro/src/lib/views/PdfView.svelte
@@ -125,9 +125,7 @@ metadata sidebar (file size, page count, format, last-updated, ATS status).
     sticky
     showNavLinks={false} />
 
-  <main
-    id="main-content"
-    class={styles.container}>
+  <section class={styles.container}>
     <section class={styles.hero}>
       <span class={styles.heroPill}>PDF &middot; A4 &middot; ONE PAGE</span>
       <h1 class={styles.heroTitle}>Printable <span class={styles.heroTitleAccent}>CV</span></h1>
@@ -278,5 +276,5 @@ metadata sidebar (file size, page count, format, last-updated, ATS status).
         </div>
       </div>
     {/if}
-  </main>
+  </section>
 </div>

--- a/sites/cv.arolariu.ro/src/presentation/ActionButton.test.ts
+++ b/sites/cv.arolariu.ro/src/presentation/ActionButton.test.ts
@@ -1,0 +1,62 @@
+/**
+ * @fileoverview Behaviour tests for the ActionButton component.
+ *
+ * Covers the five visible states:
+ *  - Renders label text inside the <button>.
+ *  - `disabled` prop disables the button.
+ *  - `loading` prop disables AND shows a spinner.
+ *  - `back && !icon` renders the arrow-left icon.
+ *  - `icon` prop renders a named icon.
+ *  - onclick handler fires when the button is clicked.
+ */
+
+import {render, fireEvent} from "@testing-library/svelte";
+import {describe, expect, it, vi} from "vitest";
+
+import ActionButton from "./ActionButton.svelte";
+
+describe("ActionButton", () => {
+  it("renders the label inside a <button>", () => {
+    const {container} = render(ActionButton, {props: {label: "Download"}});
+    const button = container.querySelector("button");
+    expect(button).not.toBeNull();
+    expect(button?.textContent).toContain("Download");
+  });
+
+  it("is disabled when disabled prop is true", () => {
+    const {container} = render(ActionButton, {props: {label: "Disabled", disabled: true}});
+    expect(container.querySelector("button")?.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("is disabled and shows a spinner when loading prop is true", () => {
+    const {container} = render(ActionButton, {props: {label: "Loading", loading: true}});
+    expect(container.querySelector("button")?.hasAttribute("disabled")).toBe(true);
+    // Spinner has aria-hidden, but its <circle> + animated <path> are the marker.
+    expect(container.querySelector("button svg circle")).not.toBeNull();
+  });
+
+  it("renders the arrow-left icon when back=true and no icon prop", () => {
+    const {container} = render(ActionButton, {props: {label: "Back", back: true}});
+    // The Icon component renders <svg> when name="arrow-left"; that
+    // SVG's <path> has the distinctive d="M15 19l-7-7 7-7" shape.
+    const path = container.querySelector("button svg path");
+    expect(path?.getAttribute("d")).toBe("M15 19l-7-7 7-7");
+  });
+
+  it("renders the named icon when icon prop is provided", () => {
+    const {container} = render(ActionButton, {props: {label: "Print", icon: "print"}});
+    // The print icon path includes "M18.75 17H20" — a distinctive
+    // marker that identifies it among the 14 registered icons.
+    const printPath = container.querySelector('button svg path[d^="M18.75 17H20"]');
+    expect(printPath).not.toBeNull();
+  });
+
+  it("fires onClick when clicked", async () => {
+    const onClick = vi.fn();
+    const {container} = render(ActionButton, {props: {label: "Click me", onClick}});
+    const button = container.querySelector("button");
+    expect(button).not.toBeNull();
+    await fireEvent.click(button!);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/sites/cv.arolariu.ro/src/presentation/Badge.test.ts
+++ b/sites/cv.arolariu.ro/src/presentation/Badge.test.ts
@@ -1,0 +1,39 @@
+/**
+ * @fileoverview Render-smoke test for the Badge primitive.
+ *
+ * Asserts:
+ *  - Renders a <span> carrying the text prop verbatim.
+ *  - aria-label falls back to title, then to text when no title is given.
+ *  - Default props (color=blue, variant=soft, size=md) produce a valid render.
+ */
+
+import {render} from "@testing-library/svelte";
+import {describe, expect, it} from "vitest";
+
+import Badge from "./Badge.svelte";
+
+describe("Badge", () => {
+  it("renders the text inside a <span>", () => {
+    const {container} = render(Badge, {props: {text: "TypeScript"}});
+    const span = container.querySelector("span");
+    expect(span).not.toBeNull();
+    expect(span?.textContent).toBe("TypeScript");
+  });
+
+  it("aria-label defaults to the text when no title is provided", () => {
+    const {container} = render(Badge, {props: {text: "Svelte"}});
+    expect(container.querySelector("span")?.getAttribute("aria-label")).toBe("Svelte");
+  });
+
+  it("aria-label uses the title when one is provided", () => {
+    const {container} = render(Badge, {props: {text: "TS", title: "TypeScript 5.x"}});
+    expect(container.querySelector("span")?.getAttribute("aria-label")).toBe("TypeScript 5.x");
+  });
+
+  it("renders with non-default color/variant/size without throwing", () => {
+    const {container} = render(Badge, {
+      props: {text: "Test", color: "green", variant: "outline", size: "sm"},
+    });
+    expect(container.querySelector("span")?.textContent).toBe("Test");
+  });
+});

--- a/sites/cv.arolariu.ro/src/presentation/Footer.test.ts
+++ b/sites/cv.arolariu.ro/src/presentation/Footer.test.ts
@@ -1,0 +1,44 @@
+/**
+ * @fileoverview Render-smoke test for the site Footer.
+ *
+ * Asserts:
+ *  - Three external social links (GitHub, LinkedIn, Website) are present,
+ *    each opening in a new tab with secure rel attrs.
+ *  - Each link carries a non-empty accessible name (aria-label).
+ *  - The copyright string from the data layer is rendered.
+ */
+
+import {render} from "@testing-library/svelte";
+import {describe, expect, it} from "vitest";
+
+import Footer from "./Footer.svelte";
+
+describe("Footer", () => {
+  it("renders three external social links", () => {
+    const {container} = render(Footer);
+    const externalLinks = container.querySelectorAll('a[target="_blank"]');
+    expect(externalLinks.length).toBe(3);
+    for (const link of externalLinks) {
+      expect(link.getAttribute("rel")).toMatch(/noopener/);
+      expect(link.getAttribute("rel")).toMatch(/noreferrer/);
+    }
+  });
+
+  it("each link carries a non-empty aria-label", () => {
+    const {container} = render(Footer);
+    const links = container.querySelectorAll("a[aria-label]");
+    expect(links.length).toBeGreaterThanOrEqual(3);
+    for (const link of links) {
+      const label = link.getAttribute("aria-label");
+      expect(label).toBeTruthy();
+      expect(label?.length ?? 0).toBeGreaterThan(0);
+    }
+  });
+
+  it("renders the copyright text", () => {
+    const {container} = render(Footer);
+    const copyParagraph = container.querySelector("footer p");
+    expect(copyParagraph).not.toBeNull();
+    expect((copyParagraph?.textContent ?? "").trim().length).toBeGreaterThan(0);
+  });
+});

--- a/sites/cv.arolariu.ro/src/presentation/Header.svelte
+++ b/sites/cv.arolariu.ro/src/presentation/Header.svelte
@@ -2,7 +2,7 @@
   import {goto} from "$app/navigation";
   import type {Snippet} from "svelte";
   import ThemeToggle from "../components/ThemeToggle.svelte";
-  import {ui} from "../data";
+  import {author, ui} from "../data";
   import {cx} from "@/lib/utils";
   import ActionButton from "@/presentation/ActionButton.svelte";
   import styles from "./Header.module.scss";
@@ -51,7 +51,7 @@
           onClick={goBack}
           variant={variant === "inverse" ? "text-inverse" : "text"} />
         <div class={styles.titleWrap}>
-          <h1 class={titleClasses}>Alexandru-Razvan Olariu</h1>
+          <h1 class={titleClasses}>{author.name}</h1>
         </div>
       </div>
       <div class={styles.actions}>

--- a/sites/cv.arolariu.ro/src/presentation/Header.svelte
+++ b/sites/cv.arolariu.ro/src/presentation/Header.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import {goto} from "$app/navigation";
+  import type {Snippet} from "svelte";
   import ThemeToggle from "../components/ThemeToggle.svelte";
   import {ui} from "../data";
   import {cx} from "@/lib/utils";
@@ -14,14 +15,14 @@
     onClick: () => void;
   };
 
-  interface Props {
+  type Props = {
     variant?: "default" | "inverse";
-    actions?: () => any; // render function for actions area
+    actions?: Snippet; // render function for actions area
     sticky?: boolean; // stick to top
     showNavLinks?: boolean; // show section nav links (non-minimal)
     class?: string; // extra classes
     actionsConfig?: ActionConfig[];
-  }
+  };
 
   let {
     variant = "default",

--- a/sites/cv.arolariu.ro/src/presentation/Header.test.ts
+++ b/sites/cv.arolariu.ro/src/presentation/Header.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @fileoverview Render test for the Header chrome component.
+ *
+ * Asserts:
+ *  - Brand <h1> always renders with the author name.
+ *  - showNavLinks=true exposes the four in-page nav anchors;
+ *    showNavLinks=false hides them.
+ *  - ThemeToggle is present (its accessible name "Toggle theme").
+ *  - actionsConfig items render as buttons with their labels.
+ */
+
+import {render} from "@testing-library/svelte";
+import {describe, expect, it, vi} from "vitest";
+
+import Header from "./Header.svelte";
+
+describe("Header", () => {
+  it("always renders the brand <h1>", () => {
+    const {container} = render(Header);
+    const h1 = container.querySelector("h1");
+    expect(h1).not.toBeNull();
+    expect(h1?.textContent).toMatch(/Olariu/);
+  });
+
+  it("renders the four in-page nav anchors when showNavLinks=true (default)", () => {
+    const {container} = render(Header);
+    const nav = container.querySelector("nav");
+    expect(nav).not.toBeNull();
+    const anchors = nav?.querySelectorAll("a[href^='#']") ?? [];
+    expect(anchors.length).toBeGreaterThanOrEqual(4);
+    const hrefs = Array.from(anchors, (a) => a.getAttribute("href"));
+    expect(hrefs).toContain("#about");
+    expect(hrefs).toContain("#experience");
+    expect(hrefs).toContain("#skills");
+    expect(hrefs).toContain("#contact");
+  });
+
+  it("hides the in-page nav when showNavLinks=false", () => {
+    const {container} = render(Header, {props: {showNavLinks: false}});
+    expect(container.querySelector("nav")).toBeNull();
+  });
+
+  it("includes the theme toggle", () => {
+    const {getByRole} = render(Header);
+    expect(getByRole("button", {name: /toggle theme/i})).toBeTruthy();
+  });
+
+  it("renders buttons for each actionsConfig entry", () => {
+    const onClick = vi.fn();
+    const {getByRole} = render(Header, {
+      props: {
+        actionsConfig: [
+          {icon: "print" as const, label: "Print", loading: false, disabled: false, onClick},
+          {icon: "download" as const, label: "Download PDF", loading: false, disabled: false, onClick},
+        ],
+      },
+    });
+    expect(getByRole("button", {name: /print/i})).toBeTruthy();
+    expect(getByRole("button", {name: /download pdf/i})).toBeTruthy();
+  });
+});

--- a/sites/cv.arolariu.ro/src/presentation/Icon.test.ts
+++ b/sites/cv.arolariu.ro/src/presentation/Icon.test.ts
@@ -1,0 +1,50 @@
+/**
+ * @fileoverview Render-smoke test for the Icon registry.
+ *
+ * Asserts:
+ *  - Each tested known name renders an <svg> element.
+ *  - An unknown name produces no SVG (the {#if/:else if} chain has no
+ *    fallback branch — it renders nothing).
+ *  - Numeric size prop produces a CSS dimension style.
+ */
+
+import {render} from "@testing-library/svelte";
+import {describe, expect, it} from "vitest";
+
+import Icon from "./Icon.svelte";
+
+describe("Icon", () => {
+  it.each([
+    ["arrow-left"],
+    ["arrow-right"],
+    ["download"],
+    ["github"],
+    ["help"],
+  ] as const)("renders an <svg> for the known name %s", (name) => {
+    const {container} = render(Icon, {props: {name}});
+    expect(container.querySelector("svg")).not.toBeNull();
+  });
+
+  it("renders nothing for an unknown name", () => {
+    // Casting through unknown is required because the IconName union
+    // does not include this string; the component still gracefully
+    // renders nothing because every branch is guarded by the name.
+    const {container} = render(Icon, {props: {name: "not-a-real-icon" as unknown as never}});
+    expect(container.querySelector("svg")).toBeNull();
+  });
+
+  it("applies width/height from a numeric size prop", () => {
+    const {container} = render(Icon, {props: {name: "github", size: 24}});
+    const svg = container.querySelector("svg");
+    // jsdom normalizes the style attribute (inserts spaces after colons),
+    // so the regex allows optional whitespace between property and value.
+    expect(svg?.getAttribute("style")).toMatch(/width:\s*24px/);
+    expect(svg?.getAttribute("style")).toMatch(/height:\s*24px/);
+  });
+
+  it("applies width/height from a CSS-string size prop", () => {
+    const {container} = render(Icon, {props: {name: "github", size: "1.5rem"}});
+    const svg = container.querySelector("svg");
+    expect(svg?.getAttribute("style")).toMatch(/width:\s*1\.5rem/);
+  });
+});

--- a/sites/cv.arolariu.ro/src/presentation/human/About.test.ts
+++ b/sites/cv.arolariu.ro/src/presentation/human/About.test.ts
@@ -1,9 +1,11 @@
 /**
  * @fileoverview Render-smoke tests for the About section.
  *
- * Verifies the biography paragraphs render and the section heading
- * is present. The biography data is pulled from `data/biography.ts`
- * and asserted on a count basis (five-point structure).
+ * Asserts the section heading renders and at least five `<p>` paragraphs
+ * appear in the output. The biography source data lives in
+ * `data/biography.ts`, but this test deliberately does not import it —
+ * it's a structural smoke test verifying the component renders enough
+ * paragraph content, not a content-completeness test against the source.
  */
 
 import {render} from "@testing-library/svelte";

--- a/sites/cv.arolariu.ro/src/presentation/human/About.test.ts
+++ b/sites/cv.arolariu.ro/src/presentation/human/About.test.ts
@@ -1,0 +1,36 @@
+/**
+ * @fileoverview Render-smoke tests for the About section.
+ *
+ * Verifies the biography paragraphs render and the section heading
+ * is present. The biography data is pulled from `data/biography.ts`
+ * and asserted on a count basis (five-point structure).
+ */
+
+import {render} from "@testing-library/svelte";
+import {beforeEach, describe, expect, it, vi} from "vitest";
+
+import About from "./About.svelte";
+
+describe("About", () => {
+  beforeEach(() => {
+    global.IntersectionObserver = vi.fn(function (this: IntersectionObserver) {
+      this.observe = vi.fn();
+      this.unobserve = vi.fn();
+      this.disconnect = vi.fn();
+      this.takeRecords = vi.fn(() => []);
+      return this;
+    }) as unknown as typeof IntersectionObserver;
+  });
+
+  it("renders an About heading", () => {
+    const {getByRole} = render(About);
+    const heading = getByRole("heading", {name: /about/i});
+    expect(heading).toBeTruthy();
+  });
+
+  it("renders the biography paragraphs", () => {
+    const {container} = render(About);
+    const paragraphs = container.querySelectorAll("p");
+    expect(paragraphs.length).toBeGreaterThanOrEqual(5);
+  });
+});

--- a/sites/cv.arolariu.ro/src/presentation/human/Competencies.test.ts
+++ b/sites/cv.arolariu.ro/src/presentation/human/Competencies.test.ts
@@ -1,0 +1,43 @@
+/**
+ * @fileoverview Render-smoke tests for the Competencies section.
+ *
+ * Verifies the section heading + the 6 competency cards render. Uses
+ * `getAllByText` for competency phrases because they appear in both
+ * card titles and card descriptions.
+ */
+
+import {render} from "@testing-library/svelte";
+import {beforeEach, describe, expect, it, vi} from "vitest";
+
+import Competencies from "./Competencies.svelte";
+
+describe("Competencies", () => {
+  beforeEach(() => {
+    global.IntersectionObserver = vi.fn(function (this: IntersectionObserver) {
+      this.observe = vi.fn();
+      this.unobserve = vi.fn();
+      this.disconnect = vi.fn();
+      this.takeRecords = vi.fn(() => []);
+      return this;
+    }) as unknown as typeof IntersectionObserver;
+  });
+
+  it("renders the Core Competencies level-2 heading", () => {
+    const {getByRole} = render(Competencies);
+    const heading = getByRole("heading", {name: /core\s+competencies/i, level: 2});
+    expect(heading).toBeTruthy();
+  });
+
+  it("renders one h3 card per competency (6 total)", () => {
+    const {getAllByRole} = render(Competencies);
+    const cards = getAllByRole("heading", {level: 3});
+    expect(cards).toHaveLength(6);
+  });
+
+  it("includes the load-bearing competency titles (somewhere on the page)", () => {
+    const {getAllByText} = render(Competencies);
+    expect(getAllByText(/engineering\s+excellence/i).length).toBeGreaterThan(0);
+    expect(getAllByText(/test-driven\s+development/i).length).toBeGreaterThan(0);
+    expect(getAllByText(/domain-driven\s+design/i).length).toBeGreaterThan(0);
+  });
+});

--- a/sites/cv.arolariu.ro/src/presentation/human/Contact.svelte
+++ b/sites/cv.arolariu.ro/src/presentation/human/Contact.svelte
@@ -10,8 +10,6 @@
     message: "",
   });
 
-  let isSubmitting = $state(false);
-  let submitMessage = $state("");
   let focusedField = $state("");
 
   async function handleSubmit(event: Event) {
@@ -162,40 +160,9 @@
 
               <button
                 type="submit"
-                disabled={isSubmitting}
                 class={styles.submitButton}>
-                {#if isSubmitting}
-                  <span class={styles.buttonContent}>
-                    <svg
-                      class={styles.spinner}
-                      xmlns="http://www.w3.org/2000/svg"
-                      fill="none"
-                      viewBox="0 0 24 24">
-                      <circle
-                        class={styles.spinnerCircle}
-                        cx="12"
-                        cy="12"
-                        r="10"
-                        stroke="currentColor"
-                        stroke-width="4"></circle>
-                      <path
-                        class={styles.spinnerPath}
-                        fill="currentColor"
-                        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                      ></path>
-                    </svg>
-                    Sending...
-                  </span>
-                {:else}
-                  Send Message
-                {/if}
+                Send Message
               </button>
-
-              {#if submitMessage}
-                <div class={styles.successMessage}>
-                  {submitMessage}
-                </div>
-              {/if}
             </form>
           </div>
         </AnimatedSection>

--- a/sites/cv.arolariu.ro/src/presentation/human/Contact.test.ts
+++ b/sites/cv.arolariu.ro/src/presentation/human/Contact.test.ts
@@ -1,0 +1,42 @@
+/**
+ * @fileoverview Render-smoke tests for the Contact section.
+ *
+ * Verifies the section heading + the three contact-info card titles
+ * (Location / Email / Website) + the contact form is present.
+ */
+
+import {render} from "@testing-library/svelte";
+import {beforeEach, describe, expect, it, vi} from "vitest";
+
+import Contact from "./Contact.svelte";
+
+describe("Contact", () => {
+  beforeEach(() => {
+    global.IntersectionObserver = vi.fn(function (this: IntersectionObserver) {
+      this.observe = vi.fn();
+      this.unobserve = vi.fn();
+      this.disconnect = vi.fn();
+      this.takeRecords = vi.fn(() => []);
+      return this;
+    }) as unknown as typeof IntersectionObserver;
+  });
+
+  it("renders the 'Get In Touch' level-2 heading", () => {
+    const {getByRole} = render(Contact);
+    const heading = getByRole("heading", {name: /get\s+in\s+touch/i, level: 2});
+    expect(heading).toBeTruthy();
+  });
+
+  it("renders the three contact-info card titles", () => {
+    const {getAllByText} = render(Contact);
+    expect(getAllByText(/^Location$/i).length).toBeGreaterThan(0);
+    expect(getAllByText(/^Email$/i).length).toBeGreaterThan(0);
+    expect(getAllByText(/^Website$/i).length).toBeGreaterThan(0);
+  });
+
+  it("renders the message form (name + email + message inputs)", () => {
+    const {container} = render(Contact);
+    const inputs = container.querySelectorAll("input, textarea");
+    expect(inputs.length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/sites/cv.arolariu.ro/src/presentation/human/Education.test.ts
+++ b/sites/cv.arolariu.ro/src/presentation/human/Education.test.ts
@@ -1,0 +1,46 @@
+/**
+ * @fileoverview Render-smoke tests for the Education & Certifications section.
+ *
+ * Verifies both the academic background subsection and the grouped
+ * certifications subsection (Microsoft + GitHub) render their headings
+ * and eyebrow labels.
+ */
+
+import {render} from "@testing-library/svelte";
+import {beforeEach, describe, expect, it, vi} from "vitest";
+
+import Education from "./Education.svelte";
+
+describe("Education", () => {
+  beforeEach(() => {
+    global.IntersectionObserver = vi.fn(function (this: IntersectionObserver) {
+      this.observe = vi.fn();
+      this.unobserve = vi.fn();
+      this.disconnect = vi.fn();
+      this.takeRecords = vi.fn(() => []);
+      return this;
+    }) as unknown as typeof IntersectionObserver;
+  });
+
+  it("renders the Education & Certifications level-2 heading", () => {
+    const {getByRole} = render(Education);
+    const heading = getByRole("heading", {name: /education.*certifications/i, level: 2});
+    expect(heading).toBeTruthy();
+  });
+
+  it("renders the Academic Background subheading", () => {
+    const {getByRole} = render(Education);
+    expect(getByRole("heading", {name: /academic\s+background/i, level: 3})).toBeTruthy();
+  });
+
+  it("renders the Professional Certifications subheading", () => {
+    const {getByRole} = render(Education);
+    expect(getByRole("heading", {name: /professional\s+certifications/i, level: 3})).toBeTruthy();
+  });
+
+  it("renders the Microsoft and GitHub credential eyebrows", () => {
+    const {getAllByText} = render(Education);
+    expect(getAllByText(/Microsoft.*credentials/i).length).toBeGreaterThan(0);
+    expect(getAllByText(/GitHub.*credentials/i).length).toBeGreaterThan(0);
+  });
+});

--- a/sites/cv.arolariu.ro/src/presentation/human/Experience.test.ts
+++ b/sites/cv.arolariu.ro/src/presentation/human/Experience.test.ts
@@ -1,9 +1,12 @@
 /**
  * @fileoverview Render-smoke tests for the Experience timeline.
  *
- * Asserts the count of timeline items matches `experiencesAsArray`
- * (currently 5 roles: M365 AI, Sovereign Clouds, Azure Tech Eng,
- * Intel, Ubisoft) and that the most recent role title appears.
+ * Asserts that the Professional Experience heading renders, at least
+ * one timeline item (button[aria-expanded] card) is present, and the
+ * most recent Microsoft role surfaces somewhere in the rendered output.
+ * Intentionally loose on counts — the exact number of roles is data
+ * the test does not import, so this is a structural smoke test, not
+ * a content-completeness test.
  */
 
 import {render} from "@testing-library/svelte";

--- a/sites/cv.arolariu.ro/src/presentation/human/Experience.test.ts
+++ b/sites/cv.arolariu.ro/src/presentation/human/Experience.test.ts
@@ -1,0 +1,41 @@
+/**
+ * @fileoverview Render-smoke tests for the Experience timeline.
+ *
+ * Asserts the count of timeline items matches `experiencesAsArray`
+ * (currently 5 roles: M365 AI, Sovereign Clouds, Azure Tech Eng,
+ * Intel, Ubisoft) and that the most recent role title appears.
+ */
+
+import {render} from "@testing-library/svelte";
+import {beforeEach, describe, expect, it, vi} from "vitest";
+
+import Experience from "./Experience.svelte";
+
+describe("Experience", () => {
+  beforeEach(() => {
+    global.IntersectionObserver = vi.fn(function (this: IntersectionObserver) {
+      this.observe = vi.fn();
+      this.unobserve = vi.fn();
+      this.disconnect = vi.fn();
+      this.takeRecords = vi.fn(() => []);
+      return this;
+    }) as unknown as typeof IntersectionObserver;
+  });
+
+  it("renders the Professional Experience heading", () => {
+    const {getByRole} = render(Experience);
+    const heading = getByRole("heading", {name: /professional\s+experience/i});
+    expect(heading).toBeTruthy();
+  });
+
+  it("renders one timeline item per experience entry", () => {
+    const {container} = render(Experience);
+    const cards = container.querySelectorAll("button[aria-expanded]");
+    expect(cards.length).toBeGreaterThan(0);
+  });
+
+  it("includes the most recent Microsoft role (M365 AI mentioned somewhere)", () => {
+    const {getAllByText} = render(Experience);
+    expect(getAllByText(/M365 AI/i).length).toBeGreaterThan(0);
+  });
+});

--- a/sites/cv.arolariu.ro/src/presentation/human/Hero.svelte
+++ b/sites/cv.arolariu.ro/src/presentation/human/Hero.svelte
@@ -6,6 +6,13 @@
   let heroVisible = $state(false);
   let imageLoaded = $state(false);
 
+  const nameParts = $derived.by(() => {
+    const lastSpace = author.name.lastIndexOf(" ");
+    return lastSpace === -1
+      ? {firstName: author.name, lastName: ""}
+      : {firstName: author.name.slice(0, lastSpace), lastName: author.name.slice(lastSpace + 1)};
+  });
+
   // Trigger hero animation shortly after mount
   $effect(() => {
     // If the user prefers reduced motion, surface the hero immediately
@@ -57,8 +64,8 @@
 
     <div class={cx(styles.nameWrapper, heroVisible ? styles.fadeVisible : styles.fadeHidden)}>
       <h1 class={styles.name}>
-        <span class={styles.firstName}>Alexandru-Razvan</span>
-        <span class={styles.lastName}> Olariu </span>
+        <span class={styles.firstName}>{nameParts.firstName}</span>
+        <span class={styles.lastName}> {nameParts.lastName} </span>
       </h1>
     </div>
 
@@ -86,7 +93,7 @@
 
     <div class={cx(styles.descriptionWrapper, heroVisible ? styles.fadeVisible : styles.fadeHidden)}>
       <p class={styles.description}>
-        {new Date().getFullYear() - 2000}-year-old passionate software engineer based in {author.location}, dedicated to creating innovative
+        {author.age}-year-old passionate software engineer based in {author.location}, dedicated to creating innovative
         solutions and building exceptional digital experiences.
       </p>
     </div>

--- a/sites/cv.arolariu.ro/src/presentation/human/Hero.svelte
+++ b/sites/cv.arolariu.ro/src/presentation/human/Hero.svelte
@@ -8,6 +8,17 @@
 
   // Trigger hero animation shortly after mount
   $effect(() => {
+    // If the user prefers reduced motion, surface the hero immediately
+    // instead of waiting 200ms — the CSS-side scale-in animation is
+    // already gated by prefers-reduced-motion, so the timer was the
+    // last remaining motion-driven delay.
+    const prefersReducedMotion = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
+
+    if (prefersReducedMotion) {
+      heroVisible = true;
+      return;
+    }
+
     const t = setTimeout(() => (heroVisible = true), 200);
     return () => clearTimeout(t);
   });

--- a/sites/cv.arolariu.ro/src/presentation/human/Hero.svelte
+++ b/sites/cv.arolariu.ro/src/presentation/human/Hero.svelte
@@ -31,6 +31,10 @@
       <img
         src="/author.jpeg"
         alt={author.name}
+        width="199"
+        height="199"
+        decoding="async"
+        fetchpriority="high"
         onload={handleImageLoad}
         class={cx(
           styles.avatar,

--- a/sites/cv.arolariu.ro/src/presentation/human/Hero.test.ts
+++ b/sites/cv.arolariu.ro/src/presentation/human/Hero.test.ts
@@ -1,0 +1,46 @@
+/**
+ * @fileoverview Render-smoke tests for the Hero section.
+ *
+ * Verifies the section renders without throwing in jsdom (the
+ * IntersectionObserver mock guards against the setup-file's
+ * arrow-function mock that can't be `new`-invoked) and that key
+ * editorial content (author name, taglines, CTAs) is present.
+ */
+
+import {render} from "@testing-library/svelte";
+import {beforeEach, describe, expect, it, vi} from "vitest";
+
+import Hero from "./Hero.svelte";
+
+describe("Hero", () => {
+  beforeEach(() => {
+    global.IntersectionObserver = vi.fn(function (this: IntersectionObserver) {
+      this.observe = vi.fn();
+      this.unobserve = vi.fn();
+      this.disconnect = vi.fn();
+      this.takeRecords = vi.fn(() => []);
+      return this;
+    }) as unknown as typeof IntersectionObserver;
+  });
+
+  it("renders the author's name in the level-1 heading", () => {
+    const {getByRole} = render(Hero);
+    const heading = getByRole("heading", {name: /Alexandru-Razvan\s+Olariu/i, level: 1});
+    expect(heading).toBeTruthy();
+  });
+
+  it("renders all three role taglines at least once", () => {
+    const {getAllByText} = render(Hero);
+    expect(getAllByText(/software engineer/i).length).toBeGreaterThan(0);
+    expect(getAllByText(/solution architect/i).length).toBeGreaterThan(0);
+    expect(getAllByText(/mentor/i).length).toBeGreaterThan(0);
+  });
+
+  it("exposes the two CTAs as links", () => {
+    const {getAllByRole} = render(Hero);
+    const links = getAllByRole("link");
+    const labels = links.map((l) => l.textContent?.trim().toLowerCase() ?? "");
+    expect(labels.some((l) => /get in touch/.test(l))).toBe(true);
+    expect(labels.some((l) => /view my work/.test(l))).toBe(true);
+  });
+});

--- a/sites/cv.arolariu.ro/src/presentation/human/Hero.test.ts
+++ b/sites/cv.arolariu.ro/src/presentation/human/Hero.test.ts
@@ -43,4 +43,14 @@ describe("Hero", () => {
     expect(labels.some((l) => /get in touch/.test(l))).toBe(true);
     expect(labels.some((l) => /view my work/.test(l))).toBe(true);
   });
+
+  it("renders the avatar with intrinsic dimensions and async decoding", () => {
+    const {container} = render(Hero);
+    const img = container.querySelector("img[src='/author.jpeg']");
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute("width")).toBe("199");
+    expect(img?.getAttribute("height")).toBe("199");
+    expect(img?.getAttribute("decoding")).toBe("async");
+    expect(img?.getAttribute("fetchpriority")).toBe("high");
+  });
 });

--- a/sites/cv.arolariu.ro/src/presentation/human/Testimonials.test.ts
+++ b/sites/cv.arolariu.ro/src/presentation/human/Testimonials.test.ts
@@ -1,0 +1,37 @@
+/**
+ * @fileoverview Render-smoke tests for the Testimonials section.
+ *
+ * Verifies the section heading + that the testimonial count rendered
+ * matches `testimonialsAsArray`.
+ */
+
+import {render} from "@testing-library/svelte";
+import {beforeEach, describe, expect, it, vi} from "vitest";
+
+import {testimonialsAsArray} from "@/data/testimonials";
+
+import Testimonials from "./Testimonials.svelte";
+
+describe("Testimonials", () => {
+  beforeEach(() => {
+    global.IntersectionObserver = vi.fn(function (this: IntersectionObserver) {
+      this.observe = vi.fn();
+      this.unobserve = vi.fn();
+      this.disconnect = vi.fn();
+      this.takeRecords = vi.fn(() => []);
+      return this;
+    }) as unknown as typeof IntersectionObserver;
+  });
+
+  it("renders the 'Colleagues Say' heading", () => {
+    const {getByRole} = render(Testimonials);
+    const heading = getByRole("heading", {name: /colleagues\s+say/i});
+    expect(heading).toBeTruthy();
+  });
+
+  it("renders one blockquote per testimonial entry", () => {
+    const {container} = render(Testimonials);
+    const quotes = container.querySelectorAll("blockquote");
+    expect(quotes).toHaveLength(testimonialsAsArray.length);
+  });
+});

--- a/sites/cv.arolariu.ro/src/routes/+error.svelte
+++ b/sites/cv.arolariu.ro/src/routes/+error.svelte
@@ -22,13 +22,13 @@ Global error page displayed when route loading fails or an unhandled error occur
 This component is automatically rendered by SvelteKit when an error occurs.
 -->
 <script lang="ts">
-  import {page} from "$app/stores";
+  import {page} from "$app/state";
   import {goto} from "$app/navigation";
   import ThemeToggle from "@/components/ThemeToggle.svelte";
   import styles from "./ErrorPage.module.scss";
 
-  const error = $derived($page.error);
-  const status = $derived($page.status);
+  const error = $derived(page.error);
+  const status = $derived(page.status);
 
   const errorMessages: Record<number, {title: string; description: string}> = {
     404: {

--- a/sites/cv.arolariu.ro/src/routes/+error.svelte
+++ b/sites/cv.arolariu.ro/src/routes/+error.svelte
@@ -23,7 +23,7 @@ This component is automatically rendered by SvelteKit when an error occurs.
 -->
 <script lang="ts">
   import {page} from "$app/state";
-  import {goto} from "$app/navigation";
+  import {goto, invalidateAll} from "$app/navigation";
   import ThemeToggle from "@/components/ThemeToggle.svelte";
   import styles from "./ErrorPage.module.scss";
 
@@ -56,8 +56,8 @@ This component is automatically rendered by SvelteKit when an error occurs.
     goto("/");
   }
 
-  function retry(): void {
-    window.location.reload();
+  async function retry(): Promise<void> {
+    await invalidateAll();
   }
 </script>
 

--- a/sites/cv.arolariu.ro/src/routes/+layout.svelte
+++ b/sites/cv.arolariu.ro/src/routes/+layout.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import "@/styles/global.scss";
   import {onNavigate, preloadData} from "$app/navigation";
-  import {page} from "$app/stores";
+  import {page} from "$app/state";
   import ScrollProgress from "@/components/ScrollProgress.svelte";
   import CommandPalette from "@/components/CommandPalette.svelte";
   import {onMount} from "svelte";
@@ -31,7 +31,7 @@
 
     const prefetch = (): void => {
       for (const route of prefetchRoutes) {
-        if ($page.url.pathname !== route) {
+        if (page.url.pathname !== route) {
           preloadData(route).catch(() => {
             // Silently ignore prefetch errors
           });

--- a/sites/cv.arolariu.ro/src/routes/+layout.svelte
+++ b/sites/cv.arolariu.ro/src/routes/+layout.svelte
@@ -33,6 +33,8 @@
 <ScrollProgress />
 <CommandPalette />
 
-<main id="main-content">
+<main
+  id="main-content"
+  tabindex="-1">
   {@render children?.()}
 </main>

--- a/sites/cv.arolariu.ro/src/routes/+layout.svelte
+++ b/sites/cv.arolariu.ro/src/routes/+layout.svelte
@@ -5,10 +5,16 @@
   import ScrollProgress from "@/components/ScrollProgress.svelte";
   import CommandPalette from "@/components/CommandPalette.svelte";
   import {onMount} from "svelte";
+  import type {Snippet} from "svelte";
 
-  // Enable View Transitions API for smooth route changes
+  interface Props {
+    children?: Snippet;
+  }
+
+  const {children}: Props = $props();
+
+  // Enable View Transitions API for smooth route changes.
   onNavigate((navigation) => {
-    // Skip if View Transitions API is not supported
     if (!document.startViewTransition) return;
 
     return new Promise((resolve) => {
@@ -19,21 +25,18 @@
     });
   });
 
-  // Prefetch routes on mount for instant navigation
+  // Prefetch the three top-level routes on first idle.
   onMount(() => {
-    // Prefetch main routes after initial render
     const prefetchRoutes = ["/human", "/pdf", "/json"];
 
-    // Use requestIdleCallback for non-blocking prefetch
-    const prefetch = () => {
-      prefetchRoutes.forEach((route) => {
-        // Don't prefetch current route
+    const prefetch = (): void => {
+      for (const route of prefetchRoutes) {
         if ($page.url.pathname !== route) {
           preloadData(route).catch(() => {
             // Silently ignore prefetch errors
           });
         }
-      });
+      }
     };
 
     if ("requestIdleCallback" in window) {
@@ -48,5 +51,5 @@
 <CommandPalette />
 
 <main id="main-content">
-  <slot />
+  {@render children?.()}
 </main>

--- a/sites/cv.arolariu.ro/src/routes/+layout.svelte
+++ b/sites/cv.arolariu.ro/src/routes/+layout.svelte
@@ -24,6 +24,12 @@
   });
 </script>
 
+<a
+  href="#main-content"
+  class="sr-only sr-only-focusable">
+  Skip to main content
+</a>
+
 <ScrollProgress />
 <CommandPalette />
 

--- a/sites/cv.arolariu.ro/src/routes/+layout.svelte
+++ b/sites/cv.arolariu.ro/src/routes/+layout.svelte
@@ -9,7 +9,7 @@
     children?: Snippet;
   }
 
-  const {children}: Props = $props();
+  let {children}: Props = $props();
 
   // Enable View Transitions API for smooth route changes.
   onNavigate((navigation) => {

--- a/sites/cv.arolariu.ro/src/routes/+layout.svelte
+++ b/sites/cv.arolariu.ro/src/routes/+layout.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
   import "@/styles/global.scss";
-  import {onNavigate, preloadData} from "$app/navigation";
-  import {page} from "$app/state";
+  import {onNavigate} from "$app/navigation";
   import ScrollProgress from "@/components/ScrollProgress.svelte";
   import CommandPalette from "@/components/CommandPalette.svelte";
-  import {onMount} from "svelte";
   import type {Snippet} from "svelte";
 
   interface Props {
@@ -23,27 +21,6 @@
         await navigation.complete;
       });
     });
-  });
-
-  // Prefetch the three top-level routes on first idle.
-  onMount(() => {
-    const prefetchRoutes = ["/human", "/pdf", "/json"];
-
-    const prefetch = (): void => {
-      for (const route of prefetchRoutes) {
-        if (page.url.pathname !== route) {
-          preloadData(route).catch(() => {
-            // Silently ignore prefetch errors
-          });
-        }
-      }
-    };
-
-    if ("requestIdleCallback" in window) {
-      requestIdleCallback(prefetch, {timeout: 2000});
-    } else {
-      setTimeout(prefetch, 100);
-    }
   });
 </script>
 

--- a/sites/cv.arolariu.ro/src/routes/+layout.ts
+++ b/sites/cv.arolariu.ro/src/routes/+layout.ts
@@ -1,0 +1,27 @@
+/**
+ * @fileoverview Root layout module for the CV site.
+ *
+ * @remarks
+ * Declares the SvelteKit page options inherited by every nested route:
+ *
+ *  - `prerender = true` — All routes are statically generated at build
+ *    time. The CV's data lives in `src/data/*.ts` and is fully known
+ *    when `vite build` runs, so there is no need for runtime SSR.
+ *
+ *  - `ssr = true` — Pages render to HTML during the build (required
+ *    for prerendering). At runtime this is a no-op; the user receives
+ *    pre-baked HTML.
+ *
+ *  - `csr = true` — After hydration, the page becomes a full SPA
+ *    (View Transitions, Command Palette, scroll progress, etc.).
+ *
+ *  - `trailingSlash = "never"` — Canonical URLs without a trailing
+ *    slash (`/human`, not `/human/`), keeping social previews tidy.
+ *
+ * @see https://svelte.dev/docs/kit/page-options
+ */
+
+export const prerender = true;
+export const ssr = true;
+export const csr = true;
+export const trailingSlash = "never";

--- a/sites/cv.arolariu.ro/src/routes/error.test.ts
+++ b/sites/cv.arolariu.ro/src/routes/error.test.ts
@@ -7,12 +7,18 @@
  */
 
 import {render} from "@testing-library/svelte";
-import {describe, expect, it} from "vitest";
+import {beforeEach, describe, expect, it} from "vitest";
 
 import ErrorPage from "./+error.svelte";
 import {page} from "../__mocks__/$app/state";
 
 describe("+error.svelte", () => {
+  beforeEach(() => {
+    page.status = 200;
+    page.error = null;
+    page.url = new URL("https://cv.arolariu.ro/");
+  });
+
   it("renders the 404 title for a 404 status", () => {
     page.status = 404;
     page.error = {message: "test"};

--- a/sites/cv.arolariu.ro/src/routes/error.test.ts
+++ b/sites/cv.arolariu.ro/src/routes/error.test.ts
@@ -1,0 +1,37 @@
+/**
+ * @fileoverview Render-smoke tests for the global +error.svelte boundary.
+ *
+ * Asserts:
+ *  - The default 404 mapping renders the "Page Not Found" title.
+ *  - The Try-Again button is hidden for 4xx errors but shown for 5xx.
+ */
+
+import {render} from "@testing-library/svelte";
+import {describe, expect, it} from "vitest";
+
+import ErrorPage from "./+error.svelte";
+import {page} from "../__mocks__/$app/state";
+
+describe("+error.svelte", () => {
+  it("renders the 404 title for a 404 status", () => {
+    page.status = 404;
+    page.error = {message: "test"};
+    const {getByRole} = render(ErrorPage);
+    expect(getByRole("heading", {name: /page not found/i, level: 1})).toBeTruthy();
+  });
+
+  it("shows only Go Home for a 4xx error", () => {
+    page.status = 404;
+    page.error = {message: "test"};
+    const {getByRole, queryByRole} = render(ErrorPage);
+    expect(getByRole("button", {name: /go home/i})).toBeTruthy();
+    expect(queryByRole("button", {name: /try again/i})).toBeNull();
+  });
+
+  it("shows the retry button on 5xx errors", () => {
+    page.status = 503;
+    page.error = {message: "boom"};
+    const {getByRole} = render(ErrorPage);
+    expect(getByRole("button", {name: /try again/i})).toBeTruthy();
+  });
+});

--- a/sites/cv.arolariu.ro/src/routes/error.test.ts
+++ b/sites/cv.arolariu.ro/src/routes/error.test.ts
@@ -9,8 +9,9 @@
 import {render} from "@testing-library/svelte";
 import {beforeEach, describe, expect, it} from "vitest";
 
+import {page} from "$app/state";
+
 import ErrorPage from "./+error.svelte";
-import {page} from "../__mocks__/$app/state";
 
 describe("+error.svelte", () => {
   beforeEach(() => {

--- a/sites/cv.arolariu.ro/src/routes/json/page.test.ts
+++ b/sites/cv.arolariu.ro/src/routes/json/page.test.ts
@@ -1,0 +1,50 @@
+/**
+ * @fileoverview Render-smoke test for the /json route.
+ *
+ * Asserts that JsonView mounts and surfaces its four key surfaces:
+ *  - The four code-sample tab labels (curl, JavaScript, Python, PowerShell).
+ *  - At least one <pre>/<code> block (the JSON dump).
+ *  - At least one interactive control (copy/download/tab switch button).
+ */
+
+import {render} from "@testing-library/svelte";
+import {beforeEach, describe, expect, it, vi} from "vitest";
+
+import Page from "./+page.svelte";
+
+describe("/json route", () => {
+  beforeEach(() => {
+    global.IntersectionObserver = vi.fn(function (this: IntersectionObserver) {
+      this.observe = vi.fn();
+      this.unobserve = vi.fn();
+      this.disconnect = vi.fn();
+      this.takeRecords = vi.fn(() => []);
+      return this;
+    }) as unknown as typeof IntersectionObserver;
+  });
+
+  it("mounts without throwing", () => {
+    const {container} = render(Page);
+    expect(container.firstChild).not.toBeNull();
+  });
+
+  it("renders all four code-sample tab labels", () => {
+    const {getAllByText} = render(Page);
+    expect(getAllByText(/^curl$/i).length).toBeGreaterThan(0);
+    expect(getAllByText(/^JavaScript$/).length).toBeGreaterThan(0);
+    expect(getAllByText(/^Python$/).length).toBeGreaterThan(0);
+    expect(getAllByText(/^PowerShell$/).length).toBeGreaterThan(0);
+  });
+
+  it("renders at least one code block containing the JSON dump", () => {
+    const {container} = render(Page);
+    const codeBlocks = container.querySelectorAll("pre, code");
+    expect(codeBlocks.length).toBeGreaterThan(0);
+  });
+
+  it("renders at least one button (copy/download/tab)", () => {
+    const {container} = render(Page);
+    const buttons = container.querySelectorAll("button");
+    expect(buttons.length).toBeGreaterThan(0);
+  });
+});

--- a/sites/cv.arolariu.ro/src/routes/layout.test.ts
+++ b/sites/cv.arolariu.ro/src/routes/layout.test.ts
@@ -31,4 +31,15 @@ describe("root layout", () => {
     const main = container.querySelector("main#main-content");
     expect(main).not.toBeNull();
   });
+
+  it("renders a skip-to-main link as the first focusable element", () => {
+    const childSnippet = createRawSnippet(() => ({
+      render: () => `<span>inner</span>`,
+    }));
+
+    const {container} = render(Layout, {props: {children: childSnippet}});
+    const skipLink = container.querySelector("a[href='#main-content']");
+    expect(skipLink).not.toBeNull();
+    expect(skipLink?.textContent?.trim()).toMatch(/skip to main content/i);
+  });
 });

--- a/sites/cv.arolariu.ro/src/routes/layout.test.ts
+++ b/sites/cv.arolariu.ro/src/routes/layout.test.ts
@@ -1,0 +1,44 @@
+/**
+ * @fileoverview Render-smoke test for the root SvelteKit layout.
+ *
+ * Asserts that:
+ *  - The layout renders provided children (snippet pass-through).
+ *  - Sibling chrome (ScrollProgress, CommandPalette) mounts alongside content.
+ */
+
+import {render} from "@testing-library/svelte";
+import {beforeEach, describe, expect, it, vi} from "vitest";
+import {createRawSnippet} from "svelte";
+
+import Layout from "./+layout.svelte";
+
+describe("root layout", () => {
+  beforeEach(() => {
+    global.IntersectionObserver = vi.fn(function (this: IntersectionObserver) {
+      this.observe = vi.fn();
+      this.unobserve = vi.fn();
+      this.disconnect = vi.fn();
+      this.takeRecords = vi.fn(() => []);
+      return this;
+    }) as unknown as typeof IntersectionObserver;
+  });
+
+  it("renders children passed via the children snippet", () => {
+    const childSnippet = createRawSnippet(() => ({
+      render: () => `<p data-testid="layout-child">Test child</p>`,
+    }));
+
+    const {getByTestId} = render(Layout, {props: {children: childSnippet}});
+    expect(getByTestId("layout-child").textContent).toBe("Test child");
+  });
+
+  it("renders the main landmark element wrapping content", () => {
+    const childSnippet = createRawSnippet(() => ({
+      render: () => `<span>inner</span>`,
+    }));
+
+    const {container} = render(Layout, {props: {children: childSnippet}});
+    const main = container.querySelector("main#main-content");
+    expect(main).not.toBeNull();
+  });
+});

--- a/sites/cv.arolariu.ro/src/routes/layout.test.ts
+++ b/sites/cv.arolariu.ro/src/routes/layout.test.ts
@@ -7,22 +7,12 @@
  */
 
 import {render} from "@testing-library/svelte";
-import {beforeEach, describe, expect, it, vi} from "vitest";
+import {describe, expect, it} from "vitest";
 import {createRawSnippet} from "svelte";
 
 import Layout from "./+layout.svelte";
 
 describe("root layout", () => {
-  beforeEach(() => {
-    global.IntersectionObserver = vi.fn(function (this: IntersectionObserver) {
-      this.observe = vi.fn();
-      this.unobserve = vi.fn();
-      this.disconnect = vi.fn();
-      this.takeRecords = vi.fn(() => []);
-      return this;
-    }) as unknown as typeof IntersectionObserver;
-  });
-
   it("renders children passed via the children snippet", () => {
     const childSnippet = createRawSnippet(() => ({
       render: () => `<p data-testid="layout-child">Test child</p>`,

--- a/sites/cv.arolariu.ro/src/routes/layout.test.ts
+++ b/sites/cv.arolariu.ro/src/routes/layout.test.ts
@@ -30,6 +30,10 @@ describe("root layout", () => {
     const {container} = render(Layout, {props: {children: childSnippet}});
     const main = container.querySelector("main#main-content");
     expect(main).not.toBeNull();
+    // tabindex=-1 is required so the skip-link actually moves keyboard
+    // focus into <main> on activation (Chrome/Edge/Safari only shift
+    // focus to the fragment target if the target is focusable).
+    expect(main?.getAttribute("tabindex")).toBe("-1");
   });
 
   it("renders a skip-to-main link as the first focusable element", () => {

--- a/sites/cv.arolariu.ro/src/routes/pdf/page.test.ts
+++ b/sites/cv.arolariu.ro/src/routes/pdf/page.test.ts
@@ -1,0 +1,60 @@
+/**
+ * @fileoverview Render-smoke test for the /pdf route.
+ *
+ * Asserts that PdfView mounts and surfaces the native PDF preview
+ * plus the metadata sidebar constants (file size, format, ATS
+ * status). These come from src/lib/pdf/pdfViewerState.ts and are
+ * the most stable non-stylistic anchors on the page. The download
+ * filename constant is verified indirectly via the PDF object's
+ * data/aria-label attributes since the filename itself is only
+ * applied to a dynamically-created `<a download>` element.
+ */
+
+import {render} from "@testing-library/svelte";
+import {beforeEach, describe, expect, it, vi} from "vitest";
+
+import Page from "./+page.svelte";
+
+describe("/pdf route", () => {
+  beforeEach(() => {
+    // PdfView (via AnimatedSection) constructs `new IntersectionObserver(...)`.
+    // The global stub in vitest.setup.ts is an arrow function and cannot be
+    // called with `new`, so override with a constructor-friendly form here.
+    global.IntersectionObserver = vi.fn(function (this: IntersectionObserver) {
+      this.observe = vi.fn();
+      this.unobserve = vi.fn();
+      this.disconnect = vi.fn();
+      this.takeRecords = vi.fn(() => []);
+      return this;
+    }) as unknown as typeof IntersectionObserver;
+  });
+
+  it("mounts without throwing", () => {
+    const {container} = render(Page);
+    expect(container.firstChild).not.toBeNull();
+  });
+
+  it("renders the PDF preview object referencing the CV asset", () => {
+    // The download filename (PDF_DOWNLOAD_FILENAME) is only ever used as the
+    // `download` attribute on a dynamically-created `<a>` and never rendered
+    // as visible text. The stable on-page anchor that identifies the same CV
+    // artifact is the native `<object>` element's aria-label/title and its
+    // `data` attribute pointing at the CV asset.
+    const {container} = render(Page);
+    const obj = container.querySelector('object[type="application/pdf"]');
+    expect(obj).not.toBeNull();
+    expect(obj?.getAttribute("data")).toMatch(/cv\.pdf$/);
+    expect(obj?.getAttribute("aria-label")).toMatch(/Alexandru-Razvan Olariu/);
+  });
+
+  it("renders the file-size and format-display metadata", () => {
+    const {getAllByText} = render(Page);
+    expect(getAllByText(/114 KB/).length).toBeGreaterThan(0);
+    expect(getAllByText(/A4 PDF/).length).toBeGreaterThan(0);
+  });
+
+  it("renders the ATS-compatible status", () => {
+    const {getAllByText} = render(Page);
+    expect(getAllByText(/Compatible/).length).toBeGreaterThan(0);
+  });
+});

--- a/sites/cv.arolariu.ro/src/routes/rest/json/server.test.ts
+++ b/sites/cv.arolariu.ro/src/routes/rest/json/server.test.ts
@@ -141,6 +141,14 @@ describe("CV JSON API Endpoint", () => {
       expect(data).toHaveProperty("meta");
       expect(data.meta.format).toBe("cv.minimal");
     });
+
+    it("should not include the education section in minimal format", async () => {
+      const event = createMockEvent({format: "minimal"});
+      const response = await GET(event);
+      const data = (await response.json()) as {education?: unknown};
+
+      expect(data.education).toBeUndefined();
+    });
   });
 
   describe("GET /rest/json?section=", () => {
@@ -163,6 +171,16 @@ describe("CV JSON API Endpoint", () => {
       expect(response.status).toBe(404);
       expect(data).toHaveProperty("error");
       expect(data).toHaveProperty("availableSections");
+    });
+
+    it("should mention the requested name and list basics among available sections", async () => {
+      const event = createMockEvent({section: "nope"});
+      const response = await GET(event);
+      const data = (await response.json()) as {error: string; availableSections: string[]};
+
+      expect(response.status).toBe(404);
+      expect(data.error).toContain("nope");
+      expect(data.availableSections).toContain("basics");
     });
   });
 
@@ -198,6 +216,34 @@ describe("CV JSON API Endpoint", () => {
 
         const secondResponse = await GET(eventWithEtag);
         expect(secondResponse.status).toBe(304);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("emits a matching ETag header on the 304 response", async () => {
+      // The endpoint hashes the full payload (including `generatedAt`),
+      // so we freeze time to keep the two ETags identical.
+      const fixedDate = new Date("2024-01-01T00:00:00.000Z");
+      vi.useFakeTimers();
+      vi.setSystemTime(fixedDate);
+
+      try {
+        const firstResponse = await GET(createMockEvent());
+        const etag = firstResponse.headers.get("ETag");
+        expect(etag).toMatch(/^"cv-[a-z0-9]+"$/);
+
+        const url = new URL("http://localhost/rest/json");
+        const eventWithEtag = {
+          request: new Request(url.toString(), {
+            headers: {"If-None-Match": etag ?? ""},
+          }),
+          url,
+        } as RequestEvent;
+
+        const secondResponse = await GET(eventWithEtag);
+        expect(secondResponse.status).toBe(304);
+        expect(secondResponse.headers.get("ETag")).toBe(etag);
       } finally {
         vi.useRealTimers();
       }

--- a/sites/cv.arolariu.ro/src/service-worker.ts
+++ b/sites/cv.arolariu.ro/src/service-worker.ts
@@ -155,19 +155,20 @@ self.addEventListener("fetch", (event: FetchEvent) => {
       // No cache, fetch from network
       try {
         const networkResponse = await fetch(request);
-        // Cache successful responses
+
+        // Cache successful responses for next visit.
         if (networkResponse.ok) {
           const responseToCache = networkResponse.clone();
-          caches
-            .open(CACHE_NAME)
-            .then((cache) => {
-              cache.put(request, responseToCache);
-              return responseToCache;
-            })
-            .catch(() => {
-              // Caching failed
-            });
+          event.waitUntil(
+            caches
+              .open(CACHE_NAME)
+              .then((cache) => cache.put(request, responseToCache))
+              .catch(() => {
+                /* Caching failed — visit still succeeds via the network response above. */
+              }),
+          );
         }
+
         return networkResponse;
       } catch {
         // Network failed, return offline fallback for HTML requests

--- a/sites/cv.arolariu.ro/src/styles/global.scss
+++ b/sites/cv.arolariu.ro/src/styles/global.scss
@@ -211,6 +211,43 @@ a[role="button"]:active,
   }
 }
 
+/* Screen-reader-only utility for content that should be perceivable by AT
+   but invisible until focused. Pattern lifted from inclusive-components.design. */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.sr-only-focusable:focus,
+.sr-only-focusable:focus-visible {
+  position: fixed;
+  top: 1rem;
+  left: 1rem;
+  width: auto;
+  height: auto;
+  padding: 0.75rem 1.25rem;
+  margin: 0;
+  overflow: visible;
+  clip: auto;
+  white-space: normal;
+  z-index: 10000;
+  background: var(--cv-color-blue-600, #2563eb);
+  color: white;
+  text-decoration: none;
+  font-weight: 600;
+  border-radius: var(--cv-radius-md, 0.5rem);
+  box-shadow: var(--cv-shadow-lg, 0 10px 15px rgba(0, 0, 0, 0.1));
+  outline: 2px solid white;
+  outline-offset: 2px;
+}
+
 @media (prefers-reduced-motion: reduce) {
   html {
     scroll-behavior: auto;

--- a/sites/cv.arolariu.ro/src/styles/global.scss
+++ b/sites/cv.arolariu.ro/src/styles/global.scss
@@ -221,6 +221,8 @@ a[role="button"]:active,
   margin: -1px;
   overflow: hidden;
   clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%); /* Modern equivalent of clip; covers browsers
+                            that have deprecated the legacy property. */
   white-space: nowrap;
   border: 0;
 }

--- a/sites/cv.arolariu.ro/tsconfig.json
+++ b/sites/cv.arolariu.ro/tsconfig.json
@@ -11,6 +11,15 @@
         "./src/*"
       ]
     },
+    // Reason: The two settings below override stricter defaults from the
+    // root tsconfig.json because they fight the CSS Modules pattern used
+    // throughout this site. SvelteKit/Vite types *.module.scss imports
+    // as Record<string, string> (an index signature), so every styles.foo
+    // access in every component would trip these rules. The other strict
+    // rules (exactOptionalPropertyTypes, noImplicitAny, strict, etc.)
+    // remain enforced.
+    "noPropertyAccessFromIndexSignature": false,
+    "noUncheckedIndexedAccess": false
   },
   "exclude": [
     "node_modules"

--- a/sites/cv.arolariu.ro/vite.config.js
+++ b/sites/cv.arolariu.ro/vite.config.js
@@ -1,6 +1,0 @@
-import {sveltekit} from "@sveltejs/kit/vite";
-import {defineConfig} from "vite";
-
-export default defineConfig({
-  plugins: [sveltekit()],
-});

--- a/sites/cv.arolariu.ro/vite.config.ts
+++ b/sites/cv.arolariu.ro/vite.config.ts
@@ -1,0 +1,16 @@
+/**
+ * @fileoverview Vite configuration for the cv.arolariu.ro SvelteKit app.
+ *
+ * Only the SvelteKit Vite plugin is wired here; everything else is
+ * driven by `svelte.config.js` (adapter, alias) and the SvelteKit
+ * conventions.
+ *
+ * @see https://vitejs.dev/config/
+ */
+
+import {sveltekit} from "@sveltejs/kit/vite";
+import {defineConfig} from "vite";
+
+export default defineConfig({
+  plugins: [sveltekit()],
+});

--- a/sites/cv.arolariu.ro/vite.config.ts
+++ b/sites/cv.arolariu.ro/vite.config.ts
@@ -11,10 +11,15 @@
  *   (`lib/utils/copy.ts` and `lib/utils/download.ts` use them for
  *   irrecoverable browser-API failures).
  *
- * - `build.target = "es2022"` lets esbuild emit modern ECMAScript
- *   features (top-level await, class fields, `Error.cause`) instead
- *   of down-leveling. Every browser the site supports (Chrome 94+,
- *   Firefox 93+, Safari 16+, Edge 94+) handles ES2022 natively.
+ * - `build.target = "esnext"` lets esbuild emit any modern ECMAScript
+ *   syntax without down-leveling. The codebase doesn't use features
+ *   beyond ES2022 today, so output is currently identical to
+ *   `target: "es2022"` — but the directive future-proofs the build
+ *   so adopting ES2023+ syntax later doesn't require revisiting this
+ *   config. All browsers the site targets (Chrome 94+, Firefox 93+,
+ *   Safari 16+, Edge 94+) handle ES2022 natively; if a future
+ *   contributor lands a dependency that uses syntax esbuild can't
+ *   parse, the build fails fast — explicit beats silent down-leveling.
  *
  * @see https://vitejs.dev/config/
  */
@@ -28,6 +33,6 @@ export default defineConfig({
     pure: ["console.log", "console.debug", "console.info"],
   },
   build: {
-    target: "es2022",
+    target: "esnext",
   },
 });

--- a/sites/cv.arolariu.ro/vite.config.ts
+++ b/sites/cv.arolariu.ro/vite.config.ts
@@ -1,9 +1,20 @@
 /**
  * @fileoverview Vite configuration for the cv.arolariu.ro SvelteKit app.
  *
- * Only the SvelteKit Vite plugin is wired here; everything else is
- * driven by `svelte.config.js` (adapter, alias) and the SvelteKit
- * conventions.
+ * The SvelteKit Vite plugin is wired here; adapter and alias config
+ * lives in `svelte.config.js`. Two production-only tweaks:
+ *
+ * - `esbuild.pure` marks diagnostic console calls (`log`, `debug`,
+ *   `info`) as side-effect-free so esbuild's tree-shaker drops them
+ *   from the production bundle. `console.error` and `console.warn`
+ *   are intentionally retained as legitimate production diagnostics
+ *   (`lib/utils/copy.ts` and `lib/utils/download.ts` use them for
+ *   irrecoverable browser-API failures).
+ *
+ * - `build.target = "es2022"` lets esbuild emit modern ECMAScript
+ *   features (top-level await, class fields, `Error.cause`) instead
+ *   of down-leveling. Every browser the site supports (Chrome 94+,
+ *   Firefox 93+, Safari 16+, Edge 94+) handles ES2022 natively.
  *
  * @see https://vitejs.dev/config/
  */
@@ -13,4 +24,10 @@ import {defineConfig} from "vite";
 
 export default defineConfig({
   plugins: [sveltekit()],
+  esbuild: {
+    pure: ["console.log", "console.debug", "console.info"],
+  },
+  build: {
+    target: "es2022",
+  },
 });

--- a/sites/cv.arolariu.ro/vitest.config.ts
+++ b/sites/cv.arolariu.ro/vitest.config.ts
@@ -30,6 +30,7 @@ export default mergeConfig(
         $lib: path.resolve(__dirname, "./src/lib"),
         "$app/environment": path.resolve(__dirname, "./src/__mocks__/$app/environment.ts"),
         "$app/navigation": path.resolve(__dirname, "./src/__mocks__/$app/navigation.ts"),
+        "$app/state": path.resolve(__dirname, "./src/__mocks__/$app/state.ts"),
         "$app/stores": path.resolve(__dirname, "./src/__mocks__/$app/stores.ts"),
       },
       conditions: ["browser"],


### PR DESCRIPTION
This pull request introduces several improvements and refactors across the codebase, with a primary focus on enhancing test coverage for the main CV sections, improving the reliability and maintainability of derived state in Svelte components, and updating the integration of Microsoft Clarity analytics. It also introduces a new Vitest mock for SvelteKit's `$app/state` module to enable more robust and isolated component testing.

Key changes include:

### Testing and Test Infrastructure

* Added comprehensive render-smoke tests for all major CV sections (`About`, `Competencies`, `Contact`, `Education`, `Experience`, `Hero`, `Testimonials`) to verify that critical content and structure are present and to facilitate future refactoring with confidence. Each test suite includes setup to mock `IntersectionObserver` for jsdom compatibility. [[1]](diffhunk://#diff-709c9fecff3863af3f1e507739c1df9312da23080d8b87d4039b7957cd8d684fR1-R36) [[2]](diffhunk://#diff-1523095cf1431b3c5c1055359f4b894d80ebc28ee2a06bb9f4551c19122e9cf1R1-R43) [[3]](diffhunk://#diff-202ccd2724287fdea274deba4db901615f95f6177577652aa2f9895f7e143ab7R1-R42) [[4]](diffhunk://#diff-19abf5969db58e1435486ca98ce301c1b7990ae4135d3eedfccbac7f75eeb427R1-R46) [[5]](diffhunk://#diff-0b6ac4829421bee610d5d0f9e968badf983349a64bd9887e8aaac31a701d0dc0R1-R41) [[6]](diffhunk://#diff-9f84307257406bb2f725ab8262a2edeb6a140721418a420525dab162e2ff75d8R1-R46) [[7]](diffhunk://#diff-f7fe037e219a646f1bb96a9a43c2ec589fd98c03e77fd4a86a03628b46473719R1-R37)
* Introduced a Vitest mock for the SvelteKit `$app/state` virtual module, providing inert state objects for `page`, `navigating`, and `updated` to allow components to render in tests without a SvelteKit runtime.

### State Management and Svelte Store Usage

* Refactored all usages of `$derived()` to `$derived.by()` in `CommandPalette.svelte`, and updated all references to derived stores to use their value directly (e.g., `flatCommands` instead of `flatCommands()`). This improves reactivity and aligns with best practices for the store API. [[1]](diffhunk://#diff-37204561204fc3abf16e3fe6f16f0fee3a6c8e818f4c4267320882875ff6d00dL27-R27) [[2]](diffhunk://#diff-37204561204fc3abf16e3fe6f16f0fee3a6c8e818f4c4267320882875ff6d00dL211-R215) [[3]](diffhunk://#diff-37204561204fc3abf16e3fe6f16f0fee3a6c8e818f4c4267320882875ff6d00dL225-R240) [[4]](diffhunk://#diff-37204561204fc3abf16e3fe6f16f0fee3a6c8e818f4c4267320882875ff6d00dL273-R270) [[5]](diffhunk://#diff-37204561204fc3abf16e3fe6f16f0fee3a6c8e818f4c4267320882875ff6d00dL302-R300) [[6]](diffhunk://#diff-37204561204fc3abf16e3fe6f16f0fee3a6c8e818f4c4267320882875ff6d00dL387-R392) [[7]](diffhunk://#diff-37204561204fc3abf16e3fe6f16f0fee3a6c8e818f4c4267320882875ff6d00dL426-R424)
* Updated `ScrollProgress.svelte` to define `showProgress` as a `const` instead of `let` for clarity and correctness.
* Replaced `$app/stores` with `$app/state` in the global error page to use the new mock-friendly state module.

### Analytics and Performance

* Deferred the loading of the Microsoft Clarity analytics script by moving it to the end of the `<body>` with the `defer` attribute, ensuring it does not block the critical render path and improving page load performance. [[1]](diffhunk://#diff-8dfd7bc8a0331df74df7869e5456313a1bc6c7e9e22f8fe2b7ecea2d2f754fffL157-L171) [[2]](diffhunk://#diff-8dfd7bc8a0331df74df7869e5456313a1bc6c7e9e22f8fe2b7ecea2d2f754fffR181-R195)

### Type and Prop Improvements

* Updated component prop types to use `Snippet` from Svelte where appropriate, clarifying expected children types and improving type safety in `AnimatedSection.svelte` and `+layout.svelte`. [[1]](diffhunk://#diff-62ef3eaf8c89af7abf91f27f926849d2d087ab2a69db9cb96f8c587b2ce6c1d6R2-R10) [[2]](diffhunk://#diff-598c7da6ddaa42cf1acfc9e89a80b1fec19285181537918fe3531906c1db71adL3-L11)

These changes collectively improve the reliability, maintainability, and testability of the application, while also ensuring better performance and developer experience.