### PR TITLE
test(cv): Phase 5 — component test coverage expansion

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -433,7 +433,7 @@
     "*.cs": "$(capture).*.cs",
     "*.ts": "$(capture).*.ts",
     "*.tsx": "$(capture).*.tsx, $(capture).*.scss, $(capture).*.css",
-    "*.svelte": "$(capture).module.scss, $(capture).test.ts, $(capture).module.test.ts"
+    "*.svelte": "$(capture).*.scss, $(capture).*.ts"
   },
   "explorer.incrementalNaming": "smart",
   "explorer.openEditors.minVisible": 0,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -432,7 +432,8 @@
     "*.py": "$(capture).*.py",
     "*.cs": "$(capture).*.cs",
     "*.ts": "$(capture).*.ts",
-    "*.tsx": "$(capture).*.tsx, $(capture).*.scss, $(capture).*.css"
+    "*.tsx": "$(capture).*.tsx, $(capture).*.scss, $(capture).*.css",
+    "*.svelte": "$(capture).module.scss, $(capture).test.ts, $(capture).module.test.ts"
   },
   "explorer.incrementalNaming": "smart",
   "explorer.openEditors.minVisible": 0,

--- a/sites/cv.arolariu.ro/src/components/ScrollProgress.test.ts
+++ b/sites/cv.arolariu.ro/src/components/ScrollProgress.test.ts
@@ -1,0 +1,45 @@
+/**
+ * @fileoverview Render test for ScrollProgress (route-gated visibility).
+ *
+ * Asserts:
+ *  - On routes other than /human, ScrollProgress renders nothing.
+ *  - On /human, ScrollProgress renders a <div role="progressbar"> with
+ *    ARIA value-min/max set to 0/100.
+ *
+ * Setup: mutate the $app/state mock's `page.url` before render. The
+ * mock exports a mutable `page` object (per Phase 2 follow-up typing).
+ */
+
+import {render} from "@testing-library/svelte";
+import {beforeEach, describe, expect, it} from "vitest";
+
+import {page} from "../__mocks__/$app/state";
+import ScrollProgress from "./ScrollProgress.svelte";
+
+describe("ScrollProgress", () => {
+  beforeEach(() => {
+    page.url = new URL("https://cv.arolariu.ro/");
+  });
+
+  it("renders nothing on routes other than /human", () => {
+    page.url = new URL("https://cv.arolariu.ro/");
+    const {container} = render(ScrollProgress);
+    expect(container.querySelector("div[role='progressbar']")).toBeNull();
+  });
+
+  it("renders nothing on /json", () => {
+    page.url = new URL("https://cv.arolariu.ro/json");
+    const {container} = render(ScrollProgress);
+    expect(container.querySelector("div[role='progressbar']")).toBeNull();
+  });
+
+  it("renders a progressbar with ARIA bounds on /human", () => {
+    page.url = new URL("https://cv.arolariu.ro/human");
+    const {container} = render(ScrollProgress);
+    const bar = container.querySelector("div[role='progressbar']");
+    expect(bar).not.toBeNull();
+    expect(bar?.getAttribute("aria-label")).toBe("Page scroll progress");
+    expect(bar?.getAttribute("aria-valuemin")).toBe("0");
+    expect(bar?.getAttribute("aria-valuemax")).toBe("100");
+  });
+});

--- a/sites/cv.arolariu.ro/src/components/ThemeToggle.test.ts
+++ b/sites/cv.arolariu.ro/src/components/ThemeToggle.test.ts
@@ -1,0 +1,46 @@
+/**
+ * @fileoverview Behaviour test for the ThemeToggle component.
+ *
+ * Asserts:
+ *  - Renders a single <button> with the accessible-name "Toggle theme".
+ *  - Clicking the button flips `useTheme().current` to the opposite value.
+ *
+ * Notes:
+ *  - useTheme is a Svelte 5 runes-class singleton. The first test to
+ *    run will see whatever value localStorage's mock returns; we
+ *    explicitly set the theme before each assertion to avoid order
+ *    dependence with other tests in the suite.
+ */
+
+import {render, fireEvent} from "@testing-library/svelte";
+import {beforeEach, describe, expect, it} from "vitest";
+
+import {useTheme} from "@/hooks/useTheme.svelte";
+import ThemeToggle from "./ThemeToggle.svelte";
+
+describe("ThemeToggle", () => {
+  beforeEach(() => {
+    // Pin theme to "dark" so the click-to-toggle assertion is deterministic.
+    useTheme().set("dark");
+  });
+
+  it("renders a Toggle Theme button", () => {
+    const {getByRole} = render(ThemeToggle);
+    const button = getByRole("button", {name: /toggle theme/i});
+    expect(button).toBeTruthy();
+  });
+
+  it("clicking the button toggles the theme from dark to light", async () => {
+    expect(useTheme().current).toBe("dark");
+    const {getByRole} = render(ThemeToggle);
+    await fireEvent.click(getByRole("button", {name: /toggle theme/i}));
+    expect(useTheme().current).toBe("light");
+  });
+
+  it("a second click toggles back from light to dark", async () => {
+    useTheme().set("light");
+    const {getByRole} = render(ThemeToggle);
+    await fireEvent.click(getByRole("button", {name: /toggle theme/i}));
+    expect(useTheme().current).toBe("dark");
+  });
+});

--- a/sites/cv.arolariu.ro/src/components/motion/AnimatedSection.test.ts
+++ b/sites/cv.arolariu.ro/src/components/motion/AnimatedSection.test.ts
@@ -1,0 +1,71 @@
+/**
+ * @fileoverview Render-smoke test for AnimatedSection.
+ *
+ * Asserts:
+ *  - Renders a <section> element.
+ *  - Children passed via the children snippet appear inside the section.
+ *  - The id and class props are forwarded to the rendered element.
+ *  - aria-label is built from the id ("Section: {id}") or falls back
+ *    to a default when no id is given.
+ *
+ * Notes:
+ *  - vitest.setup.ts installs a non-constructor IntersectionObserver
+ *    stub. AnimatedSection's transitive import uses `new` on it, so
+ *    we install a constructor-friendly override in beforeEach (same
+ *    pattern as the human-view section tests).
+ */
+
+import {render} from "@testing-library/svelte";
+import {beforeEach, describe, expect, it, vi} from "vitest";
+import {createRawSnippet} from "svelte";
+
+import AnimatedSection from "./AnimatedSection.svelte";
+
+describe("AnimatedSection", () => {
+  beforeEach(() => {
+    global.IntersectionObserver = vi.fn(function (this: IntersectionObserver) {
+      this.observe = vi.fn();
+      this.unobserve = vi.fn();
+      this.disconnect = vi.fn();
+      this.takeRecords = vi.fn(() => []);
+      return this;
+    }) as unknown as typeof IntersectionObserver;
+  });
+
+  it("renders a <section> wrapping the children snippet", () => {
+    const childSnippet = createRawSnippet(() => ({
+      render: () => `<span data-testid="child">inside</span>`,
+    }));
+    const {container, getByTestId} = render(AnimatedSection, {props: {children: childSnippet}});
+    expect(container.querySelector("section")).not.toBeNull();
+    expect(getByTestId("child").textContent).toBe("inside");
+  });
+
+  it("forwards the id prop to the <section>", () => {
+    const childSnippet = createRawSnippet(() => ({render: () => `<span>x</span>`}));
+    const {container} = render(AnimatedSection, {props: {children: childSnippet, id: "about"}});
+    expect(container.querySelector("section")?.getAttribute("id")).toBe("about");
+  });
+
+  it("forwards the class prop to the <section>", () => {
+    const childSnippet = createRawSnippet(() => ({render: () => `<span>x</span>`}));
+    const {container} = render(AnimatedSection, {
+      props: {children: childSnippet, class: "custom-class"},
+    });
+    expect(container.querySelector("section")?.className).toContain("custom-class");
+  });
+
+  it("derives aria-label from the id prop when present", () => {
+    const childSnippet = createRawSnippet(() => ({render: () => `<span>x</span>`}));
+    const {container} = render(AnimatedSection, {
+      props: {children: childSnippet, id: "experience"},
+    });
+    expect(container.querySelector("section")?.getAttribute("aria-label")).toBe("Section: experience");
+  });
+
+  it("uses a generic aria-label when no id is provided", () => {
+    const childSnippet = createRawSnippet(() => ({render: () => `<span>x</span>`}));
+    const {container} = render(AnimatedSection, {props: {children: childSnippet}});
+    expect(container.querySelector("section")?.getAttribute("aria-label")).toBe("Content section");
+  });
+});

--- a/sites/cv.arolariu.ro/src/presentation/ActionButton.test.ts
+++ b/sites/cv.arolariu.ro/src/presentation/ActionButton.test.ts
@@ -1,0 +1,62 @@
+/**
+ * @fileoverview Behaviour tests for the ActionButton component.
+ *
+ * Covers the five visible states:
+ *  - Renders label text inside the <button>.
+ *  - `disabled` prop disables the button.
+ *  - `loading` prop disables AND shows a spinner.
+ *  - `back && !icon` renders the arrow-left icon.
+ *  - `icon` prop renders a named icon.
+ *  - onclick handler fires when the button is clicked.
+ */
+
+import {render, fireEvent} from "@testing-library/svelte";
+import {describe, expect, it, vi} from "vitest";
+
+import ActionButton from "./ActionButton.svelte";
+
+describe("ActionButton", () => {
+  it("renders the label inside a <button>", () => {
+    const {container} = render(ActionButton, {props: {label: "Download"}});
+    const button = container.querySelector("button");
+    expect(button).not.toBeNull();
+    expect(button?.textContent).toContain("Download");
+  });
+
+  it("is disabled when disabled prop is true", () => {
+    const {container} = render(ActionButton, {props: {label: "Disabled", disabled: true}});
+    expect(container.querySelector("button")?.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("is disabled and shows a spinner when loading prop is true", () => {
+    const {container} = render(ActionButton, {props: {label: "Loading", loading: true}});
+    expect(container.querySelector("button")?.hasAttribute("disabled")).toBe(true);
+    // Spinner has aria-hidden, but its <circle> + animated <path> are the marker.
+    expect(container.querySelector("button svg circle")).not.toBeNull();
+  });
+
+  it("renders the arrow-left icon when back=true and no icon prop", () => {
+    const {container} = render(ActionButton, {props: {label: "Back", back: true}});
+    // The Icon component renders <svg> when name="arrow-left"; that
+    // SVG's <path> has the distinctive d="M15 19l-7-7 7-7" shape.
+    const path = container.querySelector("button svg path");
+    expect(path?.getAttribute("d")).toBe("M15 19l-7-7 7-7");
+  });
+
+  it("renders the named icon when icon prop is provided", () => {
+    const {container} = render(ActionButton, {props: {label: "Print", icon: "print"}});
+    // The print icon path includes "M18.75 17H20" — a distinctive
+    // marker that identifies it among the 14 registered icons.
+    const printPath = container.querySelector('button svg path[d^="M18.75 17H20"]');
+    expect(printPath).not.toBeNull();
+  });
+
+  it("fires onClick when clicked", async () => {
+    const onClick = vi.fn();
+    const {container} = render(ActionButton, {props: {label: "Click me", onClick}});
+    const button = container.querySelector("button");
+    expect(button).not.toBeNull();
+    await fireEvent.click(button!);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/sites/cv.arolariu.ro/src/presentation/Badge.test.ts
+++ b/sites/cv.arolariu.ro/src/presentation/Badge.test.ts
@@ -1,0 +1,39 @@
+/**
+ * @fileoverview Render-smoke test for the Badge primitive.
+ *
+ * Asserts:
+ *  - Renders a <span> carrying the text prop verbatim.
+ *  - aria-label falls back to title, then to text when no title is given.
+ *  - Default props (color=blue, variant=soft, size=md) produce a valid render.
+ */
+
+import {render} from "@testing-library/svelte";
+import {describe, expect, it} from "vitest";
+
+import Badge from "./Badge.svelte";
+
+describe("Badge", () => {
+  it("renders the text inside a <span>", () => {
+    const {container} = render(Badge, {props: {text: "TypeScript"}});
+    const span = container.querySelector("span");
+    expect(span).not.toBeNull();
+    expect(span?.textContent).toBe("TypeScript");
+  });
+
+  it("aria-label defaults to the text when no title is provided", () => {
+    const {container} = render(Badge, {props: {text: "Svelte"}});
+    expect(container.querySelector("span")?.getAttribute("aria-label")).toBe("Svelte");
+  });
+
+  it("aria-label uses the title when one is provided", () => {
+    const {container} = render(Badge, {props: {text: "TS", title: "TypeScript 5.x"}});
+    expect(container.querySelector("span")?.getAttribute("aria-label")).toBe("TypeScript 5.x");
+  });
+
+  it("renders with non-default color/variant/size without throwing", () => {
+    const {container} = render(Badge, {
+      props: {text: "Test", color: "green", variant: "outline", size: "sm"},
+    });
+    expect(container.querySelector("span")?.textContent).toBe("Test");
+  });
+});

--- a/sites/cv.arolariu.ro/src/presentation/Footer.test.ts
+++ b/sites/cv.arolariu.ro/src/presentation/Footer.test.ts
@@ -1,0 +1,44 @@
+/**
+ * @fileoverview Render-smoke test for the site Footer.
+ *
+ * Asserts:
+ *  - Three external social links (GitHub, LinkedIn, Website) are present,
+ *    each opening in a new tab with secure rel attrs.
+ *  - Each link carries a non-empty accessible name (aria-label).
+ *  - The copyright string from the data layer is rendered.
+ */
+
+import {render} from "@testing-library/svelte";
+import {describe, expect, it} from "vitest";
+
+import Footer from "./Footer.svelte";
+
+describe("Footer", () => {
+  it("renders three external social links", () => {
+    const {container} = render(Footer);
+    const externalLinks = container.querySelectorAll('a[target="_blank"]');
+    expect(externalLinks.length).toBe(3);
+    for (const link of externalLinks) {
+      expect(link.getAttribute("rel")).toMatch(/noopener/);
+      expect(link.getAttribute("rel")).toMatch(/noreferrer/);
+    }
+  });
+
+  it("each link carries a non-empty aria-label", () => {
+    const {container} = render(Footer);
+    const links = container.querySelectorAll("a[aria-label]");
+    expect(links.length).toBeGreaterThanOrEqual(3);
+    for (const link of links) {
+      const label = link.getAttribute("aria-label");
+      expect(label).toBeTruthy();
+      expect(label?.length ?? 0).toBeGreaterThan(0);
+    }
+  });
+
+  it("renders the copyright text", () => {
+    const {container} = render(Footer);
+    const copyParagraph = container.querySelector("footer p");
+    expect(copyParagraph).not.toBeNull();
+    expect((copyParagraph?.textContent ?? "").trim().length).toBeGreaterThan(0);
+  });
+});

--- a/sites/cv.arolariu.ro/src/presentation/Header.test.ts
+++ b/sites/cv.arolariu.ro/src/presentation/Header.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @fileoverview Render test for the Header chrome component.
+ *
+ * Asserts:
+ *  - Brand <h1> always renders with the author name.
+ *  - showNavLinks=true exposes the four in-page nav anchors;
+ *    showNavLinks=false hides them.
+ *  - ThemeToggle is present (its accessible name "Toggle theme").
+ *  - actionsConfig items render as buttons with their labels.
+ */
+
+import {render} from "@testing-library/svelte";
+import {describe, expect, it, vi} from "vitest";
+
+import Header from "./Header.svelte";
+
+describe("Header", () => {
+  it("always renders the brand <h1>", () => {
+    const {container} = render(Header);
+    const h1 = container.querySelector("h1");
+    expect(h1).not.toBeNull();
+    expect(h1?.textContent).toMatch(/Olariu/);
+  });
+
+  it("renders the four in-page nav anchors when showNavLinks=true (default)", () => {
+    const {container} = render(Header);
+    const nav = container.querySelector("nav");
+    expect(nav).not.toBeNull();
+    const anchors = nav?.querySelectorAll("a[href^='#']") ?? [];
+    expect(anchors.length).toBeGreaterThanOrEqual(4);
+    const hrefs = Array.from(anchors, (a) => a.getAttribute("href"));
+    expect(hrefs).toContain("#about");
+    expect(hrefs).toContain("#experience");
+    expect(hrefs).toContain("#skills");
+    expect(hrefs).toContain("#contact");
+  });
+
+  it("hides the in-page nav when showNavLinks=false", () => {
+    const {container} = render(Header, {props: {showNavLinks: false}});
+    expect(container.querySelector("nav")).toBeNull();
+  });
+
+  it("includes the theme toggle", () => {
+    const {getByRole} = render(Header);
+    expect(getByRole("button", {name: /toggle theme/i})).toBeTruthy();
+  });
+
+  it("renders buttons for each actionsConfig entry", () => {
+    const onClick = vi.fn();
+    const {getByRole} = render(Header, {
+      props: {
+        actionsConfig: [
+          {icon: "print" as const, label: "Print", loading: false, disabled: false, onClick},
+          {icon: "download" as const, label: "Download PDF", loading: false, disabled: false, onClick},
+        ],
+      },
+    });
+    expect(getByRole("button", {name: /print/i})).toBeTruthy();
+    expect(getByRole("button", {name: /download pdf/i})).toBeTruthy();
+  });
+});

--- a/sites/cv.arolariu.ro/src/presentation/Icon.test.ts
+++ b/sites/cv.arolariu.ro/src/presentation/Icon.test.ts
@@ -1,0 +1,50 @@
+/**
+ * @fileoverview Render-smoke test for the Icon registry.
+ *
+ * Asserts:
+ *  - Each tested known name renders an <svg> element.
+ *  - An unknown name produces no SVG (the {#if/:else if} chain has no
+ *    fallback branch — it renders nothing).
+ *  - Numeric size prop produces a CSS dimension style.
+ */
+
+import {render} from "@testing-library/svelte";
+import {describe, expect, it} from "vitest";
+
+import Icon from "./Icon.svelte";
+
+describe("Icon", () => {
+  it.each([
+    ["arrow-left"],
+    ["arrow-right"],
+    ["download"],
+    ["github"],
+    ["help"],
+  ] as const)("renders an <svg> for the known name %s", (name) => {
+    const {container} = render(Icon, {props: {name}});
+    expect(container.querySelector("svg")).not.toBeNull();
+  });
+
+  it("renders nothing for an unknown name", () => {
+    // Casting through unknown is required because the IconName union
+    // does not include this string; the component still gracefully
+    // renders nothing because every branch is guarded by the name.
+    const {container} = render(Icon, {props: {name: "not-a-real-icon" as unknown as never}});
+    expect(container.querySelector("svg")).toBeNull();
+  });
+
+  it("applies width/height from a numeric size prop", () => {
+    const {container} = render(Icon, {props: {name: "github", size: 24}});
+    const svg = container.querySelector("svg");
+    // jsdom normalizes the style attribute (inserts spaces after colons),
+    // so the regex allows optional whitespace between property and value.
+    expect(svg?.getAttribute("style")).toMatch(/width:\s*24px/);
+    expect(svg?.getAttribute("style")).toMatch(/height:\s*24px/);
+  });
+
+  it("applies width/height from a CSS-string size prop", () => {
+    const {container} = render(Icon, {props: {name: "github", size: "1.5rem"}});
+    const svg = container.querySelector("svg");
+    expect(svg?.getAttribute("style")).toMatch(/width:\s*1\.5rem/);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 5 of the cv.arolariu.ro quality sweep — close render-test coverage gaps on the eight remaining `.svelte` components without colocated tests, plus a small VS Code editor-tooling tweak.

### Coverage added

| Component | New tests | What's covered |
|-----------|----------:|-----------------|
| Badge | 4 | text rendering, aria-label fallback chain, non-default props |
| Icon | 8 | five known-name SVG renderings via `it.each`, unknown-name no-op, numeric & string size styling |
| Footer | 3 | three external social links with secure rel, accessible names, copyright present |
| ActionButton | 6 | label, disabled, loading spinner, back-arrow, icon prop, click handler |
| ThemeToggle | 3 | button presence + accessible name + click flips `useTheme().current` |
| ScrollProgress | 3 | hidden on `/`, hidden on `/json`, visible on `/human` with ARIA bounds |
| AnimatedSection | 5 | section element, children pass-through, id/class/aria-label forwarding |
| Header | 5 | brand `<h1>`, conditional in-page nav, theme toggle, actionsConfig buttons |

### Editor tooling
- `.vscode/settings.json` — add `*.svelte` rule to `explorer.fileNesting.patterns` so each component's `.module.scss`, `.test.ts`, `.module.test.ts` siblings fold under the parent `.svelte` file in the Explorer (mirrors the existing rules for `.py`/`.cs`/`.ts`/`.tsx`).

### Verification
- `npm run test:unit` — **335/335 passing** (298 Phase-4 baseline + 37 net new across 8 test files)
- `svelte-check` — no new errors vs baseline
- Final code review: zero Critical / zero Important issues; three Minor nits flagged as low-priority follow-ups (wording polish, redundant URL set, `as unknown as never` cast)

### Out of scope (future phases)
- Wrapper view tests (`HumanView.svelte`, root `+page.svelte`, `human/+page.svelte`) — already covered transitively by section tests
- Service-worker unit tests — separate plan (needs CacheStorage / Service Worker global mocking)
- E2E Playwright suite expansion — separate plan
- Visual-regression / Storybook stories — different deliverable

### Plan reference
`docs/superpowers/plans/2026-05-11-cv-test-coverage.md` (gitignored, local)

## Test plan
- [x] Vitest unit suite green (335/335)
- [x] Final cross-commit code review (Ready to merge)
- [ ] CI green on preview merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)