### PR TITLE
fix(website): ship tombstone service worker to clear stale Workbox SW

### DIFF
--- a/sites/arolariu.ro/public/sw.js
+++ b/sites/arolariu.ro/public/sw.js
@@ -1,0 +1,38 @@
+// Tombstone service worker.
+//
+// Earlier builds of arolariu.ro shipped a Workbox-built service worker. The
+// current codebase no longer registers one, but service workers persist on
+// devices until explicitly unregistered. On mobile, the stale Workbox SW kept
+// intercepting blob-URL fetches and returning no-response errors, which
+// saturated the main thread on view-scans (reproducing the freeze; incognito,
+// where no SW runs, was clean).
+//
+// This file exists only to clear those stale registrations. Browsers fetch it
+// during their normal SW update check, byte-compare against the previously
+// installed script, see new bytes, and run install -> activate. Activate then
+// drops caches, unregisters, and reloads open tabs so they make uncached,
+// un-intercepted requests.
+//
+// Devices that never registered a service worker for this origin are
+// unaffected: nothing fetches this file unless an existing registration
+// triggers an update check.
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(self.skipWaiting());
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    (async () => {
+      const cacheNames = await caches.keys();
+      await Promise.all(cacheNames.map((name) => caches.delete(name)));
+
+      await self.registration.unregister();
+
+      const clients = await self.clients.matchAll({type: "window"});
+      for (const client of clients) {
+        client.navigate(client.url);
+      }
+    })(),
+  );
+});


### PR DESCRIPTION
## Summary
- Older builds of arolariu.ro shipped a Workbox-built service worker; the current codebase no longer registers one, but SWs persist on devices until explicitly unregistered
- Confirmed root cause of the mobile freeze on view-scans: stale Workbox SW intercepts blob-URL fetches and returns `no-response`, saturating the main thread. Incognito reproduction was clean (no SW = no freeze), confirming the diagnosis
- Ship a tombstone `public/sw.js` at the same URL the old SW lived at. On install/activate it drops all caches, unregisters itself, and reloads any open tabs so they make uncached, un-intercepted requests
- Devices that never registered a SW for this origin are unaffected — the file is only fetched when an existing registration triggers an update check

## Scope note
This PR addresses **only the freeze**. The manual-sync "Failed to sync scans" failure is a separate, server-side root cause that persists in incognito mode (no SW or client state involved). That needs fresh server logs from `dev.arolariu.ro` after this deploy to identify, since the previous Clerk-middleware-not-detected errors were from the now-fixed `/auth/profile` prefetch path (PR #768).

## Test plan
- [ ] Deploy to `dev.arolariu.ro`
- [ ] On a mobile device currently experiencing the freeze, load the site in a regular (non-incognito) tab — the new SW should install on next navigation, activate, unregister, and reload the page
- [ ] After the auto-reload, check `chrome://serviceworker-internals/` (Android) or Safari Develop → Service Workers (iOS) — confirm no registration remains for `dev.arolariu.ro`
- [ ] Confirm view-scans no longer freezes in the regular (non-incognito) tab
- [ ] Confirm blob thumbnails still load (now fetched directly, no longer intercepted)
- [ ] Optional: open DevTools → Application → Service Workers on the deployed site and confirm "unregistered" before/after the tombstone takes effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)