### PR TITLE
fix(website): generate Next.js route types before tsc/tsgo

### DIFF
--- a/.github/workflows/official-website-build.yml
+++ b/.github/workflows/official-website-build.yml
@@ -157,10 +157,15 @@ jobs:
         run: |
           echo "::group::🧬 Running tsgo --noEmit"
           START_TIME=$(date +%s)
-          # The npm package name (@typescript/native-preview) differs from the
-          # bin name (tsgo). npm's registry does not reverse-lookup bins, so
-          # bare `npx tsgo` fails with E404. -p specifies the package; -y
-          # answers the install prompt non-interactively in CI.
+          # First: generate Next.js route-aware ambient types (PageProps,
+          # LayoutProps, route literal unions) under .next/types/. Without
+          # this step tsgo reports TS2304 for every PageProps/LayoutProps
+          # use across the app (and SVG-import errors that cascade from them).
+          npx next typegen
+          # Then run tsgo. The npm package name (@typescript/native-preview)
+          # differs from the bin name (tsgo); npm's registry does not
+          # reverse-lookup bins, so bare `npx tsgo` fails with E404. -p
+          # specifies the package; -y skips the install prompt in CI.
           npx -y -p @typescript/native-preview tsgo --noEmit -p tsconfig.json
           END_TIME=$(date +%s)
           DURATION=$((END_TIME - START_TIME))

--- a/sites/arolariu.ro/scripts/typecheck.ts
+++ b/sites/arolariu.ro/scripts/typecheck.ts
@@ -6,47 +6,62 @@
  * Runs `tsc --noEmit -p tsconfig.json` against the website project using the
  * existing `typescript` devDep (NOT the preview tsgo).
  *
+ * Before invoking tsc, runs `next typegen` to (re)generate the route-aware
+ * ambient types (`PageProps`, `LayoutProps`, route literal unions) under
+ * `.next/types/`. Without this step the type-check sees those globals as
+ * undefined and emits dozens of false-positive `TS2304` errors.
+ *
  * Invoked by:
  *   - `npm run typecheck` (direct, by humans)
  *   - `beforeBuild.ts` (as part of `npm run build`)
  *   - the Docker frontend build (which runs `npm run build` inside the image)
  *
- * Fails the build on any non-zero tsc exit. Streams tsc output unmodified.
+ * Fails the build on any non-zero exit from either step. Streams output unmodified.
  */
 
 import {spawn} from "node:child_process";
 
-export default async function typeCheck(): Promise<void> {
-  console.info("[arolariu.ro::typecheck] Running tsc --noEmit -p tsconfig.json...");
-
-  await new Promise<void>((resolve, reject) => {
+/** Spawns one CLI step and resolves on exit 0, rejects otherwise. */
+function runStep(label: string, command: string, args: readonly string[]): Promise<void> {
+  return new Promise((resolve, reject) => {
     // On Windows, `npx` is a .cmd shim that spawn() refuses to run directly
     // (Node 18.20+ security mitigation, CVE-2024-27980). Route through cmd.exe
-    // /c — a real binary that resolves PATHEXT for us. This mirrors the pattern
-    // landed in scripts/workers/lint.worker.ts during Phase 2.
+    // /c — a real binary that resolves PATHEXT for us. Mirrors the pattern in
+    // scripts/workers/shell.ts.
     const isWindows = process.platform === "win32";
-    const [cmd, args] = isWindows
-      ? ["cmd.exe", ["/c", "npx", "tsc", "--noEmit", "-p", "tsconfig.json"]]
-      : ["npx", ["tsc", "--noEmit", "-p", "tsconfig.json"]];
+    const [spawnCmd, spawnArgs]: [string, string[]] = isWindows
+      ? ["cmd.exe", ["/c", command, ...args]]
+      : [command, [...args]];
 
-    const child = spawn(cmd, args, {
+    const child = spawn(spawnCmd, spawnArgs, {
       stdio: "inherit",
       windowsHide: true,
     });
 
     child.on("close", (code) => {
       if (code === 0) {
-        console.info("[arolariu.ro::typecheck] Type-check passed.");
         resolve();
       } else {
-        reject(new Error(`tsc exited with code ${code}`));
+        reject(new Error(`${label} exited with code ${code}`));
       }
     });
 
-    child.on("error", (error) => {
-      reject(error);
-    });
+    child.on("error", reject);
   });
+}
+
+export default async function typeCheck(): Promise<void> {
+  // Step 1: regenerate Next.js route-aware ambient types. Without this, tsc
+  // reports TS2304 for every `PageProps`/`LayoutProps` use across the app
+  // (and the SVG-import errors that cascade from those broken types).
+  console.info("[arolariu.ro::typecheck] Generating Next.js route types (next typegen)...");
+  await runStep("next typegen", "npx", ["next", "typegen"]);
+
+  // Step 2: type-check with tsc.
+  console.info("[arolariu.ro::typecheck] Running tsc --noEmit -p tsconfig.json...");
+  await runStep("tsc", "npx", ["tsc", "--noEmit", "-p", "tsconfig.json"]);
+
+  console.info("[arolariu.ro::typecheck] Type-check passed.");
 }
 
 // Auto-invoke only when this file is the process entry point (`npm run typecheck`,


### PR DESCRIPTION
## Summary

The 26 type-check errors discovered by tsgo in CI ([failing run](https://github.com/arolariu/arolariu.ro/actions/runs/25972208152/job/76346096402)) all trace to a single missing step: Next.js 16's route-aware ambient types (`PageProps`, `LayoutProps`, route literal unions) live in `.next/types/routes.d.ts`, which is only generated by `next typegen` / `next dev` / `next build`. tsgo and tsc run before any of those, so the types are undefined.

This PR adds `next typegen` as a prerequisite step in both type-check tracks:

- **Local / Docker track**: `sites/arolariu.ro/scripts/typecheck.ts` now runs `next typegen` (~5-7s) before tsc. Both invocations use a shared `runStep()` helper for symmetry.
- **CI track**: `.github/workflows/official-website-build.yml` runs `npx next typegen` before the existing tsgo step.

## Error categories solved

| Count | Code | Pattern | Cause |
|---|---|---|---|
| 24 | TS2304 | `Cannot find name 'PageProps'` / `'LayoutProps'` | `.next/types/routes.d.ts` not generated |
| 2 | TS2307 | `Cannot find module '@/app/logo.svg'` | Cascade from broken routes types (the broken types break the program graph, causing `next/image-types/global`'s SVG declaration to no longer resolve) |

## Verification

Locally on a wiped `.next/`:
```
$ npx -y -p @typescript/native-preview tsgo --noEmit -p tsconfig.json
# (after `next typegen`): 0 errors, exit 0
```

Down from 26 errors before this change.

## Test plan
- [ ] CI tsgo step passes after `next typegen` runs.
- [ ] Local `npm run typecheck` (in `sites/arolariu.ro/`) passes from a clean `.next/`.
- [ ] Docker frontend build's `next build` → `beforeBuild.ts` → `typecheck.ts` still works (beforeBuild's typecheck.ts now includes typegen as its first step).