### PR TITLE
chore(ci): bump website test phase timeout from 30 to 60 minutes

### DIFF
--- a/.github/workflows/official-website-build.yml
+++ b/.github/workflows/official-website-build.yml
@@ -114,7 +114,7 @@ jobs:
     name: 🧪 Test phase (1/2)
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment || 'development'}}
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - name: 🛫 Checking out the branch inside the runner environment...
         uses: actions/checkout@v6


### PR DESCRIPTION
### Summary

Doubles the `timeout-minutes` on the `test` job in `.github/workflows/official-website-build.yml` from **30 to 60 minutes**.

### Why

The unit + E2E test phase has been bumping up against the 30-minute ceiling. The extra headroom covers:
- Playwright cold starts
- Network flakes during dependency install
- Slow GitHub-hosted runners

This prevents legitimately slow runs from failing the pipeline before producing useful diagnostics.

### Scope

One-line change to the `test` job's `timeout-minutes`. No code, no behavior change outside CI.