### PR TITLE
fix(website): point mobile nav profile link at existing /my-profile route

### DIFF
--- a/sites/arolariu.ro/src/app/domains/invoices/_components/MobileBottomNav.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_components/MobileBottomNav.tsx
@@ -85,7 +85,7 @@ export default function MobileBottomNav(): React.JSX.Element {
     },
     {
       labelKey: "profile",
-      href: "/auth/profile",
+      href: "/my-profile",
       icon: TbUser,
     },
   ];


### PR DESCRIPTION
## Summary
- `MobileBottomNav.tsx:88` linked to `/auth/profile`, which is not a routable page in this app
- On mobile the bottom nav is fixed in viewport, so Next.js continuously prefetched the broken link
- Each 404 prefetch rendered `global-not-found.tsx`, which calls Clerk's `currentUser()` and threw `"auth() was called but Clerk can't detect usage of clerkMiddleware()"` under that render context
- The repeating 500s appeared as `>>> Error fetching user from Auth Service:` (digest `2463623867`) in dev.arolariu.ro logs and contributed to the view-scans mobile freeze
- Point the nav at the existing `/my-profile` route — the only call site of `/auth/profile` in the codebase

## Test plan
- [ ] Open view-scans on mobile; confirm Network tab no longer shows `GET /auth/profile/?_rsc=… 404`
- [ ] Tap the Profile icon in the bottom nav; confirm navigation to `/my-profile` works
- [ ] Check server logs for absence of digest `2463623867` / `Error fetching user from Auth Service` entries after deploy
- [ ] Manual sync on view-scans no longer surfaces the `Failed to sync scans` toast tied to this prefetch storm

🤖 Generated with [Claude Code](https://claude.com/claude-code)