### PR TITLE
fix(website): lazy-import emailService inside sendEmail to escape Turbopack hash leak

### DIFF
--- a/sites/arolariu.ro/src/lib/actions/email/sendEmail.ts
+++ b/sites/arolariu.ro/src/lib/actions/email/sendEmail.ts
@@ -17,7 +17,17 @@ import type {ReactElement} from "react";
 
 import {DEFAULT_LOCALE, type EmailLocale} from "@/../emails/_i18n";
 import {emailTemplates, type EmailTemplateKey, type EmailTemplatePropsMap} from "@/../emails/_registry";
-import {emailService} from "@/lib/email";
+
+// `emailService` is imported lazily inside the action body — NOT at the top
+// level — so its transitive dependency chain (react-email → prettier) does
+// not enter the static import graph of any client component that imports
+// this server action (e.g. ShareInvoiceDialog). Turbopack's production
+// externalization mishandles prettier by emitting a content-hashed
+// identifier (`prettier-<hash>/plugins/html`) into the surrounding SSR
+// chunk, which then fails ERR_MODULE_NOT_FOUND at request time and surfaces
+// as a masked 500 on unrelated routes (e.g. fetchScans on view-scans).
+// Keeping the chain out of the static graph removes prettier from those
+// chunks entirely.
 
 /**
  * Caller-supplied input to {@link sendEmail}.
@@ -106,6 +116,7 @@ export async function sendEmail<K extends EmailTemplateKey>(input: SendEmailInpu
     const subject = await entry.template.getSubject(locale, subjectVars);
     const react: ReactElement = await template(renderProps);
 
+    const {emailService} = await import("@/lib/email");
     await emailService.sendEmail({
       to: input.to,
       subject,


### PR DESCRIPTION
## Summary
Turbopack production builds emit a content-hashed identifier (`prettier-3c69a91af3bc4731/plugins/html`) into the SSR chunk `__0_vas.5._.js` and then fail `ERR_MODULE_NOT_FOUND` at request time. The view-scans manual sync POSTs to that chunk and gets a masked 500 (digest `1291069725`). The previous `serverExternalPackages` change (#771) didn't help — Turbopack ignores that signal for this code path.

The chain Turbopack was pulling into the view-scans server bundle:

```
view-scans/island.tsx
  → DialogContainer (_contexts)
    → ShareInvoiceDialog ("use client")
      → sendEmail (server action, static import)
        → emailService ("server-only", static import)
          → react-email (render)
            → prettier  ← Turbopack hashes this in
```

Even though `emailService` is `server-only` and `ShareInvoiceDialog` is `"use client"`, the static top-level `import {emailService}` made the whole subtree part of the surrounding SSR chunk's module graph. Lazy-importing emailService inside the action body breaks the static chain so prettier no longer enters that chunk.

## Change
Inside `sendEmail.ts`:
- Remove top-level `import {emailService} from "@/lib/email"`
- Add `const {emailService} = await import("@/lib/email")` inside the try block, just before the call
- emailService loads only when the action is actually invoked
- Email-sending behaviour is unchanged

## Test plan
- [ ] Deploy to `dev.arolariu.ro`
- [ ] On view-scans, click manual sync — confirm no `Failed to sync scans` toast and a 200 response on the POST
- [ ] Check server logs for absence of digest `1291069725` (prettier hash error)
- [ ] Exercise an email-sending flow (e.g. ShareInvoiceDialog → send invite) and confirm the email still goes out via Resend
- [ ] If digest `3160853926` (the @react-pdf/renderer hash error) still fires when opening ExportDialog, follow up with the same lazy-import pattern on `pdf` / `InvoicePDF`

## Related
- #768 — Clerk middleware errors via broken nav link (merged)
- #770 — Tombstone service worker for mobile freeze (open)
- #771 — `serverExternalPackages` (merged but ineffective for this case; harmless to leave in)

🤖 Generated with [Claude Code](https://claude.com/claude-code)