### PR TITLE
feat(dx): exclude .esproj from Prettier; add format targets for status + exp

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -56,3 +56,6 @@ package-lock.json
 **/build/**
 **/out/**
 **/output/**
+
+# Visual Studio extensibility project files (XML-based, owned by VS, not for Prettier)
+**/*.esproj

--- a/package.json
+++ b/package.json
@@ -67,6 +67,8 @@
     "format:cv": "node scripts/format.ts cv",
     "format:website": "node scripts/format.ts website",
     "format:api": "node scripts/format.ts api",
+    "format:status": "node scripts/format.ts status",
+    "format:exp": "node scripts/format.ts exp",
     "lint": "node scripts/lint.ts all",
     "lint:components": "node scripts/lint.ts packages",
     "lint:cv": "node scripts/lint.ts cv",

--- a/scripts/format.ts
+++ b/scripts/format.ts
@@ -23,7 +23,7 @@ import {
 import type {FormatTarget, FormatWorkerInput, FormatWorkerResult} from "./types/format.ts";
 
 /** All available format targets in consistent order */
-const allTargets: FormatTarget[] = ["packages", "website", "cv", "api"];
+const allTargets: FormatTarget[] = ["packages", "website", "cv", "api", "status", "exp"];
 
 /** Target display configuration with icons and colors */
 const targetConfig: Record<FormatTarget, {icon: string; color: (s: string) => string; description: string}> = {
@@ -31,6 +31,8 @@ const targetConfig: Record<FormatTarget, {icon: string; color: (s: string) => st
   website: {icon: "🌐", color: (s: string) => styleText("blue", s), description: "Next.js Website"},
   cv: {icon: "📄", color: (s: string) => styleText("magenta", s), description: "SvelteKit CV"},
   api: {icon: "⚙️", color: (s: string) => styleText("yellow", s), description: ".NET Backend"},
+  status: {icon: "📊", color: (s: string) => styleText("green", s), description: "SvelteKit Status Page"},
+  exp: {icon: "🐍", color: (s: string) => styleText("magentaBright", s), description: "FastAPI Experimental (Python)"},
 };
 
 /** Box drawing characters for fancy borders */
@@ -91,9 +93,12 @@ function createProgressBar(completed: number, total: number, width: number = 20)
  * Creates a status badge for a worker result.
  *
  * @param result - The format worker result.
- * @returns A colored badge (CLEAN/FORMATTED/FAILED).
+ * @returns A colored badge (CLEAN/FORMATTED/FAILED/SKIPPED).
  */
 function createStatusBadge(result: FormatWorkerResult): string {
+  if (result.skipped) {
+    return styleText(["bgGray", "white"], " SKIPPED ");
+  }
   if (result.exitCode !== 0) {
     return styleText(["bgRed", "white"], " FAILED ");
   }
@@ -148,9 +153,11 @@ function printWorkerResult(result: FormatWorkerResult, index?: number): void {
   // Calculate padding: we need to account for ANSI codes in colored strings
   const titleVisibleLength = indexBadge.length + 2 + result.target.length + 1 + config.description.length + 2; // icon is ~2 chars
 
-  // Badge visible lengths: CLEAN=7, FAILED=8, FORMATTED=11
+  // Badge visible lengths: CLEAN=7, SKIPPED=9, FAILED=8, FORMATTED=11
   let badgeVisibleLength = 7; // CLEAN
-  if (result.exitCode !== 0) {
+  if (result.skipped) {
+    badgeVisibleLength = 9; // SKIPPED
+  } else if (result.exitCode !== 0) {
     badgeVisibleLength = 8; // FAILED
   } else if (result.formatted) {
     badgeVisibleLength = 11; // FORMATTED
@@ -228,6 +235,7 @@ function printSummaryBox(results: FormatWorkerResult[]): void {
   const alreadyFormatted = results.filter((r) => r.checkPassed).length;
   const formatted = results.filter((r) => r.formatted).length;
   const failed = results.filter((r) => r.exitCode !== 0).length;
+  const skipped = results.filter((r) => r.skipped === true).length;
   const totalDuration = results.reduce((sum, r) => sum + r.durationMs, 0);
   const totalFiles = results.reduce((sum, r) => sum + r.fileCount, 0);
   const totalMemory = results.reduce((sum, r) => sum + r.peakMemoryBytes, 0);
@@ -240,7 +248,7 @@ function printSummaryBox(results: FormatWorkerResult[]): void {
   console.log();
 
   // Progress bar showing success rate
-  const successCount = alreadyFormatted + formatted;
+  const successCount = alreadyFormatted + formatted + skipped;
   const progressBar = createProgressBar(successCount, results.length, 25);
   console.log(`   Success Rate: ${progressBar}`);
   console.log();
@@ -261,6 +269,10 @@ function printSummaryBox(results: FormatWorkerResult[]): void {
   if (failed > 0) {
     const bar = styleText("red", "█".repeat(failed));
     console.log(`   ${styleText("red", "●")} ${styleText("bold", "Failed:")}    ${bar} ${styleText("red", String(failed))} target(s) failed`);
+  }
+  if (skipped > 0) {
+    const bar = styleText("gray", "█".repeat(skipped));
+    console.log(`   ${styleText("gray", "●")} ${styleText("bold", "Skipped:")}   ${bar} ${styleText("gray", String(skipped))} target(s) skipped (tool not installed)`);
   }
 
   console.log();
@@ -578,11 +590,13 @@ export async function main(arg?: string, filePatterns?: string[]): Promise<numbe
       case "website":
       case "cv":
       case "api":
+      case "status":
+      case "exp":
         exitCode = await runOnSingleTarget(arg, filePatterns);
         break;
       default:
         console.error(styleText("red", `✗ Invalid target: "${arg}"`));
-        console.log(styleText("gray", "\n💡 Valid targets: all, packages, website, cv, api\n"));
+        console.log(styleText("gray", "\n💡 Valid targets: all, packages, website, cv, api, status, exp\n"));
         return 1;
     }
 

--- a/scripts/types/format.ts
+++ b/scripts/types/format.ts
@@ -21,8 +21,10 @@
  * - `website`: Main Next.js site (Prettier)
  * - `cv`: CV SvelteKit site (Prettier)
  * - `api`: .NET backend (dotnet format)
+ * - `status`: SvelteKit Status Page (Prettier)
+ * - `exp`: FastAPI Experimental Python service (Ruff)
  */
-export type FormatTarget = "packages" | "website" | "cv" | "api";
+export type FormatTarget = "packages" | "website" | "cv" | "api" | "status" | "exp";
 
 /**
  * Input payload for the format worker thread.
@@ -82,6 +84,10 @@ export interface FormatWorkerResult {
   readonly resultText: string;
   /** Error message if the worker encountered an exception */
   readonly error?: string;
+  /** Whether the target was skipped (e.g. required tool not found on PATH) */
+  readonly skipped?: boolean;
+  /** Human-readable reason why the target was skipped */
+  readonly skipReason?: string;
   /** Worker thread ID (unique per worker) */
   readonly workerId: number;
   /** Total duration including thread startup and module loading (milliseconds) */

--- a/scripts/workers/format.worker.test.ts
+++ b/scripts/workers/format.worker.test.ts
@@ -1,0 +1,35 @@
+/**
+ * @fileoverview Unit tests for format.worker helpers.
+ * @module scripts/workers/format.worker.test
+ */
+
+import {describe, expect, it} from "vitest";
+
+// We re-implement isToolAvailable inline-equivalent here because format.worker.ts
+// runs as a worker thread and does not export its helpers. The contract under
+// test is purely: "spawn <cmd> --version; resolve true on exit 0 else false."
+//
+// Keeping this test colocated with the worker signals intent to anyone
+// touching the worker that the probe contract must be preserved.
+
+import {spawn} from "node:child_process";
+
+async function probe(cmd: string): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    const child = spawn(cmd, ["--version"], {stdio: "pipe", windowsHide: true});
+    child.on("close", (code) => resolve(code === 0));
+    child.on("error", () => resolve(false));
+  });
+}
+
+describe("isToolAvailable probe (mirror of format.worker.ts)", () => {
+  it("returns true for an existing tool (node)", async () => {
+    const result = await probe("node");
+    expect(result).toBe(true);
+  });
+
+  it("returns false for a non-existing tool", async () => {
+    const result = await probe("definitely-not-a-real-tool-xyzzy-12345");
+    expect(result).toBe(false);
+  });
+});

--- a/scripts/workers/format.worker.test.ts
+++ b/scripts/workers/format.worker.test.ts
@@ -23,8 +23,12 @@ async function probe(cmd: string): Promise<boolean> {
 }
 
 describe("isToolAvailable probe (mirror of format.worker.ts)", () => {
-  it("returns true for an existing tool (node)", async () => {
-    const result = await probe("node");
+  // Use process.execPath (absolute path to the current node binary) instead of
+  // the bare name "node" so the test doesn't depend on PATH layout. A restricted
+  // environment that runs vitest via npx but omits `node` from PATH would
+  // otherwise produce a spurious failure.
+  it("returns true for an existing tool (current node binary)", async () => {
+    const result = await probe(process.execPath);
     expect(result).toBe(true);
   });
 

--- a/scripts/workers/format.worker.ts
+++ b/scripts/workers/format.worker.ts
@@ -27,10 +27,11 @@ import type {FormatTarget, FormatWorkerInput, FormatWorkerResult} from "../types
 const CACHE_DIR = "artifacts";
 
 // Directory mappings for Prettier targets
-const directoryMap: Record<Exclude<FormatTarget, "api">, string> = {
+const directoryMap: Record<Exclude<FormatTarget, "api" | "exp">, string> = {
   packages: "packages/components/**",
   website: "sites/arolariu.ro/**",
   cv: "sites/cv.arolariu.ro/**",
+  status: "sites/status.arolariu.ro/**",
 };
 
 /**
@@ -68,6 +69,16 @@ async function runCommand(command: string, args: string[]): Promise<{code: numbe
 }
 
 /**
+ * Checks whether a CLI tool exists on PATH by attempting `<tool> --version`.
+ * @param cmd The tool name (e.g. "ruff", "dotnet")
+ * @returns true if the tool exited with code 0
+ */
+async function isToolAvailable(cmd: string): Promise<boolean> {
+  const result = await runCommand(cmd, ["--version"]);
+  return result.code === 0;
+}
+
+/**
  * Checks if code is properly formatted for a target.
  * @param target The target to check
  * @param customPatterns Optional custom file patterns for selective targeting
@@ -80,6 +91,13 @@ async function checkTarget(
   if (target === "api") {
     // For .NET, custom patterns are not supported via dotnet format CLI easily
     return runCommand("dotnet", ["format", "arolariu.slnx", "--verify-no-changes", "--verbosity", "quiet"]);
+  }
+
+  if (target === "exp") {
+    // Ruff check mode: format check + import sort check (no auto-fix).
+    const formatCheck = await runCommand("ruff", ["format", "--check", "sites/exp.arolariu.ro"]);
+    if (formatCheck.code !== 0) return formatCheck;
+    return runCommand("ruff", ["check", "--select", "I", "sites/exp.arolariu.ro"]);
   }
 
   // Prettier targets - use custom patterns if provided
@@ -118,6 +136,13 @@ async function formatTarget(
   if (target === "api") {
     // For .NET, custom patterns are not supported via dotnet format CLI easily
     return runCommand("dotnet", ["format", "arolariu.slnx", "--verbosity", "quiet"]);
+  }
+
+  if (target === "exp") {
+    // Ruff write mode: format files + auto-fix only import sorting (isort, rule I).
+    const fmt = await runCommand("ruff", ["format", "sites/exp.arolariu.ro"]);
+    if (fmt.code !== 0) return fmt;
+    return runCommand("ruff", ["check", "--select", "I", "--fix", "sites/exp.arolariu.ro"]);
   }
 
   // Prettier targets - use custom patterns if provided
@@ -210,6 +235,48 @@ export default async function formatWorker(input: FormatWorkerInput): Promise<Fo
   });
 
   try {
+    // Tool availability gate for external-tool targets.
+    if (target === "exp") {
+      const available = await isToolAvailable("ruff");
+      if (!available) {
+        return {
+          target,
+          checkPassed: false,
+          formatted: false,
+          exitCode: 0,
+          resultText: `  ⊘ ${target} skipped: Ruff not found on PATH\n`,
+          skipped: true,
+          skipReason: "Ruff not installed. Install via 'pipx install ruff' or 'pip install ruff'.",
+          workerId,
+          durationMs: Math.round(performance.now() - startTime),
+          workTimeMs: 0,
+          initTimeMs: 0,
+          fileCount: 0,
+          peakMemoryBytes,
+        };
+      }
+    }
+    if (target === "api") {
+      const available = await isToolAvailable("dotnet");
+      if (!available) {
+        return {
+          target,
+          checkPassed: false,
+          formatted: false,
+          exitCode: 0,
+          resultText: `  ⊘ ${target} skipped: dotnet not found on PATH\n`,
+          skipped: true,
+          skipReason: "dotnet CLI not installed. Install the .NET SDK from https://dot.net/.",
+          workerId,
+          durationMs: Math.round(performance.now() - startTime),
+          workTimeMs: 0,
+          initTimeMs: 0,
+          fileCount: 0,
+          peakMemoryBytes,
+        };
+      }
+    }
+
     // ===== INITIALIZATION PHASE =====
     const initStartTime = performance.now();
 

--- a/scripts/workers/format.worker.ts
+++ b/scripts/workers/format.worker.ts
@@ -282,8 +282,8 @@ export default async function formatWorker(input: FormatWorkerInput): Promise<Fo
 
     // For Prettier targets, resolve config file (this is the main init cost)
     // For API (.NET), initialization is minimal
-    if (target !== "api") {
-      await resolveConfigFile(); // Pre-warm the config resolution
+    if (target !== "api" && target !== "exp") {
+      await resolveConfigFile(); // Pre-warm the config resolution (Prettier targets only)
     }
     trackMemory();
 

--- a/scripts/workers/format.worker.ts
+++ b/scripts/workers/format.worker.ts
@@ -275,6 +275,13 @@ export default async function formatWorker(input: FormatWorkerInput): Promise<Fo
 
   try {
     // Tool availability gate for external-tool targets.
+    //
+    // Skipped-result conventions (apply to both `exp` and `api` branches below):
+    //   - exitCode: 0   → `format all` overall still passes; missing tools don't fail the pipeline.
+    //   - checkPassed: false → a skipped target is NOT counted in `alreadyFormatted` (the
+    //     "clean" tally) — it has its own `skipped` counter and a SKIPPED badge.
+    //   - formatted: false → not counted in the "Fixed" tally either.
+    //   - skipped: true is the sole sentinel the summary uses to bucket the result.
     if (target === "exp") {
       const ruff = await resolveRuff();
       if (!ruff) {

--- a/scripts/workers/format.worker.ts
+++ b/scripts/workers/format.worker.ts
@@ -79,6 +79,39 @@ async function isToolAvailable(cmd: string): Promise<boolean> {
 }
 
 /**
+ * Resolves how to invoke ruff. Returns the command + args prefix, or `null`
+ * if ruff is not available at all.
+ *
+ * Probe order:
+ *   1. `ruff` on PATH (standard install via pipx, system pip, or PATH-aware install).
+ *   2. `python -m ruff` (fallback for Microsoft Store Python or other sandboxed installs
+ *      where pip places ruff outside PATH but Python itself is reachable).
+ *
+ * Cached at module scope; valid for the lifetime of this worker process.
+ */
+let cachedRuffInvocation: readonly string[] | null | undefined;
+
+async function resolveRuff(): Promise<readonly string[] | null> {
+  if (cachedRuffInvocation !== undefined) return cachedRuffInvocation;
+
+  if (await isToolAvailable("ruff")) {
+    cachedRuffInvocation = ["ruff"];
+    return cachedRuffInvocation;
+  }
+
+  if (await isToolAvailable("python")) {
+    const result = await runCommand("python", ["-m", "ruff", "--version"]);
+    if (result.code === 0) {
+      cachedRuffInvocation = ["python", "-m", "ruff"];
+      return cachedRuffInvocation;
+    }
+  }
+
+  cachedRuffInvocation = null;
+  return cachedRuffInvocation;
+}
+
+/**
  * Checks if code is properly formatted for a target.
  * @param target The target to check
  * @param customPatterns Optional custom file patterns for selective targeting
@@ -95,9 +128,12 @@ async function checkTarget(
 
   if (target === "exp") {
     // Ruff check mode: format check + import sort check (no auto-fix).
-    const formatCheck = await runCommand("ruff", ["format", "--check", "sites/exp.arolariu.ro"]);
+    const ruff = await resolveRuff();
+    if (!ruff) return {code: 1, output: "Ruff not found on PATH and not invokable via python -m"};
+    const [cmd, ...prefix] = ruff as string[];
+    const formatCheck = await runCommand(cmd, [...prefix, "format", "--check", "sites/exp.arolariu.ro"]);
     if (formatCheck.code !== 0) return formatCheck;
-    return runCommand("ruff", ["check", "--select", "I", "sites/exp.arolariu.ro"]);
+    return runCommand(cmd, [...prefix, "check", "--select", "I", "sites/exp.arolariu.ro"]);
   }
 
   // Prettier targets - use custom patterns if provided
@@ -140,9 +176,12 @@ async function formatTarget(
 
   if (target === "exp") {
     // Ruff write mode: format files + auto-fix only import sorting (isort, rule I).
-    const fmt = await runCommand("ruff", ["format", "sites/exp.arolariu.ro"]);
+    const ruff = await resolveRuff();
+    if (!ruff) return {code: 1, output: "Ruff not found on PATH and not invokable via python -m"};
+    const [cmd, ...prefix] = ruff as string[];
+    const fmt = await runCommand(cmd, [...prefix, "format", "sites/exp.arolariu.ro"]);
     if (fmt.code !== 0) return fmt;
-    return runCommand("ruff", ["check", "--select", "I", "--fix", "sites/exp.arolariu.ro"]);
+    return runCommand(cmd, [...prefix, "check", "--select", "I", "--fix", "sites/exp.arolariu.ro"]);
   }
 
   // Prettier targets - use custom patterns if provided
@@ -237,16 +276,16 @@ export default async function formatWorker(input: FormatWorkerInput): Promise<Fo
   try {
     // Tool availability gate for external-tool targets.
     if (target === "exp") {
-      const available = await isToolAvailable("ruff");
-      if (!available) {
+      const ruff = await resolveRuff();
+      if (!ruff) {
         return {
           target,
           checkPassed: false,
           formatted: false,
           exitCode: 0,
-          resultText: `  ⊘ ${target} skipped: Ruff not found on PATH\n`,
+          resultText: `  ⊘ ${target} skipped: Ruff not found (tried 'ruff' and 'python -m ruff')\n`,
           skipped: true,
-          skipReason: "Ruff not installed. Install via 'pipx install ruff' or 'pip install ruff'.",
+          skipReason: "Ruff not installed. Install via 'pipx install ruff' (recommended), or 'pip install ruff' if Python+pip is configured for PATH access.",
           workerId,
           durationMs: Math.round(performance.now() - startTime),
           workTimeMs: 0,

--- a/sites/exp.arolariu.ro/api/admin.py
+++ b/sites/exp.arolariu.ro/api/admin.py
@@ -33,10 +33,7 @@ def _get_client_id() -> str:
     provider's client ID (MICROSOFT_PROVIDER_AUTHENTICATION_CLIENT_ID) which
     is auto-set by App Service when Easy Auth is configured.
     """
-    return (
-        os.getenv("EXP_ENTRA_APP_CLIENT_ID", "")
-        or os.getenv("MICROSOFT_PROVIDER_AUTHENTICATION_CLIENT_ID", "")
-    )
+    return os.getenv("EXP_ENTRA_APP_CLIENT_ID", "") or os.getenv("MICROSOFT_PROVIDER_AUTHENTICATION_CLIENT_ID", "")
 
 
 def _is_azure_mode() -> bool:
@@ -95,11 +92,7 @@ def _load_azure_config_for_label(label: str) -> dict[str, str]:
     from azure.identity import DefaultAzureCredential
 
     client_id = os.getenv("AZURE_CLIENT_ID")
-    credential = (
-        DefaultAzureCredential(managed_identity_client_id=client_id)
-        if client_id
-        else DefaultAzureCredential()
-    )
+    credential = DefaultAzureCredential(managed_identity_client_id=client_id) if client_id else DefaultAzureCredential()
 
     endpoint = os.getenv("AZURE_APPCONFIG_ENDPOINT", "")
     config = load(
@@ -119,11 +112,7 @@ def _set_azure_config_value(key: str, value: str, label: str) -> None:
     from azure.identity import DefaultAzureCredential
 
     client_id = os.getenv("AZURE_CLIENT_ID")
-    credential = (
-        DefaultAzureCredential(managed_identity_client_id=client_id)
-        if client_id
-        else DefaultAzureCredential()
-    )
+    credential = DefaultAzureCredential(managed_identity_client_id=client_id) if client_id else DefaultAzureCredential()
 
     endpoint = os.getenv("AZURE_APPCONFIG_ENDPOINT", "")
     client = AzureAppConfigurationClient(base_url=endpoint, credential=credential)
@@ -230,10 +219,7 @@ def _build_admin_html(*, infra: str, client_id: str, tenant_id: str, commit_sha:
     is_azure = infra == "azure"
     auth_label = "MSAL (Entra ID)" if is_azure else "None (open)"
     short_sha = commit_sha[:12] if len(commit_sha) >= 12 else commit_sha
-    commit_url = (
-        f"https://github.com/arolariu/arolariu.ro/commit/{commit_sha}"
-        if commit_sha != "unknown" else ""
-    )
+    commit_url = f"https://github.com/arolariu/arolariu.ro/commit/{commit_sha}" if commit_sha != "unknown" else ""
 
     # Pre-build long HTML fragments to stay under line-length limit.
     sha_badge = (
@@ -248,11 +234,11 @@ def _build_admin_html(*, infra: str, client_id: str, tenant_id: str, commit_sha:
         "<span class='tab active' data-label='DEVELOPMENT' onclick='switchLabel(this)'>DEV</span>"
         "<span class='tab' data-label='PRODUCTION' onclick='switchLabel(this)'>PROD</span>"
         "</div>"
-        if is_azure else ""
+        if is_azure
+        else ""
     )
     signin_btn = (
-        "<button class='btn btn-signin' id='btn-signin' onclick='signIn()'>Sign In</button>"
-        if is_azure else ""
+        "<button class='btn btn-signin' id='btn-signin' onclick='signIn()'>Sign In</button>" if is_azure else ""
     )
 
     return f"""\

--- a/sites/exp.arolariu.ro/api/config.test.py
+++ b/sites/exp.arolariu.ro/api/config.test.py
@@ -84,10 +84,7 @@ class TestConfigAuthorization:
             )
 
         assert response.status_code == 403
-        assert (
-            response.json()["error"]
-            == "Header target 'api' is not allowed. Expected one of: website."
-        )
+        assert response.json()["error"] == "Header target 'api' is not allowed. Expected one of: website."
 
 
 class TestConfigContract:

--- a/sites/exp.arolariu.ro/config/catalog.py
+++ b/sites/exp.arolariu.ro/config/catalog.py
@@ -239,8 +239,7 @@ _CONFIG_KEY_DOCUMENTATION: Final[dict[str, ConfigKeyDocumentation]] = {
     ),
     "Endpoints:AI:OCR:Key": ConfigKeyDocumentation(
         description=(
-            "Credential under the Endpoint hierarchy for API integrations "
-            "that still require an OCR service key."
+            "Credential under the Endpoint hierarchy for API integrations that still require an OCR service key."
         ),
         usage=(
             "API-only and server-only. Prefer managed identity when supported, "
@@ -264,8 +263,7 @@ _CONFIG_KEY_DOCUMENTATION: Final[dict[str, ConfigKeyDocumentation]] = {
     ),
     "Endpoints:Service:Api": ConfigKeyDocumentation(
         description=(
-            "Base URL of the backend API under the Endpoint hierarchy, "
-            "called by the website from server-only code."
+            "Base URL of the backend API under the Endpoint hierarchy, called by the website from server-only code."
         ),
         usage=(
             "Website-only. Use this value for server-to-server fetches instead "
@@ -278,8 +276,7 @@ _CONFIG_KEY_DOCUMENTATION: Final[dict[str, ConfigKeyDocumentation]] = {
             "binary assets and server-side storage helpers."
         ),
         usage=(
-            "Safe for server-side rendering and upload helpers, "
-            "but do not expose raw storage clients to browser code."
+            "Safe for server-side rendering and upload helpers, but do not expose raw storage clients to browser code."
         ),
     ),
     "Identity:Tenant:Id": ConfigKeyDocumentation(
@@ -392,9 +389,7 @@ def get_refresh_interval_for_targets(targets: Sequence[str]) -> int:
     """Return the maximum refresh interval declared by the supplied targets."""
 
     intervals = [
-        index.refresh_interval_seconds
-        for target in targets
-        if (index := get_target_index(target)) is not None
+        index.refresh_interval_seconds for target in targets if (index := get_target_index(target)) is not None
     ]
     return max(intervals, default=DEFAULT_REFRESH_INTERVAL_SECONDS)
 
@@ -406,18 +401,9 @@ def _resolve_config_snapshot(
 ) -> ConfigResolutionResult:
     """Resolve indexed config values and report any missing required keys."""
 
-    missing_required_keys = tuple(
-        sorted(
-            key
-            for key in required_keys
-            if config_snapshot.get(key) is None
-        )
-    )
+    missing_required_keys = tuple(sorted(key for key in required_keys if config_snapshot.get(key) is None))
 
-    resolved_config = {
-        key: config_snapshot.get(key, "")
-        for key in _dedupe(required_keys + optional_keys)
-    }
+    resolved_config = {key: config_snapshot.get(key, "") for key in _dedupe(required_keys + optional_keys)}
 
     return ConfigResolutionResult(missing_required_keys=missing_required_keys, config=resolved_config)
 

--- a/sites/exp.arolariu.ro/config/loader.py
+++ b/sites/exp.arolariu.ro/config/loader.py
@@ -35,6 +35,7 @@ class ConfigLoaderStats:
     load_count: int
     last_loaded_at: str | None
 
+
 # Global config snapshot. Access is synchronized because request handlers and
 # refresh logic may run concurrently in the same process.
 _config: ConfigSnapshot = {}
@@ -144,11 +145,7 @@ def _load_azure_config(label: str | None = None) -> ConfigSnapshot:
     from azure.identity import DefaultAzureCredential
 
     client_id = os.getenv("AZURE_CLIENT_ID")
-    credential = (
-        DefaultAzureCredential(managed_identity_client_id=client_id)
-        if client_id
-        else DefaultAzureCredential()
-    )
+    credential = DefaultAzureCredential(managed_identity_client_id=client_id) if client_id else DefaultAzureCredential()
 
     endpoint = os.getenv("AZURE_APPCONFIG_ENDPOINT")
     if not endpoint:
@@ -297,11 +294,7 @@ def get_config_section(prefix: str) -> ConfigSnapshot:
 
     config_snapshot = get_config()
     section_prefix = f"{prefix}:"
-    return {
-        key: value
-        for key, value in config_snapshot.items()
-        if key.startswith(section_prefix)
-    }
+    return {key: value for key, value in config_snapshot.items() if key.startswith(section_prefix)}
 
 
 def refresh_config() -> ConfigSnapshot:
@@ -409,7 +402,4 @@ def extract_features(config: Mapping[str, str], feature_ids: Sequence[str]) -> F
     always receive a full feature map for the registered IDs.
     """
 
-    return {
-        feature_id: _resolve_feature_state(config, feature_id)
-        for feature_id in feature_ids
-    }
+    return {feature_id: _resolve_feature_state(config, feature_id) for feature_id in feature_ids}

--- a/sites/exp.arolariu.ro/config/loader.test.py
+++ b/sites/exp.arolariu.ro/config/loader.test.py
@@ -10,6 +10,7 @@ import pytest
 def reset_config():
     """Reset global config between tests."""
     import config.loader as config_loader
+
     config_loader._config = {}
     config_loader._loaded = False
     config_loader._last_loaded_at = None
@@ -26,22 +27,27 @@ def reset_config():
 class TestGetConfigValue:
     def test_returns_value_for_existing_key(self):
         import config.loader as config_loader
+
         config_loader._config = {"test:key": "test-value"}
         config_loader._loaded = True
         from config.loader import get_config_value
+
         assert get_config_value("test:key") == "test-value"
 
     def test_returns_none_for_missing_key(self):
         import config.loader as config_loader
+
         config_loader._config = {"test:key": "test-value"}
         config_loader._loaded = True
         from config.loader import get_config_value
+
         assert get_config_value("missing:key") is None
 
 
 class TestGetConfigSection:
     def test_returns_matching_keys(self):
         import config.loader as config_loader
+
         config_loader._config = {
             "Endpoints:Storage": "http://storage",
             "Endpoints:SQL": "http://sql",
@@ -49,6 +55,7 @@ class TestGetConfigSection:
         }
         config_loader._loaded = True
         from config.loader import get_config_section
+
         result = get_config_section("Endpoints")
         assert len(result) == 2
         assert "Endpoints:Storage" in result
@@ -115,6 +122,7 @@ class TestLoadLocalConfig:
 class TestRefreshInterval:
     def test_is_refresh_due_when_interval_elapsed(self, monkeypatch):
         import config.loader as config_loader
+
         monkeypatch.setenv("EXP_CONFIG_REFRESH_INTERVAL_SECONDS", "10")
         config_loader._loaded = True
         config_loader._last_loaded_at = 0.0
@@ -123,6 +131,7 @@ class TestRefreshInterval:
 
     def test_is_not_due_when_interval_disabled(self, monkeypatch):
         import config.loader as config_loader
+
         monkeypatch.setenv("EXP_CONFIG_REFRESH_INTERVAL_SECONDS", "0")
         config_loader._loaded = True
         config_loader._last_loaded_at = 0.0

--- a/sites/exp.arolariu.ro/models.py
+++ b/sites/exp.arolariu.ro/models.py
@@ -152,15 +152,13 @@ class ApiBuildTimeConfig(ExpModel):
     cognitive_services_endpoint: str = Field(
         alias="Endpoints:AI:OCR",
         description=(
-            "OCR endpoint under the Endpoint hierarchy, "
-            "used by document analysis and related enrichment flows."
+            "OCR endpoint under the Endpoint hierarchy, used by document analysis and related enrichment flows."
         ),
     )
     cognitive_services_key: str = Field(
         alias="Endpoints:AI:OCR:Key",
         description=(
-            "Credential under the Endpoint hierarchy, used by the API "
-            "when an OCR integration still requires a key."
+            "Credential under the Endpoint hierarchy, used by the API when an OCR integration still requires a key."
         ),
     )
 
@@ -201,8 +199,7 @@ class WebsiteBuildTimeConfig(ExpModel):
     api_endpoint: str = Field(
         alias="Endpoints:Service:Api",
         description=(
-            "Base URL of the API service under the Endpoint hierarchy, "
-            "called by the website from server-side code."
+            "Base URL of the API service under the Endpoint hierarchy, called by the website from server-side code."
         ),
     )
     storage_account_endpoint: str = Field(
@@ -248,8 +245,7 @@ class WebsiteRunTimeConfig(WebsiteBuildTimeConfig):
     resend_api_key: str = Field(
         alias="Communication:Email:ApiKey",
         description=(
-            "Optional email API key used by server-side email flows. Empty "
-            "string means email is not configured."
+            "Optional email API key used by server-side email flows. Empty string means email is not configured."
         ),
     )
 

--- a/sites/exp.arolariu.ro/security/authz.py
+++ b/sites/exp.arolariu.ro/security/authz.py
@@ -293,9 +293,7 @@ def _authorize_azure_for_targets(
         return AuthorizationResult(False, 401, "Unauthorized caller.")
 
     matched_targets = tuple(
-        target
-        for target in allowed_targets
-        if not caller_ids.isdisjoint(_identity_policy().get(target, set()))
+        target for target in allowed_targets if not caller_ids.isdisjoint(_identity_policy().get(target, set()))
     )
     if not matched_targets:
         return AuthorizationResult(False, 403, "Caller is not allowed for the requested resource.")

--- a/sites/exp.arolariu.ro/telemetry/bootstrap.py
+++ b/sites/exp.arolariu.ro/telemetry/bootstrap.py
@@ -16,10 +16,7 @@ from telemetry.settings import TelemetrySettings, get_telemetry_settings
 
 logger = logging.getLogger(__name__)
 
-_DEFAULT_LOG_FORMAT = (
-    "%(asctime)s %(levelname)s %(name)s "
-    "trace_id=%(otelTraceID)s span_id=%(otelSpanID)s %(message)s"
-)
+_DEFAULT_LOG_FORMAT = "%(asctime)s %(levelname)s %(name)s trace_id=%(otelTraceID)s span_id=%(otelSpanID)s %(message)s"
 
 
 @dataclass(frozen=True, slots=True)
@@ -238,9 +235,7 @@ def _configure_tracing(
     tracer_provider = dependencies.TracerProvider(resource=resource, sampler=sampler)
 
     if settings.console_trace_export_enabled:
-        tracer_provider.add_span_processor(
-            dependencies.BatchSpanProcessor(dependencies.ConsoleSpanExporter())
-        )
+        tracer_provider.add_span_processor(dependencies.BatchSpanProcessor(dependencies.ConsoleSpanExporter()))
 
     if settings.azure_export_enabled:
         tracer_provider.add_span_processor(
@@ -252,9 +247,7 @@ def _configure_tracing(
         )
 
     if settings.otlp_export_enabled:
-        tracer_provider.add_span_processor(
-            dependencies.BatchSpanProcessor(dependencies.OTLPSpanExporter())
-        )
+        tracer_provider.add_span_processor(dependencies.BatchSpanProcessor(dependencies.OTLPSpanExporter()))
 
     dependencies.trace_module.set_tracer_provider(tracer_provider)
     return tracer_provider
@@ -340,9 +333,7 @@ def _configure_logging(
         )
 
     if settings.otlp_export_enabled:
-        logger_provider.add_log_record_processor(
-            dependencies.BatchLogRecordProcessor(dependencies.OTLPLogExporter())
-        )
+        logger_provider.add_log_record_processor(dependencies.BatchLogRecordProcessor(dependencies.OTLPLogExporter()))
 
     dependencies.logs_module(logger_provider)
 
@@ -359,11 +350,7 @@ def _get_metric_attributes(
 ) -> dict[str, ScalarAttributeValue]:
     """Drop ``None`` values from metric-attribute dictionaries."""
 
-    return {
-        key: value
-        for key, value in attributes.items()
-        if value is not None
-    }
+    return {key: value for key, value in attributes.items() if value is not None}
 
 
 def _create_observation_callback(
@@ -376,11 +363,11 @@ def _create_observation_callback(
 
     def observe(_options: Any) -> list[Any]:
         return [
-                dependencies.observation_type(
-                    value_getter(),
-                    _get_metric_attributes({"exp.infra.mode": settings.infra_mode}),
-                )
-            ]
+            dependencies.observation_type(
+                value_getter(),
+                _get_metric_attributes({"exp.infra.mode": settings.infra_mode}),
+            )
+        ]
 
     return observe
 
@@ -429,9 +416,11 @@ def _configure_custom_metrics(runtime: TelemetryRuntime) -> None:
         callbacks=[
             _create_observation_callback(
                 runtime.dependencies,
-                lambda: __import__("runtime.metrics", fromlist=["get_process_runtime_snapshot"])
-                .get_process_runtime_snapshot()
-                .uptime_seconds,
+                lambda: (
+                    __import__("runtime.metrics", fromlist=["get_process_runtime_snapshot"])
+                    .get_process_runtime_snapshot()
+                    .uptime_seconds
+                ),
                 settings=runtime.settings,
             )
         ],
@@ -443,9 +432,11 @@ def _configure_custom_metrics(runtime: TelemetryRuntime) -> None:
         callbacks=[
             _create_observation_callback(
                 runtime.dependencies,
-                lambda: __import__("runtime.metrics", fromlist=["get_request_metrics_snapshot"])
-                .get_request_metrics_snapshot()
-                .total_requests,
+                lambda: (
+                    __import__("runtime.metrics", fromlist=["get_request_metrics_snapshot"])
+                    .get_request_metrics_snapshot()
+                    .total_requests
+                ),
                 settings=runtime.settings,
             )
         ],
@@ -457,9 +448,11 @@ def _configure_custom_metrics(runtime: TelemetryRuntime) -> None:
         callbacks=[
             _create_observation_callback(
                 runtime.dependencies,
-                lambda: __import__("runtime.metrics", fromlist=["get_served_config_metrics_snapshot"])
-                .get_served_config_metrics_snapshot()
-                .responses_total,
+                lambda: (
+                    __import__("runtime.metrics", fromlist=["get_served_config_metrics_snapshot"])
+                    .get_served_config_metrics_snapshot()
+                    .responses_total
+                ),
                 settings=runtime.settings,
             )
         ],
@@ -471,9 +464,11 @@ def _configure_custom_metrics(runtime: TelemetryRuntime) -> None:
         callbacks=[
             _create_observation_callback(
                 runtime.dependencies,
-                lambda: __import__("runtime.metrics", fromlist=["get_served_config_metrics_snapshot"])
-                .get_served_config_metrics_snapshot()
-                .values_total,
+                lambda: (
+                    __import__("runtime.metrics", fromlist=["get_served_config_metrics_snapshot"])
+                    .get_served_config_metrics_snapshot()
+                    .values_total
+                ),
                 settings=runtime.settings,
             )
         ],


### PR DESCRIPTION
## Summary
- Adds `**/*.esproj` to `.prettierignore` (4 affected projects: arolariu, cv, docs, status).
- Adds two new format targets: `status` (Prettier on SvelteKit) and `exp` (Ruff on Python).
- Adds a tool-availability probe in `format.worker.ts` — `format all` continues with a SKIPPED badge when ruff/dotnet are missing.
- `format all` now runs 6 targets in parallel.

Spec: `docs/superpowers/specs/2026-05-16-dx-tooling-improvements-design.md` (Section 2). Phase 1 of 3.

## Test plan
- [ ] `npm run format all` from a clean tree → 6 targets reported, missing tools show SKIPPED.
- [ ] `npm run format:status` and `npm run format:exp` work in isolation.
- [ ] `.esproj` files are not touched by `npm run format`.
- [ ] `npx vitest run scripts/workers/format.worker.test.ts` passes.