### PR TITLE
fix(website): externalize prettier and @react-pdf/renderer from server bundle

### DIFF
--- a/sites/arolariu.ro/next.config.ts
+++ b/sites/arolariu.ro/next.config.ts
@@ -144,6 +144,15 @@ const nextConfig: NextConfig = {
 
   transpilePackages: ["import-in-the-middle", "require-in-the-middle"],
 
+  // Force these to be resolved at runtime via Node's module resolver rather
+  // than bundled. Both are on Next.js's default auto-externals list, but
+  // Turbopack production builds were emitting content-hashed identifiers
+  // (e.g. `prettier-3c69a91af3bc4731/plugins/html`) into the server chunk and
+  // failing with ERR_MODULE_NOT_FOUND at request time — surfacing as masked
+  // 500s on server actions (e.g. fetchScans on /domains/invoices/view-scans).
+  // Listing them explicitly here forces the documented externals path.
+  serverExternalPackages: ["prettier", "@react-pdf/renderer"],
+
   experimental: {
     // Enable server source maps in development for debugging
     serverSourceMaps: isDebugBuild,


### PR DESCRIPTION
## Summary
Server logs on `dev.arolariu.ro` showed repeating `ERR_MODULE_NOT_FOUND` errors for content-hashed module names:

```
Cannot find package 'prettier-3c69a91af3bc4731/plugins/html'
  imported from /app/.next/server/chunks/ssr/[turbopack]_runtime.js
Cannot find package '@react-pdf/renderer-5f716e9bc7d68b8a'
  imported from /app/.next/server/chunks/ssr/[turbopack]_runtime.js
```

Those hashed identifiers are Turbopack's internal external-module IDs leaking into emitted server chunks instead of being resolved back to the real package names at chunk emission time. At request time, Node's module resolver can't find them, the server bundle fails to load, and Next.js returns a masked 500 ("An error occurred in the Server Components render") — **the same 500 the view-scans manual sync has been hitting in incognito** (confirming this is server-side, not SW or client-state related).

## Why this fix
Both packages are already on Next.js's default auto-externalized list (`packages/next/src/lib/server-external-packages.jsonc`), but the Turbopack production externalization path is mishandling them in this build. Listing them explicitly in `serverExternalPackages` forces the documented externals code path so Node resolves them via normal package resolution at runtime.

- `prettier` enters through `react-email` (which has `html-to-text` + `prettier` as runtime deps for HTML email rendering)
- `@react-pdf/renderer` is imported by `ExportDialog.tsx` / `InvoicePDF.tsx` — both correctly marked `"use client"`, but Turbopack still drags the package through the server bundle for SSR analysis

## If this doesn't fully clear it
Escalation: lazy-load `InvoicePDF` via `next/dynamic({ ssr: false })` in `ExportDialog.tsx` so `@react-pdf/renderer` never enters any server bundle. Shipping the smallest fix first.

## Test plan
- [ ] Deploy to `dev.arolariu.ro`
- [ ] On view-scans, click manual sync — confirm no `Failed to sync scans` toast
- [ ] Check server logs for absence of:
  - `prettier-3c69a91af3bc4731/plugins/html` (digest `1291069725`)
  - `@react-pdf/renderer-5f716e9bc7d68b8a` (digest `3160853926`)
- [ ] Confirm the view-invoices export-to-PDF flow still works end-to-end (this is the legitimate use of `@react-pdf/renderer`)
- [ ] Confirm email rendering (if any flow exercises it) still works (legitimate use of `react-email` → `prettier`)

## Related
- PR #768 fixed the Clerk middleware errors caused by the broken `/auth/profile` link
- PR #770 ships the tombstone service worker that fixes the mobile freeze

🤖 Generated with [Claude Code](https://claude.com/claude-code)