### PR TITLE
test(arolariu.ro): push Vitest coverage close to 100% on non-component surface

### DIFF
--- a/sites/arolariu.ro/src/app/api/health/route.test.ts
+++ b/sites/arolariu.ro/src/app/api/health/route.test.ts
@@ -203,4 +203,31 @@ describe("/api/health", () => {
     expect(body.build.siteUrl).toBe("unknown");
     expect(body.build.infraMode).toBe("unknown");
   });
+
+  it("uses Azure production URLs when AZURE_CLIENT_ID is set", async () => {
+    // Set AZURE_CLIENT_ID before importing so the module-level constant picks it up
+    vi.stubEnv("AZURE_CLIENT_ID", "test-azure-client-id");
+    mockFetch.mockResolvedValue({ok: true, status: 200});
+
+    const {GET} = await import("./route");
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    // With AZURE_CLIENT_ID set, URLs should use https://
+    expect(body.dependencies[0]?.url).toContain("https://exp.arolariu.ro");
+    expect(body.dependencies[1]?.url).toContain("https://api.arolariu.ro");
+  });
+
+  it("returns unknown nextVersion when next/package.json version is undefined", async () => {
+    // Override the next/package.json mock to export version as undefined
+    vi.doMock("next/package.json", () => ({version: undefined}));
+    mockFetch.mockResolvedValue({ok: true, status: 200});
+
+    const {GET} = await import("./route");
+    const response = await GET();
+    const body = await response.json();
+
+    expect(body.process.nextVersion).toBe("unknown");
+  });
 });

--- a/sites/arolariu.ro/src/app/api/user/route.test.ts
+++ b/sites/arolariu.ro/src/app/api/user/route.test.ts
@@ -396,6 +396,43 @@ describe("GET /api/user", () => {
     );
   });
 
+  it("should throw and fallback to guest when jwtSecret is null", async () => {
+    mockAuth.mockResolvedValue({
+      isAuthenticated: false,
+      userId: null,
+    });
+    // fetchApiJwtSecret returns null → the guard at line 151 throws
+    mockFetchApiJwtSecret.mockResolvedValue(null);
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    const data: UserInformation = await response.json();
+
+    // Error catch block returns fallback guest user
+    expect(data.user).toBeNull();
+    expect(data.userIdentifier).toBe("00000000-0000-0000-0000-000000000000");
+    expect(data.userJwt).toBe("");
+  });
+
+  it("should throw and fallback to guest when jwtSecret is empty string", async () => {
+    mockAuth.mockResolvedValue({
+      isAuthenticated: true,
+      userId: "user-123",
+    });
+    // fetchApiJwtSecret returns empty string → the guard at line 151 throws
+    mockFetchApiJwtSecret.mockResolvedValue("");
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    const data: UserInformation = await response.json();
+
+    expect(data.user).toBeNull();
+    expect(data.userIdentifier).toBe("00000000-0000-0000-0000-000000000000");
+    expect(data.userJwt).toBe("");
+  });
+
   it("should use N/A when user object has no identifiers", async () => {
     const mockUser = {
       id: null,

--- a/sites/arolariu.ro/src/app/domains/invoices/_contexts/DialogContext.test.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_contexts/DialogContext.test.tsx
@@ -355,6 +355,30 @@ describe("useDialog", () => {
     expect(result.current.currentDialog.mode).toBe("edit");
   });
 
+  test("openWith overrides mode and payload at call time", () => {
+    const {result} = renderHook(() => useDialog("SHARED__INVOICE_SHARE", "view", {id: 0}), {wrapper});
+
+    act(() => {
+      result.current.openWith("edit", {id: 42});
+    });
+
+    expect(result.current.currentDialog.type).toBe("SHARED__INVOICE_SHARE");
+    expect(result.current.currentDialog.mode).toBe("edit");
+    expect(result.current.currentDialog.payload).toStrictEqual({id: 42});
+  });
+
+  test("openWith falls back to hook-level payload when call-site payload is omitted", () => {
+    const defaultPayload = {id: 99};
+    const {result} = renderHook(() => useDialog("SHARED__INVOICE_SHARE", "view", defaultPayload), {wrapper});
+
+    act(() => {
+      result.current.openWith("add"); // no payload argument
+    });
+
+    expect(result.current.currentDialog.mode).toBe("add");
+    expect(result.current.currentDialog.payload).toStrictEqual(defaultPayload);
+  });
+
   test("context maintains singleton reference to dialog state type", () => {
     // Create multiple hooks
     const {result: hook1} = renderHook(() => useDialog("SHARED__INVOICE_SHARE"), {wrapper});

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_utils/analytics.test.ts
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_utils/analytics.test.ts
@@ -40,9 +40,7 @@ describe("getCategorySpending — fallback fill color", () => {
     // Cast a numeric value outside the known ProductCategory map keys (e.g., 999)
     // to exercise the `|| "var(--ac-chart-1)"` branch on line 48.
     const unknownCategory = 999 as unknown as (typeof ProductCategory)[keyof typeof ProductCategory];
-    const items = [
-      new ProductBuilder().withCategory(unknownCategory).withTotalPrice(25).build(),
-    ];
+    const items = [new ProductBuilder().withCategory(unknownCategory).withTotalPrice(25).build()];
 
     const result = getCategorySpending(items);
 
@@ -1154,10 +1152,7 @@ describe("computeShoppingPatterns", () => {
       .withPaymentAmount(120)
       .build();
 
-    const result = computeShoppingPatterns(
-      [currentMonthInvoice, year2022Invoice, year2023Invoice],
-      new Date("2024-03-01"),
-    );
+    const result = computeShoppingPatterns([currentMonthInvoice, year2022Invoice, year2023Invoice], new Date("2024-03-01"));
 
     expect(result.historicalByDay[20]).toBeDefined();
     expect(result.historicalByDay[20]?.yearsWithData).toBe(2);

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_utils/analytics.test.ts
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_utils/analytics.test.ts
@@ -35,6 +35,23 @@ vi.mock("@/lib/currency", () => ({
   }),
 }));
 
+describe("getCategorySpending — fallback fill color", () => {
+  it("should use fallback color for category not in CATEGORY_COLORS map", () => {
+    // Cast a numeric value outside the known ProductCategory map keys (e.g., 999)
+    // to exercise the `|| "var(--ac-chart-1)"` branch on line 48.
+    const unknownCategory = 999 as unknown as (typeof ProductCategory)[keyof typeof ProductCategory];
+    const items = [
+      new ProductBuilder().withCategory(unknownCategory).withTotalPrice(25).build(),
+    ];
+
+    const result = getCategorySpending(items);
+
+    expect(result).toHaveLength(1);
+    // Should fall back to "var(--ac-chart-1)" because 999 is not in CATEGORY_COLORS
+    expect(result[0]?.fill).toBe("var(--ac-chart-1)");
+  });
+});
+
 describe("getSpendingTrend", () => {
   it("should return empty array if fewer than 2 invoices", () => {
     const invoice = new InvoiceBuilder().build();
@@ -218,6 +235,64 @@ describe("getSpendingTrend", () => {
 
     expect(result[0]?.invoices[0]?.name).toBe("Invoice abc12345");
   });
+
+  it("should fall back to createdAt when paymentInformation is missing on allInvoices entries", () => {
+    // Lines 172-178: paymentInformation?.transactionDate ?? inv.createdAt,
+    // paymentInformation?.totalCostAmount ?? 0, paymentInformation?.currency?.code ?? "RON"
+    const invoice1 = new InvoiceBuilder()
+      .withId("inv1")
+      .withCreatedAt(new Date("2024-03-10"))
+      .withTransactionDate(new Date("2024-03-10"))
+      .withPaymentAmount(100)
+      .withPaymentCurrency("RON")
+      .build();
+
+    const invoice2 = new InvoiceBuilder()
+      .withId("inv2")
+      .withCreatedAt(new Date("2024-03-20"))
+      .withTransactionDate(new Date("2024-03-20"))
+      .withPaymentAmount(50)
+      .withPaymentCurrency("RON")
+      .build();
+    // Strip paymentInformation so optional chaining paths fire
+    (invoice2 as any).paymentInformation = null;
+
+    const result = getSpendingTrend(invoice1, [invoice1, invoice2]);
+
+    // invoice2 has no paymentInformation: amount falls back to 0, currency to "RON",
+    // date falls back to invoice2.createdAt (2024-03-20 → same month as invoice1)
+    expect(result).toHaveLength(1);
+    expect(result[0]?.date).toContain("Mar");
+    // invoice2 contributes 0 (null paymentInformation → amount ?? 0)
+    expect(result[0]?.amount).toBe(100);
+  });
+
+  it("should fall back to currentInvoice.createdAt when its paymentInformation is missing", () => {
+    // Line 204: currentInvoice.paymentInformation?.transactionDate ?? currentInvoice.createdAt
+    const invoice1 = new InvoiceBuilder()
+      .withId("inv1")
+      .withCreatedAt(new Date("2024-04-05"))
+      .withTransactionDate(new Date("2024-04-05"))
+      .withPaymentAmount(100)
+      .withPaymentCurrency("RON")
+      .build();
+
+    const invoice2 = new InvoiceBuilder()
+      .withId("current")
+      .withCreatedAt(new Date("2024-04-15"))
+      .withTransactionDate(new Date("2024-04-15"))
+      .withPaymentAmount(200)
+      .withPaymentCurrency("RON")
+      .build();
+    // Strip paymentInformation from the currentInvoice so line 204 uses createdAt
+    (invoice2 as any).paymentInformation = null;
+
+    const result = getSpendingTrend(invoice2, [invoice1, invoice2]);
+
+    // Both are April — the current month key should match April (from createdAt fallback)
+    expect(result).toHaveLength(1);
+    expect(result[0]?.isCurrent).toBe(true);
+  });
 });
 
 describe("getComparisonStats", () => {
@@ -351,6 +426,78 @@ describe("getComparisonStats", () => {
     expect(result.currentAmount).toBe(500);
     expect(result.averageAmount).toBe(100);
   });
+
+  it("should use fallback values when current invoice paymentInformation is missing (lines 250-254)", () => {
+    // Lines 250-254: currentInvoice.paymentInformation?.totalCostAmount ?? 0,
+    // paymentInformation?.currency?.code ?? "RON", currentInvoice.items?.length ?? 0
+    const currentInvoice = new InvoiceBuilder().withId("current").build();
+    (currentInvoice as any).paymentInformation = null;
+    (currentInvoice as any).items = null;
+
+    const otherInvoice = new InvoiceBuilder().withId("other").withPaymentAmount(100).withPaymentCurrency("RON").build();
+
+    // With fewer than 2 invoices (early-return path with fallback fields):
+    const singleResult = getComparisonStats(currentInvoice, [currentInvoice]);
+    expect(singleResult.currentAmount).toBe(0); // totalCostAmount ?? 0
+    expect(singleResult.currentItemCount).toBe(0); // items?.length ?? 0
+    expect(singleResult.totalInvoices).toBe(1);
+
+    // With 2+ invoices, currentAmountInRON still uses the fallbacks
+    const multiResult = getComparisonStats(currentInvoice, [currentInvoice, otherInvoice]);
+    expect(multiResult.currentAmount).toBe(0);
+    expect(multiResult.currentItemCount).toBe(0);
+  });
+
+  it("should handle missing paymentInformation on other invoices (lines 278-293)", () => {
+    // Lines 278-293: amounts map with optional chaining on other invoices
+    const currentInvoice = new InvoiceBuilder().withId("current").withPaymentAmount(150).withPaymentCurrency("RON").build();
+
+    const otherInvoice1 = new InvoiceBuilder().withId("other1").withPaymentAmount(100).withPaymentCurrency("RON").build();
+    const otherInvoice2 = new InvoiceBuilder().withId("other2").withPaymentAmount(200).withPaymentCurrency("RON").build();
+    // Strip paymentInformation from other2 so optional chaining fires
+    (otherInvoice2 as any).paymentInformation = null;
+
+    const result = getComparisonStats(currentInvoice, [currentInvoice, otherInvoice1, otherInvoice2]);
+
+    // other2 contributes 0 (amount ?? 0); only other1's 100 counts
+    // averageAmount = (100 + 0) / 2 = 50
+    expect(result.averageAmount).toBe(50);
+    // minAmount and maxAmount from [100, 0]
+    expect(result.minAmount).toBe(0);
+    expect(result.maxAmount).toBe(100);
+  });
+
+  it("should handle missing paymentInformation on same-merchant invoices (lines 305-312)", () => {
+    // Lines 305-312: sameMerchantAmounts map with optional chaining
+    const currentInvoice = new InvoiceBuilder()
+      .withId("current")
+      .withMerchantReference("merchant-x")
+      .withPaymentAmount(200)
+      .withPaymentCurrency("RON")
+      .build();
+
+    const sameMerchantInvoice = new InvoiceBuilder()
+      .withId("same")
+      .withMerchantReference("merchant-x")
+      .withPaymentAmount(100)
+      .withPaymentCurrency("RON")
+      .build();
+    // Strip paymentInformation so the optional chaining on line 305-308 fires
+    (sameMerchantInvoice as any).paymentInformation = null;
+
+    const differentMerchant = new InvoiceBuilder()
+      .withId("diff")
+      .withMerchantReference("merchant-y")
+      .withPaymentAmount(50)
+      .withPaymentCurrency("RON")
+      .build();
+
+    const result = getComparisonStats(currentInvoice, [currentInvoice, sameMerchantInvoice, differentMerchant]);
+
+    // sameMerchantInvoice has null paymentInformation → amount ?? 0, currency ?? "RON"
+    // sameMerchantAvg = 0 (only same-merchant invoice has 0 amount)
+    expect(result.sameMerchantAvg).toBe(0);
+  });
 });
 
 describe("getMerchantBreakdown", () => {
@@ -430,6 +577,43 @@ describe("getMerchantBreakdown", () => {
     expect(result[0]?.total).toBe(950);
     expect(result[0]?.average).toBe(475);
   });
+
+  it("should filter out invoices with EMPTY_GUID merchant reference", () => {
+    const emptyGuidInvoice = new InvoiceBuilder()
+      .withMerchantReference("00000000-0000-0000-0000-000000000000")
+      .withPaymentAmount(100)
+      .withPaymentCurrency("RON")
+      .build();
+
+    const validInvoice = new InvoiceBuilder()
+      .withMerchantReference("merchant-valid")
+      .withPaymentAmount(200)
+      .withPaymentCurrency("RON")
+      .build();
+
+    const result = getMerchantBreakdown([emptyGuidInvoice, validInvoice]);
+
+    // Only merchant-valid should appear; EMPTY_GUID invoice is filtered
+    expect(result).toHaveLength(1);
+    expect(result[0]?.name).toBe("merchant-valid");
+  });
+
+  it("should use fallback amount/currency when paymentInformation is missing (lines 362-363)", () => {
+    // Lines 362-363: inv.paymentInformation?.totalCostAmount ?? 0 and currency?.code ?? "RON"
+    const invoiceWithoutPayment = new InvoiceBuilder()
+      .withMerchantReference("merchant-nopay")
+      .withPaymentAmount(100)
+      .withPaymentCurrency("RON")
+      .build();
+    (invoiceWithoutPayment as any).paymentInformation = null;
+
+    const result = getMerchantBreakdown([invoiceWithoutPayment]);
+
+    // amount ?? 0 → total = 0, currency ?? "RON" (still RON, toRON(0, "RON", year) = 0)
+    expect(result).toHaveLength(1);
+    expect(result[0]?.total).toBe(0);
+    expect(result[0]?.average).toBe(0);
+  });
 });
 
 describe("getCategoryComparison", () => {
@@ -479,6 +663,36 @@ describe("getCategoryComparison", () => {
     expect(result).toHaveLength(1);
     expect(result[0]?.category).toContain("FRUITS");
     expect(result[0]?.current).toBe(75);
+    expect(result[0]?.average).toBe(0);
+  });
+
+  it("should use fallback empty array when currentInvoice.items is null (line 410)", () => {
+    // Line 410: const currentItems = currentInvoice.items ?? [];
+    const invoice = new InvoiceBuilder().withId("current").build();
+    (invoice as any).items = null;
+
+    const result = getCategoryComparison(invoice, [invoice]);
+
+    // null items falls back to [], so length === 0 → returns []
+    expect(result).toEqual([]);
+  });
+
+  it("should use fallback empty array when other invoice items are null (line 427)", () => {
+    // Line 427: const items = inv.items ?? [];
+    const currentInvoice = new InvoiceBuilder()
+      .withId("current")
+      .withItems([{category: ProductCategory.BEVERAGES, totalPrice: 40} as any])
+      .build();
+
+    const otherInvoice = new InvoiceBuilder().withId("other").withPaymentAmount(50).build();
+    (otherInvoice as any).items = null;
+
+    const result = getCategoryComparison(currentInvoice, [currentInvoice, otherInvoice]);
+
+    // otherInvoice.items ?? [] → empty, so historical average for BEVERAGES = 0
+    expect(result).toHaveLength(1);
+    expect(result[0]?.category).toContain("BEVERAGES");
+    expect(result[0]?.current).toBe(40);
     expect(result[0]?.average).toBe(0);
   });
 });
@@ -855,6 +1069,100 @@ describe("computeShoppingPatterns", () => {
 
     expect(result.spendingByDay[15]?.invoiceIds).toContain("test-invoice-id");
     expect(result.spendingByDay[15]?.invoiceNames).toContain("Test Invoice");
+  });
+
+  it("should compute historical comparison when prior-year same-month invoices exist (lines 618-649)", () => {
+    // This exercises computeHistoricalComparison's inner block:
+    // when `historical && historical.years.size > 0` is true.
+    // We need current-month invoices (Jan 2024) and prior-year same-month invoices (Jan 2023).
+    const currentMonthInvoice = new InvoiceBuilder()
+      .withId("cur-jan-2024")
+      .withName("Jan 2024 Shopping")
+      .withTransactionDate(new Date("2024-01-10"))
+      .withPaymentAmount(150)
+      .build();
+
+    // Historical: January 2023, same day-of-month (10th) → should create comparison
+    const priorYearInvoice = new InvoiceBuilder()
+      .withId("hist-jan-2023")
+      .withName("Jan 2023 Shopping")
+      .withTransactionDate(new Date("2023-01-10"))
+      .withPaymentAmount(100)
+      .build();
+
+    const allInvoices = [currentMonthInvoice, priorYearInvoice];
+    const result = computeShoppingPatterns(allInvoices, new Date("2024-01-01"));
+
+    // Current month has spending on day 10
+    expect(result.spendingByDay[10]?.amount).toBe(150);
+
+    // historicalByDay should have an entry for day 10 (from priorYearInvoice)
+    // meaning historicalByDay[10] is populated and the if-block at line 616 fires
+    expect(result.historicalByDay[10]).toBeDefined();
+    expect(result.historicalByDay[10]?.yearsWithData).toBe(1);
+    expect(result.historicalByDay[10]?.historicalAverage).toBe(100);
+    // current (150) > historical (100) → isAboveAverage = true
+    expect(result.historicalByDay[10]?.isAboveAverage).toBe(true);
+    // percentageDiff = (150-100)/100*100 = 50%
+    expect(result.historicalByDay[10]?.percentageDiff).toBe(50);
+  });
+
+  it("should compute historicalAverage=0 percentageDiff=0 when prior-year amount is zero (line 618)", () => {
+    // Exercise the ternary: percentageDiff = historicalAverage > 0 ? ... : 0
+    const currentMonthInvoice = new InvoiceBuilder()
+      .withId("cur-feb-2024")
+      .withName("Feb 2024 Shopping")
+      .withTransactionDate(new Date("2024-02-05"))
+      .withPaymentAmount(80)
+      .build();
+
+    const priorYearZeroInvoice = new InvoiceBuilder()
+      .withId("hist-feb-2023")
+      .withName("Feb 2023 Shopping")
+      .withTransactionDate(new Date("2023-02-05"))
+      .withPaymentAmount(0)
+      .build();
+
+    const result = computeShoppingPatterns([currentMonthInvoice, priorYearZeroInvoice], new Date("2024-02-01"));
+
+    // historicalAverage = 0 → percentageDiff = 0 (else branch of ternary)
+    expect(result.historicalByDay[5]).toBeDefined();
+    expect(result.historicalByDay[5]?.historicalAverage).toBe(0);
+    expect(result.historicalByDay[5]?.percentageDiff).toBe(0);
+  });
+
+  it("should compute historical comparison with multiple prior years on same day", () => {
+    // Verifies yearsWithData > 1 path through computeHistoricalComparison
+    const currentMonthInvoice = new InvoiceBuilder()
+      .withId("cur-mar-2024")
+      .withName("Mar 2024")
+      .withTransactionDate(new Date("2024-03-20"))
+      .withPaymentAmount(200)
+      .build();
+
+    const year2022Invoice = new InvoiceBuilder()
+      .withId("hist-mar-2022")
+      .withName("Mar 2022")
+      .withTransactionDate(new Date("2022-03-20"))
+      .withPaymentAmount(80)
+      .build();
+
+    const year2023Invoice = new InvoiceBuilder()
+      .withId("hist-mar-2023")
+      .withName("Mar 2023")
+      .withTransactionDate(new Date("2023-03-20"))
+      .withPaymentAmount(120)
+      .build();
+
+    const result = computeShoppingPatterns(
+      [currentMonthInvoice, year2022Invoice, year2023Invoice],
+      new Date("2024-03-01"),
+    );
+
+    expect(result.historicalByDay[20]).toBeDefined();
+    expect(result.historicalByDay[20]?.yearsWithData).toBe(2);
+    // average = (80 + 120) / 2 = 100
+    expect(result.historicalByDay[20]?.historicalAverage).toBe(100);
   });
 });
 

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_utils/statistics.test.ts
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_utils/statistics.test.ts
@@ -1560,4 +1560,257 @@ describe("Statistics Functions", () => {
       });
     });
   });
+
+  /**
+   * Deep-pass coverage tests targeting specific uncovered branches.
+   * Maps to Phase 6 of the Vitest coverage push.
+   */
+  describe("Deep-pass: Uncovered Branch Coverage", () => {
+    // --- Line 424: computeKPIs with null items array ---
+    describe("computeKPIs - null items array", () => {
+      it("should treat null items as zero items (items?.length ?? 0 branch)", () => {
+        const invoice = createTestInvoice({amount: 100});
+        // @ts-expect-error - Intentionally testing null items
+        invoice.items = null;
+
+        const result = computeKPIs([invoice]);
+
+        expect(result.totalItems).toBe(0);
+        expect(result.averageItemsPerInvoice).toBe(0);
+      });
+    });
+
+    // --- Line 484: computeMonthlySpending - both transactionDate and createdAt null ---
+    describe("computeMonthlySpending - null transactionDate and createdAt fallback", () => {
+      it("should fall back to new Date() when both transactionDate and createdAt are null", () => {
+        const invoice = createTestInvoice({amount: 50, date: new Date("2025-06-01")});
+        // @ts-expect-error - Intentionally testing null transactionDate
+        invoice.paymentInformation.transactionDate = null;
+        // @ts-expect-error - Intentionally testing null createdAt
+        invoice.createdAt = null;
+
+        // Should not throw; falls back to new Date() so produces current month
+        const result = computeMonthlySpending([invoice]);
+
+        expect(result).toHaveLength(1);
+        // The month key should be a valid YYYY-MM string
+        expect(result[0]?.monthKey).toMatch(/^\d{4}-\d{2}$/);
+      });
+    });
+
+    // --- Line 504: computeMonthlySpending - invoice name fallback branch ---
+    describe("computeMonthlySpending - invoice.name fallback", () => {
+      it("should use invoice id prefix when invoice.name is empty string", () => {
+        const invoice = createTestInvoice({amount: 100, date: new Date("2025-01-15")});
+        // Force name to empty so the || branch is taken
+        (invoice as {name: string}).name = "";
+
+        const result = computeMonthlySpending([invoice]);
+
+        // The invoices array inside MonthlySpending should contain a fallback name
+        expect(result).toHaveLength(1);
+        const invoiceEntry = result[0]?.invoices[0];
+        expect(invoiceEntry?.name).toMatch(/^Invoice /);
+      });
+
+      it("should use invoice.name when it is non-empty", () => {
+        const invoice = createTestInvoice({amount: 100, date: new Date("2025-01-15")});
+        (invoice as {name: string}).name = "My Named Invoice";
+
+        const result = computeMonthlySpending([invoice]);
+
+        expect(result[0]?.invoices[0]?.name).toBe("My Named Invoice");
+      });
+    });
+
+    // --- Line 599: computeCategoryAggregates - null invoice.category fallback ---
+    describe("computeCategoryAggregates - null invoice.category", () => {
+      it("should treat null category as 0 (Uncategorized)", () => {
+        const invoice = createTestInvoice({amount: 100});
+        // @ts-expect-error - Intentionally testing null category
+        invoice.category = null;
+
+        const result = computeCategoryAggregates([invoice]);
+
+        expect(result).toHaveLength(1);
+        expect(result[0]?.categoryId).toBe(0);
+        expect(result[0]?.category).toBe("Uncategorized");
+      });
+    });
+
+    // --- Line 612: computeCategoryAggregates - zero totalSpending branch ---
+    describe("computeCategoryAggregates - zero totalSpending percentage", () => {
+      it("should return 0% when all invoice amounts are zero", () => {
+        const invoice = createTestInvoice({amount: 0, category: 100});
+
+        const result = computeCategoryAggregates([invoice]);
+
+        expect(result).toHaveLength(1);
+        expect(result[0]?.percentage).toBe(0);
+      });
+    });
+
+    // --- Line 713: computeDailySpending - both dates invalid, invoice is skipped ---
+    describe("computeDailySpending - both dates invalid", () => {
+      it("should skip invoice when both transactionDate and createdAt resolve to epoch", () => {
+        const invoice = createTestInvoice({amount: 100, date: new Date("2025-01-15")});
+        // @ts-expect-error - Intentionally testing invalid transactionDate
+        invoice.paymentInformation.transactionDate = "not-a-date";
+        // @ts-expect-error - Intentionally testing invalid createdAt
+        invoice.createdAt = "not-a-date";
+
+        const result = computeDailySpending([invoice]);
+
+        // Invoice should be skipped entirely
+        expect(result).toHaveLength(0);
+      });
+    });
+
+    // --- Line 842: computeTimeOfDay - both transactionDate and createdAt null ---
+    describe("computeTimeOfDay - null transactionDate and createdAt fallback", () => {
+      it("should fall back to new Date() when both transactionDate and createdAt are null", () => {
+        const invoice = createTestInvoice({amount: 100});
+        // @ts-expect-error - Intentionally testing null transactionDate
+        invoice.paymentInformation.transactionDate = null;
+        // @ts-expect-error - Intentionally testing null createdAt
+        invoice.createdAt = null;
+
+        // Should not throw; invoice is counted in some segment
+        const result = computeTimeOfDay([invoice]);
+
+        const totalInvoices = result.reduce((sum, s) => sum + s.invoiceCount, 0);
+        expect(totalInvoices).toBe(1);
+      });
+    });
+
+    // --- Lines 906-910, 913: countNewMerchants - merchant before current month branch ---
+    describe("computeMonthComparison - countNewMerchants before-month branch", () => {
+      it("should correctly identify merchant from before current month as not new", () => {
+        // merchant-1 appears in Jan (before Feb current month) and Feb → not new
+        // merchant-2 appears only in Feb → new
+        const invoices = [
+          createTestInvoice({merchantId: "merchant-1", amount: 100, date: new Date("2025-01-10")}),
+          createTestInvoice({merchantId: "merchant-1", amount: 150, date: new Date("2025-02-05")}),
+          createTestInvoice({merchantId: "merchant-2", amount: 200, date: new Date("2025-02-15")}),
+          createTestInvoice({merchantId: "merchant-3", amount: 50, date: new Date("2025-01-20")}),
+        ];
+
+        const result = computeMonthComparison(invoices);
+
+        // merchant-2 is new (only in Feb); merchant-1 and merchant-3 are not new
+        expect(result.newMerchantCount).toBe(1);
+      });
+
+      it("should count zero new merchants when all current-month merchants appeared before", () => {
+        const invoices = [
+          createTestInvoice({merchantId: "merchant-1", amount: 100, date: new Date("2025-01-10")}),
+          createTestInvoice({merchantId: "merchant-1", amount: 150, date: new Date("2025-02-05")}),
+        ];
+
+        const result = computeMonthComparison(invoices);
+
+        expect(result.newMerchantCount).toBe(0);
+      });
+
+      it("should handle invoice without valid merchant in countNewMerchants", () => {
+        // Empty merchantId should be skipped in countNewMerchants
+        const invoices = [
+          createTestInvoice({merchantId: "", amount: 100, date: new Date("2025-01-10")}),
+          createTestInvoice({merchantId: "", amount: 150, date: new Date("2025-02-05")}),
+        ];
+
+        const result = computeMonthComparison(invoices);
+
+        expect(result.newMerchantCount).toBe(0);
+      });
+    });
+
+    // --- Lines 964-965: computeMonthComparison - previousMonth from monthlyData ---
+    describe("computeMonthComparison - previous month selection", () => {
+      it("should select the second-to-last month as previousMonth when 3+ months exist", () => {
+        const invoices = [
+          createTestInvoice({amount: 100, date: new Date("2025-01-15")}),
+          createTestInvoice({amount: 200, date: new Date("2025-02-15")}),
+          createTestInvoice({amount: 300, date: new Date("2025-03-15")}),
+        ];
+
+        const result = computeMonthComparison(invoices);
+
+        // Current month is March, previous month is February
+        expect(result.currentMonth.monthKey).toBe("2025-03");
+        expect(result.previousMonth?.monthKey).toBe("2025-02");
+        expect(result.spendingDelta).toBe(100); // 300 - 200
+      });
+    });
+
+    // --- Line 1147: computeMerchantTrends - createdAt and transactionDate both null fallback ---
+    describe("computeMerchantTrends - null transactionDate and createdAt fallback", () => {
+      it("should fall back to new Date() when both dates are null for trend computation", () => {
+        const invoice = createTestInvoice({merchantId: "merchant-1", amount: 100, date: new Date("2025-01-15")});
+        // @ts-expect-error - Intentionally testing null transactionDate
+        invoice.paymentInformation.transactionDate = null;
+        // @ts-expect-error - Intentionally testing null createdAt
+        invoice.createdAt = null;
+
+        // Should not throw; falls back to current date for month key
+        const result = computeMerchantTrends([invoice], 5);
+
+        expect(result).toHaveLength(1);
+        expect(result[0]?.merchantId).toBe("merchant-1");
+        expect(result[0]?.monthlyData).toHaveLength(1);
+      });
+    });
+
+    // --- Lines 1231-1235: computeMerchantVisitFrequency - initialization of new merchantData entry ---
+    describe("computeMerchantVisitFrequency - multiple merchants initialization", () => {
+      it("should initialize fresh merchant data for each new merchant encountered", () => {
+        const invoices = [
+          createTestInvoice({merchantId: "alpha", amount: 50, date: new Date("2025-01-10")}),
+          createTestInvoice({merchantId: "beta", amount: 75, date: new Date("2025-01-12")}),
+          createTestInvoice({merchantId: "gamma", amount: 25, date: new Date("2025-01-14")}),
+        ];
+
+        const result = computeMerchantVisitFrequency(invoices);
+
+        expect(result).toHaveLength(3);
+        const alpha = result.find((r) => r.merchantId === "alpha");
+        const beta = result.find((r) => r.merchantId === "beta");
+        const gamma = result.find((r) => r.merchantId === "gamma");
+        expect(alpha?.totalVisits).toBe(1);
+        expect(beta?.totalVisits).toBe(1);
+        expect(gamma?.totalVisits).toBe(1);
+      });
+
+      it("should handle null transactionDate in computeMerchantVisitFrequency with createdAt fallback", () => {
+        const invoice = createTestInvoice({merchantId: "merchant-1", amount: 100, date: new Date("2025-01-15")});
+        // @ts-expect-error - Intentionally testing null transactionDate
+        invoice.paymentInformation.transactionDate = null;
+
+        const result = computeMerchantVisitFrequency([invoice]);
+
+        // Should fall back to createdAt; still produce one result
+        expect(result).toHaveLength(1);
+        expect(result[0]?.merchantId).toBe("merchant-1");
+      });
+    });
+
+    // --- Line 1668: computeAllergenFrequency - totalProducts === 0 percentage branch ---
+    // This branch (percentage = 0 when totalProducts === 0) is reached when allergenMap has
+    // entries but totalProducts is 0 — structurally impossible because allergens are only
+    // added when products are iterated (which also increments totalProducts).
+    // Rule-2 skip: the false branch of `totalProducts > 0` in allergenFrequency is a
+    // defensive default that cannot be reached through the public API.
+    //
+    // --- Lines 1286-1287: computeMerchantVisitFrequency - averageBasketSize/averageSpendPerVisit
+    // when visits === 0 --- structurally unreachable since visits is incremented before the
+    // averages are computed. Rule-2 skip.
+    //
+    // --- Line 1593: computeTopProducts - averagePrice when priceCount === 0 ---
+    // Structurally unreachable: priceCount is incremented for every product map entry. Rule-2 skip.
+    //
+    // --- Line 1166: computeMerchantTrends - monthlyMap undefined branch ---
+    // merchantMonthlyData.get(merchantId) is always set in Step 3 for every merchant that
+    // passed isValidMerchantRef, which is the same set that populated sortedMerchants in Step 2.
+    // Rule-2 skip: defensive ternary whose false arm cannot be triggered externally.
+  });
 });

--- a/sites/arolariu.ro/src/app/domains/invoices/view-scans/_hooks/useScans.test.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-scans/_hooks/useScans.test.tsx
@@ -51,6 +51,20 @@ vi.mock("zustand/react/shallow", () => ({
   useShallow: vi.fn((fn: unknown) => fn),
 }));
 
+// Mock the toast utility so we can assert on success/error calls.
+// Use `vi.hoisted` because `vi.mock` is hoisted above top-level declarations.
+const {mockToast} = vi.hoisted(() => ({
+  mockToast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+vi.mock("@arolariu/components", () => ({
+  toast: mockToast,
+}));
+
 // Import vitest functions AFTER mocks
 import {act, renderHook, waitFor} from "@testing-library/react";
 import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
@@ -277,6 +291,10 @@ describe("useScans", () => {
 
       expect(syncDone).toBe(true);
       expect(mockStoreState.setIsSyncing).toHaveBeenCalledWith(false);
+      // The suppression contract: with isMountedRef.current=false, the
+      // error toast must NOT fire even though sync rejected. console.error
+      // still logs (the guard wraps only the toast call).
+      expect(mockToast.error).not.toHaveBeenCalled();
       consoleErrorSpy.mockRestore();
     });
 
@@ -326,6 +344,9 @@ describe("useScans", () => {
       expect(mockStoreState.setScans).toHaveBeenCalled();
       expect(mockStoreState.setLastSyncTimestamp).toHaveBeenCalled();
       expect(mockStoreState.setIsSyncing).toHaveBeenCalledWith(false);
+      // The manual-sync contract: success toast fires exactly when
+      // `manual=true && isMountedRef.current=true`.
+      expect(mockToast.success).toHaveBeenCalledWith("Scans synced successfully");
     });
   });
 

--- a/sites/arolariu.ro/src/app/domains/invoices/view-scans/_hooks/useScans.test.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-scans/_hooks/useScans.test.tsx
@@ -249,6 +249,37 @@ describe("useScans", () => {
       consoleErrorSpy.mockRestore();
     });
 
+    it("should suppress error toast when component is unmounted before sync rejects", async () => {
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      // Use a deferred promise so we can control when the fetch resolves/rejects
+      let rejectFetch!: (err: Error) => void;
+      const deferredFetch = new Promise<never>((_, reject) => {
+        rejectFetch = reject;
+      });
+      mockFetchScans.mockReturnValue(deferredFetch);
+
+      const {result, unmount} = renderHook(() => useScans());
+
+      // Kick off the sync — it will await the deferred promise
+      let syncDone = false;
+      const syncPromise = result.current.syncScans().then(() => {
+        syncDone = true;
+      });
+
+      // Unmount to set isMountedRef.current = false
+      unmount();
+
+      // Now reject the deferred fetch
+      rejectFetch(new Error("Network error after unmount"));
+      await syncPromise.catch(() => {});
+      await Promise.resolve(); // flush microtasks
+
+      expect(syncDone).toBe(true);
+      expect(mockStoreState.setIsSyncing).toHaveBeenCalledWith(false);
+      consoleErrorSpy.mockRestore();
+    });
+
     it("should add cachedAt timestamp to fetched scans", async () => {
       const fetchedScans = [
         {
@@ -279,6 +310,22 @@ describe("useScans", () => {
           }),
         ]),
       );
+    });
+  });
+
+  describe("manual sync", () => {
+    it("should show success toast when manual=true and component is mounted", async () => {
+      mockFetchScans.mockResolvedValue([]);
+
+      const {result} = renderHook(() => useScans());
+
+      await act(async () => {
+        await result.current.syncScans(true);
+      });
+
+      expect(mockStoreState.setScans).toHaveBeenCalled();
+      expect(mockStoreState.setLastSyncTimestamp).toHaveBeenCalled();
+      expect(mockStoreState.setIsSyncing).toHaveBeenCalledWith(false);
     });
   });
 

--- a/sites/arolariu.ro/src/app/my-profile/_utils/helpers.test.ts
+++ b/sites/arolariu.ro/src/app/my-profile/_utils/helpers.test.ts
@@ -521,5 +521,21 @@ describe("my-profile helpers", () => {
       const result = deepMerge(target, source);
       expect(result).toEqual({a: {b: 1}});
     });
+
+    it("should skip inherited enumerable properties from source prototype chain", () => {
+      // Create a source object with an inherited enumerable property via prototype
+      // Object.hasOwn returns false for inherited keys, exercising the false branch at line 160
+      const proto = {inherited: "should-be-skipped"};
+      const source = Object.create(proto) as {inherited: string; own: string};
+      source.own = "included";
+
+      const target = {own: "original", inherited: "not-overwritten"};
+      const result = deepMerge(target, source as unknown as Partial<typeof target>);
+
+      // Own key from source is merged
+      expect(result.own).toBe("included");
+      // Inherited key is NOT merged (Object.hasOwn is false)
+      expect(result.inherited).toBe("not-overwritten");
+    });
   });
 });

--- a/sites/arolariu.ro/src/contexts/FontContext.test.tsx
+++ b/sites/arolariu.ro/src/contexts/FontContext.test.tsx
@@ -2,6 +2,14 @@ import {act, renderHook} from "@testing-library/react";
 import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
 import {FontContextProvider, useFontContext} from "./FontContext";
 
+// Mock @/lib/utils.client so we can control isBrowserStorageAvailable per-suite.
+// The default (vi.fn returning true) matches the beforeEach localStorage mock below.
+vi.mock("@/lib/utils.client", () => ({
+  isBrowserStorageAvailable: vi.fn(() => true),
+}));
+
+import {isBrowserStorageAvailable} from "@/lib/utils.client";
+
 // Mock next/font/google fonts
 vi.mock("next/font/google", () => ({
   Caudex: vi.fn(() => ({
@@ -365,6 +373,36 @@ describe("FontContext", () => {
       }).toThrow("useFontContext must be used within a FontContextProvider");
 
       consoleSpy.mockRestore();
+    });
+  });
+
+  describe("when localStorage is unavailable (isBrowserStorageAvailable returns false)", () => {
+    beforeEach(() => {
+      vi.mocked(isBrowserStorageAvailable).mockReturnValue(false);
+    });
+
+    it("should initialise with normal font when localStorage is unavailable", () => {
+      const wrapper = ({children}: {children: React.ReactNode}) => <FontContextProvider>{children}</FontContextProvider>;
+
+      const {result} = renderHook(() => useFontContext(), {wrapper});
+
+      // Falls through to the default "normal" return without reading localStorage
+      expect(result.current.fontType).toBe("normal");
+    });
+
+    it("should not persist font preference when localStorage is unavailable", () => {
+      const wrapper = ({children}: {children: React.ReactNode}) => <FontContextProvider>{children}</FontContextProvider>;
+
+      const {result} = renderHook(() => useFontContext(), {wrapper});
+
+      act(() => {
+        result.current.setFont("dyslexic");
+      });
+
+      // State should update in memory even without localStorage
+      expect(result.current.fontType).toBe("dyslexic");
+      // But localStorage.setItem should NOT have been called
+      expect(localStorageMock["selectedFont"]).toBeUndefined();
     });
   });
 

--- a/sites/arolariu.ro/src/hooks/useUserInformation.test.tsx
+++ b/sites/arolariu.ro/src/hooks/useUserInformation.test.tsx
@@ -264,6 +264,35 @@ describe("useUserInformation - abort signal handling", () => {
     });
   });
 
+  describe("DOMException AbortError with non-aborted signal (race condition)", () => {
+    beforeEach(() => {
+      vi.stubEnv("NODE_ENV", "development");
+    });
+
+    it("silences DOMException AbortError even when signal.aborted is false at catch time", async () => {
+      // This covers the second half of the isAbort OR: signal is NOT aborted yet
+      // but a DOMException "AbortError" is thrown — a real race condition in browsers.
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      // Reject with a DOMException AbortError but do NOT abort the signal
+      mockFetch.mockRejectedValue(new DOMException("The operation was aborted.", "AbortError"));
+
+      const {result} = renderHook(() => useUserInformation());
+
+      await waitFor(() => {
+        // In dev mode, silenced → isError stays false and isLoading is not reset
+        // (shouldSkipLoadingReset = dev && signal.aborted; signal NOT aborted here,
+        //  so isLoading DOES get reset to false)
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // Should NOT log the AbortError and should NOT set isError (treated as abort)
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+      expect(result.current.isError).toBe(false);
+      consoleErrorSpy.mockRestore();
+    });
+  });
+
   describe("in production mode", () => {
     beforeEach(() => {
       vi.stubEnv("NODE_ENV", "production");

--- a/sites/arolariu.ro/src/lib/actions/scans/fetchScans.test.ts
+++ b/sites/arolariu.ro/src/lib/actions/scans/fetchScans.test.ts
@@ -475,6 +475,46 @@ describe("fetchScans", () => {
       expect(result[0]?.sizeInBytes).toBe(0);
     });
 
+    it("should skip blobs marked as usedByInvoice", async () => {
+      const mockBlobs = [
+        {
+          name: "scans/test-user-guid/used-scan.jpg",
+          metadata: {
+            scanId: "used-scan",
+            usedByInvoice: "true",
+          },
+          properties: {
+            contentType: "image/jpeg",
+            contentLength: 1024,
+          },
+        },
+        {
+          name: "scans/test-user-guid/available-scan.jpg",
+          metadata: {
+            scanId: "available-scan",
+          },
+          properties: {
+            contentType: "image/jpeg",
+            contentLength: 512,
+          },
+        },
+      ];
+
+      mockListBlobsFlat.mockReturnValue({
+        [Symbol.asyncIterator]: async function* () {
+          for (const blob of mockBlobs) {
+            yield blob;
+          }
+        },
+      });
+
+      const result = await fetchScans();
+
+      // The used-by-invoice blob must be skipped
+      expect(result).toHaveLength(1);
+      expect(result[0]?.id).toBe("available-scan");
+    });
+
     it("should handle blob with no metadata object at all", async () => {
       const mockBlobs = [
         {

--- a/sites/arolariu.ro/src/lib/actions/scans/registerScan.test.ts
+++ b/sites/arolariu.ro/src/lib/actions/scans/registerScan.test.ts
@@ -196,6 +196,74 @@ describe("registerScan", () => {
   });
 
   describe("blob metadata handling", () => {
+    it("should record metadata completion telemetry when setMetadata succeeds", async () => {
+      // Arrange - exercises the setMetadata success branch (lines 170-171 in source).
+      // mockReset: true in vitest.config.ts resets all vi.fn() implementations between tests,
+      // so createBlobClient's chain must be re-established explicitly here.
+      const {createBlobClient} = await import("@/lib/azure/storageClient");
+      const mockSetMetadata = vi.fn().mockResolvedValue(undefined);
+      vi.mocked(createBlobClient).mockResolvedValue({
+        getContainerClient: vi.fn().mockReturnValue({
+          getBlockBlobClient: vi.fn().mockReturnValue({
+            setMetadata: mockSetMetadata,
+          }),
+        }),
+      } as never);
+
+      const {addSpanEvent} = await import("@/instrumentation.server");
+      const mockAddSpanEvent = vi.mocked(addSpanEvent);
+
+      vi.spyOn(fetchUserModule, "fetchBFFUserFromAuthService").mockResolvedValue({
+        user: null,
+        userIdentifier: "user_123",
+        userJwt: "mock-jwt-token",
+      });
+
+      const result = await registerScan({
+        scanId: "test-scan-id",
+        blobUrl: "https://storage.blob.core.windows.net/invoices/scans/user_123/test.jpg",
+        fileName: "test.jpg",
+        mimeType: "image/jpeg",
+        sizeInBytes: 1024,
+      });
+
+      // setMetadata succeeded: the success span event at line 170 must be emitted
+      expect(result.success).toBe(true);
+      expect(mockSetMetadata).toHaveBeenCalled();
+      expect(mockAddSpanEvent).toHaveBeenCalledWith("azure.blob.metadata.complete");
+    });
+
+    it("should use fallback blob name extraction when URL has no container prefix", async () => {
+      // Exercises the `?? urlPath.slice(1)` branch at line 166.
+      // The URL does not contain "/invoices/" so split returns undefined and the fallback is used.
+      const {createBlobClient} = await import("@/lib/azure/storageClient");
+      const mockSetMetadata = vi.fn().mockResolvedValue(undefined);
+      vi.mocked(createBlobClient).mockResolvedValue({
+        getContainerClient: vi.fn().mockReturnValue({
+          getBlockBlobClient: vi.fn().mockReturnValue({
+            setMetadata: mockSetMetadata,
+          }),
+        }),
+      } as never);
+
+      vi.spyOn(fetchUserModule, "fetchBFFUserFromAuthService").mockResolvedValue({
+        user: null,
+        userIdentifier: "user_123",
+        userJwt: "mock-jwt-token",
+      });
+
+      // URL without /invoices/ triggers the fallback urlPath.slice(1)
+      const result = await registerScan({
+        scanId: "test-scan-id",
+        blobUrl: "https://storage.blob.core.windows.net/scans/user_123/test.jpg",
+        fileName: "test.jpg",
+        mimeType: "image/jpeg",
+        sizeInBytes: 1024,
+      });
+
+      expect(result.success).toBe(true);
+    });
+
     it("should continue successfully when setMetadata fails (non-fatal)", async () => {
       // Arrange - testing that scan registration succeeds even if metadata fails
       // The actual setMetadata is wrapped in try-catch in the source and is non-fatal

--- a/sites/arolariu.ro/src/lib/config/configProxy.test.ts
+++ b/sites/arolariu.ro/src/lib/config/configProxy.test.ts
@@ -317,6 +317,18 @@ describe("configProxy typed helpers", () => {
 
       expect(result).toBe("");
     });
+
+    it("falls back to API_JWT env var when exp returns empty string", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValueOnce(createJsonResponse(createConfigValuePayload("Auth:JWT:Secret", ""))));
+      process.env["API_JWT"] = "env-jwt-from-empty-exp";
+
+      const {fetchApiJwtSecret, invalidateConfigCache} = await import("./configProxy");
+      invalidateConfigCache();
+
+      const result = await fetchApiJwtSecret();
+
+      expect(result).toBe("env-jwt-from-empty-exp");
+    });
   });
 
   // ─────────────────────────────────────────────────────────────────────────
@@ -359,6 +371,18 @@ describe("configProxy typed helpers", () => {
       const result = await fetchResendApiKey();
 
       expect(result).toBe("");
+    });
+
+    it("falls back to RESEND_API_KEY env var when exp returns empty string", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValueOnce(createJsonResponse(createConfigValuePayload("Communication:Email:ApiKey", ""))));
+      process.env["RESEND_API_KEY"] = "re_env_from_empty_exp";
+
+      const {fetchResendApiKey, invalidateConfigCache} = await import("./configProxy");
+      invalidateConfigCache();
+
+      const result = await fetchResendApiKey();
+
+      expect(result).toBe("re_env_from_empty_exp");
     });
   });
 });
@@ -559,6 +583,53 @@ describe("configProxy circuit breaker", () => {
     // We verify by checking that fetch was called (which means the conversion succeeded)
     const requestInit = (fetchMock.mock.calls[0] as [string, RequestInit])[1];
     expect(requestInit.headers).toBeDefined();
+  });
+
+  it("uses label=PRODUCTION when SITE_ENV is set to PRODUCTION", async () => {
+    vi.stubEnv("SITE_ENV", "PRODUCTION");
+    vi.resetModules();
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(createJsonResponse(createConfigValuePayload("Endpoints:Service:Api", "https://api.prod.example.com")));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const {fetchConfigValue, invalidateConfigCache} = await import("./configProxy");
+    invalidateConfigCache();
+
+    await fetchConfigValue("Endpoints:Service:Api");
+
+    expect((fetchMock.mock.calls[0] as [string])[0]).toContain("label=PRODUCTION");
+
+    vi.unstubAllEnvs();
+  });
+
+  it("returns empty bearer token when Azure credential getToken returns null", async () => {
+    process.env["AZURE_CLIENT_ID"] = "test-managed-identity-id";
+    vi.resetModules();
+
+    vi.doMock("@/lib/azure/credentials", () => ({
+      getAzureCredential: () => ({
+        getToken: vi.fn().mockResolvedValue(null), // null token — exercises line 179
+      }),
+    }));
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(createJsonResponse(createConfigValuePayload("Endpoints:Service:Api", "https://api.example.com")));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const {fetchConfigValue, invalidateConfigCache} = await import("./configProxy");
+    invalidateConfigCache();
+
+    const value = await fetchConfigValue("Endpoints:Service:Api");
+    expect(value).toBe("https://api.example.com");
+
+    // When token is null, no Authorization header should be sent
+    const requestHeaders = (fetchMock.mock.calls[0] as [string, RequestInit])[1].headers as Record<string, string>;
+    expect(requestHeaders["Authorization"]).toBeUndefined();
+
+    delete process.env["AZURE_CLIENT_ID"];
   });
 
   it("should re-close circuit breaker after cooldown", async () => {

--- a/sites/arolariu.ro/src/lib/config/featureFlags.server.test.ts
+++ b/sites/arolariu.ro/src/lib/config/featureFlags.server.test.ts
@@ -4,10 +4,11 @@
 import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
 
 const mockFetchConfigValue = vi.fn<(key: string) => Promise<string>>();
+const mockSetSpanAttributes = vi.fn();
 
 vi.mock("server-only", () => ({}));
 vi.mock("@/instrumentation.server", () => ({
-  setSpanAttributes: vi.fn(),
+  setSpanAttributes: (...args: Parameters<typeof mockSetSpanAttributes>) => mockSetSpanAttributes(...args),
   getTraceparentHeader: vi.fn(() => ""),
   injectTraceContextHeaders: vi.fn(() => ({})),
 }));
@@ -22,6 +23,7 @@ describe("featureFlags.server", () => {
   beforeEach(() => {
     vi.resetModules();
     mockFetchConfigValue.mockReset();
+    mockSetSpanAttributes.mockReset();
   });
 
   afterEach(() => {
@@ -88,5 +90,23 @@ describe("featureFlags.server", () => {
     expect(flags).toEqual(DEFAULT_FEATURE_FLAGS);
     expect(flags.commanderEnabled).toBe(true);
     expect(flags.webVitalsEnabled).toBe(false);
+  });
+
+  it("returns defaults when setSpanAttributes throws unexpectedly (outer catch block)", async () => {
+    // Arrange - Successful fetch, but setSpanAttributes throws — exercises the outer catch (line 59)
+    mockFetchConfigValue.mockImplementation(async (key: string) => {
+      if (key === "website.commander.enabled") return "true";
+      if (key === "website.web-vitals.enabled") return "false";
+      return "false";
+    });
+    mockSetSpanAttributes.mockImplementationOnce(() => {
+      throw new Error("Tracing system failure");
+    });
+
+    const {getWebsiteFeatureFlags, DEFAULT_FEATURE_FLAGS} = await import("./featureFlags.server");
+    const flags = await getWebsiteFeatureFlags();
+
+    // Should fall back to defaults on any unexpected error
+    expect(flags).toEqual(DEFAULT_FEATURE_FLAGS);
   });
 });

--- a/sites/arolariu.ro/src/lib/utils.generic.test.ts
+++ b/sites/arolariu.ro/src/lib/utils.generic.test.ts
@@ -212,6 +212,14 @@ describe("formatDate", () => {
     // null input now returns empty string (safe default)
     expect(formatted).toBe("");
   });
+
+  it("should format with individual year/month/day fields (no dateStyle default)", async () => {
+    const {formatDate} = await import("./utils.generic");
+    // Providing `year` triggers the hasIndividualFields branch — dateStyle must not be injected
+    const formatted = formatDate("2024-06-15", {locale: "en-US", year: "numeric", month: "long", day: "numeric"});
+    expect(formatted).toContain("2024");
+    expect(formatted).toContain("June");
+  });
 });
 
 describe("toSafeDate", () => {
@@ -350,6 +358,36 @@ describe("formatRelativeTime", () => {
   it("should handle future dates", () => {
     const fiveMinFuture = new Date(Date.now() + 5 * 60_000);
     expect(formatRelativeTime(fiveMinFuture)).toContain("from now");
+  });
+
+  it("should return 'in less than a minute' for a future date under 60 seconds", () => {
+    const thirtySecsFuture = new Date(Date.now() + 30_000);
+    expect(formatRelativeTime(thirtySecsFuture)).toBe("in less than a minute");
+  });
+
+  it("should return singular hour form for future dates", () => {
+    const oneHourFuture = new Date(Date.now() + 1 * 3600_000 + 60_000);
+    expect(formatRelativeTime(oneHourFuture)).toBe("1 hour from now");
+  });
+
+  it("should return singular day form for future dates", () => {
+    const oneDayFuture = new Date(Date.now() + 1 * 86400_000 + 60_000);
+    expect(formatRelativeTime(oneDayFuture)).toBe("1 day from now");
+  });
+
+  it("should return singular week form for future dates", () => {
+    const oneWeekFuture = new Date(Date.now() + 7 * 86400_000 + 60_000);
+    expect(formatRelativeTime(oneWeekFuture)).toBe("1 week from now");
+  });
+
+  it("should return plural month form for future dates beyond 5 weeks", () => {
+    const twoMonthsFuture = new Date(Date.now() + 60 * 86400_000);
+    expect(formatRelativeTime(twoMonthsFuture)).toBe("2 months from now");
+  });
+
+  it("should return singular month form for a future date about 1 month away", () => {
+    const oneMonthFuture = new Date(Date.now() + 35 * 86400_000 + 60_000);
+    expect(formatRelativeTime(oneMonthFuture)).toBe("1 month from now");
   });
 });
 

--- a/sites/arolariu.ro/src/lib/utils.server.test.ts
+++ b/sites/arolariu.ro/src/lib/utils.server.test.ts
@@ -793,6 +793,26 @@ describe("fetchWithTimeout - edge cases", () => {
     const [fetchUrl3] = firstCall3!;
     expect(fetchUrl3).toBe("https://api.example.com/rest/v1/invoices");
   });
+
+  it("should merge caller-supplied headers with trace context headers", async () => {
+    const {fetchWithTimeout} = await import("./utils.server");
+    const mockFetch = vi.fn().mockResolvedValue(new Response("OK"));
+    globalThis.fetch = mockFetch;
+
+    // Provide explicit headers in options — exercises the `options.headers ? new Headers(options.headers) : new Headers()` true branch
+    const options: RequestInit = {
+      method: "POST",
+      headers: {"Authorization": "Bearer test-token", "Content-Type": "application/json"},
+    };
+
+    await fetchWithTimeout("https://api.example.com/data", options);
+
+    const [, fetchOptions] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(fetchOptions.headers).toMatchObject({
+      "Authorization": "Bearer test-token",
+      "Content-Type": "application/json",
+    });
+  });
 });
 
 describe("verifyJwtToken", () => {

--- a/sites/arolariu.ro/src/lib/utils.server.test.ts
+++ b/sites/arolariu.ro/src/lib/utils.server.test.ts
@@ -802,14 +802,14 @@ describe("fetchWithTimeout - edge cases", () => {
     // Provide explicit headers in options — exercises the `options.headers ? new Headers(options.headers) : new Headers()` true branch
     const options: RequestInit = {
       method: "POST",
-      headers: {"Authorization": "Bearer test-token", "Content-Type": "application/json"},
+      headers: {Authorization: "Bearer test-token", "Content-Type": "application/json"},
     };
 
     await fetchWithTimeout("https://api.example.com/data", options);
 
     const [, fetchOptions] = mockFetch.mock.calls[0] as [string, RequestInit];
     expect(fetchOptions.headers).toMatchObject({
-      "Authorization": "Bearer test-token",
+      Authorization: "Bearer test-token",
       "Content-Type": "application/json",
     });
   });

--- a/sites/arolariu.ro/src/stores/preferencesStore.ts
+++ b/sites/arolariu.ro/src/stores/preferencesStore.ts
@@ -243,6 +243,7 @@ const createPreferencesSlice = (
 /**
  * Development store with DevTools integration.
  */
+/* v8 ignore next 10 -- dev-only store factory; unreachable when NODE_ENV !== "development" */
 const createDevStore = () =>
   create<PreferencesStore>()(
     devtools(
@@ -281,6 +282,7 @@ const createProdStore = () => create<PreferencesStore>()(persist((set, get) => c
  * }
  * ```
  */
+/* v8 ignore next -- createDevStore() branch unreachable when NODE_ENV !== "development" */
 export const usePreferencesStore = process.env.NODE_ENV === "development" ? createDevStore() : createProdStore();
 
 // ===========================================

--- a/sites/arolariu.ro/src/stores/scansStore.test.tsx
+++ b/sites/arolariu.ro/src/stores/scansStore.test.tsx
@@ -278,6 +278,22 @@ describe("useScansStore", () => {
 
       expect(useScansStore.getState().selectedScans[0]?.name).toBe("New Name");
     });
+
+    it("should only update matching selected scan name and leave others unchanged", () => {
+      // Exercises the falsy branch of selectedScans.map() ternary in updateScanName
+      const scan1 = createTestScan("1", {name: "Original 1"});
+      const scan2 = createTestScan("2", {name: "Original 2"});
+
+      act(() => {
+        useScansStore.getState().setScans([scan1, scan2]);
+        useScansStore.getState().toggleScanSelection(scan1);
+        useScansStore.getState().toggleScanSelection(scan2);
+        useScansStore.getState().updateScanName("1", "Updated 1");
+      });
+
+      expect(useScansStore.getState().selectedScans.find((s) => s.id === "1")?.name).toBe("Updated 1");
+      expect(useScansStore.getState().selectedScans.find((s) => s.id === "2")?.name).toBe("Original 2");
+    });
   });
 
   describe("updateScanBlobUrl", () => {
@@ -302,6 +318,22 @@ describe("useScansStore", () => {
       });
 
       expect(useScansStore.getState().selectedScans[0]?.blobUrl).toBe("https://new.url/scan.jpg");
+    });
+
+    it("should only update matching selected scan blob URL and leave others unchanged", () => {
+      // Exercises the falsy branch of selectedScans.map() ternary in updateScanBlobUrl
+      const scan1 = createTestScan("1", {blobUrl: "https://old.url/scan1.jpg"});
+      const scan2 = createTestScan("2", {blobUrl: "https://old.url/scan2.jpg"});
+
+      act(() => {
+        useScansStore.getState().setScans([scan1, scan2]);
+        useScansStore.getState().toggleScanSelection(scan1);
+        useScansStore.getState().toggleScanSelection(scan2);
+        useScansStore.getState().updateScanBlobUrl("1", "https://new.url/scan1.jpg");
+      });
+
+      expect(useScansStore.getState().selectedScans.find((s) => s.id === "1")?.blobUrl).toBe("https://new.url/scan1.jpg");
+      expect(useScansStore.getState().selectedScans.find((s) => s.id === "2")?.blobUrl).toBe("https://old.url/scan2.jpg");
     });
   });
 
@@ -503,6 +535,23 @@ describe("useScansStore", () => {
       expect(useScansStore.getState().scans[0]?.status).toBe(ScanStatus.READY);
       expect(useScansStore.getState().scans[1]?.status).toBe(ScanStatus.READY);
     });
+
+    it("should only update the matching selected scan and leave other selected scans unchanged", () => {
+      // Exercises the falsy branch of selectedScans.map() ternary (s.id !== scanId)
+      const scan1 = createTestScan("1", {status: ScanStatus.READY});
+      const scan2 = createTestScan("2", {status: ScanStatus.READY});
+
+      act(() => {
+        useScansStore.getState().setScans([scan1, scan2]);
+        useScansStore.getState().toggleScanSelection(scan1);
+        useScansStore.getState().toggleScanSelection(scan2);
+        // Updating scan1 while scan2 is also selected exercises the non-matching branch
+        useScansStore.getState().updateScanStatus("1", ScanStatus.ARCHIVED);
+      });
+
+      expect(useScansStore.getState().selectedScans.find((s) => s.id === "1")?.status).toBe(ScanStatus.ARCHIVED);
+      expect(useScansStore.getState().selectedScans.find((s) => s.id === "2")?.status).toBe(ScanStatus.READY);
+    });
   });
 
   describe("setSelectedScans", () => {
@@ -568,6 +617,22 @@ describe("useScansStore", () => {
 
       const unchanged = useScansStore.getState().scans.find((s) => s.id === "2");
       expect(unchanged?.metadata).toEqual({original: "2"});
+    });
+
+    it("should only update matching selected scan metadata and leave others unchanged", () => {
+      // Exercises the falsy branch of selectedScans.map() ternary in updateScanMetadata
+      const scan1 = createTestScan("1", {metadata: {original: "1"}});
+      const scan2 = createTestScan("2", {metadata: {original: "2"}});
+
+      act(() => {
+        useScansStore.getState().setScans([scan1, scan2]);
+        useScansStore.getState().toggleScanSelection(scan1);
+        useScansStore.getState().toggleScanSelection(scan2);
+        useScansStore.getState().updateScanMetadata("1", {changed: "true"});
+      });
+
+      expect(useScansStore.getState().selectedScans.find((s) => s.id === "1")?.metadata).toEqual({original: "1", changed: "true"});
+      expect(useScansStore.getState().selectedScans.find((s) => s.id === "2")?.metadata).toEqual({original: "2"});
     });
   });
 

--- a/sites/arolariu.ro/src/stores/scansStore.tsx
+++ b/sites/arolariu.ro/src/stores/scansStore.tsx
@@ -344,6 +344,7 @@ const createScansSlice = (set: (partial: Partial<ScansStore> | ((state: ScansSto
 /**
  * Development store with DevTools integration
  */
+/* v8 ignore next 10 -- dev-only store factory; unreachable when NODE_ENV !== "development" */
 const createDevStore = () =>
   create<ScansStore>()(
     devtools(
@@ -386,4 +387,5 @@ const createProdStore = () => create<ScansStore>()(persist((set) => createScansS
  * }
  * ```
  */
+/* v8 ignore next -- createDevStore() branch unreachable when NODE_ENV !== "development" */
 export const useScansStore = process.env.NODE_ENV === "development" ? createDevStore() : createProdStore();

--- a/sites/arolariu.ro/src/stores/storage/indexedDBStorage.test.ts
+++ b/sites/arolariu.ro/src/stores/storage/indexedDBStorage.test.ts
@@ -6,8 +6,8 @@
  * The actual Dexie functionality is tested indirectly through the store tests.
  */
 
-import {describe, expect, it, vi} from "vitest";
-import {ZUSTAND_TABLES, createIndexedDBStorage, createSharedStorage} from "./indexedDBStorage";
+import {afterEach, describe, expect, it, vi} from "vitest";
+import {ZUSTAND_TABLES, createIndexedDBStorage, createSharedStorage, getDatabaseInstance, resetDatabaseInstance} from "./indexedDBStorage";
 
 /** Test entity type */
 interface TestEntity {
@@ -503,6 +503,12 @@ describe("resetDatabaseInstance and getDatabaseInstance", () => {
     expect(() => resetDatabaseInstance()).not.toThrow();
   });
 
+  it("should be a no-op when dbInstance is already null", () => {
+    // Call twice: first resets any live instance, second exercises the falsy branch
+    resetDatabaseInstance();
+    expect(() => resetDatabaseInstance()).not.toThrow();
+  });
+
   it("should export getDatabaseInstance function", async () => {
     const {getDatabaseInstance} = await import("./indexedDBStorage");
     expect(typeof getDatabaseInstance).toBe("function");
@@ -763,5 +769,116 @@ describe("Error handling for specific uncovered lines", () => {
     // The function has try-catch to prevent throwing
 
     consoleErrorSpy.mockRestore();
+  });
+});
+
+describe("Forced-error catch-branch coverage", () => {
+  /**
+   * These tests force Dexie's db.transaction() to throw so the catch blocks
+   * in getItem / removeItem / createSharedStorage's three methods are exercised.
+   * The spy is restored in afterEach to avoid leaking into other tests.
+   */
+  afterEach(() => {
+    vi.restoreAllMocks();
+    resetDatabaseInstance();
+  });
+
+  it("createIndexedDBStorage.getItem catch branch: logs error and returns null when transaction throws", async () => {
+    // Arrange
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const db = getDatabaseInstance();
+    expect(db).not.toBeNull();
+    // Force db.transaction to throw so the catch block at lines 204-207 is reached
+    vi.spyOn(db!, "transaction").mockRejectedValue(new Error("simulated getItem failure"));
+
+    const storage = createTestStorage();
+
+    // Act
+    const result = await storage.getItem("any-key");
+
+    // Assert — catch path: returns null and logs the error
+    expect(result).toBeNull();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining("Error retrieving entities"), expect.any(Error));
+  });
+
+  it("createIndexedDBStorage.removeItem catch branch: logs error and does not throw when transaction throws", async () => {
+    // Arrange
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const db = getDatabaseInstance();
+    expect(db).not.toBeNull();
+    // Force db.transaction to throw so the catch block at line 266-268 is reached
+    vi.spyOn(db!, "transaction").mockRejectedValue(new Error("simulated removeItem failure"));
+
+    const storage = createTestStorage();
+
+    // Act — must not throw
+    await expect(storage.removeItem("any-key")).resolves.toBeUndefined();
+
+    // Assert — catch path logs the error
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining("Error clearing IndexedDB"), expect.any(Error));
+  });
+
+  it("createSharedStorage.getItem catch branch: logs error and returns null when transaction throws", async () => {
+    // Arrange
+    interface SharedState {
+      data: string;
+    }
+
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const db = getDatabaseInstance();
+    expect(db).not.toBeNull();
+    // Force db.transaction to throw so the catch block at lines 303-306 is reached
+    vi.spyOn(db!, "transaction").mockRejectedValue(new Error("simulated shared getItem failure"));
+
+    const storage = createSharedStorage<SharedState>();
+
+    // Act
+    const result = await storage.getItem("shared-key");
+
+    // Assert — catch path: returns null and logs the error
+    expect(result).toBeNull();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining("Error retrieving from shared storage"), expect.any(Error));
+  });
+
+  it("createSharedStorage.setItem catch branch: logs error and does not throw when transaction throws", async () => {
+    // Arrange
+    interface SharedState {
+      data: string;
+    }
+
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const db = getDatabaseInstance();
+    expect(db).not.toBeNull();
+    // Force db.transaction to throw so the catch block at lines 321-323 is reached
+    vi.spyOn(db!, "transaction").mockRejectedValue(new Error("simulated shared setItem failure"));
+
+    const storage = createSharedStorage<SharedState>();
+
+    // Act — must not throw
+    await expect(storage.setItem("shared-key", {state: {data: "x"}, version: 1})).resolves.toBeUndefined();
+
+    // Assert — catch path logs the error
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining("Error storing to shared storage"), expect.any(Error));
+  });
+
+  it("createSharedStorage.removeItem catch branch: logs error and does not throw when transaction throws", async () => {
+    // Arrange
+    interface SharedState {
+      data: string;
+    }
+
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const db = getDatabaseInstance();
+    expect(db).not.toBeNull();
+    // Force db.transaction to throw so the catch block at lines 335-337 is reached
+    vi.spyOn(db!, "transaction").mockRejectedValue(new Error("simulated shared removeItem failure"));
+
+    const storage = createSharedStorage<SharedState>();
+
+    // Act — must not throw
+    await expect(storage.removeItem("shared-key")).resolves.toBeUndefined();
+
+    // Assert — catch path logs the error
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining("Error removing from shared storage"), expect.any(Error));
   });
 });

--- a/sites/arolariu.ro/src/stores/storage/indexedDBStorage.ts
+++ b/sites/arolariu.ro/src/stores/storage/indexedDBStorage.ts
@@ -149,6 +149,7 @@ function getTable<E extends BaseEntity>(db: ZustandDB, tableName: EntityTableNam
       return db.merchants as unknown as Table<E, string>;
     case "scans":
       return db.scans as unknown as Table<E, string>;
+    /* v8 ignore next 2 -- TypeScript's EntityTableName exhausts all valid cases; unreachable at runtime */
     default:
       throw new Error(`Unsupported table name: ${tableName}`);
   }

--- a/sites/arolariu.ro/src/workers/host/bootHandshake.test.ts
+++ b/sites/arolariu.ro/src/workers/host/bootHandshake.test.ts
@@ -104,6 +104,85 @@ describe("createBootHandshake", () => {
     expect(closeEvent).toHaveBeenCalled();
   });
 
+  it("handles a 'ready' event arriving after the timeout (bootTimeoutId already null)", async () => {
+    // Exercises the `if (bootTimeoutId !== null)` false branch (line 150).
+    // This race can happen when the timeout fires first (setting bootTimeoutId=null
+    // and rejecting), and then the late ready event still arrives on the port.
+    vi.useFakeTimers();
+    try {
+      const stubWorker: Worker = {
+        postMessage: () => {},
+        terminate: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => true,
+        onmessage: null,
+        onmessageerror: null,
+        onerror: null,
+      } as unknown as Worker;
+
+      const handshake = createBootHandshake({
+        worker: stubWorker,
+        capabilities: CAPS,
+        onEvent: () => {},
+        bootstrapTimeoutMs: 50,
+      });
+      const settled = handshake.ready.catch((e: unknown) => e);
+      // Advance time to fire the bootstrap timeout — sets bootTimeoutId=null.
+      vi.advanceTimersByTime(60);
+      await settled;
+      // Now send a late 'ready' event on the parent port — bootTimeoutId is null.
+      // The port's onmessage handler is still wired (the timeout only sets
+      // bootTimeoutId=null; it doesn't clear the port handler). Calling it
+      // exercises the `if (bootTimeoutId !== null)` false branch.
+      const parentEventPort = handshake.parentEventPort;
+      // The onmessage must still be set after timeout (only bootTimeoutId is cleared).
+      expect(parentEventPort.onmessage).not.toBeNull();
+      expect(() => {
+        parentEventPort.onmessage!(new MessageEvent("message", {data: {kind: "ready"}}));
+      }).not.toThrow();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("teardown() is idempotent — second call is a no-op", async () => {
+    // Exercises the `if (tornDown) return` guard (line 244 of bootHandshake.ts).
+    const mock = createMockWorker({api: {ping: async () => "pong"}});
+    const handshake = createBootHandshake({
+      worker: mock.worker,
+      capabilities: CAPS,
+      onEvent: () => {},
+      bootstrapTimeoutMs: 10_000,
+    });
+    await handshake.ready;
+    handshake.teardown();
+    // Second call must not throw.
+    expect(() => handshake.teardown()).not.toThrow();
+  });
+
+  it("filters stray ready events arriving after bootstrap (steady-state listener)", async () => {
+    // Exercises the `if (nextEv.kind === "ready") return` branch (line 158).
+    // After bootstrap, the steady-state listener filters out stray ready events.
+    const events: unknown[] = [];
+    const mock = createMockWorker({api: {ping: async () => "pong"}});
+    const handshake = createBootHandshake({
+      worker: mock.worker,
+      capabilities: CAPS,
+      onEvent: (e) => events.push(e),
+      bootstrapTimeoutMs: 10_000,
+    });
+    await handshake.ready;
+    // Send a stray ready event — must be filtered by the steady-state listener.
+    const workerEventPort = getEventPort();
+    if (workerEventPort) {
+      emitEvent(workerEventPort, {kind: "ready"});
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    }
+    // No "ready" events should have reached the onEvent sink.
+    expect(events.find((e) => (e as {kind?: string}).kind === "ready")).toBeUndefined();
+  });
+
   it("rethrows synchronously when validateBootstrap rejects malformed capabilities", () => {
     // Exercises the synchronous validation-failure branch of
     // createBootHandshake. validateBootstrap requires `crossOriginIsolated`
@@ -130,6 +209,45 @@ describe("createBootHandshake", () => {
         bootstrapTimeoutMs: 1_000,
       });
     }).toThrow("invalid bootstrap message");
+  });
+
+  it("forwards non-ready events arriving before the handshake completes (defensive parity)", async () => {
+    // This test drives the pre-ready onEvent branch (line 165 of bootHandshake.ts).
+    // We send a non-ready event on the parent event port BEFORE the ready event
+    // by directly triggering the port's onmessage handler.
+    const events: unknown[] = [];
+
+    // Use a stub worker that never replies — we drive the port manually.
+    const stubWorker: Worker = {
+      postMessage: () => {},
+      terminate: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => true,
+      onmessage: null,
+      onmessageerror: null,
+      onerror: null,
+    } as unknown as Worker;
+
+    const handshake = createBootHandshake({
+      worker: stubWorker,
+      capabilities: CAPS,
+      onEvent: (e) => events.push(e),
+      bootstrapTimeoutMs: 10_000,
+    });
+
+    // The parent event port has its onmessage wired by createBootHandshake.
+    // Trigger a pre-ready log event directly — this exercises the defensive
+    // parity branch that forwards non-ready events before handshake completes.
+    const parentEventPort = handshake.parentEventPort;
+    if (parentEventPort.onmessage) {
+      parentEventPort.onmessage(new MessageEvent("message", {data: {kind: "log", level: "info", msg: "pre-ready"}}));
+    }
+    expect(events).toContainEqual({kind: "log", level: "info", msg: "pre-ready"});
+
+    // Clean up: teardown the handshake (avoids the bootstrap timeout leaking).
+    handshake.rejectIfPending(new Error("test done"));
+    handshake.teardown();
   });
 
   it("rethrows synchronously when worker.postMessage throws", () => {

--- a/sites/arolariu.ro/src/workers/host/bootHandshake.test.ts
+++ b/sites/arolariu.ro/src/workers/host/bootHandshake.test.ts
@@ -164,6 +164,13 @@ describe("createBootHandshake", () => {
   it("filters stray ready events arriving after bootstrap (steady-state listener)", async () => {
     // Exercises the `if (nextEv.kind === "ready") return` branch (line 158).
     // After bootstrap, the steady-state listener filters out stray ready events.
+    //
+    // Drive the parent event port directly rather than posting to the
+    // worker-side port. The previous version posted via `getEventPort()` and
+    // relied on the MessageChannel transfer being plumbed — if the harness
+    // ever stops plumbing the channel, the assertion becomes vacuously true.
+    // Calling `parentEventPort.onmessage` directly removes that ambiguity
+    // and pins the filter behaviour on the parent side where it actually lives.
     const events: unknown[] = [];
     const mock = createMockWorker({api: {ping: async () => "pong"}});
     const handshake = createBootHandshake({
@@ -173,13 +180,15 @@ describe("createBootHandshake", () => {
       bootstrapTimeoutMs: 10_000,
     });
     await handshake.ready;
-    // Send a stray ready event — must be filtered by the steady-state listener.
-    const workerEventPort = getEventPort();
-    if (workerEventPort) {
-      emitEvent(workerEventPort, {kind: "ready"});
-      await new Promise<void>((resolve) => setTimeout(resolve, 0));
-    }
-    // No "ready" events should have reached the onEvent sink.
+    // Baseline: confirm the parent port's steady-state handler is wired.
+    const parentEventPort = handshake.parentEventPort;
+    expect(parentEventPort.onmessage).not.toBeNull();
+    const countBefore = events.length;
+    // Drive a stray "ready" event directly into the parent port. The
+    // steady-state listener must filter it before reaching `onEvent`.
+    parentEventPort.onmessage!(new MessageEvent("message", {data: {kind: "ready"}}));
+    // No new event reached the sink.
+    expect(events.length).toBe(countBefore);
     expect(events.find((e) => (e as {kind?: string}).kind === "ready")).toBeUndefined();
   });
 

--- a/sites/arolariu.ro/src/workers/host/bootHandshake.ts
+++ b/sites/arolariu.ro/src/workers/host/bootHandshake.ts
@@ -205,6 +205,7 @@ export function createBootHandshake(opts: CreateBootHandshakeOptions): BootHands
   // even after a truthy guard. `typeof rejectBoot === "function"` is a
   // primitive predicate it does narrow correctly.
   const ejectBoot = (err: unknown): void => {
+    /* v8 ignore next - rejectBoot is always non-null at call sites (synchronous failure path only) */
     if (typeof rejectBoot === "function") rejectBoot(err);
   };
 

--- a/sites/arolariu.ro/src/workers/host/buildCallProxy.test.ts
+++ b/sites/arolariu.ro/src/workers/host/buildCallProxy.test.ts
@@ -143,6 +143,74 @@ describe("buildCallProxy", () => {
     expect(endCall).toHaveBeenCalledOnce();
   });
 
+  it("returns undefined for symbol-keyed property access", () => {
+    // Exercises the `typeof prop !== "string"` true branch (line 48).
+    const {proxy} = makeFixture({ping: async () => "pong"});
+    const value = (proxy as unknown as Record<symbol, unknown>)[Symbol.iterator];
+    expect(value).toBeUndefined();
+  });
+
+  it("rejects when getTarget() returns null after ensureReady (no target branch)", async () => {
+    // Exercises the `if (!target)` branch (line 78): getTarget returns null
+    // even after ensureReady, which should throw "no target after ensureReady".
+    const inFlight = createInFlightRegistry();
+    const bridge = createTelemetryBridge("test", {logger: SILENT_LOGGER});
+    type Api = {missing: () => Promise<string>};
+    const proxy = buildCallProxy<Api>({
+      inFlight,
+      bridge,
+      defaultCallTimeoutMs: 0,
+      ensureReady: async () => {},
+      getTarget: () => null, // always returns null
+      lifecycle: {beginCall: () => {}, endCall: () => {}},
+    });
+    const proxyAsRecord = proxy as unknown as Record<string, () => Promise<unknown>>;
+    await expect(proxyAsRecord["missing"]!()).rejects.toThrow("Worker host has no target after ensureReady");
+  });
+
+  it("resolves normally when an AbortSignal is passed but not yet aborted", async () => {
+    // Exercises the `if (signal.aborted)` false branch (line 58) — the signal is
+    // passed as last arg (triggering the instanceof check) but is not aborted,
+    // so the call proceeds normally.
+    const ac = new AbortController();
+    // Do NOT abort — signal.aborted is false.
+    const {proxy} = makeFixture({echo: async (msg: string) => `echo:${msg}`});
+    const echoWithSignal = proxy.echo as unknown as (msg: string, signal: AbortSignal) => Promise<string>;
+    await expect(echoWithSignal("hi", ac.signal)).resolves.toBe("echo:hi");
+  });
+
+  it("rejects with fallback Error when pre-aborted signal has no reason", async () => {
+    // Exercises the `signal.reason ?? new Error("aborted")` fallback in the
+    // pre-aborted path (line 59) when signal.reason is undefined.
+    // ac.abort() with no argument leaves reason as undefined on some runtimes.
+    const ac = new AbortController();
+    ac.abort(); // no reason → reason may be undefined or DOMException
+    const {proxy} = makeFixture({slow: async (_signal: AbortSignal) => "done"});
+    // The call should reject — either with `reason` or with the "aborted" fallback.
+    await expect(proxy.slow(ac.signal)).rejects.toThrow();
+  });
+
+  it("rejects with 'no method' error when the target object lacks the requested method", async () => {
+    // Drives the `typeof fn !== "function"` branch (line 81 of buildCallProxy.ts).
+    // We provide a target that has no methods at all — getTarget() returns an
+    // object with no callable properties, so any prop access yields undefined.
+    const inFlight = createInFlightRegistry();
+    const bridge = createTelemetryBridge("test", {logger: SILENT_LOGGER});
+    // An empty object has no methods; the proxy will call getTarget() and then
+    // try to look up the method by name — undefined is not a function.
+    const emptyTarget = {} as unknown as {missing: () => Promise<string>};
+    const proxy = buildCallProxy<typeof emptyTarget>({
+      inFlight,
+      bridge,
+      defaultCallTimeoutMs: 0,
+      ensureReady: async () => {},
+      getTarget: () => emptyTarget as never,
+      lifecycle: {beginCall: () => {}, endCall: () => {}},
+    });
+    const proxyAsRecord = proxy as unknown as Record<string, () => Promise<unknown>>;
+    await expect(proxyAsRecord["missing"]!()).rejects.toThrow('Worker host has no method "missing"');
+  });
+
   it("rethrows plain Error from the target without WorkerError wrapping", async () => {
     // See the matching note on the __workerError envelope test: explicit
     // `Promise<unknown>` keeps the inferred return type from collapsing

--- a/sites/arolariu.ro/src/workers/host/createWorkerHost.test.ts
+++ b/sites/arolariu.ro/src/workers/host/createWorkerHost.test.ts
@@ -599,6 +599,43 @@ describe("createWorkerHost", () => {
     });
   });
 
+  describe("idle reboot (lazy-reboot on idle timer)", () => {
+    // Coverage: line 198 of createWorkerHost.ts — the `onIdleHandler` that
+    // calls `tearDownWorker("lazy-reboot")` when the idle timer fires.
+    it("silently tears down the worker when the idle timer fires after all calls complete", async () => {
+      vi.useFakeTimers();
+      try {
+        let mock = createMockWorker({api: greetImpl});
+        let loadCount = 0;
+        const host = createWorkerHost<GreetApi>({
+          name: "idle-reboot",
+          load: () => {
+            loadCount += 1;
+            mock = createMockWorker({api: greetImpl});
+            return mock.worker;
+          },
+          idleTimeoutMs: 500,
+          defaultCallTimeoutMs: 0,
+        });
+        // Boot the worker and make a call so lifecycle reaches 'ready'.
+        await host.warmUp();
+        expect(host.state).toBe("ready");
+        expect(loadCount).toBe(1);
+        // Advance past the idle timeout — this fires the idle timer which calls
+        // tearDownWorker("lazy-reboot"), tearing down the worker silently.
+        vi.advanceTimersByTime(600);
+        // The host state remains at "ready" after lazy-reboot (state not changed).
+        // The next call triggers a fresh boot.
+        const resultPromise = host.api.greet("after-idle");
+        await resultPromise;
+        // A new load() call must have happened for the fresh boot.
+        expect(loadCount).toBe(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
   describe("dispose without prior boot", () => {
     it("dispose on an unbooted host resolves cleanly and leaves state disposed", async () => {
       const mock = createMockWorker({api: greetImpl});
@@ -606,6 +643,53 @@ describe("createWorkerHost", () => {
       expect(host.state).toBe("idle");
       await host.dispose();
       expect(host.state).toBe("disposed");
+    });
+  });
+
+  describe("subscribeToEvents", () => {
+    it("unsubscribeToEvents stops notifications", async () => {
+      // Exercises the `subscribeToEvents` unsubscribe closure (lines 476-478).
+      const mock = createMockWorker({api: greetImpl});
+      const host = createWorkerHost<GreetApi>({name: "test", load: () => mock.worker});
+      await host.warmUp();
+      const events: unknown[] = [];
+      const unsubscribe = host.subscribeToEvents((e) => events.push(e));
+      const countBefore = events.length;
+      unsubscribe();
+      // After unsubscribe, future events should not be received.
+      const port = getEventPort();
+      if (port) {
+        emitEvent(port, {kind: "log", level: "info", msg: "after-unsub"});
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      }
+      expect(events.length).toBe(countBefore);
+    });
+
+    it("misbehaving event listener does not poison sibling listeners (try/catch guard)", async () => {
+      // Exercises the try/catch around listener invocation in forwardEvent (lines 372-374).
+      // A throwing listener must not prevent sibling listeners from receiving events.
+      const mock = createMockWorker({api: greetImpl});
+      const host = createWorkerHost<GreetApi>({
+        name: "test",
+        load: () => mock.worker,
+      });
+      await host.warmUp();
+      const received: unknown[] = [];
+      // Register a throwing listener first.
+      host.subscribeToEvents(() => {
+        throw new Error("bad listener");
+      });
+      // Then a good sibling listener.
+      host.subscribeToEvents((e) => received.push(e));
+      const port = getEventPort();
+      if (port) {
+        emitEvent(port, {kind: "log", level: "info", msg: "survivor"});
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      }
+      // The sibling must have received the event despite the bad listener.
+      if (port) {
+        expect(received).toContainEqual({kind: "log", level: "info", msg: "survivor"});
+      }
     });
   });
 
@@ -777,6 +861,55 @@ describe("createWorkerHost", () => {
         // The error is wrapped as WorkerError with fallback name "Error" and String(cause) message
         expect(err).toBeInstanceOf(WorkerError);
       }
+    });
+  });
+
+  describe("concurrent ensureReady (bootPromise reuse)", () => {
+    // Coverage: `if (!bootPromise)` false branch (line 443) — when two concurrent
+    // warmUp calls run simultaneously, the second finds bootPromise already set.
+    it("two concurrent warmUp calls share the same boot promise", async () => {
+      const mock = createMockWorker({api: greetImpl});
+      let loadCount = 0;
+      const host = createWorkerHost<GreetApi>({
+        name: "concurrent-boot",
+        load: () => {
+          loadCount += 1;
+          return createMockWorker({api: greetImpl}).worker;
+        },
+        defaultCallTimeoutMs: 0,
+      });
+      // Fire two warmUp calls concurrently before either completes.
+      const [p1, p2] = [host.warmUp(), host.warmUp()];
+      await Promise.all([p1, p2]);
+      // Worker should only have been loaded once (bootPromise deduplicates).
+      expect(loadCount).toBe(1);
+      expect(host.state).toBe("ready");
+      void mock;
+    });
+  });
+
+  describe("restart signal.reason fallback", () => {
+    it("restart signal.reason undefined uses Error('aborted') fallback", async () => {
+      // Exercises the `signal.reason ?? new Error("aborted")` branch (line 490)
+      // where reason is undefined — the polyfill path.
+      let mock = createMockWorker({api: greetImpl});
+      const host = createWorkerHost<GreetApi>({
+        name: "test",
+        load: () => {
+          mock = createMockWorker({api: greetImpl});
+          return mock.worker;
+        },
+      });
+      await host.warmUp();
+      mock.simulateCrash();
+      // Create a fake pre-aborted signal with undefined reason (polyfill behavior).
+      const fakeSignal = {
+        aborted: true,
+        reason: undefined,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+      } as unknown as AbortSignal;
+      await expect(host.restart(fakeSignal)).rejects.toThrow("aborted");
     });
   });
 

--- a/sites/arolariu.ro/src/workers/host/createWorkerHost.test.ts
+++ b/sites/arolariu.ro/src/workers/host/createWorkerHost.test.ts
@@ -657,11 +657,12 @@ describe("createWorkerHost", () => {
       const countBefore = events.length;
       unsubscribe();
       // After unsubscribe, future events should not be received.
+      // Pre-assert the event port exists so a torn-down host fails the test
+      // rather than producing a vacuous green.
       const port = getEventPort();
-      if (port) {
-        emitEvent(port, {kind: "log", level: "info", msg: "after-unsub"});
-        await new Promise<void>((resolve) => setTimeout(resolve, 0));
-      }
+      expect(port).not.toBeNull();
+      emitEvent(port!, {kind: "log", level: "info", msg: "after-unsub"});
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
       expect(events.length).toBe(countBefore);
     });
 
@@ -681,15 +682,14 @@ describe("createWorkerHost", () => {
       });
       // Then a good sibling listener.
       host.subscribeToEvents((e) => received.push(e));
+      // Pre-assert the event port exists so a missing port fails the test
+      // rather than producing a vacuous green.
       const port = getEventPort();
-      if (port) {
-        emitEvent(port, {kind: "log", level: "info", msg: "survivor"});
-        await new Promise<void>((resolve) => setTimeout(resolve, 0));
-      }
+      expect(port).not.toBeNull();
+      emitEvent(port!, {kind: "log", level: "info", msg: "survivor"});
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
       // The sibling must have received the event despite the bad listener.
-      if (port) {
-        expect(received).toContainEqual({kind: "log", level: "info", msg: "survivor"});
-      }
+      expect(received).toContainEqual({kind: "log", level: "info", msg: "survivor"});
     });
   });
 

--- a/sites/arolariu.ro/src/workers/host/mockWorker.test.ts
+++ b/sites/arolariu.ro/src/workers/host/mockWorker.test.ts
@@ -25,28 +25,20 @@ beforeEach(() => {
 
 describe("createMockWorker", () => {
   describe("postMessage with StructuredSerializeOptions transfer arg", () => {
-    it("treats a StructuredSerializeOptions object as an empty ports list", () => {
+    it("accepts a non-array transfer arg without throwing", () => {
       // Exercises the `Array.isArray(transfer) ? transfer : []` else-branch
-      // (lines 82-86 of mockWorker.ts). Passing a StructuredSerializeOptions
-      // object (not an array) means no MessagePorts are forwarded.
-      // The bootstrapHandler receives a MessageEvent with an empty ports list.
-      let receivedPorts: MessagePort[] | null = null;
-
-      // Intercept the fakeSelf to inspect what the bootstrap handler gets.
-      // We can do this by creating a mock and calling postMessage with a
-      // StructuredSerializeOptions argument.
+      // (lines 82-86 of mockWorker.ts). When `postMessage` is called with a
+      // `StructuredSerializeOptions` object (not an array), the else-branch
+      // resolves the ports list to `[]`. The bootstrap handler is already
+      // wired by `expose()` and discards the custom-kind message; the only
+      // contract here is that the branch is reachable without throwing.
+      // v8 coverage confirms the branch fires.
       const mock = createMockWorker({api: {ping: async () => "pong"}});
-
-      // Call postMessage with StructuredSerializeOptions (not an array).
-      // The mock ignores the message since the bootstrap handler on fakeSelf
-      // is already set up by expose(). This just exercises the branch.
       const structuredSerializeOpts: StructuredSerializeOptions = {transfer: []};
-      // The worker's postMessage should accept StructuredSerializeOptions
-      // without throwing — the else-branch of `Array.isArray(transfer)` runs.
+
       expect(() => {
         mock.worker.postMessage({kind: "custom-msg"}, structuredSerializeOpts);
       }).not.toThrow();
-      void receivedPorts; // suppress unused-var lint
     });
   });
 

--- a/sites/arolariu.ro/src/workers/host/mockWorker.test.ts
+++ b/sites/arolariu.ro/src/workers/host/mockWorker.test.ts
@@ -1,0 +1,91 @@
+/**
+ * @fileoverview Focused unit tests for the `MockWorker` utility.
+ * @module workers/host/mockWorker.test
+ *
+ * @remarks
+ * The `createMockWorker` helper is exercised transitively through
+ * `createWorkerHost.test.ts`, but several branches in `mockWorker.ts` can
+ * only be reached with targeted tests:
+ *
+ * - `postMessage` with a `StructuredSerializeOptions` transfer arg (not an
+ *   array) → the `Array.isArray(transfer) ? transfer : []` else-branch
+ *   yields an empty ports list (lines 82-86).
+ * - `simulateMessageError()` after `worker.terminate()` → the early-return
+ *   guard `if (terminated) return` (line 127).
+ */
+
+import {beforeEach, describe, expect, it} from "vitest";
+
+import {__resetForTesting} from "../runtime/exposeWorker";
+import {createMockWorker} from "./mockWorker";
+
+beforeEach(() => {
+  __resetForTesting();
+});
+
+describe("createMockWorker", () => {
+  describe("postMessage with StructuredSerializeOptions transfer arg", () => {
+    it("treats a StructuredSerializeOptions object as an empty ports list", () => {
+      // Exercises the `Array.isArray(transfer) ? transfer : []` else-branch
+      // (lines 82-86 of mockWorker.ts). Passing a StructuredSerializeOptions
+      // object (not an array) means no MessagePorts are forwarded.
+      // The bootstrapHandler receives a MessageEvent with an empty ports list.
+      let receivedPorts: MessagePort[] | null = null;
+
+      // Intercept the fakeSelf to inspect what the bootstrap handler gets.
+      // We can do this by creating a mock and calling postMessage with a
+      // StructuredSerializeOptions argument.
+      const mock = createMockWorker({api: {ping: async () => "pong"}});
+
+      // Call postMessage with StructuredSerializeOptions (not an array).
+      // The mock ignores the message since the bootstrap handler on fakeSelf
+      // is already set up by expose(). This just exercises the branch.
+      const structuredSerializeOpts: StructuredSerializeOptions = {transfer: []};
+      // The worker's postMessage should accept StructuredSerializeOptions
+      // without throwing — the else-branch of `Array.isArray(transfer)` runs.
+      expect(() => {
+        mock.worker.postMessage({kind: "custom-msg"}, structuredSerializeOpts);
+      }).not.toThrow();
+      void receivedPorts; // suppress unused-var lint
+    });
+  });
+
+  describe("simulateMessageError after terminate", () => {
+    it("is a no-op when the worker has already been terminated", () => {
+      // Exercises the `if (terminated) return` guard in simulateMessageError
+      // (line 127 of mockWorker.ts). After terminate(), the mock sets
+      // terminated=true, and simulateMessageError must return early.
+      const mock = createMockWorker({api: {ping: async () => "pong"}});
+      mock.worker.terminate();
+      // Should not throw — the guard returns early before touching messageErrorHandler.
+      expect(() => mock.simulateMessageError()).not.toThrow();
+    });
+  });
+
+  describe("postMessage when terminated", () => {
+    it("is a no-op after the worker has been terminated", () => {
+      // Exercises the `if (terminated) return` guard in postMessage
+      // (line 82 of mockWorker.ts).
+      const mock = createMockWorker({api: {ping: async () => "pong"}});
+      mock.worker.terminate();
+      // postMessage after terminate must not throw — it returns early.
+      expect(() => mock.worker.postMessage({custom: "msg"}, [])).not.toThrow();
+    });
+  });
+
+  describe("whenTerminated", () => {
+    it("resolves when terminate() is called", async () => {
+      const mock = createMockWorker({api: {ping: async () => "pong"}});
+      mock.worker.terminate();
+      await expect(mock.whenTerminated).resolves.toBeUndefined();
+    });
+  });
+
+  describe("simulateCrash", () => {
+    it("resolves whenTerminated and marks worker as terminated", async () => {
+      const mock = createMockWorker({api: {ping: async () => "pong"}});
+      mock.simulateCrash();
+      await expect(mock.whenTerminated).resolves.toBeUndefined();
+    });
+  });
+});

--- a/sites/arolariu.ro/src/workers/host/raceWithSignal.test.ts
+++ b/sites/arolariu.ro/src/workers/host/raceWithSignal.test.ts
@@ -30,6 +30,33 @@ describe("raceWithSignal", () => {
     ac.abort(new Error("late"));
   });
 
+  it("rejects mid-flight with fallback Error when reason is undefined on mid-flight abort", async () => {
+    // Exercises the `signal.reason ?? new Error("aborted")` fallback inside
+    // the onAbort listener (line 24 of raceWithSignal.ts). This path fires
+    // when the signal aborts mid-flight (not pre-aborted) and reason is
+    // undefined (polyfill path).
+    let triggerAbort!: () => void;
+    const fakeSignal = {
+      aborted: false,
+      reason: undefined as unknown,
+      addEventListener: (_type: string, handler: () => void) => {
+        triggerAbort = handler;
+      },
+      removeEventListener: () => {},
+    } as unknown as AbortSignal;
+
+    const body = new Promise<number>(() => {
+      /* never resolves */
+    });
+    const racePromise = raceWithSignal(body, fakeSignal);
+    racePromise.catch(() => {});
+
+    // Abort mid-flight — reason is still undefined, so the fallback fires.
+    triggerAbort();
+
+    await expect(racePromise).rejects.toThrow("aborted");
+  });
+
   it("uses an Error('aborted') fallback when reason is undefined (polyfill path)", async () => {
     // Spec-compliant runtimes always set `reason`, but a polyfill might not.
     const fakeSignal = {

--- a/sites/arolariu.ro/src/workers/host/workerEnvelope.test.ts
+++ b/sites/arolariu.ro/src/workers/host/workerEnvelope.test.ts
@@ -69,6 +69,15 @@ describe("validateBootstrap", () => {
     expect(validateBootstrap(m)).toBe(false);
   });
 
+  it("rejects messages where eventPort is an object but missing postMessage", () => {
+    // Exercises line 91 of workerEnvelope.ts: `if (!hasEventPostMessage) return false`.
+    // The rpcPort has a valid postMessage, but the eventPort only has a duck-typed
+    // object without a callable postMessage — the validator must reject it.
+    const m = makeValid() as Record<string, unknown>;
+    m["eventPort"] = {notPostMessage: true};
+    expect(validateBootstrap(m)).toBe(false);
+  });
+
   it("rejects messages missing capabilities", () => {
     const m = makeValid() as Record<string, unknown>;
     delete m["capabilities"];

--- a/sites/arolariu.ro/src/workers/host/workerLifecycle.test.ts
+++ b/sites/arolariu.ro/src/workers/host/workerLifecycle.test.ts
@@ -165,6 +165,30 @@ describe("createWorkerLifecycle", () => {
     });
   });
 
+  describe("scheduleIdle guard: inFlight > 0 prevents idle scheduling", () => {
+    // Coverage: line 62 of workerLifecycle.ts — `if (inFlight > 0) return`.
+    // When endCall fires but there are still other in-flight calls, scheduleIdle
+    // must return early without arming the idle timer.
+    it("does not schedule idle timer when a second call is still in-flight after endCall", () => {
+      const onIdle = vi.fn();
+      const lifecycle = createWorkerLifecycle({idleTimeoutMs: 500, onIdle});
+      lifecycle.bootBegin();
+      lifecycle.bootComplete();
+      // Start two concurrent calls.
+      lifecycle.beginCall();
+      lifecycle.beginCall();
+      // End only the first — inFlight is still 1. scheduleIdle should not fire.
+      lifecycle.endCall();
+      vi.advanceTimersByTime(600);
+      // Idle timer must NOT have fired because inFlight is still 1.
+      expect(onIdle).not.toHaveBeenCalled();
+      // End the second call — now inFlight drops to 0 and idle timer can arm.
+      lifecycle.endCall();
+      vi.advanceTimersByTime(600);
+      expect(onIdle).toHaveBeenCalledOnce();
+    });
+  });
+
   describe("inflight tracking", () => {
     it("increments and decrements correctly", () => {
       const lifecycle = createWorkerLifecycle({idleTimeoutMs: 1000});

--- a/sites/arolariu.ro/src/workers/react/useWorker.test.tsx
+++ b/sites/arolariu.ro/src/workers/react/useWorker.test.tsx
@@ -1,5 +1,6 @@
 import {act, render, renderHook} from "@testing-library/react";
 import {StrictMode} from "react";
+import {renderToStaticMarkup} from "react-dom/server";
 import {afterEach, beforeEach, describe, expect, it} from "vitest";
 
 import {createWorkerHost} from "../host";
@@ -88,6 +89,23 @@ describe("useWorker", () => {
     unmount();
     // After unmount, the host's internal state is `disposed`; we can't
     // observe it via the hook anymore.
+  });
+
+  // Coverage: getServerSnapshot — called by React's server-side renderer to
+  // produce an SSR snapshot. Workers are client-only, so the snapshot is
+  // always the host's initial state "idle". Exercised via renderToStaticMarkup
+  // which invokes the server code path of useSyncExternalStore.
+  it("getServerSnapshot returns 'idle' during server rendering", () => {
+    const {factory} = makeFactory();
+    function Probe() {
+      const w = useWorker(factory);
+      return <div data-testid='state'>{w.state}</div>;
+    }
+    // renderToStaticMarkup drives the server-side path of useSyncExternalStore,
+    // which calls getServerSnapshot() instead of getSnapshot().
+    const html = renderToStaticMarkup(<Probe />);
+    // The server snapshot is always "idle" (host initial state before any boot).
+    expect(html).toContain("idle");
   });
 
   // Pins the disposed-host re-creation contract: when an effect re-runs and

--- a/sites/arolariu.ro/src/workers/runtime/exposeWorker.test.ts
+++ b/sites/arolariu.ro/src/workers/runtime/exposeWorker.test.ts
@@ -1,7 +1,7 @@
 import {beforeEach, describe, expect, it, vi} from "vitest";
 
 import {WORKER_PROTOCOL_VERSION} from "../host/workerEnvelope";
-import {__resetForTesting, expose, getEventPort} from "./exposeWorker";
+import {__resetForTesting, expose, getBootstrapCapabilities, getEventPort} from "./exposeWorker";
 
 /**
  * Build a minimal `self`-like object for the test, with `addEventListener`
@@ -97,6 +97,15 @@ describe("expose", () => {
     const fakeSelf = makeFakeSelf();
     expose({greet: async () => "hi"}, {self: fakeSelf as unknown as DedicatedWorkerGlobalScope});
     expect(getEventPort()).toBeNull();
+  });
+
+  it("getBootstrapCapabilities returns null before bootstrap completes", () => {
+    // Exercises line 56 of exposeWorker.ts — `getBootstrapCapabilities()` must
+    // return `null` when called before the bootstrap handshake has completed.
+    const fakeSelf = makeFakeSelf();
+    expose({greet: async () => "hi"}, {self: fakeSelf as unknown as DedicatedWorkerGlobalScope});
+    // No bootstrap fired yet — capabilities pointer is null.
+    expect(getBootstrapCapabilities()).toBeNull();
   });
 
   it("passes non-function API values through unwrapped (else branch)", () => {

--- a/sites/arolariu.ro/vitest.config.ts
+++ b/sites/arolariu.ro/vitest.config.ts
@@ -23,12 +23,22 @@ export default mergeConfig(
       exclude: ["**/node_modules/**", "**/tests/**"], // Exclude E2E tests directory
       coverage: {
         exclude: [
+          // ── existing entries ──
           "**/instrumentation.server.ts",
           "**/instrumentation.ts",
           "**/.next/**",
           "**/tests/**",
           "**/export/InvoicePDF.tsx", // @react-pdf/renderer template — not unit-testable
           "**/*.stories.tsx", // Storybook stories
+
+          // ── presentational React components (team policy: not unit-tested) ──
+          "**/emails/**/*.tsx",
+          "src/components/Navigation.tsx",
+          "src/app/_components/PreferencesSubscriptions.tsx",
+
+          // ── SCSS modules (instrumented by v8 as a side effect of import) ──
+          "**/*.module.scss",
+          "**/*.scss",
         ],
       },
     },


### PR DESCRIPTION
## Coverage push for `sites/arolariu.ro`

Pushes Vitest coverage on the non-component surface as close to 100% as practical without contorting production code. CI threshold (90%) unchanged.

### Before / After

| Metric | Baseline | Final | Delta |
|--------|----------|-------|-------|
| Statements | 94.86% (3473/3661) | **99.82%** (3371/3377) | +4.96 |
| Branches | 83.43% (1370/1642) | **96.84%** (1410/1456) | +13.41 |
| Functions | 91.93% (730/794) | **99.71%** (701/703) | +7.78 |
| Lines | 95.16% (3265/3431) | **99.96%** (3162/3163) | +4.80 |

The denominators dropped because Phase 1 excluded presentational React components (emails, `Navigation.tsx`, `PreferencesSubscriptions.tsx`) and SCSS modules from coverage instrumentation. The lifted percentages are honest — every non-component file now has either real tests or a documented Rule-2 / Rule-3 justification for the remaining gap.

### Internal landing zone target (set in the spec)

| Metric | Target | Final | Status |
|--------|--------|-------|--------|
| Statements | ≥98% | 99.82% | ✓ |
| Branches | ≥95% | 96.84% | ✓ |
| Functions | ≥99% | 99.71% | ✓ |
| Lines | ≥99% | 99.96% | ✓ |

### Commits (atomic per phase)

| Phase | Commit | What it did |
|-------|--------|-------------|
| 1 | `b2bcfe92` | Excluded presentational components and SCSS modules from coverage instrumentation |
| 2 | `67a7f72d` | Closed branch gaps in hooks (useScans, useUserInformation) and contexts (DialogContext, FontContext) |
| 3 | `f52c47ea` | Closed error-path and fallback branches in server APIs (/api/health, /api/user) and scan-related server actions |
| 4 | `668e27df` | Closed branch and function gaps in utils and lib (converter, configProxy, featureFlags.server, utils.generic, utils.server, my-profile helpers) |
| 5 | `ee8460ae` | Deep-pass coverage for `view-invoice/[id]/_utils/analytics.ts` — 15 new test cases, branches 78% → 90.78% |
| 6 | `487c2604` | Deep-pass coverage for `view-invoices/_utils/statistics.ts` — 29 new test cases, branches 87% → 93.19% |
| 7 | `2634eb5a` | Store dev-factory annotations (preferencesStore, scansStore) + indexedDB error-handler tests |
| 8 | `f2b0b6aa` | Closed timing and edge branches across 9 worker-infrastructure files; created the missing `mockWorker.test.ts` |

### What changed

**`vitest.config.ts`** — added 6 exclusion patterns:
- `**/emails/**/*.tsx` (templates + visual chrome — verified visually via React Email dev server)
- `src/components/Navigation.tsx`
- `src/app/_components/PreferencesSubscriptions.tsx`
- `**/*.module.scss` and `**/*.scss` (instrumented by v8 as a side effect of import; the base monorepo config only excluded `*.css` / `*.module.css`)

**27 test files** added new test cases (1735 insertions, 4 deletions across the whole diff). One new colocated test file (`src/workers/host/mockWorker.test.ts`).

**4 production source files** received `v8 ignore` annotations (6 lines total, 0 logic changes):

| File | Annotation | Reason |
|------|------------|--------|
| `src/workers/host/bootHandshake.ts` | `/* v8 ignore next */` | `rejectBoot` is always non-null at call sites (synchronous failure path only) |
| `src/stores/storage/indexedDBStorage.ts` | `/* v8 ignore next 2 */` | TypeScript's `EntityTableName` exhausts all valid cases; switch default unreachable at runtime |
| `src/stores/preferencesStore.ts` | `/* v8 ignore next */` + `/* v8 ignore next 10 */` | dev-only `createDevStore` factory; unreachable when `NODE_ENV !== "development"` |
| `src/stores/scansStore.tsx` | `/* v8 ignore next */` + `/* v8 ignore next 10 */` | same dev-only factory pattern |

### Rule-2 leftovers (untested branches with no annotation)

Per the spec's decision rule, defensive defaults whose left operand is type-narrowed are left untested without `v8 ignore` annotations. Production source stays clean. Each subagent that left a Rule-2 branch documented it in their phase commit message. Highlights:

- `usePackageFilters` (line 84) — switch `default: return 0` on TypeScript-narrowed key union
- `useFilteredInvoices` (line 120) — `a.paymentInformation?.transactionDate` optional chain on a required field
- `FontContext` (lines 262-268) — SSR-only branches under happy-dom + post-safety-check unreachable
- Several `?? "default"` patterns after `String.split().pop()` in `lib/actions/scans/*` — `split()` always returns at least one element
- `analytics.ts` lines 604-613, 640-649, 688 — post-`??=` guards that TypeScript requires but can never trigger
- `statistics.ts` lines 1166, 1286-1287, 1593, 1668 — structurally unreachable count/length checks after map-entry initialization

### Files at < per-phase per-file target (acknowledged)

| File | Branches | Reason |
|------|----------|--------|
| `analytics.ts` | 90.78% | Phase 5 acceptance criteria explicitly allowed this — "this file may legitimately have unreachable defensive defaults"; 3 post-`??=` guard ranges left per Rule 2 |
| `statistics.ts` | 93.19% | Same shape — 4 structurally-unreachable defensive guards left per Rule 2 |
| `bootHandshake.ts` | 87.5% | One genuinely-unreachable branch annotated with `v8 ignore`; v8 doesn't honor the hint for conditional branch coverage in this version |

### Test count

2018 tests, 102 test files, all passing.

### Spec / plan references

- Spec: `docs/superpowers/specs/2026-05-16-vitest-coverage-push-design.md`
- Plan: `docs/superpowers/plans/2026-05-16-vitest-coverage-push-plan.md`

### Co-authoring

Phases 2-8 implementer commits include `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>` trailers — work was executed by subagents per the spec's "subagent-driven phase workflow" approach.
