### PR TITLE
refactor(cv): Phase 3 — accessibility + image perf

### DIFF
--- a/sites/cv.arolariu.ro/src/components/CommandPalette.module.scss
+++ b/sites/cv.arolariu.ro/src/components/CommandPalette.module.scss
@@ -1,15 +1,5 @@
 @use "../styles/breakpoints";
 
-.backdrop {
-  position: fixed;
-  inset: 0;
-  z-index: 50;
-  cursor: pointer;
-  background: rgb(0 0 0 / 0.5);
-  backdrop-filter: blur(4px);
-  animation: fade-in 150ms ease-out;
-}
-
 .modal {
   position: fixed;
   top: 20%;
@@ -326,8 +316,35 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .backdrop,
   .modal {
     animation: none;
+  }
+}
+
+/* Backdrop styling for the native <dialog>. The browser draws ::backdrop
+   only when the dialog is opened via showModal(). */
+dialog.modal::backdrop {
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
+}
+
+/* The native <dialog> defaults to fixed inset:auto + width:fit-content,
+   so neutralise the user-agent box and let our existing .modal rule
+   handle positioning/sizing. */
+dialog.modal {
+  padding: 0;
+  border: none;
+  background: transparent;
+  max-width: min(32rem, calc(100vw - 2rem));
+}
+
+dialog.modal:not([open]) {
+  display: none;
+}
+
+/* Reduced motion: skip the backdrop blur (cheap on modern GPUs but not free). */
+@media (prefers-reduced-motion: reduce) {
+  dialog.modal::backdrop {
+    backdrop-filter: none;
   }
 }

--- a/sites/cv.arolariu.ro/src/components/CommandPalette.svelte
+++ b/sites/cv.arolariu.ro/src/components/CommandPalette.svelte
@@ -22,6 +22,7 @@
   let searchQuery = $state("");
   let selectedIndex = $state(0);
   let inputRef = $state<HTMLInputElement | null>(null);
+  let dialogRef = $state<HTMLDialogElement | null>(null);
 
   // Define all available commands
   const commands = $derived.by((): CommandAction[] => [
@@ -244,13 +245,15 @@
     isOpen = true;
     searchQuery = "";
     selectedIndex = 0;
-    setTimeout(() => inputRef?.focus(), 50);
+    if (!dialogRef?.open) dialogRef?.showModal();
+    queueMicrotask(() => inputRef?.focus());
   }
 
   function close() {
     isOpen = false;
     searchQuery = "";
     selectedIndex = 0;
+    dialogRef?.close();
   }
 
   function handleKeydown(e: KeyboardEvent) {
@@ -339,24 +342,22 @@
   };
 </script>
 
-{#if isOpen}
-  <!-- Backdrop -->
-  <div
-    class={styles.backdrop}
-    onclick={close}
-    onkeydown={(e) => e.key === "Escape" && close()}
-    role="button"
-    tabindex="-1"
-    aria-label="Close command palette">
-  </div>
-
-  <!-- Command Palette Modal -->
-  <div
-    class={styles.modal}
-    role="dialog"
-    aria-modal="true"
-    aria-label="Command palette">
-    <div class={styles.panel}>
+<!-- Command Palette Modal (native <dialog> handles focus-trap, ESC, backdrop, inert) -->
+<dialog
+  bind:this={dialogRef}
+  class={styles.modal}
+  aria-label="Command palette"
+  onclose={() => {
+    isOpen = false;
+    searchQuery = "";
+    selectedIndex = 0;
+  }}
+  onclick={(e) => {
+    // Close when the user clicks the backdrop (i.e. the dialog element itself,
+    // not any of its descendants).
+    if (e.target === dialogRef) close();
+  }}>
+  <div class={styles.panel}>
       <!-- Search input -->
       <div class={styles.searchRow}>
         <svg
@@ -450,8 +451,7 @@
         </div>
       </div>
     </div>
-  </div>
-{/if}
+</dialog>
 
 <!-- Keyboard shortcut hint (always visible) -->
 <button

--- a/sites/cv.arolariu.ro/src/components/CommandPalette.test.ts
+++ b/sites/cv.arolariu.ro/src/components/CommandPalette.test.ts
@@ -1,0 +1,35 @@
+/**
+ * @fileoverview Render tests for the CommandPalette component.
+ *
+ * Asserts the migration to the native <dialog> element:
+ *  - The element is `<dialog>`, not `<div role="dialog">`.
+ *  - It carries an accessible name (aria-label or aria-labelledby).
+ *  - Initially closed (no `open` attribute) so it does not steal focus on mount.
+ */
+
+import {render} from "@testing-library/svelte";
+import {describe, expect, it} from "vitest";
+
+import CommandPalette from "./CommandPalette.svelte";
+
+describe("CommandPalette", () => {
+  it("uses the native <dialog> element", () => {
+    const {container} = render(CommandPalette);
+    const dialog = container.querySelector("dialog");
+    expect(dialog).not.toBeNull();
+  });
+
+  it("dialog has an accessible name", () => {
+    const {container} = render(CommandPalette);
+    const dialog = container.querySelector("dialog");
+    const ariaLabel = dialog?.getAttribute("aria-label");
+    const labelledBy = dialog?.getAttribute("aria-labelledby");
+    expect(ariaLabel ?? labelledBy).toBeTruthy();
+  });
+
+  it("dialog starts closed", () => {
+    const {container} = render(CommandPalette);
+    const dialog = container.querySelector("dialog");
+    expect(dialog?.hasAttribute("open")).toBe(false);
+  });
+});

--- a/sites/cv.arolariu.ro/src/components/HelpDialog.module.scss
+++ b/sites/cv.arolariu.ro/src/components/HelpDialog.module.scss
@@ -1,18 +1,5 @@
 @use "../styles/breakpoints";
 
-.overlay {
-  position: fixed;
-  inset: 0;
-  z-index: 50;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 1rem;
-  background: rgb(0 0 0 / 0.5);
-  backdrop-filter: blur(4px);
-  animation: fade-in 200ms ease-out;
-}
-
 .panel {
   width: 100%;
   max-width: 48rem;
@@ -670,8 +657,41 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .overlay,
   .panel {
     animation: none;
+  }
+}
+
+/* Backdrop styling for the native <dialog>. The browser draws ::backdrop
+   only when the dialog is opened via showModal(). */
+dialog.panel::backdrop {
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
+}
+
+/* The native <dialog> defaults to fixed inset:auto + width:fit-content
+   and ships its own padding/border/background. Neutralise the user-agent
+   box so our existing .panel rule controls the visual chrome. */
+dialog.panel {
+  padding: 0;
+  border: 1px solid var(--cv-color-gray-200);
+  background: var(--cv-color-white);
+  max-width: min(48rem, calc(100vw - 2rem));
+  margin: auto;
+}
+
+:global(.dark) dialog.panel {
+  border-color: var(--cv-color-gray-700);
+  background: var(--cv-color-gray-900);
+}
+
+dialog.panel:not([open]) {
+  display: none;
+}
+
+/* Reduced motion: skip the backdrop blur. */
+@media (prefers-reduced-motion: reduce) {
+  dialog.panel::backdrop {
+    backdrop-filter: none;
   }
 }

--- a/sites/cv.arolariu.ro/src/components/HelpDialog.svelte
+++ b/sites/cv.arolariu.ro/src/components/HelpDialog.svelte
@@ -6,76 +6,29 @@
   // Bindable open flag; parent can bind:open, and we set open=false to close
   let {open = $bindable(false)} = $props();
 
-  let container: HTMLDivElement | null = $state(null);
-  let panel: HTMLDivElement | null = $state(null);
+  let dialogRef = $state<HTMLDialogElement | null>(null);
   let closeBtn: HTMLButtonElement | null = $state(null);
-  let previouslyFocused: HTMLElement | null = null;
   let activeTab = $state<"info" | "shortcuts" | "features">("info");
 
-  function focusFirstElement() {
-    if (!panel) return;
-    const focusable = panel.querySelectorAll<HTMLElement>(
-      'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])',
-    );
-    const first = focusable[0];
-    (first ?? closeBtn ?? panel).focus();
+  function close() {
+    open = false;
+    dialogRef?.close();
   }
 
-  function trapTab(e: KeyboardEvent) {
-    if (!open || !panel) return;
-    if (e.key !== "Tab") return;
-    const focusable = panel.querySelectorAll<HTMLElement>(
-      'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])',
-    );
-    if (focusable.length === 0) return;
-    const first = focusable[0];
-    const last = focusable[focusable.length - 1];
-    if (!first || !last) return;
-    const active = document.activeElement as HTMLElement | null;
-
-    if (e.shiftKey) {
-      if (active === first || !panel.contains(active)) {
-        last.focus();
-        e.preventDefault();
-      }
-    } else {
-      if (active === last) {
-        first.focus();
-        e.preventDefault();
-      }
-    }
-  }
-
-  function handleKeydown(e: KeyboardEvent) {
-    if (!open) return;
-    if (e.key === "Escape") {
-      e.stopPropagation();
-      e.preventDefault();
-      open = false;
-    } else if (e.key === "Tab") {
-      trapTab(e);
-    }
-  }
-
-  function handleOverlayClick(e: MouseEvent) {
-    if (!open) return;
-    if (e.target === container) {
-      open = false;
-    }
-  }
-
+  // Sync the bindable `open` prop into the native <dialog> imperative API.
+  // The browser handles focus-trap, ESC, backdrop, and inert siblings.
   $effect(() => {
-    if (!open) {
-      previouslyFocused?.focus?.();
-      return;
+    if (!dialogRef) return;
+    if (open && !dialogRef.open) {
+      dialogRef.showModal();
+      // Defer focus until after the browser opens the dialog. The native
+      // <dialog> would auto-focus the first focusable descendant, but we
+      // explicitly steer focus to the close button for parity with the
+      // previous behaviour.
+      queueMicrotask(() => closeBtn?.focus());
+    } else if (!open && dialogRef.open) {
+      dialogRef.close();
     }
-    previouslyFocused = document.activeElement as HTMLElement | null;
-    const prevOverflow = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-    requestAnimationFrame(() => focusFirstElement());
-    return () => {
-      document.body.style.overflow = prevOverflow;
-    };
   });
 
   // Keyboard shortcuts data
@@ -137,24 +90,20 @@
   }
 </script>
 
-{#if open}
-  <!-- Overlay -->
-  <div
-    bind:this={container}
-    class={styles.overlay}
-    role="presentation"
-    onclick={handleOverlayClick}
-    onkeydown={handleKeydown}>
-    <!-- Dialog panel -->
-    <div
-      bind:this={panel}
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="help-dialog-title"
-      aria-describedby="help-dialog-description"
-      class={styles.panel}
-      tabindex="-1"
-      onkeydown={handleKeydown}>
+<!-- Help dialog (native <dialog> handles focus-trap, ESC, backdrop, inert) -->
+<dialog
+  bind:this={dialogRef}
+  class={styles.panel}
+  aria-labelledby="help-dialog-title"
+  aria-describedby="help-dialog-description"
+  onclose={() => {
+    open = false;
+  }}
+  onclick={(e) => {
+    // Close when the user clicks the backdrop (i.e. the dialog element itself,
+    // not any of its descendants).
+    if (e.target === dialogRef) close();
+  }}>
       <!-- Header -->
       <header class={styles.header}>
         <div class={styles.headerTitleGroup}>
@@ -182,7 +131,7 @@
         </div>
         <button
           bind:this={closeBtn}
-          onclick={() => (open = false)}
+          onclick={close}
           class={styles.closeButton}
           aria-label={ui.buttons.close}>
           <svg
@@ -407,12 +356,10 @@
         <div class={styles.footerContent}>
           <p class={styles.footerText}> Built with care using modern web technologies </p>
           <button
-            onclick={() => (open = false)}
+            onclick={close}
             class={styles.footerButton}>
             {ui.buttons.close}
           </button>
         </div>
       </footer>
-    </div>
-  </div>
-{/if}
+</dialog>

--- a/sites/cv.arolariu.ro/src/components/HelpDialog.test.ts
+++ b/sites/cv.arolariu.ro/src/components/HelpDialog.test.ts
@@ -1,0 +1,35 @@
+/**
+ * @fileoverview Render tests for the HelpDialog component.
+ *
+ * Asserts the migration to the native <dialog> element:
+ *  - The element is `<dialog>`, not `<div role="dialog">`.
+ *  - It carries an accessible name.
+ *  - Initially closed.
+ */
+
+import {render} from "@testing-library/svelte";
+import {describe, expect, it} from "vitest";
+
+import HelpDialog from "./HelpDialog.svelte";
+
+describe("HelpDialog", () => {
+  it("uses the native <dialog> element", () => {
+    const {container} = render(HelpDialog);
+    const dialog = container.querySelector("dialog");
+    expect(dialog).not.toBeNull();
+  });
+
+  it("dialog has an accessible name", () => {
+    const {container} = render(HelpDialog);
+    const dialog = container.querySelector("dialog");
+    const ariaLabel = dialog?.getAttribute("aria-label");
+    const labelledBy = dialog?.getAttribute("aria-labelledby");
+    expect(ariaLabel ?? labelledBy).toBeTruthy();
+  });
+
+  it("dialog starts closed", () => {
+    const {container} = render(HelpDialog);
+    const dialog = container.querySelector("dialog");
+    expect(dialog?.hasAttribute("open")).toBe(false);
+  });
+});

--- a/sites/cv.arolariu.ro/src/presentation/human/Hero.svelte
+++ b/sites/cv.arolariu.ro/src/presentation/human/Hero.svelte
@@ -8,6 +8,17 @@
 
   // Trigger hero animation shortly after mount
   $effect(() => {
+    // If the user prefers reduced motion, surface the hero immediately
+    // instead of waiting 200ms — the CSS-side scale-in animation is
+    // already gated by prefers-reduced-motion, so the timer was the
+    // last remaining motion-driven delay.
+    const prefersReducedMotion = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
+
+    if (prefersReducedMotion) {
+      heroVisible = true;
+      return;
+    }
+
     const t = setTimeout(() => (heroVisible = true), 200);
     return () => clearTimeout(t);
   });

--- a/sites/cv.arolariu.ro/src/presentation/human/Hero.svelte
+++ b/sites/cv.arolariu.ro/src/presentation/human/Hero.svelte
@@ -31,6 +31,10 @@
       <img
         src="/author.jpeg"
         alt={author.name}
+        width="199"
+        height="199"
+        decoding="async"
+        fetchpriority="high"
         onload={handleImageLoad}
         class={cx(
           styles.avatar,

--- a/sites/cv.arolariu.ro/src/presentation/human/Hero.test.ts
+++ b/sites/cv.arolariu.ro/src/presentation/human/Hero.test.ts
@@ -43,4 +43,14 @@ describe("Hero", () => {
     expect(labels.some((l) => /get in touch/.test(l))).toBe(true);
     expect(labels.some((l) => /view my work/.test(l))).toBe(true);
   });
+
+  it("renders the avatar with intrinsic dimensions and async decoding", () => {
+    const {container} = render(Hero);
+    const img = container.querySelector("img[src='/author.jpeg']");
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute("width")).toBe("199");
+    expect(img?.getAttribute("height")).toBe("199");
+    expect(img?.getAttribute("decoding")).toBe("async");
+    expect(img?.getAttribute("fetchpriority")).toBe("high");
+  });
 });

--- a/sites/cv.arolariu.ro/src/routes/+layout.svelte
+++ b/sites/cv.arolariu.ro/src/routes/+layout.svelte
@@ -33,6 +33,8 @@
 <ScrollProgress />
 <CommandPalette />
 
-<main id="main-content">
+<main
+  id="main-content"
+  tabindex="-1">
   {@render children?.()}
 </main>

--- a/sites/cv.arolariu.ro/src/routes/+layout.svelte
+++ b/sites/cv.arolariu.ro/src/routes/+layout.svelte
@@ -24,6 +24,12 @@
   });
 </script>
 
+<a
+  href="#main-content"
+  class="sr-only sr-only-focusable">
+  Skip to main content
+</a>
+
 <ScrollProgress />
 <CommandPalette />
 

--- a/sites/cv.arolariu.ro/src/routes/layout.test.ts
+++ b/sites/cv.arolariu.ro/src/routes/layout.test.ts
@@ -31,4 +31,15 @@ describe("root layout", () => {
     const main = container.querySelector("main#main-content");
     expect(main).not.toBeNull();
   });
+
+  it("renders a skip-to-main link as the first focusable element", () => {
+    const childSnippet = createRawSnippet(() => ({
+      render: () => `<span>inner</span>`,
+    }));
+
+    const {container} = render(Layout, {props: {children: childSnippet}});
+    const skipLink = container.querySelector("a[href='#main-content']");
+    expect(skipLink).not.toBeNull();
+    expect(skipLink?.textContent?.trim()).toMatch(/skip to main content/i);
+  });
 });

--- a/sites/cv.arolariu.ro/src/routes/layout.test.ts
+++ b/sites/cv.arolariu.ro/src/routes/layout.test.ts
@@ -30,6 +30,10 @@ describe("root layout", () => {
     const {container} = render(Layout, {props: {children: childSnippet}});
     const main = container.querySelector("main#main-content");
     expect(main).not.toBeNull();
+    // tabindex=-1 is required so the skip-link actually moves keyboard
+    // focus into <main> on activation (Chrome/Edge/Safari only shift
+    // focus to the fragment target if the target is focusable).
+    expect(main?.getAttribute("tabindex")).toBe("-1");
   });
 
   it("renders a skip-to-main link as the first focusable element", () => {

--- a/sites/cv.arolariu.ro/src/styles/global.scss
+++ b/sites/cv.arolariu.ro/src/styles/global.scss
@@ -211,6 +211,43 @@ a[role="button"]:active,
   }
 }
 
+/* Screen-reader-only utility for content that should be perceivable by AT
+   but invisible until focused. Pattern lifted from inclusive-components.design. */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.sr-only-focusable:focus,
+.sr-only-focusable:focus-visible {
+  position: fixed;
+  top: 1rem;
+  left: 1rem;
+  width: auto;
+  height: auto;
+  padding: 0.75rem 1.25rem;
+  margin: 0;
+  overflow: visible;
+  clip: auto;
+  white-space: normal;
+  z-index: 10000;
+  background: var(--cv-color-blue-600, #2563eb);
+  color: white;
+  text-decoration: none;
+  font-weight: 600;
+  border-radius: var(--cv-radius-md, 0.5rem);
+  box-shadow: var(--cv-shadow-lg, 0 10px 15px rgba(0, 0, 0, 0.1));
+  outline: 2px solid white;
+  outline-offset: 2px;
+}
+
 @media (prefers-reduced-motion: reduce) {
   html {
     scroll-behavior: auto;

--- a/sites/cv.arolariu.ro/src/styles/global.scss
+++ b/sites/cv.arolariu.ro/src/styles/global.scss
@@ -221,6 +221,8 @@ a[role="button"]:active,
   margin: -1px;
   overflow: hidden;
   clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%); /* Modern equivalent of clip; covers browsers
+                            that have deprecated the legacy property. */
   white-space: nowrap;
   border: 0;
 }


### PR DESCRIPTION
## Summary

Phase 3 of the cv.arolariu.ro quality sweep — accessibility hardening + above-the-fold image performance. Seven atomic commits (six tasks + one final-review fix), +273/-133 across 11 files. No visual regressions intended; all wins accrue to keyboard, screen-reader, and slow-connection users.

## What changed

### Skip-to-main link
- New `.sr-only` + `.sr-only-focusable` utility classes in `global.scss` (with both legacy `clip` and modern `clip-path: inset(50%)` for forward-compat)
- `<a href=\"#main-content\" class=\"sr-only sr-only-focusable\">Skip to main content</a>` as the first focusable element in the root layout
- `<main id=\"main-content\" tabindex=\"-1\">` so activating the link actually shifts focus in Chrome/Edge/Safari (not just scroll)

### Native `<dialog>` migrations
Both modal components now use the native `<dialog>` element with `showModal()` / `close()`. The browser handles focus trap, ESC, backdrop rendering, and inert siblings — code that was previously hand-rolled (and in places buggy). The deleted overlay div used `role=\"button\"` + `tabindex=\"-1\"` on a background `div`, which is an a11y antipattern; native `::backdrop` replaces it.

- **CommandPalette**: imperative open/close via internal state; preserves backdrop-click-to-close via `e.target === dialogRef` guard.
- **HelpDialog**: parent-controlled via `bind:open`; a `$effect` reacts to the prop and calls `showModal()` / `close()`; `onclose` syncs the prop back to `false`.

### Hero image
- `width=\"199\" height=\"199\"` (intrinsic dimensions of `author.jpeg`) — browser reserves the box during HTML parse, eliminating Cumulative Layout Shift on slow connections
- `fetchpriority=\"high\"` — upgrades request priority for this above-the-fold, preloaded asset
- `decoding=\"async\"` — keeps image decode off the main thread
- CSS `.avatar { width: 12rem; height: 12rem; }` continues to drive rendered display size

### Reduced-motion respect
Hero's `\$effect` now reads `window.matchMedia(\"(prefers-reduced-motion: reduce)\")` and surfaces the hero immediately (skipping the 200ms timer) when reduced motion is preferred. The CSS-side scale-in animation was already gated; this closes the last motion-driven delay.

## Verification

- ✅ `npm run test:unit` — **295/295 passing** (287 baseline + 8 net new across 4 test files)
- ✅ Final code review pass: zero Critical / zero Important issues remaining after fix commit
- 📋 User to run Playwright a11y spec (`tests/accessibility.spec.ts`) locally

## Follow-ups (not in this PR)

- CommandPalette's `nav-home` / `nav-human` / `nav-pdf` / `nav-json` commands don't call `close()` after `goto()`, while other commands do — pre-existing inconsistency, predates this branch
- Optional: drop the manual ESC handler in CommandPalette's keyboard handler and let the native dialog do it (current path is correct but has an extra hop)
- Optional: WebP/AVIF variant of `author.jpeg` (binary work, deferred per agent convention)
- Optional: `aria-current=\"location\"` scroll-spy on the in-page nav

## Plan reference

Implementation plan: `docs/superpowers/plans/2026-05-11-cv-a11y-and-perf.md` (gitignored, local-only).

## Test plan

- [x] Vitest unit suite green locally (295/295)
- [x] Final cross-commit code review (Ready with one Important issue, now fixed)
- [ ] User validates Playwright a11y spec (out of agent scope per repo memory rule)
- [ ] CI green on preview merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)