### PR TITLE
refactor(invoices): harden dialog pattern (typed payloads, lazy-loaded, hooks-safe)

### DIFF
--- a/sites/arolariu.ro/scripts/typecheck.ts
+++ b/sites/arolariu.ro/scripts/typecheck.ts
@@ -29,9 +29,7 @@ function runStep(label: string, command: string, args: readonly string[]): Promi
     // /c — a real binary that resolves PATHEXT for us. Mirrors the pattern in
     // scripts/workers/shell.ts.
     const isWindows = process.platform === "win32";
-    const [spawnCmd, spawnArgs]: [string, string[]] = isWindows
-      ? ["cmd.exe", ["/c", command, ...args]]
-      : [command, [...args]];
+    const [spawnCmd, spawnArgs]: [string, string[]] = isWindows ? ["cmd.exe", ["/c", command, ...args]] : [command, [...args]];
 
     const child = spawn(spawnCmd, spawnArgs, {
       stdio: "inherit",

--- a/sites/arolariu.ro/src/app/domains/invoices/_contexts/DialogContainer.test.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_contexts/DialogContainer.test.tsx
@@ -11,6 +11,33 @@ import {describe, expect, test, vi} from "vitest";
 // Mocks - Must be declared before imports that use them
 // ============================================================================
 
+// Mock next/dynamic so dynamic imports resolve synchronously in tests.
+// Each loader() is called eagerly at dynamic() call time (which happens during
+// module evaluation, before any test runs). Since all dialog modules below are
+// already mocked via vi.mock(), their import() Promises resolve in the next
+// microtask — i.e., before Vitest starts executing individual tests.
+vi.mock("next/dynamic", () => ({
+  default: (
+    loader: () => Promise<
+      | {default: React.ComponentType<Record<string, unknown>>}
+      | {ExportDialog: React.ComponentType<Record<string, unknown>>}
+    >,
+  ) => {
+    let Comp: React.ComponentType<Record<string, unknown>> | null = null;
+    void loader().then(
+      (mod: {default: React.ComponentType<Record<string, unknown>>} | {ExportDialog: React.ComponentType<Record<string, unknown>>}) => {
+        Comp = "default" in mod ? mod.default : mod.ExportDialog;
+      },
+    );
+    function DynamicComponent(props: Record<string, unknown>): React.JSX.Element | null {
+      if (!Comp) return null;
+      // Use JSX (new transform) so React doesn't need to be in scope at runtime
+      return <Comp {...props} />;
+    }
+    return DynamicComponent;
+  },
+}));
+
 // Mock server-only modules that are imported by server actions
 vi.mock("@/instrumentation.server", () => ({
   addSpanEvent: vi.fn(),
@@ -403,13 +430,13 @@ describe("DialogContainer", () => {
     test("re-renders correctly when dialog type changes", () => {
       setupMockDialogType("EDIT_INVOICE__ANALYSIS");
 
-      const {rerender} = render(<DialogContainer />);
+      const {unmount} = render(<DialogContainer />);
       expect(screen.getByTestId("analyze-dialog")).toBeInTheDocument();
 
-      // Change the dialog type
+      // Unmount, change the dialog type, remount — React.memo is bypassed on fresh mount.
+      unmount();
       setupMockDialogType("SHARED__INVOICE_SHARE");
-
-      rerender(<DialogContainer />);
+      render(<DialogContainer />);
 
       expect(screen.queryByTestId("analyze-dialog")).not.toBeInTheDocument();
       expect(screen.getByTestId("share-invoice-dialog")).toBeInTheDocument();
@@ -418,13 +445,13 @@ describe("DialogContainer", () => {
     test("transitions from open dialog to null correctly", () => {
       setupMockDialogType("EDIT_INVOICE__ITEMS");
 
-      const {rerender, container} = render(<DialogContainer />);
+      const {unmount} = render(<DialogContainer />);
       expect(screen.getByTestId("items-dialog")).toBeInTheDocument();
 
-      // Close the dialog (type becomes null)
+      // Unmount, close the dialog (type becomes null), remount — React.memo is bypassed on fresh mount.
+      unmount();
       setupMockDialogType(null);
-
-      rerender(<DialogContainer />);
+      const {container} = render(<DialogContainer />);
 
       expect(container.firstChild).toBeNull();
     });

--- a/sites/arolariu.ro/src/app/domains/invoices/_contexts/DialogContainer.test.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_contexts/DialogContainer.test.tsx
@@ -19,8 +19,7 @@ import {describe, expect, test, vi} from "vitest";
 vi.mock("next/dynamic", () => ({
   default: (
     loader: () => Promise<
-      | {default: React.ComponentType<Record<string, unknown>>}
-      | {ExportDialog: React.ComponentType<Record<string, unknown>>}
+      {default: React.ComponentType<Record<string, unknown>>} | {ExportDialog: React.ComponentType<Record<string, unknown>>}
     >,
   ) => {
     let Comp: React.ComponentType<Record<string, unknown>> | null = null;

--- a/sites/arolariu.ro/src/app/domains/invoices/_contexts/DialogContainer.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_contexts/DialogContainer.tsx
@@ -16,7 +16,9 @@ const InvoiceFeedbackDialog = dynamic(() => import("../edit-invoice/[id]/_compon
 const InvoiceImageDialog = dynamic(() => import("../edit-invoice/[id]/_components/dialogs/ImageDialog"), {ssr: false});
 const InvoiceItemsDialog = dynamic(() => import("../edit-invoice/[id]/_components/dialogs/ItemsDialog"), {ssr: false});
 const InvoiceMerchantDialog = dynamic(() => import("../edit-invoice/[id]/_components/dialogs/MerchantDialog"), {ssr: false});
-const InvoiceMerchantReceiptsDialog = dynamic(() => import("../edit-invoice/[id]/_components/dialogs/MerchantReceiptsDialog"), {ssr: false});
+const InvoiceMerchantReceiptsDialog = dynamic(() => import("../edit-invoice/[id]/_components/dialogs/MerchantReceiptsDialog"), {
+  ssr: false,
+});
 const InvoiceMetadataDialog = dynamic(() => import("../edit-invoice/[id]/_components/dialogs/MetadataDialog"), {ssr: false});
 const InvoiceRecipeDialog = dynamic(() => import("../edit-invoice/[id]/_components/dialogs/RecipeDialog"), {ssr: false});
 const InvoicesExportDialog = dynamic(() => import("../view-invoices/_components/dialogs/ExportDialog"), {ssr: false});

--- a/sites/arolariu.ro/src/app/domains/invoices/_contexts/DialogContainer.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_contexts/DialogContainer.tsx
@@ -1,80 +1,99 @@
 "use client";
 
-import DeleteInvoiceDialog from "../_dialogs/DeleteInvoiceDialog";
-import ShareInvoiceDialog from "../_dialogs/ShareInvoiceDialog";
-import AddScanDialog from "../edit-invoice/[id]/_components/dialogs/AddScanDialog";
-import AllergenDialog from "../edit-invoice/[id]/_components/dialogs/AllergenDialog";
-import AnalyzeDialog from "../edit-invoice/[id]/_components/dialogs/AnalyzeDialog";
-import BulkCategoryDialog from "../edit-invoice/[id]/_components/dialogs/BulkCategoryDialog";
-import InvoiceFeedbackDialog from "../edit-invoice/[id]/_components/dialogs/FeedbackDialog";
-import InvoiceImageDialog from "../edit-invoice/[id]/_components/dialogs/ImageDialog";
-import InvoiceItemsDialog from "../edit-invoice/[id]/_components/dialogs/ItemsDialog";
-import InvoiceMerchantDialog from "../edit-invoice/[id]/_components/dialogs/MerchantDialog";
-import InvoiceMerchantReceiptsDialog from "../edit-invoice/[id]/_components/dialogs/MerchantReceiptsDialog";
-import InvoiceMetadataDialog from "../edit-invoice/[id]/_components/dialogs/MetadataDialog";
-import InvoiceRecipeDialog from "../edit-invoice/[id]/_components/dialogs/RecipeDialog";
-import RemoveScanDialog from "../edit-invoice/[id]/_components/dialogs/RemoveScanDialog";
-import {ExportDialog as ViewInvoiceExportDialog} from "../view-invoice/[id]/_components/dialogs/ExportDialog";
-import ShareAnalyticsDialog from "../view-invoice/[id]/_components/dialogs/ShareAnalyticsDialog";
-import InvoicesExportDialog from "../view-invoices/_components/dialogs/ExportDialog";
-import InvoicesImportDialog from "../view-invoices/_components/dialogs/ImportDialog";
-import CreateInvoiceDialog from "../view-scans/_components/dialogs/CreateInvoiceDialog";
+import dynamic from "next/dynamic";
+import {memo, useMemo} from "react";
 import {useDialogs} from "./DialogContext";
+
+// All dialogs are client-only and lazy-loaded.
+// The Dialog's own open animation masks the import-fetch latency on first open.
+const AddScanDialog = dynamic(() => import("../edit-invoice/[id]/_components/dialogs/AddScanDialog"), {ssr: false});
+const AllergenDialog = dynamic(() => import("../edit-invoice/[id]/_components/dialogs/AllergenDialog"), {ssr: false});
+const AnalyzeDialog = dynamic(() => import("../edit-invoice/[id]/_components/dialogs/AnalyzeDialog"), {ssr: false});
+const BulkCategoryDialog = dynamic(() => import("../edit-invoice/[id]/_components/dialogs/BulkCategoryDialog"), {ssr: false});
+const CreateInvoiceDialog = dynamic(() => import("../view-scans/_components/dialogs/CreateInvoiceDialog"), {ssr: false});
+const DeleteInvoiceDialog = dynamic(() => import("../_dialogs/DeleteInvoiceDialog"), {ssr: false});
+const InvoiceFeedbackDialog = dynamic(() => import("../edit-invoice/[id]/_components/dialogs/FeedbackDialog"), {ssr: false});
+const InvoiceImageDialog = dynamic(() => import("../edit-invoice/[id]/_components/dialogs/ImageDialog"), {ssr: false});
+const InvoiceItemsDialog = dynamic(() => import("../edit-invoice/[id]/_components/dialogs/ItemsDialog"), {ssr: false});
+const InvoiceMerchantDialog = dynamic(() => import("../edit-invoice/[id]/_components/dialogs/MerchantDialog"), {ssr: false});
+const InvoiceMerchantReceiptsDialog = dynamic(() => import("../edit-invoice/[id]/_components/dialogs/MerchantReceiptsDialog"), {ssr: false});
+const InvoiceMetadataDialog = dynamic(() => import("../edit-invoice/[id]/_components/dialogs/MetadataDialog"), {ssr: false});
+const InvoiceRecipeDialog = dynamic(() => import("../edit-invoice/[id]/_components/dialogs/RecipeDialog"), {ssr: false});
+const InvoicesExportDialog = dynamic(() => import("../view-invoices/_components/dialogs/ExportDialog"), {ssr: false});
+const InvoicesImportDialog = dynamic(() => import("../view-invoices/_components/dialogs/ImportDialog"), {ssr: false});
+const RemoveScanDialog = dynamic(() => import("../edit-invoice/[id]/_components/dialogs/RemoveScanDialog"), {ssr: false});
+const ShareAnalyticsDialog = dynamic(() => import("../view-invoice/[id]/_components/dialogs/ShareAnalyticsDialog"), {ssr: false});
+const ShareInvoiceDialog = dynamic(() => import("../_dialogs/ShareInvoiceDialog"), {ssr: false});
+// view-invoice/[id]/_components/dialogs/ExportDialog uses a named export
+const ViewInvoiceExportDialog = dynamic(
+  () => import("../view-invoice/[id]/_components/dialogs/ExportDialog").then((m) => ({default: m.ExportDialog})),
+  {ssr: false},
+);
 
 /**
  * The DialogContainer component manages the visibility and functionality of various dialogs
- * related to invoices, merchants, recipes, and metadata.
+ * related to invoices, merchants, recipes, and metadata. Each dialog is lazy-loaded via
+ * `next/dynamic` so that routes don't ship dialog code until the user actually opens one.
+ *
+ * @remarks
+ * Wrapped in `React.memo` and the switch is memoized on `(type, mode)` so unrelated
+ * context churn doesn't re-render this tree.
+ *
  * @returns The DialogContainer component, CSR'ed.
  */
-export default function DialogContainer(): React.JSX.Element | null {
+function DialogContainerImpl(): React.JSX.Element | null {
   const {
     currentDialog: {type, mode},
   } = useDialogs();
 
-  switch (type) {
-    // edit-invoice/[id] Dialogs
-    case "EDIT_INVOICE__ANALYSIS":
-      return <AnalyzeDialog />;
-    case "EDIT_INVOICE__ITEMS":
-      return <InvoiceItemsDialog />;
-    case "EDIT_INVOICE__ALLERGENS":
-      return <AllergenDialog />;
-    case "EDIT_INVOICE__BULK_CATEGORY":
-      return <BulkCategoryDialog />;
-    case "EDIT_INVOICE__FEEDBACK":
-      return <InvoiceFeedbackDialog />;
-    case "EDIT_INVOICE__MERCHANT":
-      return <InvoiceMerchantDialog />;
-    case "EDIT_INVOICE__MERCHANT_INVOICES":
-      return <InvoiceMerchantReceiptsDialog />;
-    case "EDIT_INVOICE__METADATA":
-      return <InvoiceMetadataDialog />;
-    case "EDIT_INVOICE__IMAGE":
-      return <InvoiceImageDialog />;
-    case "EDIT_INVOICE__SCAN":
-      // Differentiate by mode: "add" shows AddScanDialog, "delete" shows RemoveScanDialog
-      return mode === "add" ? <AddScanDialog /> : <RemoveScanDialog />;
-    case "EDIT_INVOICE__RECIPE":
-      return <InvoiceRecipeDialog />;
-    // view-invoice/[id] Dialogs
-    case "VIEW_INVOICE__SHARE_ANALYTICS":
-      return <ShareAnalyticsDialog />;
-    case "VIEW_INVOICE__EXPORT":
-      return <ViewInvoiceExportDialog />;
-    // view-invoices Dialogs
-    case "VIEW_INVOICES__IMPORT":
-      return <InvoicesImportDialog />;
-    case "VIEW_INVOICES__EXPORT":
-      return <InvoicesExportDialog />;
-    // view-scans Dialogs
-    case "VIEW_SCANS__CREATE_INVOICE":
-      return <CreateInvoiceDialog />;
-    // shared dialogs
-    case "SHARED__INVOICE_DELETE":
-      return <DeleteInvoiceDialog />;
-    case "SHARED__INVOICE_SHARE":
-      return <ShareInvoiceDialog />;
-    default:
-      return null;
-  }
+  return useMemo(() => {
+    switch (type) {
+      // edit-invoice/[id] Dialogs
+      case "EDIT_INVOICE__ANALYSIS":
+        return <AnalyzeDialog />;
+      case "EDIT_INVOICE__ITEMS":
+        return <InvoiceItemsDialog />;
+      case "EDIT_INVOICE__ALLERGENS":
+        return <AllergenDialog />;
+      case "EDIT_INVOICE__BULK_CATEGORY":
+        return <BulkCategoryDialog />;
+      case "EDIT_INVOICE__FEEDBACK":
+        return <InvoiceFeedbackDialog />;
+      case "EDIT_INVOICE__MERCHANT":
+        return <InvoiceMerchantDialog />;
+      case "EDIT_INVOICE__MERCHANT_INVOICES":
+        return <InvoiceMerchantReceiptsDialog />;
+      case "EDIT_INVOICE__METADATA":
+        return <InvoiceMetadataDialog />;
+      case "EDIT_INVOICE__IMAGE":
+        return <InvoiceImageDialog />;
+      case "EDIT_INVOICE__SCAN":
+        // Differentiate by mode: "add" shows AddScanDialog, anything else shows RemoveScanDialog
+        return mode === "add" ? <AddScanDialog /> : <RemoveScanDialog />;
+      case "EDIT_INVOICE__RECIPE":
+        return <InvoiceRecipeDialog />;
+      // view-invoice/[id] Dialogs
+      case "VIEW_INVOICE__SHARE_ANALYTICS":
+        return <ShareAnalyticsDialog />;
+      case "VIEW_INVOICE__EXPORT":
+        return <ViewInvoiceExportDialog />;
+      // view-invoices Dialogs
+      case "VIEW_INVOICES__IMPORT":
+        return <InvoicesImportDialog />;
+      case "VIEW_INVOICES__EXPORT":
+        return <InvoicesExportDialog />;
+      // view-scans Dialogs
+      case "VIEW_SCANS__CREATE_INVOICE":
+        return <CreateInvoiceDialog />;
+      // shared dialogs
+      case "SHARED__INVOICE_DELETE":
+        return <DeleteInvoiceDialog />;
+      case "SHARED__INVOICE_SHARE":
+        return <ShareInvoiceDialog />;
+      default:
+        return null;
+    }
+  }, [type, mode]);
 }
+
+export default memo(DialogContainerImpl);

--- a/sites/arolariu.ro/src/app/domains/invoices/_contexts/DialogContext.test.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_contexts/DialogContext.test.tsx
@@ -1,3 +1,4 @@
+import type {Invoice} from "@/types/invoices";
 import {act, renderHook} from "@testing-library/react";
 import type {ReactNode} from "react";
 import {describe, expect, test, vi} from "vitest";
@@ -5,6 +6,7 @@ import {DialogProvider, useDialog, useDialogs} from "./DialogContext";
 
 // Wrapper component to provide context for the hooks
 const wrapper = ({children}: {children: ReactNode}) => <DialogProvider>{children}</DialogProvider>;
+const mockInvoice = {id: "invoice-1"} as Invoice;
 
 describe("DialogProvider", () => {
   test("should provide the current dialog state", () => {
@@ -157,18 +159,18 @@ describe("useDialog", () => {
   });
 
   test("it opens dialog with correct type and payload", () => {
-    const {result} = renderHook(() => useDialog("SHARED__INVOICE_SHARE", "edit", {id: 1}), {wrapper});
+    const {result} = renderHook(() => useDialog("SHARED__INVOICE_SHARE", "edit", {invoice: mockInvoice}), {wrapper});
 
     act(() => {
       result.current.open();
     });
 
     expect(result.current.currentDialog.type).toBe("SHARED__INVOICE_SHARE");
-    expect(result.current.currentDialog.payload).toStrictEqual({id: 1});
+    expect(result.current.currentDialog.payload).toStrictEqual({invoice: mockInvoice});
   });
 
   test("it closes dialog and resets state", () => {
-    const {result} = renderHook(() => useDialog("SHARED__INVOICE_SHARE", "edit", {id: 1}), {wrapper});
+    const {result} = renderHook(() => useDialog("SHARED__INVOICE_SHARE", "edit", {invoice: mockInvoice}), {wrapper});
 
     act(() => {
       result.current.open();
@@ -176,7 +178,7 @@ describe("useDialog", () => {
 
     expect(result.current.currentDialog.type).toBe("SHARED__INVOICE_SHARE");
     expect(result.current.currentDialog.mode).toBe("edit");
-    expect(result.current.currentDialog.payload).toStrictEqual({id: 1});
+    expect(result.current.currentDialog.payload).toStrictEqual({invoice: mockInvoice});
 
     act(() => {
       result.current.close();
@@ -186,7 +188,7 @@ describe("useDialog", () => {
   });
 
   test("it opens dialog with correct type, mode, and payload", () => {
-    const {result} = renderHook(() => useDialog("SHARED__INVOICE_SHARE", "edit", {id: 1}), {wrapper});
+    const {result} = renderHook(() => useDialog("SHARED__INVOICE_SHARE", "edit", {invoice: mockInvoice}), {wrapper});
 
     act(() => {
       result.current.open();
@@ -194,7 +196,7 @@ describe("useDialog", () => {
 
     expect(result.current.currentDialog.type).toBe("SHARED__INVOICE_SHARE");
     expect(result.current.currentDialog.mode).toBe("edit");
-    expect(result.current.currentDialog.payload).toStrictEqual({id: 1});
+    expect(result.current.currentDialog.payload).toStrictEqual({invoice: mockInvoice});
   });
 
   test("it does not open dialog if already open", () => {
@@ -306,7 +308,7 @@ describe("useDialog", () => {
   });
 
   test("mode and payload are preserved when opening a dialog", () => {
-    const testPayload = {id: 123, name: "Test"};
+    const testPayload = {sample: "Test"};
     const {result} = renderHook(() => useDialog("EDIT_INVOICE__METADATA", "edit", testPayload), {wrapper});
 
     act(() => {
@@ -319,7 +321,7 @@ describe("useDialog", () => {
   });
 
   test("dialog state is properly reset when closed", () => {
-    const testPayload = {id: 123};
+    const testPayload = {invoice: mockInvoice};
     const {result} = renderHook(() => useDialog("EDIT_INVOICE__ANALYSIS", "view", testPayload), {wrapper});
 
     act(() => {

--- a/sites/arolariu.ro/src/app/domains/invoices/_contexts/DialogContext.test.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_contexts/DialogContext.test.tsx
@@ -1,7 +1,7 @@
 import {act, renderHook} from "@testing-library/react";
 import type {ReactNode} from "react";
 import {describe, expect, test, vi} from "vitest";
-import {DialogProvider, useDialog} from "./DialogContext";
+import {DialogProvider, useDialog, useDialogs} from "./DialogContext";
 
 // Wrapper component to provide context for the hooks
 const wrapper = ({children}: {children: ReactNode}) => <DialogProvider>{children}</DialogProvider>;
@@ -104,6 +104,16 @@ describe("useDialog", () => {
 
     expect(() => {
       renderHook(() => useDialog("SHARED__INVOICE_SHARE"));
+    }).toThrow("useDialog must be used within a DialogProvider");
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  test("useDialogs throws when used outside of provider", () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(() => {
+      renderHook(() => useDialogs());
     }).toThrow("useDialogs must be used within a DialogProvider");
 
     consoleErrorSpy.mockRestore();
@@ -355,51 +365,67 @@ describe("useDialog", () => {
     expect(result.current.currentDialog.mode).toBe("edit");
   });
 
-  test("openWith overrides mode and payload at call time", () => {
-    const {result} = renderHook(() => useDialog("SHARED__INVOICE_SHARE", "view", {id: 0}), {wrapper});
+  test("two useDialog calls share the same canonical state reference", () => {
+    // Both hooks must live inside the SAME provider tree to share DialogStateContext.
+    const {result} = renderHook(
+      () => ({
+        hook1: useDialog("SHARED__INVOICE_SHARE"),
+        hook2: useDialog("EDIT_INVOICE__MERCHANT"),
+      }),
+      {wrapper},
+    );
 
+    // Before any open, both read the same initial-state singleton.
+    expect(result.current.hook1.currentDialog).toBe(result.current.hook2.currentDialog);
+
+    // Opening one dialog updates state for both hooks.
     act(() => {
-      result.current.openWith("edit", {id: 42});
+      result.current.hook1.open();
     });
 
-    expect(result.current.currentDialog.type).toBe("SHARED__INVOICE_SHARE");
+    expect(result.current.hook1.isOpen).toBe(true);
+    expect(result.current.hook2.isOpen).toBe(false);
+    // After state change, both hooks still see the same (updated) reference.
+    expect(result.current.hook1.currentDialog).toBe(result.current.hook2.currentDialog);
+    expect(result.current.hook1.currentDialog.type).toBe("SHARED__INVOICE_SHARE");
+  });
+
+  test("useDialogs().openDialog dispatches with type, mode, and payload", () => {
+    const {result} = renderHook(() => useDialogs(), {wrapper});
+
+    act(() => {
+      result.current.openDialog("EDIT_INVOICE__ALLERGENS", "edit", {
+        invoice: {id: "i1"} as never,
+        product: {id: "p1"} as never,
+        productIndex: 3,
+      });
+    });
+
+    expect(result.current.currentDialog.type).toBe("EDIT_INVOICE__ALLERGENS");
     expect(result.current.currentDialog.mode).toBe("edit");
-    expect(result.current.currentDialog.payload).toStrictEqual({id: 42});
+    expect(result.current.currentDialog.payload).toStrictEqual({
+      invoice: {id: "i1"},
+      product: {id: "p1"},
+      productIndex: 3,
+    });
+    expect(result.current.isOpen("EDIT_INVOICE__ALLERGENS")).toBe(true);
+    expect(result.current.isOpen("SHARED__INVOICE_SHARE")).toBe(false);
   });
 
-  test("openWith falls back to hook-level payload when call-site payload is omitted", () => {
-    const defaultPayload = {id: 99};
-    const {result} = renderHook(() => useDialog("SHARED__INVOICE_SHARE", "view", defaultPayload), {wrapper});
+  test("useDialogs().openDialog is no-op if another dialog is already open", () => {
+    const {result} = renderHook(() => useDialogs(), {wrapper});
 
     act(() => {
-      result.current.openWith("add"); // no payload argument
+      result.current.openDialog("SHARED__INVOICE_SHARE", "share");
     });
+    expect(result.current.currentDialog.type).toBe("SHARED__INVOICE_SHARE");
 
-    expect(result.current.currentDialog.mode).toBe("add");
-    expect(result.current.currentDialog.payload).toStrictEqual(defaultPayload);
-  });
-
-  test("context maintains singleton reference to dialog state type", () => {
-    // Create multiple hooks
-    const {result: hook1} = renderHook(() => useDialog("SHARED__INVOICE_SHARE"), {wrapper});
-    const {result: hook2} = renderHook(() => useDialog("EDIT_INVOICE__MERCHANT"), {wrapper});
-
-    // Store original references
-    const originalDialog1 = hook1.current.currentDialog;
-    const originalDialog2 = hook2.current.currentDialog;
-
-    expect(originalDialog1).not.toBe(originalDialog2);
-
-    // Open one dialog
     act(() => {
-      hook1.current.open();
+      result.current.openDialog("EDIT_INVOICE__ALLERGENS", "edit");
     });
 
-    // The other dialog should be closed.
-    expect(hook2.current.isOpen).toBe(false);
-    // The first dialog should be open
-    expect(hook1.current.isOpen).toBe(true);
-
-    // The references should be different now
+    // Original dialog still open; second openDialog was silently ignored.
+    expect(result.current.currentDialog.type).toBe("SHARED__INVOICE_SHARE");
+    expect(result.current.currentDialog.mode).toBe("share");
   });
 });

--- a/sites/arolariu.ro/src/app/domains/invoices/_contexts/DialogContext.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_contexts/DialogContext.tsx
@@ -87,9 +87,14 @@ const DialogActionsContext = createContext<DialogActions | undefined>(undefined)
  * DialogProvider component that manages dialog state for the application.
  *
  * @remarks
- * Internally splits state and actions into separate contexts so cards that only
- * dispatch (via `useDialogs().openDialog` or `useDialog().open`) do not re-render
- * when dialog state changes.
+ * Internally splits state and actions into two separate contexts (`DialogStateContext`
+ * and `DialogActionsContext`). The actions context value is stable for the lifetime
+ * of the provider; the state context value changes on every open/close.
+ *
+ * Both `useDialog` and `useDialogs` subscribe to BOTH contexts and therefore
+ * re-render on every dialog state change. The split exists for future flexibility
+ * (a hypothetical actions-only hook could subscribe to actions alone and avoid
+ * state-driven re-renders); today's public hooks do not exploit it.
  *
  * Preserves the "no-op if another dialog is already open" guard from the previous
  * implementation; this is enforced inside the functional setState updater.
@@ -101,7 +106,7 @@ const DialogActionsContext = createContext<DialogActions | undefined>(undefined)
  * </DialogProvider>
  * ```
  */
-export function DialogProvider({children}: Readonly<{children: ReactNode}>) {
+export function DialogProvider({children}: Readonly<{children: ReactNode}>): React.JSX.Element {
   const [dialogState, setDialogState] = useState<DialogCurrent>(INITIAL_STATE);
 
   // Empty deps: functional setState reads `prev` synchronously, no closure over state needed.
@@ -129,10 +134,18 @@ export function DialogProvider({children}: Readonly<{children: ReactNode}>) {
  * click time (e.g., per-row click handlers). For card-level "I'm bound to one
  * dialog type" usage, prefer `useDialog`.
  *
+ * Subscribes to both state and actions contexts; the consumer re-renders on
+ * every dialog state change.
+ *
  * @returns Object with `currentDialog`, `isOpen(type)`, `openDialog<T>(type, mode?, payload?)`, `closeDialog`.
  * @throws If used outside a `DialogProvider`.
  */
-export function useDialogs() {
+export function useDialogs(): {
+  currentDialog: DialogCurrent;
+  isOpen: (dialog: DialogType) => boolean;
+  openDialog: DialogActions["openDialog"];
+  closeDialog: DialogActions["closeDialog"];
+} {
   const state = use(DialogStateContext);
   const actions = use(DialogActionsContext);
   if (state === undefined || actions === undefined) {

--- a/sites/arolariu.ro/src/app/domains/invoices/_contexts/DialogContext.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_contexts/DialogContext.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type {Invoice, InvoiceScan, Merchant, Product, Recipe} from "@/types/invoices";
+import type {CachedScan} from "@/types/scans";
 import {createContext, use, useMemo, useState, type ReactNode} from "react";
 
 /**
@@ -45,7 +46,7 @@ export type DialogMode = Readonly<"view" | "add" | "edit" | "delete" | "share"> 
 export type DialogPayloads = {
   EDIT_INVOICE__ANALYSIS: {invoice: Invoice};
   EDIT_INVOICE__IMAGE: string;
-  EDIT_INVOICE__SCAN: Invoice | {invoice: Invoice; scan: InvoiceScan} | null;
+  EDIT_INVOICE__SCAN: Invoice | {invoice: Invoice; scan: InvoiceScan; scanIndex: number} | null;
   EDIT_INVOICE__MERCHANT: Merchant | null;
   EDIT_INVOICE__MERCHANT_INVOICES: Merchant | null;
   EDIT_INVOICE__RECIPE: Recipe;
@@ -58,7 +59,7 @@ export type DialogPayloads = {
   VIEW_INVOICE__EXPORT: undefined;
   VIEW_INVOICES__IMPORT: undefined;
   VIEW_INVOICES__EXPORT: undefined;
-  VIEW_SCANS__CREATE_INVOICE: {selectedScans: InvoiceScan[]};
+  VIEW_SCANS__CREATE_INVOICE: {selectedScans: CachedScan[]};
   SHARED__INVOICE_DELETE: {invoice: Invoice};
   SHARED__INVOICE_SHARE: {invoice: Invoice};
 };

--- a/sites/arolariu.ro/src/app/domains/invoices/_contexts/DialogContext.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_contexts/DialogContext.tsx
@@ -73,11 +73,7 @@ type DialogCurrent = {
 const INITIAL_STATE: DialogCurrent = {type: null, mode: null, payload: null};
 
 type DialogActions = {
-  openDialog: <T extends Exclude<DialogType, null>>(
-    dialog: T,
-    mode?: Exclude<DialogMode, null>,
-    payload?: DialogPayloads[T],
-  ) => void;
+  openDialog: <T extends Exclude<DialogType, null>>(dialog: T, mode?: Exclude<DialogMode, null>, payload?: DialogPayloads[T]) => void;
   closeDialog: () => void;
 };
 
@@ -112,9 +108,7 @@ export function DialogProvider({children}: Readonly<{children: ReactNode}>) {
   const actions = useMemo<DialogActions>(
     () => ({
       openDialog: (dialog, mode = "view", payload) =>
-        setDialogState((prev) =>
-          prev.type === null ? {type: dialog, mode, payload: payload ?? null} : prev,
-        ),
+        setDialogState((prev) => (prev.type === null ? {type: dialog, mode, payload: payload ?? null} : prev)),
       closeDialog: () => setDialogState(INITIAL_STATE),
     }),
     [],

--- a/sites/arolariu.ro/src/app/domains/invoices/_contexts/DialogContext.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_contexts/DialogContext.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import {createContext, use, useCallback, useMemo, useRef, useState, type ReactNode} from "react";
+import type {Invoice, InvoiceScan, Merchant, Product, Recipe} from "@/types/invoices";
+import {createContext, use, useMemo, useState, type ReactNode} from "react";
 
 /**
  * DialogType is a union type representing the different types of dialogs that can be opened.
  * Each string literal corresponds to a specific dialog type.
  * The null value indicates that no dialog is currently open.
- * This is useful for managing the state of the dialog in the application.
  */
 export type DialogType = Readonly<
   | "EDIT_INVOICE__ANALYSIS"
@@ -27,152 +27,164 @@ export type DialogType = Readonly<
   | "VIEW_SCANS__CREATE_INVOICE"
   | "SHARED__INVOICE_DELETE"
   | "SHARED__INVOICE_SHARE"
-> | null; // null is used to indicate no dialog is open
+> | null;
 
 export type DialogMode = Readonly<"view" | "add" | "edit" | "delete" | "share"> | null;
 
-// eslint-disable-next-line sonarjs/redundant-type-aliases
-export type DialogPayload = unknown;
+/**
+ * Compile-time registry mapping each DialogType to its expected payload shape.
+ *
+ * @remarks
+ * Drives type narrowing in `useDialog<T>(...)` and `useDialogs().openDialog<T>(...)`.
+ *
+ * **Soundness contract:** The runtime payload is `unknown`. The narrowing
+ * exposed by `useDialog` is sound only while the dialog reads its payload
+ * under `isOpen === true` — which is the existing DialogContainer contract
+ * (only the active dialog is mounted).
+ */
+export type DialogPayloads = {
+  EDIT_INVOICE__ANALYSIS: {invoice: Invoice};
+  EDIT_INVOICE__IMAGE: string;
+  EDIT_INVOICE__SCAN: Invoice | {invoice: Invoice; scan: InvoiceScan} | null;
+  EDIT_INVOICE__MERCHANT: Merchant | null;
+  EDIT_INVOICE__MERCHANT_INVOICES: Merchant | null;
+  EDIT_INVOICE__RECIPE: Recipe;
+  EDIT_INVOICE__METADATA: Record<string, string>;
+  EDIT_INVOICE__ITEMS: Invoice;
+  EDIT_INVOICE__ALLERGENS: {invoice: Invoice; product: Product; productIndex: number};
+  EDIT_INVOICE__BULK_CATEGORY: {invoice: Invoice; selectedProducts: Product[]; selectedIndices: number[]};
+  EDIT_INVOICE__FEEDBACK: {invoice: Invoice; merchant: Merchant | null};
+  VIEW_INVOICE__SHARE_ANALYTICS: {invoice: Invoice; merchant: Merchant};
+  VIEW_INVOICE__EXPORT: undefined;
+  VIEW_INVOICES__IMPORT: undefined;
+  VIEW_INVOICES__EXPORT: undefined;
+  VIEW_SCANS__CREATE_INVOICE: {selectedScans: InvoiceScan[]};
+  SHARED__INVOICE_DELETE: {invoice: Invoice};
+  SHARED__INVOICE_SHARE: {invoice: Invoice};
+};
 
 type DialogCurrent = {
   type: DialogType;
   mode: DialogMode;
-  payload: DialogPayload;
+  payload: unknown;
 };
 
-/**
- * Interface representing the value of the Dialog context.
- */
-interface DialogContextValue {
-  currentDialog: DialogCurrent;
-  isOpen: (dialog: DialogType) => boolean;
-  openDialog: (dialog: DialogType, mode?: DialogMode, payload?: DialogPayload) => void;
-  closeDialog: () => void;
-}
+const INITIAL_STATE: DialogCurrent = {type: null, mode: null, payload: null};
 
-/**
- * DialogContext is a React context that provides the current dialog state and functions to manage it.
- * It is initialized with default values, which can be overridden by the provider.
- */
-const DialogContext = createContext<DialogContextValue | undefined>(undefined);
+type DialogActions = {
+  openDialog: <T extends Exclude<DialogType, null>>(
+    dialog: T,
+    mode?: Exclude<DialogMode, null>,
+    payload?: DialogPayloads[T],
+  ) => void;
+  closeDialog: () => void;
+};
+
+/** State context — re-renders consumers on every open/close. */
+const DialogStateContext = createContext<DialogCurrent | undefined>(undefined);
+
+/** Actions context — value is stable for the lifetime of the provider. */
+const DialogActionsContext = createContext<DialogActions | undefined>(undefined);
 
 /**
  * DialogProvider component that manages dialog state for the application.
- * This component creates a context that tracks which dialog is currently open
- * and provides methods to open and close dialogs.
+ *
+ * @remarks
+ * Internally splits state and actions into separate contexts so cards that only
+ * dispatch (via `useDialogs().openDialog` or `useDialog().open`) do not re-render
+ * when dialog state changes.
+ *
+ * Preserves the "no-op if another dialog is already open" guard from the previous
+ * implementation; this is enforced inside the functional setState updater.
+ *
  * @example
  * ```tsx
- * // Wrap your component tree with DialogProvider
  * <DialogProvider>
  *   <YourApp />
  * </DialogProvider>
  * ```
- * @returns A context provider component that manages dialog state
  */
 export function DialogProvider({children}: Readonly<{children: ReactNode}>) {
-  const [dialogState, setDialogState] = useState<DialogCurrent>({
-    type: null,
-    mode: null,
-    payload: null,
-  });
+  const [dialogState, setDialogState] = useState<DialogCurrent>(INITIAL_STATE);
 
-  // Create a stable reference to the current dialog
-  const currentDialogRef = useRef<DialogCurrent>({
-    type: null,
-    mode: null,
-    payload: null,
-  });
-
-  /**
-   * Check to see if a specific dialog is open.
-   * This function takes a dialog type as an argument and returns a boolean indicating
-   * whether that dialog is currently open.
-   * It uses the currentDialog state to determine if the dialog is open.
-   */
-  const isOpen = useCallback((dialog: DialogType) => currentDialogRef.current.type === dialog, []);
-
-  /**
-   * This function tries to open a dialog.
-   * If there is already a dialog open, it does nothing.
-   * If there is no dialog open, it sets the currentDialog state to the new dialog.
-   * This is useful for preventing multiple dialogs from being open at the same time.
-   * It uses the setCurrentDialog function to update the state.
-   */
-  const openDialog = useCallback((dialog: DialogType, mode: DialogMode = "view", payload: DialogPayload = null) => {
-    if (currentDialogRef.current.type === null) {
-      // Update both ref and state atomically
-      currentDialogRef.current = {type: dialog, mode, payload};
-      setDialogState(currentDialogRef.current);
-    }
-  }, []);
-
-  /**
-   * This function closes the currently open dialog.
-   * It sets the currentDialog state back to null,
-   * indicating that no dialog is currently open.
-   * This is useful for resetting the dialog state when a dialog is closed.
-   * It uses the setCurrentDialog function to update the state.
-   * This function does not take any arguments.
-   */
-  const closeDialog = useCallback(() => {
-    currentDialogRef.current = {type: null, mode: null, payload: null};
-    setDialogState(currentDialogRef.current);
-  }, []);
-
-  // The context value
-  const value = useMemo(
+  // Empty deps: functional setState reads `prev` synchronously, no closure over state needed.
+  const actions = useMemo<DialogActions>(
     () => ({
-      currentDialog: currentDialogRef.current,
-      isOpen,
-      openDialog,
-      closeDialog,
+      openDialog: (dialog, mode = "view", payload) =>
+        setDialogState((prev) =>
+          prev.type === null ? {type: dialog, mode, payload: payload ?? null} : prev,
+        ),
+      closeDialog: () => setDialogState(INITIAL_STATE),
     }),
-
-    /**
-     * Only dialogState is used in the dependency array.
-     * This is to ensure that the context value is updated when the dialog state changes.
-     * The other functions (isOpen, openDialog, closeDialog) are stable and do not need to be re-created.
-     */
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [dialogState],
+    [],
   );
 
-  return <DialogContext value={value}>{children}</DialogContext>;
+  return (
+    <DialogActionsContext value={actions}>
+      <DialogStateContext value={dialogState}>{children}</DialogStateContext>
+    </DialogActionsContext>
+  );
 }
 
 /**
- * Custom hook to use the Dialog context, providing access to the current dialog state and functions to manage it.
- * @returns The current dialog state and functions to manage it.
+ * Hook providing the current dialog state plus dispatch actions.
+ *
+ * @remarks
+ * Use this hook when you need to dispatch dialogs with payloads only known at
+ * click time (e.g., per-row click handlers). For card-level "I'm bound to one
+ * dialog type" usage, prefer `useDialog`.
+ *
+ * @returns Object with `currentDialog`, `isOpen(type)`, `openDialog<T>(type, mode?, payload?)`, `closeDialog`.
+ * @throws If used outside a `DialogProvider`.
  */
 export function useDialogs() {
-  const context = use(DialogContext);
-  if (context === undefined) {
+  const state = use(DialogStateContext);
+  const actions = use(DialogActionsContext);
+  if (state === undefined || actions === undefined) {
     throw new Error("useDialogs must be used within a DialogProvider");
   }
-
-  return context;
+  return {
+    currentDialog: state,
+    isOpen: (dialog: DialogType) => state.type === dialog,
+    openDialog: actions.openDialog,
+    closeDialog: actions.closeDialog,
+  };
 }
 
 /**
- * Is a custom hook that provides an interface for managing dialog state.
- * It returns an object containing the current dialog state and functions to open and close dialogs.
- * @param dialogType The type of dialog to manage (e.g., "share", "merchant", "recipe")
- * @param dialogMode Optional mode for the dialog (e.g., "view", "add", "edit", "delete")
- * @param dialogPayload Optional payload to pass (e.g., data to be displayed in the dialog)
- * @returns An object containing the current dialog state and functions to open and close dialogs
+ * Hook bound to a single dialog type with optional baked-in mode and payload.
+ *
+ * @remarks
+ * The returned `currentDialog.payload` is typed as `DialogPayloads[T] | null`.
+ * This narrowing is sound only when read under `isOpen === true` (the active
+ * dialog reads its own payload). Cards that only call `open`/`close` and never
+ * read `payload` are unaffected.
+ *
+ * @param dialogType - The dialog this hook is bound to (compile-time enforced).
+ * @param dialogMode - Default mode when `open()` is called (defaults to `"view"`).
+ * @param dialogPayload - Default payload when `open()` is called.
+ * @returns Object with `currentDialog`, `isOpen` (boolean), `open()`, `close()`.
+ * @throws If used outside a `DialogProvider`.
+ *
  * @example
- * const {isOpen, open, close} = useDialog("EDIT_INVOICE__SCAN", "add", invoice);
+ * ```tsx
+ * const {isOpen, open, close} = useDialog("SHARED__INVOICE_DELETE", "delete", {invoice});
+ * ```
  */
-export function useDialog(dialogType: Exclude<DialogType, null>, dialogMode?: Exclude<DialogMode, null>, dialogPayload?: DialogPayload) {
-  const {currentDialog, isOpen, openDialog, closeDialog} = useDialogs();
-
+export function useDialog<T extends Exclude<DialogType, null>>(
+  dialogType: T,
+  dialogMode: Exclude<DialogMode, null> = "view",
+  dialogPayload?: DialogPayloads[T],
+) {
+  const state = use(DialogStateContext);
+  const actions = use(DialogActionsContext);
+  if (state === undefined || actions === undefined) {
+    throw new Error("useDialog must be used within a DialogProvider");
+  }
   return {
-    currentDialog,
-    isOpen: isOpen(dialogType),
-    // Zero-arg open preserves MouseEventHandler compatibility for onClick={open}.
-    open: () => openDialog(dialogType, dialogMode, dialogPayload),
-    // openWith allows overriding mode and payload at call time.
-    openWith: (mode: Exclude<DialogMode, null>, payload?: DialogPayload) => openDialog(dialogType, mode, payload ?? dialogPayload),
-    close: closeDialog,
+    currentDialog: state as {type: DialogType; mode: DialogMode; payload: DialogPayloads[T] | null},
+    isOpen: state.type === dialogType,
+    open: () => actions.openDialog(dialogType, dialogMode, dialogPayload),
+    close: actions.closeDialog,
   } as const;
 }

--- a/sites/arolariu.ro/src/app/domains/invoices/_contexts/DialogContext.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_contexts/DialogContext.tsx
@@ -46,9 +46,9 @@ export type DialogMode = Readonly<"view" | "add" | "edit" | "delete" | "share"> 
 export type DialogPayloads = {
   EDIT_INVOICE__ANALYSIS: {invoice: Invoice};
   EDIT_INVOICE__IMAGE: string;
-  EDIT_INVOICE__SCAN: Invoice | {invoice: Invoice; scan: InvoiceScan; scanIndex: number} | null;
-  EDIT_INVOICE__MERCHANT: Merchant | null;
-  EDIT_INVOICE__MERCHANT_INVOICES: Merchant | null;
+  EDIT_INVOICE__SCAN: Invoice | {invoice: Invoice; scan: InvoiceScan; scanIndex: number};
+  EDIT_INVOICE__MERCHANT: Merchant;
+  EDIT_INVOICE__MERCHANT_INVOICES: Merchant;
   EDIT_INVOICE__RECIPE: Recipe;
   EDIT_INVOICE__METADATA: Record<string, string>;
   EDIT_INVOICE__ITEMS: Invoice;
@@ -150,10 +150,11 @@ export function useDialogs() {
  * Hook bound to a single dialog type with optional baked-in mode and payload.
  *
  * @remarks
- * The returned `currentDialog.payload` is typed as `DialogPayloads[T] | null`.
+ * The returned `currentDialog.payload` is typed as `DialogPayloads[T]`.
  * This narrowing is sound only when read under `isOpen === true` (the active
  * dialog reads its own payload). Cards that only call `open`/`close` and never
- * read `payload` are unaffected.
+ * read `payload` are unaffected. Callers MUST ensure they never dispatch a
+ * dialog without its required payload — guard your trigger buttons.
  *
  * @param dialogType - The dialog this hook is bound to (compile-time enforced).
  * @param dialogMode - Default mode when `open()` is called (defaults to `"view"`).
@@ -177,7 +178,7 @@ export function useDialog<T extends Exclude<DialogType, null>>(
     throw new Error("useDialog must be used within a DialogProvider");
   }
   return {
-    currentDialog: state as {type: DialogType; mode: DialogMode; payload: DialogPayloads[T] | null},
+    currentDialog: state as {type: DialogType; mode: DialogMode; payload: DialogPayloads[T]},
     isOpen: state.type === dialogType,
     open: () => actions.openDialog(dialogType, dialogMode, dialogPayload),
     close: actions.closeDialog,

--- a/sites/arolariu.ro/src/app/domains/invoices/_dialogs/DeleteInvoiceDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_dialogs/DeleteInvoiceDialog.tsx
@@ -65,14 +65,14 @@ export default function DeleteInvoiceDialog(): React.JSX.Element {
     currentDialog: {payload},
   } = useDialog("SHARED__INVOICE_DELETE", "delete");
 
-  const {invoice} = payload as {invoice: Invoice};
+  const invoice: Invoice | null = payload?.invoice ?? null;
 
   const [confirmText, setConfirmText] = useState<string>("");
   const [understoodCheckbox, setUnderstoodCheckbox] = useState<boolean>(false);
   const [isDeleting, setIsDeleting] = useState<boolean>(false);
 
-  const invoiceName = invoice.name || `${invoice.id.slice(0, 8)}`;
-  const isConfirmValid = confirmText === invoiceName && understoodCheckbox;
+  const invoiceName = invoice?.name || (invoice ? `${invoice.id.slice(0, 8)}` : "");
+  const isConfirmValid = invoice ? confirmText === invoiceName && understoodCheckbox : false;
 
   const handleConfirmTextChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     setConfirmText(e.target.value);
@@ -90,7 +90,7 @@ export default function DeleteInvoiceDialog(): React.JSX.Element {
   }, [close]);
 
   const handleDelete = useCallback(async () => {
-    if (!isConfirmValid) return;
+    if (!invoice || !isConfirmValid) return;
 
     setIsDeleting(true);
 
@@ -114,12 +114,14 @@ export default function DeleteInvoiceDialog(): React.JSX.Element {
     } finally {
       setIsDeleting(false);
     }
-  }, [invoice.id, isConfirmValid, handleClose, router, removeInvoice]);
+  }, [invoice, isConfirmValid, handleClose, router, removeInvoice, t]);
 
   // Calculate deletion impact
-  const itemCount = invoice.items?.length ?? 0;
-  const scanCount = invoice.scans?.length ?? 0;
-  const sharedCount = invoice.sharedWith?.length ?? 0;
+  const itemCount = invoice?.items?.length ?? 0;
+  const scanCount = invoice?.scans?.length ?? 0;
+  const sharedCount = invoice?.sharedWith?.length ?? 0;
+
+  if (!invoice) return <></>;
 
   return (
     <Dialog

--- a/sites/arolariu.ro/src/app/domains/invoices/_dialogs/DeleteInvoiceDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_dialogs/DeleteInvoiceDialog.tsx
@@ -126,7 +126,9 @@ export default function DeleteInvoiceDialog(): React.JSX.Element {
     <Dialog
       open={isOpen}
       // eslint-disable-next-line react/jsx-no-bind -- simple dialog close handler
-      onOpenChange={(shouldOpen) => { if (!shouldOpen) handleClose(); }}>
+      onOpenChange={(shouldOpen) => {
+        if (!shouldOpen) handleClose();
+      }}>
       <DialogContent className={styles["dialogContentMaxW"]}>
         <DialogHeader>
           <DialogTitle className={styles["dialogTitleRed"]}>

--- a/sites/arolariu.ro/src/app/domains/invoices/_dialogs/DeleteInvoiceDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_dialogs/DeleteInvoiceDialog.tsx
@@ -2,7 +2,6 @@
 
 import deleteInvoice from "@/lib/actions/invoices/deleteInvoice";
 import {useInvoicesStore} from "@/stores";
-import type {Invoice} from "@/types/invoices";
 import {
   Alert,
   AlertDescription,
@@ -64,14 +63,14 @@ export default function DeleteInvoiceDialog(): React.JSX.Element {
     currentDialog: {payload},
   } = useDialog("SHARED__INVOICE_DELETE", "delete");
 
-  const invoice: Invoice | null = payload?.invoice ?? null;
+  const {invoice} = payload;
 
   const [confirmText, setConfirmText] = useState<string>("");
   const [understoodCheckbox, setUnderstoodCheckbox] = useState<boolean>(false);
   const [isDeleting, setIsDeleting] = useState<boolean>(false);
 
-  const invoiceName = invoice?.name || (invoice ? `${invoice.id.slice(0, 8)}` : "");
-  const isConfirmValid = invoice ? confirmText === invoiceName && understoodCheckbox : false;
+  const invoiceName = invoice.name || `${invoice.id.slice(0, 8)}`;
+  const isConfirmValid = confirmText === invoiceName && understoodCheckbox;
 
   const handleConfirmTextChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     setConfirmText(e.target.value);
@@ -89,7 +88,7 @@ export default function DeleteInvoiceDialog(): React.JSX.Element {
   }, [close]);
 
   const handleDelete = useCallback(async () => {
-    if (!invoice || !isConfirmValid) return;
+    if (!isConfirmValid) return;
 
     setIsDeleting(true);
 
@@ -116,11 +115,9 @@ export default function DeleteInvoiceDialog(): React.JSX.Element {
   }, [invoice, isConfirmValid, handleClose, router, removeInvoice, t]);
 
   // Calculate deletion impact
-  const itemCount = invoice?.items?.length ?? 0;
-  const scanCount = invoice?.scans?.length ?? 0;
-  const sharedCount = invoice?.sharedWith?.length ?? 0;
-
-  if (!invoice) return <></>;
+  const itemCount = invoice.items?.length ?? 0;
+  const scanCount = invoice.scans?.length ?? 0;
+  const sharedCount = invoice.sharedWith?.length ?? 0;
 
   return (
     <Dialog

--- a/sites/arolariu.ro/src/app/domains/invoices/_dialogs/DeleteInvoiceDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_dialogs/DeleteInvoiceDialog.tsx
@@ -60,7 +60,6 @@ export default function DeleteInvoiceDialog(): React.JSX.Element {
 
   const {
     isOpen,
-    open,
     close,
     currentDialog: {payload},
   } = useDialog("SHARED__INVOICE_DELETE", "delete");
@@ -126,8 +125,8 @@ export default function DeleteInvoiceDialog(): React.JSX.Element {
   return (
     <Dialog
       open={isOpen}
-      // eslint-disable-next-line react/jsx-no-bind -- simple dialog open/close handler
-      onOpenChange={(shouldOpen) => (shouldOpen ? open() : handleClose())}>
+      // eslint-disable-next-line react/jsx-no-bind -- simple dialog close handler
+      onOpenChange={(nextOpen) => { if (!nextOpen) handleClose(); }}>
       <DialogContent className={styles["dialogContentMaxW"]}>
         <DialogHeader>
           <DialogTitle className={styles["dialogTitleRed"]}>

--- a/sites/arolariu.ro/src/app/domains/invoices/_dialogs/DeleteInvoiceDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_dialogs/DeleteInvoiceDialog.tsx
@@ -126,7 +126,7 @@ export default function DeleteInvoiceDialog(): React.JSX.Element {
     <Dialog
       open={isOpen}
       // eslint-disable-next-line react/jsx-no-bind -- simple dialog close handler
-      onOpenChange={(nextOpen) => { if (!nextOpen) handleClose(); }}>
+      onOpenChange={(shouldOpen) => { if (!shouldOpen) handleClose(); }}>
       <DialogContent className={styles["dialogContentMaxW"]}>
         <DialogHeader>
           <DialogTitle className={styles["dialogTitleRed"]}>

--- a/sites/arolariu.ro/src/app/domains/invoices/_dialogs/ShareInvoiceDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_dialogs/ShareInvoiceDialog.tsx
@@ -4,7 +4,6 @@ import type {EmailLocale} from "@/../emails/_i18n";
 import {sendEmail} from "@/lib/actions/email";
 import patchInvoice from "@/lib/actions/invoices/patchInvoice";
 import {LAST_GUID} from "@/lib/utils.generic";
-import type {Invoice} from "@/types/invoices";
 import {
   Alert,
   AlertDescription,
@@ -163,7 +162,7 @@ export default function ShareInvoiceDialog(): React.JSX.Element {
   // Null guard: return early if no payload
   if (!payload) return <></>;
 
-  const {invoice} = payload as {invoice: Invoice};
+  const {invoice} = payload;
   const shareUrl = `${globalThis.location.origin}/domains/invoices/view-invoice/${invoice.id}`;
 
   /** Check if the invoice is currently public */

--- a/sites/arolariu.ro/src/app/domains/invoices/_dialogs/ShareInvoiceDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_dialogs/ShareInvoiceDialog.tsx
@@ -159,16 +159,13 @@ export default function ShareInvoiceDialog(): React.JSX.Element {
     close,
   } = useDialog("SHARED__INVOICE_SHARE");
 
-  // Null guard: return early if no payload
-  if (!payload) return <></>;
-
-  const {invoice} = payload;
-  const shareUrl = `${globalThis.location.origin}/domains/invoices/view-invoice/${invoice.id}`;
+  const invoice = payload?.invoice ?? null;
+  const shareUrl = invoice ? `${globalThis.location.origin}/domains/invoices/view-invoice/${invoice.id}` : "";
 
   /** Check if the invoice is currently public */
   const isInvoicePublic = useMemo(() => {
-    return invoice.sharedWith?.includes(LAST_GUID) ?? false;
-  }, [invoice.sharedWith]);
+    return invoice?.sharedWith?.includes(LAST_GUID) ?? false;
+  }, [invoice?.sharedWith]);
 
   /** Reset state when dialog closes */
   const handleClose = useCallback(() => {
@@ -188,6 +185,7 @@ export default function ShareInvoiceDialog(): React.JSX.Element {
    * Inlines the patchInvoice call directly.
    */
   const makeInvoicePublic = useCallback(async (): Promise<void> => {
+    if (!invoice) return;
     const newSharedWith = invoice.sharedWith?.includes(LAST_GUID) ? invoice.sharedWith : [...(invoice.sharedWith ?? []), LAST_GUID];
 
     const result = await patchInvoice({
@@ -198,7 +196,7 @@ export default function ShareInvoiceDialog(): React.JSX.Element {
     if (!result.success) {
       throw new Error(result.error);
     }
-  }, [invoice.id, invoice.sharedWith]);
+  }, [invoice]);
 
   /**
    * Makes the invoice public and copies the share link to clipboard.
@@ -206,6 +204,7 @@ export default function ShareInvoiceDialog(): React.JSX.Element {
    */
   const handleCopyLink = useCallback(() => {
     const copyLinkAction = async () => {
+      if (!invoice) return;
       const wasPrivate = !isInvoicePublic;
       // If invoice is not already public, make it public first
       if (wasPrivate && sharingMode === "public") {
@@ -226,7 +225,7 @@ export default function ShareInvoiceDialog(): React.JSX.Element {
       success: isInvoicePublic ? t("toasts.copyLink.successPublic") : t("toasts.copyLink.successMadePublic"),
       error: (error: unknown) => t("toasts.copyLink.error", {message: error instanceof Error ? error.message : String(error)}),
     });
-  }, [isInvoicePublic, makeInvoicePublic, router, sharingMode, shareUrl, t]);
+  }, [invoice, isInvoicePublic, makeInvoicePublic, router, sharingMode, shareUrl, t]);
 
   /**
    * Makes the invoice public and copies the QR code image to clipboard.
@@ -234,6 +233,7 @@ export default function ShareInvoiceDialog(): React.JSX.Element {
    */
   const handleCopyQRCode = useCallback(() => {
     const copyQRCodeAction = async () => {
+      if (!invoice) return;
       const wasPrivate = !isInvoicePublic;
       // If invoice is not already public, make it public first
       if (wasPrivate && sharingMode === "public") {
@@ -258,7 +258,7 @@ export default function ShareInvoiceDialog(): React.JSX.Element {
       success: isInvoicePublic ? t("toasts.copyQr.successPublic") : t("toasts.copyQr.successMadePublic"),
       error: (error: unknown) => t("toasts.copyQr.error", {message: error instanceof Error ? error.message : String(error)}),
     });
-  }, [isInvoicePublic, makeInvoicePublic, router, sharingMode, t]);
+  }, [invoice, isInvoicePublic, makeInvoicePublic, router, sharingMode, t]);
 
   /**
    * Sends an email invitation to share the invoice privately using the generic sendEmail server action.
@@ -272,6 +272,7 @@ export default function ShareInvoiceDialog(): React.JSX.Element {
       setIsSendingEmail(true);
 
       const sendEmailAction = async () => {
+        if (!invoice) return;
         const fromName = [user?.firstName, user?.lastName].filter(Boolean).join(" ") || "Someone";
         const result = await sendEmail({
           templateKey: "invoice-shared",
@@ -302,7 +303,7 @@ export default function ShareInvoiceDialog(): React.JSX.Element {
         },
       );
     },
-    [email, invoice.id, locale, t, user],
+    [email, invoice, locale, t, user],
   );
 
   /**
@@ -314,6 +315,7 @@ export default function ShareInvoiceDialog(): React.JSX.Element {
     setIsRevoking(true);
 
     const revokeAction = async () => {
+      if (!invoice) return;
       const newSharedWith = (invoice.sharedWith ?? []).filter((id) => id !== LAST_GUID);
 
       const result = await patchInvoice({
@@ -338,7 +340,7 @@ export default function ShareInvoiceDialog(): React.JSX.Element {
         error: (error: unknown) => t("toasts.revoke.error", {message: error instanceof Error ? error.message : String(error)}),
       },
     );
-  }, [invoice.id, invoice.sharedWith, router, handleClose, t]);
+  }, [invoice, router, handleClose, t]);
 
   /** Navigate to public sharing mode */
   const handleSelectPublic = useCallback(() => {
@@ -366,6 +368,7 @@ export default function ShareInvoiceDialog(): React.JSX.Element {
 
   /** Get the dialog description based on current state */
   const getDialogDescription = (): string => {
+    if (!invoice) return "";
     if (isInvoicePublic) {
       return t("dialogDescription.currentlyPublic", {invoiceName: invoice.name});
     }
@@ -380,6 +383,10 @@ export default function ShareInvoiceDialog(): React.JSX.Element {
         return "";
     }
   };
+
+  // All hooks above this line must run unconditionally on every render.
+  // The early return below is safe — it comes AFTER every hook.
+  if (!invoice) return <></>;
 
   return (
     <Dialog

--- a/sites/arolariu.ro/src/app/domains/invoices/_dialogs/ShareInvoiceDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_dialogs/ShareInvoiceDialog.tsx
@@ -159,13 +159,13 @@ export default function ShareInvoiceDialog(): React.JSX.Element {
     close,
   } = useDialog("SHARED__INVOICE_SHARE");
 
-  const invoice = payload?.invoice ?? null;
-  const shareUrl = invoice ? `${globalThis.location.origin}/domains/invoices/view-invoice/${invoice.id}` : "";
+  const {invoice} = payload;
+  const shareUrl = `${globalThis.location.origin}/domains/invoices/view-invoice/${invoice.id}`;
 
   /** Check if the invoice is currently public */
   const isInvoicePublic = useMemo(() => {
-    return invoice?.sharedWith?.includes(LAST_GUID) ?? false;
-  }, [invoice?.sharedWith]);
+    return invoice.sharedWith?.includes(LAST_GUID) ?? false;
+  }, [invoice.sharedWith]);
 
   /** Reset state when dialog closes */
   const handleClose = useCallback(() => {
@@ -185,7 +185,6 @@ export default function ShareInvoiceDialog(): React.JSX.Element {
    * Inlines the patchInvoice call directly.
    */
   const makeInvoicePublic = useCallback(async (): Promise<void> => {
-    if (!invoice) return;
     const newSharedWith = invoice.sharedWith?.includes(LAST_GUID) ? invoice.sharedWith : [...(invoice.sharedWith ?? []), LAST_GUID];
 
     const result = await patchInvoice({
@@ -204,7 +203,6 @@ export default function ShareInvoiceDialog(): React.JSX.Element {
    */
   const handleCopyLink = useCallback(() => {
     const copyLinkAction = async () => {
-      if (!invoice) return;
       const wasPrivate = !isInvoicePublic;
       // If invoice is not already public, make it public first
       if (wasPrivate && sharingMode === "public") {
@@ -233,7 +231,6 @@ export default function ShareInvoiceDialog(): React.JSX.Element {
    */
   const handleCopyQRCode = useCallback(() => {
     const copyQRCodeAction = async () => {
-      if (!invoice) return;
       const wasPrivate = !isInvoicePublic;
       // If invoice is not already public, make it public first
       if (wasPrivate && sharingMode === "public") {
@@ -272,7 +269,6 @@ export default function ShareInvoiceDialog(): React.JSX.Element {
       setIsSendingEmail(true);
 
       const sendEmailAction = async () => {
-        if (!invoice) return;
         const fromName = [user?.firstName, user?.lastName].filter(Boolean).join(" ") || "Someone";
         const result = await sendEmail({
           templateKey: "invoice-shared",
@@ -315,7 +311,6 @@ export default function ShareInvoiceDialog(): React.JSX.Element {
     setIsRevoking(true);
 
     const revokeAction = async () => {
-      if (!invoice) return;
       const newSharedWith = (invoice.sharedWith ?? []).filter((id) => id !== LAST_GUID);
 
       const result = await patchInvoice({
@@ -368,7 +363,6 @@ export default function ShareInvoiceDialog(): React.JSX.Element {
 
   /** Get the dialog description based on current state */
   const getDialogDescription = (): string => {
-    if (!invoice) return "";
     if (isInvoicePublic) {
       return t("dialogDescription.currentlyPublic", {invoiceName: invoice.name});
     }
@@ -383,10 +377,6 @@ export default function ShareInvoiceDialog(): React.JSX.Element {
         return "";
     }
   };
-
-  // All hooks above this line must run unconditionally on every render.
-  // The early return below is safe — it comes AFTER every hook.
-  if (!invoice) return <></>;
 
   return (
     <Dialog

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/cards/MerchantCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/cards/MerchantCard.tsx
@@ -12,7 +12,7 @@ import {
 } from "@arolariu/components";
 import {useTranslations} from "next-intl";
 import {TbArrowRight, TbShoppingBag, TbShoppingCart} from "react-icons/tb";
-import {useDialog} from "../../../../_contexts/DialogContext";
+import {useDialogs} from "../../../../_contexts/DialogContext";
 import styles from "./MerchantCard.module.scss";
 
 type Props = {
@@ -35,8 +35,9 @@ type Props = {
  * - **View All Receipts**: Opens `MerchantReceiptsDialog` showing all invoices
  *   from this merchant with filtering and sorting
  *
- * **Dialog Integration**: Uses `useDialog` hook to open `INVOICE_MERCHANT` and
- * `INVOICE_MERCHANT_INVOICES` dialogs in "view" mode with merchant as payload.
+ * **Dialog Integration**: Uses `useDialogs().openDialog` invoked from button
+ * `onClick` handlers (after the early-return guard narrows merchant to non-null).
+ * This ensures the dialog is never dispatched with a null payload.
  *
  * **Domain Context**: Part of the edit-invoice sidebar, providing quick access
  * to merchant context and cross-invoice navigation.
@@ -56,10 +57,10 @@ type Props = {
  */
 export default function MerchantCard({merchant}: Readonly<Props>): React.JSX.Element {
   const t = useTranslations("IMS--Cards.merchantCard");
-  const {open: openMerchantInfoDialog} = useDialog("EDIT_INVOICE__MERCHANT", "view", merchant);
-  const {open: openMerchantReceiptsDialog} = useDialog("EDIT_INVOICE__MERCHANT_INVOICES", "view", merchant);
+  const {openDialog} = useDialogs();
 
-  // Early return if merchant is null
+  // Early return if merchant is null — guards both trigger buttons from rendering,
+  // which guarantees neither dialog can be dispatched with a null payload.
   if (!merchant) {
     return (
       <Card className={styles["card"]}>
@@ -96,7 +97,8 @@ export default function MerchantCard({merchant}: Readonly<Props>): React.JSX.Ele
                   <Button
                     variant='outline'
                     className={styles["actionButton"]}
-                    onClick={openMerchantInfoDialog}>
+                    // eslint-disable-next-line react/jsx-no-bind -- merchant is narrowed non-null here
+                    onClick={() => openDialog("EDIT_INVOICE__MERCHANT", "view", merchant)}>
                     <span>{t("buttons.viewMerchantDetails")}</span>
                     <TbArrowRight className={styles["arrowIcon"]} />
                   </Button>
@@ -115,7 +117,8 @@ export default function MerchantCard({merchant}: Readonly<Props>): React.JSX.Ele
                   <Button
                     variant='outline'
                     className={styles["actionButton"]}
-                    onClick={openMerchantReceiptsDialog}>
+                    // eslint-disable-next-line react/jsx-no-bind -- merchant is narrowed non-null here
+                    onClick={() => openDialog("EDIT_INVOICE__MERCHANT_INVOICES", "view", merchant)}>
                     <TbShoppingBag className={styles["buttonIcon"]} />
                     <span>{t("buttons.viewAllReceipts")}</span>
                     <TbArrowRight className={styles["arrowIcon"]} />

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/AddScanDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/AddScanDialog.tsx
@@ -69,7 +69,7 @@ export default function AddScanDialog(): React.JSX.Element {
     close,
   } = useDialog("EDIT_INVOICE__SCAN", "add");
 
-  const invoice = payload as Invoice | null;
+  const invoice: Invoice | null = payload && typeof payload === "object" && !("scan" in payload) ? (payload as Invoice) : null;
 
   const [file, setFile] = useState<File | null>(null);
   const [scanType, setScanType] = useState<InvoiceScanType>(InvoiceScanType.JPEG);

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/AllergenDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/AllergenDialog.tsx
@@ -10,7 +10,7 @@
  */
 
 import updateProduct from "@/lib/actions/invoices/updateProduct";
-import type {Allergen, Invoice, Product} from "@/types/invoices";
+import type {Allergen} from "@/types/invoices";
 import {
   Badge,
   Button,
@@ -108,9 +108,7 @@ export default function AllergenDialog(): React.JSX.Element {
     close,
   } = useDialog("EDIT_INVOICE__ALLERGENS");
 
-  const invoice: Invoice | null = payload?.invoice ?? null;
-  const product: Product | null = payload?.product ?? null;
-  const productIndex = payload?.productIndex;
+  const {invoice, product, productIndex} = payload;
 
   const [allergens, setAllergens] = useState<Allergen[]>(product?.detectedAllergens ?? []);
   const [customAllergen, setCustomAllergen] = useState("");

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/AllergenDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/AllergenDialog.tsx
@@ -25,7 +25,7 @@ import {
   toast,
 } from "@arolariu/components";
 import {useTranslations} from "next-intl";
-import {useCallback, useState} from "react";
+import {useCallback, useEffect, useState} from "react";
 import {TbPlus, TbX} from "react-icons/tb";
 import {useDialog} from "../../../../_contexts/DialogContext";
 import styles from "./AllergenDialog.module.scss";
@@ -52,15 +52,6 @@ const COMMON_ALLERGENS: ReadonlyArray<string> = [
   "Molluscs",
   "Sulfites",
 ] as const;
-
-/**
- * Payload type for the allergen dialog.
- */
-interface AllergenDialogPayload {
-  readonly invoice: Invoice;
-  readonly product: Product;
-  readonly productIndex: number;
-}
 
 /**
  * Dialog for editing allergens on a single product.
@@ -117,11 +108,19 @@ export default function AllergenDialog(): React.JSX.Element {
     close,
   } = useDialog("EDIT_INVOICE__ALLERGENS");
 
-  const {invoice, product, productIndex} = (payload ?? {}) as Partial<AllergenDialogPayload>;
+  const invoice: Invoice | null = payload?.invoice ?? null;
+  const product: Product | null = payload?.product ?? null;
+  const productIndex = payload?.productIndex;
 
   const [allergens, setAllergens] = useState<Allergen[]>(product?.detectedAllergens ?? []);
   const [customAllergen, setCustomAllergen] = useState("");
   const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    setAllergens(product?.detectedAllergens ?? []);
+    setCustomAllergen("");
+    setIsSaving(false);
+  }, [product]);
 
   /**
    * Adds a new allergen to the list.
@@ -228,7 +227,7 @@ export default function AllergenDialog(): React.JSX.Element {
     }
   }, [invoice, product, productIndex, allergens, close, t]);
 
-  if (!product) {
+  if (!invoice || !product || productIndex === undefined) {
     return <></>;
   }
 

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/AnalyzeDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/AnalyzeDialog.tsx
@@ -276,7 +276,9 @@ export default function AnalyzeDialog(): React.JSX.Element {
     <Dialog
       open={isOpen}
       // eslint-disable-next-line react/jsx-no-bind -- simple dialog close handler
-      onOpenChange={(shouldOpen) => { if (!shouldOpen) close(); }}>
+      onOpenChange={(shouldOpen) => {
+        if (!shouldOpen) close();
+      }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
           <DialogTitle className={styles["dialogTitle"]}>

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/AnalyzeDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/AnalyzeDialog.tsx
@@ -2,7 +2,7 @@
 
 import {useDialog} from "@/app/domains/invoices/_contexts/DialogContext";
 import analyzeInvoice from "@/lib/actions/invoices/analyzeInvoice";
-import {type Invoice, InvoiceAnalysisOptions} from "@/types/invoices";
+import {InvoiceAnalysisOptions} from "@/types/invoices";
 import {
   Badge,
   Button,
@@ -87,7 +87,7 @@ export default function AnalyzeDialog(): React.JSX.Element {
     currentDialog: {payload},
   } = useDialog("EDIT_INVOICE__ANALYSIS");
 
-  const invoice: Invoice | null = payload?.invoice ?? null;
+  const {invoice} = payload;
 
   const [selectedOption, setSelectedOption] = useState<InvoiceAnalysisOptions>(InvoiceAnalysisOptions.CompleteAnalysis);
   const [selectedEnhancements, setSelectedEnhancements] = useState<string[]>([]);
@@ -186,8 +186,6 @@ export default function AnalyzeDialog(): React.JSX.Element {
   }, []);
 
   const handleAnalysis = useCallback(async () => {
-    if (!invoice) return;
-
     setIsAnalyzing(true);
     setProgress(0);
 
@@ -267,8 +265,6 @@ export default function AnalyzeDialog(): React.JSX.Element {
       setCurrentStep("");
     }
   }, [invoice, selectedOption, selectedEnhancements, close, t]);
-
-  if (!invoice) return <></>;
 
   const selectedConfig = analysisOptions.find((opt) => opt.id === selectedOption);
 

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/AnalyzeDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/AnalyzeDialog.tsx
@@ -1,4 +1,4 @@
-﻿"use client";
+"use client";
 
 import {useDialog} from "@/app/domains/invoices/_contexts/DialogContext";
 import analyzeInvoice from "@/lib/actions/invoices/analyzeInvoice";
@@ -276,7 +276,7 @@ export default function AnalyzeDialog(): React.JSX.Element {
     <Dialog
       open={isOpen}
       // eslint-disable-next-line react/jsx-no-bind -- simple dialog close handler
-      onOpenChange={(nextOpen) => { if (!nextOpen) close(); }}>
+      onOpenChange={(shouldOpen) => { if (!shouldOpen) close(); }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
           <DialogTitle className={styles["dialogTitle"]}>

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/AnalyzeDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/AnalyzeDialog.tsx
@@ -88,7 +88,7 @@ export default function AnalyzeDialog(): React.JSX.Element {
     currentDialog: {payload},
   } = useDialog("EDIT_INVOICE__ANALYSIS");
 
-  const {invoice} = payload as {invoice: Invoice};
+  const invoice: Invoice | null = payload?.invoice ?? null;
 
   const [selectedOption, setSelectedOption] = useState<InvoiceAnalysisOptions>(InvoiceAnalysisOptions.CompleteAnalysis);
   const [selectedEnhancements, setSelectedEnhancements] = useState<string[]>([]);
@@ -187,6 +187,8 @@ export default function AnalyzeDialog(): React.JSX.Element {
   }, []);
 
   const handleAnalysis = useCallback(async () => {
+    if (!invoice) return;
+
     setIsAnalyzing(true);
     setProgress(0);
 
@@ -265,7 +267,9 @@ export default function AnalyzeDialog(): React.JSX.Element {
       setProgress(0);
       setCurrentStep("");
     }
-  }, [invoice.id, selectedOption, selectedEnhancements, close, t]);
+  }, [invoice, selectedOption, selectedEnhancements, close, t]);
+
+  if (!invoice) return <></>;
 
   const selectedConfig = analysisOptions.find((opt) => opt.id === selectedOption);
 

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/AnalyzeDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/AnalyzeDialog.tsx
@@ -1,4 +1,4 @@
-"use client";
+﻿"use client";
 
 import {useDialog} from "@/app/domains/invoices/_contexts/DialogContext";
 import analyzeInvoice from "@/lib/actions/invoices/analyzeInvoice";
@@ -83,7 +83,6 @@ export default function AnalyzeDialog(): React.JSX.Element {
   const t = useTranslations("IMS--Dialogs.analyzeDialog");
   const {
     isOpen,
-    open,
     close,
     currentDialog: {payload},
   } = useDialog("EDIT_INVOICE__ANALYSIS");
@@ -276,8 +275,8 @@ export default function AnalyzeDialog(): React.JSX.Element {
   return (
     <Dialog
       open={isOpen}
-      // eslint-disable-next-line react/jsx-no-bind -- this is a simple fn.
-      onOpenChange={(shouldOpen) => (shouldOpen ? open() : close())}>
+      // eslint-disable-next-line react/jsx-no-bind -- simple dialog close handler
+      onOpenChange={(nextOpen) => { if (!nextOpen) close(); }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
           <DialogTitle className={styles["dialogTitle"]}>

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/BulkCategoryDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/BulkCategoryDialog.tsx
@@ -9,7 +9,7 @@
  */
 
 import updateProduct from "@/lib/actions/invoices/updateProduct";
-import type {Invoice, Product, ProductCategory} from "@/types/invoices";
+import type {ProductCategory} from "@/types/invoices";
 import {
   Button,
   Dialog,
@@ -91,9 +91,7 @@ export default function BulkCategoryDialog(): React.JSX.Element {
     close,
   } = useDialog("EDIT_INVOICE__BULK_CATEGORY");
 
-  const invoice: Invoice | null = payload?.invoice ?? null;
-  const selectedProducts: Product[] = payload?.selectedProducts ?? [];
-  const selectedIndices: number[] = payload?.selectedIndices ?? [];
+  const {invoice, selectedProducts, selectedIndices} = payload;
 
   const [selectedCategory, setSelectedCategory] = useState<ProductCategory | null>(null);
   const [isSaving, setIsSaving] = useState(false);

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/BulkCategoryDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/BulkCategoryDialog.tsx
@@ -34,15 +34,6 @@ import {useDialog} from "../../../../_contexts/DialogContext";
 import styles from "./BulkCategoryDialog.module.scss";
 
 /**
- * Payload type for the bulk category dialog.
- */
-interface BulkCategoryDialogPayload {
-  readonly invoice: Invoice;
-  readonly selectedProducts: Product[];
-  readonly selectedIndices: number[];
-}
-
-/**
  * Dialog for bulk category reassignment of products.
  *
  * @remarks
@@ -100,7 +91,9 @@ export default function BulkCategoryDialog(): React.JSX.Element {
     close,
   } = useDialog("EDIT_INVOICE__BULK_CATEGORY");
 
-  const {invoice, selectedProducts, selectedIndices} = (payload ?? {}) as Partial<BulkCategoryDialogPayload>;
+  const invoice: Invoice | null = payload?.invoice ?? null;
+  const selectedProducts: Product[] = payload?.selectedProducts ?? [];
+  const selectedIndices: number[] = payload?.selectedIndices ?? [];
 
   const [selectedCategory, setSelectedCategory] = useState<ProductCategory | null>(null);
   const [isSaving, setIsSaving] = useState(false);
@@ -224,7 +217,7 @@ export default function BulkCategoryDialog(): React.JSX.Element {
     }
   }, [invoice, selectedProducts, selectedIndices, selectedCategory, close, router, t]);
 
-  if (!selectedProducts || selectedProducts.length === 0) {
+  if (!invoice || selectedProducts.length === 0 || selectedIndices.length === 0) {
     return <></>;
   }
 

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/FeedbackDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/FeedbackDialog.tsx
@@ -1,4 +1,4 @@
-"use client";
+﻿"use client";
 
 import type {Invoice, Merchant} from "@/types/invoices";
 import {
@@ -68,7 +68,6 @@ export default function FeedbackDialog(): React.JSX.Element {
   const {
     currentDialog: {payload},
     isOpen,
-    open,
     close,
   } = useDialog("EDIT_INVOICE__FEEDBACK");
 
@@ -182,8 +181,8 @@ export default function FeedbackDialog(): React.JSX.Element {
   return (
     <Dialog
       open={isOpen}
-      // eslint-disable-next-line react/jsx-no-bind -- this is a simple fn.
-      onOpenChange={(shouldOpen) => (shouldOpen ? open() : close())}>
+      // eslint-disable-next-line react/jsx-no-bind -- simple dialog close handler
+      onOpenChange={(nextOpen) => { if (!nextOpen) close(); }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
           <DialogTitle>{t("title")}</DialogTitle>

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/FeedbackDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/FeedbackDialog.tsx
@@ -72,7 +72,8 @@ export default function FeedbackDialog(): React.JSX.Element {
     close,
   } = useDialog("EDIT_INVOICE__FEEDBACK");
 
-  const {invoice, merchant} = payload as {invoice: Invoice; merchant: Merchant | null};
+  const invoice: Invoice | null = payload?.invoice ?? null;
+  const merchant: Merchant | null = payload?.merchant ?? null;
   const features = [
     t("features.spendingTrends"),
     t("features.priceComparisons"),
@@ -104,6 +105,10 @@ export default function FeedbackDialog(): React.JSX.Element {
   const handleSubmit = useCallback(
     async (e: React.SubmitEvent) => {
       e.preventDefault();
+
+      if (!invoice) {
+        return;
+      }
 
       // Show loading toast
       const loadingToast = toast(t("toasts.sending.title"), {
@@ -157,7 +162,7 @@ export default function FeedbackDialog(): React.JSX.Element {
         close();
       }
     },
-    [feedback, invoice.id, rating, selectedFeatures, close, t],
+    [feedback, invoice, rating, selectedFeatures, close, t],
   );
 
   const handleToggleFeature = useCallback((e: React.MouseEvent<HTMLElement>) => {
@@ -171,6 +176,8 @@ export default function FeedbackDialog(): React.JSX.Element {
   const handleFeedbackChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setFeedback(e.target.value);
   }, []);
+
+  if (!invoice) return <></>;
 
   return (
     <Dialog

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/FeedbackDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/FeedbackDialog.tsx
@@ -182,7 +182,9 @@ export default function FeedbackDialog(): React.JSX.Element {
     <Dialog
       open={isOpen}
       // eslint-disable-next-line react/jsx-no-bind -- simple dialog close handler
-      onOpenChange={(shouldOpen) => { if (!shouldOpen) close(); }}>
+      onOpenChange={(shouldOpen) => {
+        if (!shouldOpen) close();
+      }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
           <DialogTitle>{t("title")}</DialogTitle>

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/FeedbackDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/FeedbackDialog.tsx
@@ -1,4 +1,4 @@
-﻿"use client";
+"use client";
 
 import type {Invoice, Merchant} from "@/types/invoices";
 import {
@@ -182,7 +182,7 @@ export default function FeedbackDialog(): React.JSX.Element {
     <Dialog
       open={isOpen}
       // eslint-disable-next-line react/jsx-no-bind -- simple dialog close handler
-      onOpenChange={(nextOpen) => { if (!nextOpen) close(); }}>
+      onOpenChange={(shouldOpen) => { if (!shouldOpen) close(); }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
           <DialogTitle>{t("title")}</DialogTitle>

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/FeedbackDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/FeedbackDialog.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import type {Invoice, Merchant} from "@/types/invoices";
 import {
   Badge,
   Button,
@@ -71,8 +70,7 @@ export default function FeedbackDialog(): React.JSX.Element {
     close,
   } = useDialog("EDIT_INVOICE__FEEDBACK");
 
-  const invoice: Invoice | null = payload?.invoice ?? null;
-  const merchant: Merchant | null = payload?.merchant ?? null;
+  const {invoice, merchant} = payload;
   const features = [
     t("features.spendingTrends"),
     t("features.priceComparisons"),
@@ -104,10 +102,6 @@ export default function FeedbackDialog(): React.JSX.Element {
   const handleSubmit = useCallback(
     async (e: React.SubmitEvent) => {
       e.preventDefault();
-
-      if (!invoice) {
-        return;
-      }
 
       // Show loading toast
       const loadingToast = toast(t("toasts.sending.title"), {
@@ -175,8 +169,6 @@ export default function FeedbackDialog(): React.JSX.Element {
   const handleFeedbackChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setFeedback(e.target.value);
   }, []);
-
-  if (!invoice) return <></>;
 
   return (
     <Dialog

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/ImageDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/ImageDialog.tsx
@@ -53,7 +53,9 @@ export default function ImageDialog(): React.JSX.Element {
     <Dialog
       open={isOpen}
       // eslint-disable-next-line react/jsx-no-bind -- simple dialog close handler
-      onOpenChange={(shouldOpen) => { if (!shouldOpen) close(); }}>
+      onOpenChange={(shouldOpen) => {
+        if (!shouldOpen) close();
+      }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
           <DialogTitle>{t("title", {image})}</DialogTitle>

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/ImageDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/ImageDialog.tsx
@@ -1,4 +1,4 @@
-import {Dialog, DialogContent, DialogHeader, DialogTitle} from "@arolariu/components";
+﻿import {Dialog, DialogContent, DialogHeader, DialogTitle} from "@arolariu/components";
 import {useTranslations} from "next-intl";
 import Image from "next/image";
 import {useDialog} from "../../../../_contexts/DialogContext";
@@ -42,7 +42,6 @@ export default function ImageDialog(): React.JSX.Element {
   const {
     currentDialog: {payload},
     isOpen,
-    open,
     close,
   } = useDialog("EDIT_INVOICE__IMAGE");
 
@@ -53,8 +52,8 @@ export default function ImageDialog(): React.JSX.Element {
   return (
     <Dialog
       open={isOpen}
-      // eslint-disable-next-line react/jsx-no-bind -- this is a simple fn.
-      onOpenChange={(shouldOpen) => (shouldOpen ? open() : close())}>
+      // eslint-disable-next-line react/jsx-no-bind -- simple dialog close handler
+      onOpenChange={(nextOpen) => { if (!nextOpen) close(); }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
           <DialogTitle>{t("title", {image})}</DialogTitle>

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/ImageDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/ImageDialog.tsx
@@ -1,4 +1,4 @@
-﻿import {Dialog, DialogContent, DialogHeader, DialogTitle} from "@arolariu/components";
+import {Dialog, DialogContent, DialogHeader, DialogTitle} from "@arolariu/components";
 import {useTranslations} from "next-intl";
 import Image from "next/image";
 import {useDialog} from "../../../../_contexts/DialogContext";
@@ -53,7 +53,7 @@ export default function ImageDialog(): React.JSX.Element {
     <Dialog
       open={isOpen}
       // eslint-disable-next-line react/jsx-no-bind -- simple dialog close handler
-      onOpenChange={(nextOpen) => { if (!nextOpen) close(); }}>
+      onOpenChange={(shouldOpen) => { if (!shouldOpen) close(); }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
           <DialogTitle>{t("title", {image})}</DialogTitle>

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/ImageDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/ImageDialog.tsx
@@ -46,7 +46,9 @@ export default function ImageDialog(): React.JSX.Element {
     close,
   } = useDialog("EDIT_INVOICE__IMAGE");
 
-  const image = payload as string;
+  const image: string | null = payload;
+
+  if (!image) return <></>;
 
   return (
     <Dialog

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/ItemsDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/ItemsDialog.tsx
@@ -1,4 +1,4 @@
-"use client";
+﻿"use client";
 
 import {usePaginationWithSearch} from "@/hooks";
 import {Invoice, Product, ProductCategory} from "@/types/invoices";
@@ -73,7 +73,6 @@ export default function ItemsDialog(): React.JSX.Element {
   const {
     currentDialog: {payload},
     isOpen,
-    open,
     close,
   } = useDialog("EDIT_INVOICE__ITEMS");
 
@@ -172,8 +171,8 @@ export default function ItemsDialog(): React.JSX.Element {
   return (
     <Dialog
       open={isOpen}
-      // eslint-disable-next-line react/jsx-no-bind -- this is a simple fn.
-      onOpenChange={(shouldOpen) => (shouldOpen ? open() : close())}>
+      // eslint-disable-next-line react/jsx-no-bind -- simple dialog close handler
+      onOpenChange={(nextOpen) => { if (!nextOpen) close(); }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
           <DialogTitle>{t("title")}</DialogTitle>

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/ItemsDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/ItemsDialog.tsx
@@ -172,7 +172,9 @@ export default function ItemsDialog(): React.JSX.Element {
     <Dialog
       open={isOpen}
       // eslint-disable-next-line react/jsx-no-bind -- simple dialog close handler
-      onOpenChange={(shouldOpen) => { if (!shouldOpen) close(); }}>
+      onOpenChange={(shouldOpen) => {
+        if (!shouldOpen) close();
+      }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
           <DialogTitle>{t("title")}</DialogTitle>

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/ItemsDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/ItemsDialog.tsx
@@ -20,7 +20,7 @@ import {
   TableRow,
 } from "@arolariu/components";
 import {useTranslations} from "next-intl";
-import {useCallback, useState} from "react";
+import {useCallback, useEffect, useState} from "react";
 import {TbDisc, TbPlus, TbTrash} from "react-icons/tb";
 import {useDialog} from "../../../../_contexts/DialogContext";
 import styles from "./ItemsDialog.module.scss";
@@ -77,12 +77,17 @@ export default function ItemsDialog(): React.JSX.Element {
     close,
   } = useDialog("EDIT_INVOICE__ITEMS");
 
-  const {items} = payload as Invoice;
+  const invoice: Invoice | null = payload;
+  const items = invoice?.items ?? [];
 
-  const [editableItems, setEditableItems] = useState<Product[]>(items || []);
+  const [editableItems, setEditableItems] = useState<Product[]>(items);
   const {currentPage, setCurrentPage, totalPages, paginatedItems, pageSize} = usePaginationWithSearch<Product>({
     items: editableItems,
   });
+
+  useEffect(() => {
+    setEditableItems(invoice?.items ?? []);
+  }, [invoice]);
 
   const handleSaveChanges = useCallback(() => {
     // TODO: Implement save functionality
@@ -161,6 +166,8 @@ export default function ItemsDialog(): React.JSX.Element {
     },
     [setEditableItems],
   );
+
+  if (!invoice) return <></>;
 
   return (
     <Dialog

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/ItemsDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/ItemsDialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import {usePaginationWithSearch} from "@/hooks";
-import {Invoice, Product, ProductCategory} from "@/types/invoices";
+import {Product, ProductCategory} from "@/types/invoices";
 import {
   Button,
   Dialog,
@@ -76,8 +76,8 @@ export default function ItemsDialog(): React.JSX.Element {
     close,
   } = useDialog("EDIT_INVOICE__ITEMS");
 
-  const invoice: Invoice | null = payload;
-  const items = invoice?.items ?? [];
+  const invoice = payload;
+  const items = invoice.items;
 
   const [editableItems, setEditableItems] = useState<Product[]>(items);
   const {currentPage, setCurrentPage, totalPages, paginatedItems, pageSize} = usePaginationWithSearch<Product>({
@@ -85,7 +85,7 @@ export default function ItemsDialog(): React.JSX.Element {
   });
 
   useEffect(() => {
-    setEditableItems(invoice?.items ?? []);
+    setEditableItems(invoice.items);
   }, [invoice]);
 
   const handleSaveChanges = useCallback(() => {
@@ -165,8 +165,6 @@ export default function ItemsDialog(): React.JSX.Element {
     },
     [setEditableItems],
   );
-
-  if (!invoice) return <></>;
 
   return (
     <Dialog

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/ItemsDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/ItemsDialog.tsx
@@ -1,4 +1,4 @@
-﻿"use client";
+"use client";
 
 import {usePaginationWithSearch} from "@/hooks";
 import {Invoice, Product, ProductCategory} from "@/types/invoices";
@@ -172,7 +172,7 @@ export default function ItemsDialog(): React.JSX.Element {
     <Dialog
       open={isOpen}
       // eslint-disable-next-line react/jsx-no-bind -- simple dialog close handler
-      onOpenChange={(nextOpen) => { if (!nextOpen) close(); }}>
+      onOpenChange={(shouldOpen) => { if (!shouldOpen) close(); }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
           <DialogTitle>{t("title")}</DialogTitle>

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/MerchantDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/MerchantDialog.tsx
@@ -1,4 +1,4 @@
-﻿import {formatEnum} from "@/lib/utils.generic";
+import {formatEnum} from "@/lib/utils.generic";
 import {type Merchant, MerchantCategory} from "@/types/invoices";
 import {
   Badge,
@@ -73,7 +73,7 @@ export default function MerchantDialog(): React.JSX.Element {
       <Dialog
         open={isOpen}
         // eslint-disable-next-line react/jsx-no-bind -- simple dialog close handler
-        onOpenChange={(nextOpen) => { if (!nextOpen) close(); }}>
+        onOpenChange={(shouldOpen) => { if (!shouldOpen) close(); }}>
         <DialogContent className={styles["dialogContent"]}>
           <DialogHeader className={styles["dialogHeader"]}>
             <DialogTitle>{t("title")}</DialogTitle>
@@ -90,7 +90,7 @@ export default function MerchantDialog(): React.JSX.Element {
     <Dialog
       open={isOpen}
       // eslint-disable-next-line react/jsx-no-bind -- simple dialog close handler
-      onOpenChange={(nextOpen) => { if (!nextOpen) close(); }}>
+      onOpenChange={(shouldOpen) => { if (!shouldOpen) close(); }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader className={styles["dialogHeader"]}>
           <DialogTitle>{t("title")}</DialogTitle>

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/MerchantDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/MerchantDialog.tsx
@@ -73,7 +73,9 @@ export default function MerchantDialog(): React.JSX.Element {
       <Dialog
         open={isOpen}
         // eslint-disable-next-line react/jsx-no-bind -- simple dialog close handler
-        onOpenChange={(shouldOpen) => { if (!shouldOpen) close(); }}>
+        onOpenChange={(shouldOpen) => {
+          if (!shouldOpen) close();
+        }}>
         <DialogContent className={styles["dialogContent"]}>
           <DialogHeader className={styles["dialogHeader"]}>
             <DialogTitle>{t("title")}</DialogTitle>
@@ -90,7 +92,9 @@ export default function MerchantDialog(): React.JSX.Element {
     <Dialog
       open={isOpen}
       // eslint-disable-next-line react/jsx-no-bind -- simple dialog close handler
-      onOpenChange={(shouldOpen) => { if (!shouldOpen) close(); }}>
+      onOpenChange={(shouldOpen) => {
+        if (!shouldOpen) close();
+      }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader className={styles["dialogHeader"]}>
           <DialogTitle>{t("title")}</DialogTitle>

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/MerchantDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/MerchantDialog.tsx
@@ -1,4 +1,4 @@
-import {formatEnum} from "@/lib/utils.generic";
+﻿import {formatEnum} from "@/lib/utils.generic";
 import {type Merchant, MerchantCategory} from "@/types/invoices";
 import {
   Badge,
@@ -62,7 +62,6 @@ export default function MerchantDialog(): React.JSX.Element {
   const {
     currentDialog: {payload},
     isOpen,
-    open,
     close,
   } = useDialog("EDIT_INVOICE__MERCHANT");
 
@@ -73,8 +72,8 @@ export default function MerchantDialog(): React.JSX.Element {
     return (
       <Dialog
         open={isOpen}
-        // eslint-disable-next-line react/jsx-no-bind -- this is a simple fn.
-        onOpenChange={(shouldOpen) => (shouldOpen ? open() : close())}>
+        // eslint-disable-next-line react/jsx-no-bind -- simple dialog close handler
+        onOpenChange={(nextOpen) => { if (!nextOpen) close(); }}>
         <DialogContent className={styles["dialogContent"]}>
           <DialogHeader className={styles["dialogHeader"]}>
             <DialogTitle>{t("title")}</DialogTitle>
@@ -90,8 +89,8 @@ export default function MerchantDialog(): React.JSX.Element {
   return (
     <Dialog
       open={isOpen}
-      // eslint-disable-next-line react/jsx-no-bind -- this is a simple fn.
-      onOpenChange={(shouldOpen) => (shouldOpen ? open() : close())}>
+      // eslint-disable-next-line react/jsx-no-bind -- simple dialog close handler
+      onOpenChange={(nextOpen) => { if (!nextOpen) close(); }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader className={styles["dialogHeader"]}>
           <DialogTitle>{t("title")}</DialogTitle>

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/MerchantDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/MerchantDialog.tsx
@@ -66,7 +66,7 @@ export default function MerchantDialog(): React.JSX.Element {
     close,
   } = useDialog("EDIT_INVOICE__MERCHANT");
 
-  const merchant = payload as Merchant | null;
+  const merchant: Merchant | null = payload;
 
   // Early return if merchant is null
   if (!merchant) {

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/MerchantDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/MerchantDialog.tsx
@@ -65,27 +65,7 @@ export default function MerchantDialog(): React.JSX.Element {
     close,
   } = useDialog("EDIT_INVOICE__MERCHANT");
 
-  const merchant: Merchant | null = payload;
-
-  // Early return if merchant is null
-  if (!merchant) {
-    return (
-      <Dialog
-        open={isOpen}
-        // eslint-disable-next-line react/jsx-no-bind -- simple dialog close handler
-        onOpenChange={(shouldOpen) => {
-          if (!shouldOpen) close();
-        }}>
-        <DialogContent className={styles["dialogContent"]}>
-          <DialogHeader className={styles["dialogHeader"]}>
-            <DialogTitle>{t("title")}</DialogTitle>
-            <DialogDescription>{t("noMerchantLinked")}</DialogDescription>
-          </DialogHeader>
-        </DialogContent>
-      </Dialog>
-    );
-  }
-
+  const merchant = payload;
   const merchantCategoryAsString = formatEnum(MerchantCategory, merchant.category) || "NOT_DEFINED";
 
   return (

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/MerchantReceiptsDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/MerchantReceiptsDialog.tsx
@@ -118,7 +118,9 @@ export default function MerchantReceiptsDialog(): React.JSX.Element {
     <Dialog
       open={isOpen}
       // eslint-disable-next-line react/jsx-no-bind -- simple dialog close handler
-      onOpenChange={(shouldOpen) => { if (!shouldOpen) close(); }}>
+      onOpenChange={(shouldOpen) => {
+        if (!shouldOpen) close();
+      }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
           <DialogTitle>{t("title", {merchant: merchant?.name ?? ""})}</DialogTitle>

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/MerchantReceiptsDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/MerchantReceiptsDialog.tsx
@@ -84,7 +84,7 @@ export default function MerchantReceiptsDialog(): React.JSX.Element {
     open,
     close,
   } = useDialog("EDIT_INVOICE__MERCHANT_INVOICES");
-  const merchant = payload as Merchant | null;
+  const merchant: Merchant | null = payload;
 
   const [searchQuery, setSearchQuery] = useState<string>("");
   const [receipts, setReceipts] = useState<Invoice[]>([]);

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/MerchantReceiptsDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/MerchantReceiptsDialog.tsx
@@ -1,4 +1,4 @@
-"use client";
+﻿"use client";
 
 // TODO: refactor.
 /* eslint-disable no-console -- TODO: replace console.log with proper logging */
@@ -81,7 +81,6 @@ export default function MerchantReceiptsDialog(): React.JSX.Element {
   const {
     currentDialog: {payload},
     isOpen,
-    open,
     close,
   } = useDialog("EDIT_INVOICE__MERCHANT_INVOICES");
   const merchant: Merchant | null = payload;
@@ -118,8 +117,8 @@ export default function MerchantReceiptsDialog(): React.JSX.Element {
   return (
     <Dialog
       open={isOpen}
-      // eslint-disable-next-line react/jsx-no-bind -- this is a simple fn.
-      onOpenChange={(shouldOpen) => (shouldOpen ? open() : close())}>
+      // eslint-disable-next-line react/jsx-no-bind -- simple dialog close handler
+      onOpenChange={(nextOpen) => { if (!nextOpen) close(); }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
           <DialogTitle>{t("title", {merchant: merchant?.name ?? ""})}</DialogTitle>

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/MerchantReceiptsDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/MerchantReceiptsDialog.tsx
@@ -1,4 +1,4 @@
-﻿"use client";
+"use client";
 
 // TODO: refactor.
 /* eslint-disable no-console -- TODO: replace console.log with proper logging */
@@ -118,7 +118,7 @@ export default function MerchantReceiptsDialog(): React.JSX.Element {
     <Dialog
       open={isOpen}
       // eslint-disable-next-line react/jsx-no-bind -- simple dialog close handler
-      onOpenChange={(nextOpen) => { if (!nextOpen) close(); }}>
+      onOpenChange={(shouldOpen) => { if (!shouldOpen) close(); }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
           <DialogTitle>{t("title", {merchant: merchant?.name ?? ""})}</DialogTitle>

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/MerchantReceiptsDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/MerchantReceiptsDialog.tsx
@@ -83,7 +83,7 @@ export default function MerchantReceiptsDialog(): React.JSX.Element {
     isOpen,
     close,
   } = useDialog("EDIT_INVOICE__MERCHANT_INVOICES");
-  const merchant: Merchant | null = payload;
+  const merchant = payload;
 
   const [searchQuery, setSearchQuery] = useState<string>("");
   const [receipts, setReceipts] = useState<Invoice[]>([]);
@@ -123,7 +123,7 @@ export default function MerchantReceiptsDialog(): React.JSX.Element {
       }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
-          <DialogTitle>{t("title", {merchant: merchant?.name ?? ""})}</DialogTitle>
+          <DialogTitle>{t("title", {merchant: merchant.name})}</DialogTitle>
           <DialogDescription>{t("description")}</DialogDescription>
         </DialogHeader>
 

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/MetadataDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/MetadataDialog.tsx
@@ -1,4 +1,4 @@
-"use client";
+﻿"use client";
 
 import {
   Button,
@@ -32,7 +32,7 @@ export const VALID_METADATA_KEYS = [
 
 const AddDialog = () => {
   const t = useTranslations("IMS--Dialogs.metadataDialog");
-  const {isOpen, open, close} = useDialog("EDIT_INVOICE__METADATA");
+  const {isOpen, close} = useDialog("EDIT_INVOICE__METADATA");
   const [addedMetadata, setAddedMetadata] = useState<{key: string; value: string}>({
     key: "",
     value: "",
@@ -55,8 +55,8 @@ const AddDialog = () => {
   return (
     <Dialog
       open={isOpen}
-      // eslint-disable-next-line react/jsx-no-bind -- this is a simple fn.
-      onOpenChange={(shouldOpen) => (shouldOpen ? open() : close())}>
+      // eslint-disable-next-line react/jsx-no-bind -- simple dialog close handler
+      onOpenChange={(nextOpen) => { if (!nextOpen) close(); }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
           <DialogTitle>{t("add.title")}</DialogTitle>
@@ -108,7 +108,7 @@ const AddDialog = () => {
 
 const UpdateDialog = ({metadata}: Readonly<{metadata: Record<string, string>}>) => {
   const t = useTranslations("IMS--Dialogs.metadataDialog");
-  const {isOpen, open, close} = useDialog("EDIT_INVOICE__METADATA");
+  const {isOpen, close} = useDialog("EDIT_INVOICE__METADATA");
   const [editedMetadata, setEditedMetadata] = useState<Record<string, string>>(metadata);
 
   const handleChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
@@ -124,8 +124,8 @@ const UpdateDialog = ({metadata}: Readonly<{metadata: Record<string, string>}>) 
   return (
     <Dialog
       open={isOpen}
-      // eslint-disable-next-line react/jsx-no-bind -- this is a simple fn.
-      onOpenChange={(shouldOpen) => (shouldOpen ? open() : close())}>
+      // eslint-disable-next-line react/jsx-no-bind -- simple dialog close handler
+      onOpenChange={(nextOpen) => { if (!nextOpen) close(); }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
           <DialogTitle>{t("edit.title")}</DialogTitle>
@@ -174,7 +174,7 @@ const UpdateDialog = ({metadata}: Readonly<{metadata: Record<string, string>}>) 
 
 const DeleteDialog = ({metadata}: Readonly<{metadata: Record<string, string>}>) => {
   const t = useTranslations("IMS--Dialogs.metadataDialog");
-  const {isOpen, open, close} = useDialog("EDIT_INVOICE__METADATA");
+  const {isOpen, close} = useDialog("EDIT_INVOICE__METADATA");
 
   const handleDelete = useCallback(() => {
     // Delete the metadata
@@ -185,8 +185,8 @@ const DeleteDialog = ({metadata}: Readonly<{metadata: Record<string, string>}>) 
   return (
     <Dialog
       open={isOpen}
-      // eslint-disable-next-line react/jsx-no-bind -- this is a simple fn.
-      onOpenChange={(shouldOpen) => (shouldOpen ? open() : close())}>
+      // eslint-disable-next-line react/jsx-no-bind -- simple dialog close handler
+      onOpenChange={(nextOpen) => { if (!nextOpen) close(); }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
           <DialogTitle>{t("delete.title")}</DialogTitle>

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/MetadataDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/MetadataDialog.tsx
@@ -1,4 +1,4 @@
-﻿"use client";
+"use client";
 
 import {
   Button,
@@ -56,7 +56,7 @@ const AddDialog = () => {
     <Dialog
       open={isOpen}
       // eslint-disable-next-line react/jsx-no-bind -- simple dialog close handler
-      onOpenChange={(nextOpen) => { if (!nextOpen) close(); }}>
+      onOpenChange={(shouldOpen) => { if (!shouldOpen) close(); }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
           <DialogTitle>{t("add.title")}</DialogTitle>
@@ -125,7 +125,7 @@ const UpdateDialog = ({metadata}: Readonly<{metadata: Record<string, string>}>) 
     <Dialog
       open={isOpen}
       // eslint-disable-next-line react/jsx-no-bind -- simple dialog close handler
-      onOpenChange={(nextOpen) => { if (!nextOpen) close(); }}>
+      onOpenChange={(shouldOpen) => { if (!shouldOpen) close(); }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
           <DialogTitle>{t("edit.title")}</DialogTitle>
@@ -186,7 +186,7 @@ const DeleteDialog = ({metadata}: Readonly<{metadata: Record<string, string>}>) 
     <Dialog
       open={isOpen}
       // eslint-disable-next-line react/jsx-no-bind -- simple dialog close handler
-      onOpenChange={(nextOpen) => { if (!nextOpen) close(); }}>
+      onOpenChange={(shouldOpen) => { if (!shouldOpen) close(); }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
           <DialogTitle>{t("delete.title")}</DialogTitle>

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/MetadataDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/MetadataDialog.tsx
@@ -56,7 +56,9 @@ const AddDialog = () => {
     <Dialog
       open={isOpen}
       // eslint-disable-next-line react/jsx-no-bind -- simple dialog close handler
-      onOpenChange={(shouldOpen) => { if (!shouldOpen) close(); }}>
+      onOpenChange={(shouldOpen) => {
+        if (!shouldOpen) close();
+      }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
           <DialogTitle>{t("add.title")}</DialogTitle>
@@ -125,7 +127,9 @@ const UpdateDialog = ({metadata}: Readonly<{metadata: Record<string, string>}>) 
     <Dialog
       open={isOpen}
       // eslint-disable-next-line react/jsx-no-bind -- simple dialog close handler
-      onOpenChange={(shouldOpen) => { if (!shouldOpen) close(); }}>
+      onOpenChange={(shouldOpen) => {
+        if (!shouldOpen) close();
+      }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
           <DialogTitle>{t("edit.title")}</DialogTitle>
@@ -186,7 +190,9 @@ const DeleteDialog = ({metadata}: Readonly<{metadata: Record<string, string>}>) 
     <Dialog
       open={isOpen}
       // eslint-disable-next-line react/jsx-no-bind -- simple dialog close handler
-      onOpenChange={(shouldOpen) => { if (!shouldOpen) close(); }}>
+      onOpenChange={(shouldOpen) => {
+        if (!shouldOpen) close();
+      }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
           <DialogTitle>{t("delete.title")}</DialogTitle>

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/MetadataDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/MetadataDialog.tsx
@@ -251,15 +251,15 @@ export default function MetadataDialog(): React.JSX.Element | null {
     currentDialog: {mode, payload},
   } = useDialog("EDIT_INVOICE__METADATA");
 
-  const metadata = payload as Record<string, string>;
+  const metadata: Record<string, string> | null = payload;
 
   switch (mode) {
     case "add":
       return <AddDialog />;
     case "delete":
-      return <DeleteDialog metadata={metadata} />;
+      return metadata ? <DeleteDialog metadata={metadata} /> : null;
     case "edit":
-      return <UpdateDialog metadata={metadata} />;
+      return metadata ? <UpdateDialog metadata={metadata} /> : null;
     default:
       return null;
   }

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/RecipeDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/RecipeDialog.tsx
@@ -742,17 +742,17 @@ export default function RecipeDialog(): React.JSX.Element {
     currentDialog: {mode, payload},
   } = useDialog("EDIT_INVOICE__RECIPE");
 
-  const recipe = payload as Recipe;
+  const recipe: Recipe | null = payload;
 
   switch (mode) {
     case "add":
       return <CreateDialog />;
     case "delete":
-      return <DeleteDialog recipe={recipe} />;
+      return recipe ? <DeleteDialog recipe={recipe} /> : <></>;
     case "edit":
-      return <UpdateDialog recipe={recipe} />;
+      return recipe ? <UpdateDialog recipe={recipe} /> : <></>;
     case "view":
-      return <ReadDialog recipe={recipe} />;
+      return recipe ? <ReadDialog recipe={recipe} /> : <></>;
     default:
       return <></>;
   }

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/RecipeDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/RecipeDialog.tsx
@@ -138,7 +138,9 @@ const CreateDialog = () => {
   return (
     <Dialog
       open={isOpen}
-      onOpenChange={(shouldOpen) => { if (!shouldOpen) close(); }}>
+      onOpenChange={(shouldOpen) => {
+        if (!shouldOpen) close();
+      }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
           <DialogTitle>{t("create.title")}</DialogTitle>
@@ -366,7 +368,9 @@ const ReadDialog = ({recipe}: Readonly<{recipe: Recipe}>) => {
     <Dialog
       open={isOpen}
       // eslint-disable-next-line react/jsx-no-bind -- simple dialog close handler
-      onOpenChange={(shouldOpen) => { if (!shouldOpen) close(); }}>
+      onOpenChange={(shouldOpen) => {
+        if (!shouldOpen) close();
+      }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
           <DialogTitle>{recipe.name}</DialogTitle>
@@ -458,7 +462,9 @@ const UpdateDialog = ({recipe}: Readonly<{recipe: Recipe}>) => {
     <Dialog
       open={isOpen}
       // eslint-disable-next-line react/jsx-no-bind -- simple dialog close handler
-      onOpenChange={(shouldOpen) => { if (!shouldOpen) close(); }}>
+      onOpenChange={(shouldOpen) => {
+        if (!shouldOpen) close();
+      }}>
       <DialogContent className={styles["dialogContentWide"]}>
         <DialogHeader>
           <DialogTitle>{t("update.title")}</DialogTitle>
@@ -673,7 +679,9 @@ const DeleteDialog = ({recipe}: Readonly<{recipe: Recipe}>) => {
     <AlertDialog
       open={isOpen}
       // eslint-disable-next-line react/jsx-no-bind -- simple dialog close handler
-      onOpenChange={(shouldOpen) => { if (!shouldOpen) close(); }}>
+      onOpenChange={(shouldOpen) => {
+        if (!shouldOpen) close();
+      }}>
       <AlertDialogContent>
         <AlertDialogHeader>
           <AlertDialogTitle>{t("delete.title")}</AlertDialogTitle>

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/RecipeDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/RecipeDialog.tsx
@@ -1,4 +1,4 @@
-"use client";
+﻿"use client";
 
 // TODO: refactor.
 /* eslint-disable no-console -- TODO: replace console.log with proper logging */
@@ -72,7 +72,7 @@ const CreateDialog = () => {
   const t = useTranslations("IMS--Dialogs.recipeDialog");
   const {invoice} = useEditInvoiceContext();
   const router = useRouter();
-  const {isOpen, open, close} = useDialog("EDIT_INVOICE__RECIPE");
+  const {isOpen, close} = useDialog("EDIT_INVOICE__RECIPE");
   const [recipe, setRecipe] = useState<Recipe>({
     name: "",
     description: "",
@@ -138,7 +138,7 @@ const CreateDialog = () => {
   return (
     <Dialog
       open={isOpen}
-      onOpenChange={(shouldOpen) => (shouldOpen ? open() : close())}>
+      onOpenChange={(nextOpen) => { if (!nextOpen) close(); }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
           <DialogTitle>{t("create.title")}</DialogTitle>
@@ -360,13 +360,13 @@ const CreateDialog = () => {
 
 const ReadDialog = ({recipe}: Readonly<{recipe: Recipe}>) => {
   const t = useTranslations("IMS--Dialogs.recipeDialog");
-  const {isOpen, open, close} = useDialog("EDIT_INVOICE__RECIPE");
+  const {isOpen, close} = useDialog("EDIT_INVOICE__RECIPE");
 
   return (
     <Dialog
       open={isOpen}
-      // eslint-disable-next-line react/jsx-no-bind -- this is a simple fn.
-      onOpenChange={(shouldOpen) => (shouldOpen ? open() : close())}>
+      // eslint-disable-next-line react/jsx-no-bind -- simple dialog close handler
+      onOpenChange={(nextOpen) => { if (!nextOpen) close(); }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
           <DialogTitle>{recipe.name}</DialogTitle>
@@ -438,7 +438,7 @@ const ReadDialog = ({recipe}: Readonly<{recipe: Recipe}>) => {
 
 const UpdateDialog = ({recipe}: Readonly<{recipe: Recipe}>) => {
   const t = useTranslations("IMS--Dialogs.recipeDialog");
-  const {isOpen, open, close} = useDialog("EDIT_INVOICE__RECIPE");
+  const {isOpen, close} = useDialog("EDIT_INVOICE__RECIPE");
 
   const [recipeDetails, setRecipeDetails] = useState<Recipe>(recipe);
 
@@ -457,8 +457,8 @@ const UpdateDialog = ({recipe}: Readonly<{recipe: Recipe}>) => {
   return (
     <Dialog
       open={isOpen}
-      // eslint-disable-next-line react/jsx-no-bind -- this is a simple fn.
-      onOpenChange={(shouldOpen) => (shouldOpen ? open() : close())}>
+      // eslint-disable-next-line react/jsx-no-bind -- simple dialog close handler
+      onOpenChange={(nextOpen) => { if (!nextOpen) close(); }}>
       <DialogContent className={styles["dialogContentWide"]}>
         <DialogHeader>
           <DialogTitle>{t("update.title")}</DialogTitle>
@@ -665,15 +665,15 @@ const UpdateDialog = ({recipe}: Readonly<{recipe: Recipe}>) => {
 
 const DeleteDialog = ({recipe}: Readonly<{recipe: Recipe}>) => {
   const t = useTranslations("IMS--Dialogs.recipeDialog");
-  const {isOpen, open, close} = useDialog("EDIT_INVOICE__RECIPE");
+  const {isOpen, close} = useDialog("EDIT_INVOICE__RECIPE");
 
   const handleDelete = useCallback(() => {}, []);
 
   return (
     <AlertDialog
       open={isOpen}
-      // eslint-disable-next-line react/jsx-no-bind -- this is a simple fn.
-      onOpenChange={(shouldOpen) => (shouldOpen ? open() : close())}>
+      // eslint-disable-next-line react/jsx-no-bind -- simple dialog close handler
+      onOpenChange={(nextOpen) => { if (!nextOpen) close(); }}>
       <AlertDialogContent>
         <AlertDialogHeader>
           <AlertDialogTitle>{t("delete.title")}</AlertDialogTitle>

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/RecipeDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/RecipeDialog.tsx
@@ -1,4 +1,4 @@
-﻿"use client";
+"use client";
 
 // TODO: refactor.
 /* eslint-disable no-console -- TODO: replace console.log with proper logging */
@@ -138,7 +138,7 @@ const CreateDialog = () => {
   return (
     <Dialog
       open={isOpen}
-      onOpenChange={(nextOpen) => { if (!nextOpen) close(); }}>
+      onOpenChange={(shouldOpen) => { if (!shouldOpen) close(); }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
           <DialogTitle>{t("create.title")}</DialogTitle>
@@ -366,7 +366,7 @@ const ReadDialog = ({recipe}: Readonly<{recipe: Recipe}>) => {
     <Dialog
       open={isOpen}
       // eslint-disable-next-line react/jsx-no-bind -- simple dialog close handler
-      onOpenChange={(nextOpen) => { if (!nextOpen) close(); }}>
+      onOpenChange={(shouldOpen) => { if (!shouldOpen) close(); }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
           <DialogTitle>{recipe.name}</DialogTitle>
@@ -458,7 +458,7 @@ const UpdateDialog = ({recipe}: Readonly<{recipe: Recipe}>) => {
     <Dialog
       open={isOpen}
       // eslint-disable-next-line react/jsx-no-bind -- simple dialog close handler
-      onOpenChange={(nextOpen) => { if (!nextOpen) close(); }}>
+      onOpenChange={(shouldOpen) => { if (!shouldOpen) close(); }}>
       <DialogContent className={styles["dialogContentWide"]}>
         <DialogHeader>
           <DialogTitle>{t("update.title")}</DialogTitle>
@@ -673,7 +673,7 @@ const DeleteDialog = ({recipe}: Readonly<{recipe: Recipe}>) => {
     <AlertDialog
       open={isOpen}
       // eslint-disable-next-line react/jsx-no-bind -- simple dialog close handler
-      onOpenChange={(nextOpen) => { if (!nextOpen) close(); }}>
+      onOpenChange={(shouldOpen) => { if (!shouldOpen) close(); }}>
       <AlertDialogContent>
         <AlertDialogHeader>
           <AlertDialogTitle>{t("delete.title")}</AlertDialogTitle>

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/RemoveScanDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/RemoveScanDialog.tsx
@@ -12,15 +12,6 @@ import {useDialog} from "../../../../_contexts/DialogContext";
 import styles from "./RemoveScanDialog.module.scss";
 
 /**
- * Payload structure for the remove scan dialog.
- */
-type RemoveScanPayload = {
-  invoice: Invoice;
-  scan: InvoiceScan;
-  scanIndex: number;
-};
-
-/**
  * Dialog for confirming removal of a scan from an invoice.
  *
  * @remarks
@@ -47,15 +38,16 @@ export default function RemoveScanDialog(): React.JSX.Element {
     close,
   } = useDialog("EDIT_INVOICE__SCAN", "delete");
 
-  const data = payload as RemoveScanPayload | null;
-  const invoice = data?.invoice ?? null;
-  const scan = data?.scan ?? null;
-  const scanIndex = data?.scanIndex ?? 0;
+  const data = payload && typeof payload === "object" && "scan" in payload ? payload : null;
+  const invoice: Invoice | null = data?.invoice ?? null;
+  const scan: InvoiceScan | null = data?.scan ?? null;
+  const scanIndex = data?.scanIndex ?? -1;
 
   const [isDeleting, setIsDeleting] = useState(false);
 
   const totalScans = invoice?.scans.length ?? 0;
   const isLastScan = totalScans === 1;
+  const currentScanNumber = scanIndex >= 0 ? scanIndex + 1 : 1;
 
   const handleDelete = useCallback(async () => {
     if (!invoice || !scan) return;
@@ -111,7 +103,7 @@ export default function RemoveScanDialog(): React.JSX.Element {
             {t("title")}
           </DialogTitle>
           <DialogDescription>
-            {isLastScan ? t("descriptionLastScan") : t("description", {current: String(scanIndex + 1), total: String(totalScans)})}
+            {isLastScan ? t("descriptionLastScan") : t("description", {current: String(currentScanNumber), total: String(totalScans)})}
           </DialogDescription>
         </DialogHeader>
 
@@ -120,13 +112,13 @@ export default function RemoveScanDialog(): React.JSX.Element {
             <div className={styles["previewImage"]}>
               <Image
                 src={scan.location}
-                alt={t("scanAlt", {index: String(scanIndex + 1)})}
+                alt={t("scanAlt", {index: String(currentScanNumber)})}
                 width={400}
                 height={300}
                 className={styles["scanPreviewImage"]}
               />
             </div>
-            <p className={styles["previewCaption"]}>{t("scanCaption", {index: String(scanIndex + 1)})}</p>
+            <p className={styles["previewCaption"]}>{t("scanCaption", {index: String(currentScanNumber)})}</p>
           </div>
         ) : null}
 

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/tables/ItemsTable.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/tables/ItemsTable.tsx
@@ -33,7 +33,7 @@ import {motion} from "motion/react";
 import {useLocale, useTranslations} from "next-intl";
 import {useCallback, useMemo, useState} from "react";
 import {TbEdit, TbFlask, TbPencil, TbPlus, TbRefresh, TbSearch, TbTag, TbTrash} from "react-icons/tb";
-import {useDialog} from "../../../../_contexts/DialogContext";
+import {useDialog, useDialogs} from "../../../../_contexts/DialogContext";
 import {useEditInvoiceContext} from "../../_context/EditInvoiceContext";
 import styles from "./ItemsTable.module.scss";
 
@@ -120,8 +120,7 @@ export default function ItemsTable({invoice}: Readonly<Props>) {
   const locale = useLocale();
   const t = useTranslations("IMS--Edit.itemsTable");
   const {open} = useDialog("EDIT_INVOICE__ITEMS", "edit", invoice);
-  const {openWith: openAllergenDialog} = useDialog("EDIT_INVOICE__ALLERGENS");
-  const {openWith: openBulkCategoryDialog} = useDialog("EDIT_INVOICE__BULK_CATEGORY");
+  const {openDialog} = useDialogs();
 
   // Local state for item management
   const [localItems, setLocalItems] = useState<Product[]>(invoice.items);
@@ -447,13 +446,13 @@ export default function ItemsTable({invoice}: Readonly<Props>) {
       const product = localItems[productIndex];
       if (!product) return;
 
-      openAllergenDialog("edit", {
+      openDialog("EDIT_INVOICE__ALLERGENS", "edit", {
         invoice,
         product,
         productIndex,
       });
     },
-    [localItems, invoice, openAllergenDialog],
+    [localItems, invoice, openDialog],
   );
 
   /**
@@ -472,12 +471,12 @@ export default function ItemsTable({invoice}: Readonly<Props>) {
     // Map selected indices from sorted view to actual localItems indices
     const actualIndices = selectedProducts.map((product) => localItems.indexOf(product));
 
-    openBulkCategoryDialog("edit", {
+    openDialog("EDIT_INVOICE__BULK_CATEGORY", "edit", {
       invoice,
       selectedProducts,
       selectedIndices: actualIndices,
     });
-  }, [selectedIndices, sortedItems, localItems, invoice, openBulkCategoryDialog, t]);
+  }, [selectedIndices, sortedItems, localItems, invoice, openDialog, t]);
 
   /**
    * Determines the visual indicator class for a product based on its completeness status.

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/ShareCollaborateCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/ShareCollaborateCard.tsx
@@ -34,7 +34,7 @@ import {Badge, Button, Card, CardContent, CardHeader, CardTitle, Label, Switch, 
 import {useTranslations} from "next-intl";
 import {useCallback, useMemo, useTransition} from "react";
 import {TbLock, TbShare, TbUsers, TbWorld} from "react-icons/tb";
-import {useDialog} from "../../../../_contexts/DialogContext";
+import {useDialogs} from "../../../../_contexts/DialogContext";
 import {useInvoiceContext} from "../../_context/InvoiceContext";
 import styles from "./ShareCollaborateCard.module.scss";
 
@@ -84,7 +84,7 @@ type SharingStatus = "private" | "public" | "shared";
 export function ShareCollaborateCard(): React.JSX.Element {
   const t = useTranslations("IMS--View.shareCollaborate");
   const {invoice, setInvoice} = useInvoiceContext();
-  const {openWith: openShareDialog} = useDialog("SHARED__INVOICE_SHARE");
+  const {openDialog} = useDialogs();
   const [isPending, startTransition] = useTransition();
 
   /**
@@ -207,8 +207,8 @@ export function ShareCollaborateCard(): React.JSX.Element {
    * **Performance:** Memoized with useCallback.
    */
   const handleManageSharing = useCallback((): void => {
-    openShareDialog("share", {invoice});
-  }, [invoice, openShareDialog]);
+    openDialog("SHARED__INVOICE_SHARE", "share", {invoice});
+  }, [invoice, openDialog]);
 
   return (
     <Card>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/dialogs/ShareAnalyticsDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/dialogs/ShareAnalyticsDialog.tsx
@@ -107,17 +107,11 @@ export default function ShareAnalyticsDialog(): React.JSX.Element {
   );
 
   const handleDownloadImage = useCallback(() => {
-    if (!merchant) {
-      return;
-    }
-
     // In a real app, this would generate and download an image
     toast(t("toasts.imageSaved.title"), {
       description: t("toasts.imageSaved.description", {merchant: merchant.name}),
     });
   }, [merchant, t]);
-
-  if (!invoice || !merchant) return <></>;
 
   return (
     <Dialog

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/dialogs/ShareAnalyticsDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/dialogs/ShareAnalyticsDialog.tsx
@@ -123,7 +123,9 @@ export default function ShareAnalyticsDialog(): React.JSX.Element {
     <Dialog
       open={isOpen}
       // eslint-disable-next-line react/jsx-no-bind -- simple dialog close handler
-      onOpenChange={(shouldOpen) => { if (!shouldOpen) close(); }}>
+      onOpenChange={(shouldOpen) => {
+        if (!shouldOpen) close();
+      }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
           <DialogTitle>{t("title")}</DialogTitle>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/dialogs/ShareAnalyticsDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/dialogs/ShareAnalyticsDialog.tsx
@@ -1,4 +1,4 @@
-"use client";
+﻿"use client";
 
 import {useDialog} from "@/app/domains/invoices/_contexts/DialogContext";
 import type {Invoice, Merchant} from "@/types/invoices";
@@ -68,7 +68,6 @@ export default function ShareAnalyticsDialog(): React.JSX.Element {
   const {
     currentDialog: {payload},
     isOpen,
-    open,
     close,
   } = useDialog("VIEW_INVOICE__SHARE_ANALYTICS");
 
@@ -123,8 +122,8 @@ export default function ShareAnalyticsDialog(): React.JSX.Element {
   return (
     <Dialog
       open={isOpen}
-      // eslint-disable-next-line react/jsx-no-bind -- this is a simple fn.
-      onOpenChange={(shouldOpen) => (shouldOpen ? open() : close())}>
+      // eslint-disable-next-line react/jsx-no-bind -- simple dialog close handler
+      onOpenChange={(nextOpen) => { if (!nextOpen) close(); }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
           <DialogTitle>{t("title")}</DialogTitle>
@@ -181,7 +180,7 @@ export default function ShareAnalyticsDialog(): React.JSX.Element {
                   type='email'
                   placeholder={t("email.placeholder")}
                   value={email}
-                  // eslint-disable-next-line react/jsx-no-bind -- this is a simple fn.
+                  // eslint-disable-next-line react/jsx-no-bind -- inline event handler
                   onChange={(e) => setEmail(e.target.value)}
                 />
               </div>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/dialogs/ShareAnalyticsDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/dialogs/ShareAnalyticsDialog.tsx
@@ -72,11 +72,16 @@ export default function ShareAnalyticsDialog(): React.JSX.Element {
     close,
   } = useDialog("VIEW_INVOICE__SHARE_ANALYTICS");
 
-  const {invoice, merchant} = payload as {invoice: Invoice; merchant: Merchant};
+  const invoice: Invoice | null = payload?.invoice ?? null;
+  const merchant: Merchant | null = payload?.merchant ?? null;
 
   const handleCopyImage = useCallback(async () => {
+    if (!invoice || !merchant) {
+      return;
+    }
+
     // Get the image URL from the component
-    const imageUrl = `/placeholder.svg?height=200&width=400&text=Analytics+Preview+for+${merchant?.name ?? ""}/${invoice.id}`;
+    const imageUrl = `/placeholder.svg?height=200&width=400&text=Analytics+Preview+for+${merchant.name}/${invoice.id}`;
 
     // Fetch the image data
     const response = await fetch(imageUrl);
@@ -89,7 +94,7 @@ export default function ShareAnalyticsDialog(): React.JSX.Element {
     toast(t("toasts.imageCopied.title"), {
       description: t("toasts.imageCopied.description"),
     });
-  }, [merchant, invoice, t]);
+  }, [invoice, merchant, t]);
 
   const handleSendEmail = useCallback(
     (e: React.MouseEvent) => {
@@ -103,11 +108,17 @@ export default function ShareAnalyticsDialog(): React.JSX.Element {
   );
 
   const handleDownloadImage = useCallback(() => {
+    if (!merchant) {
+      return;
+    }
+
     // In a real app, this would generate and download an image
     toast(t("toasts.imageSaved.title"), {
-      description: t("toasts.imageSaved.description", {merchant: merchant?.name ?? ""}),
+      description: t("toasts.imageSaved.description", {merchant: merchant.name}),
     });
-  }, [merchant?.name, t]);
+  }, [merchant, t]);
+
+  if (!invoice || !merchant) return <></>;
 
   return (
     <Dialog

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/dialogs/ShareAnalyticsDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/dialogs/ShareAnalyticsDialog.tsx
@@ -1,4 +1,4 @@
-﻿"use client";
+"use client";
 
 import {useDialog} from "@/app/domains/invoices/_contexts/DialogContext";
 import type {Invoice, Merchant} from "@/types/invoices";
@@ -123,7 +123,7 @@ export default function ShareAnalyticsDialog(): React.JSX.Element {
     <Dialog
       open={isOpen}
       // eslint-disable-next-line react/jsx-no-bind -- simple dialog close handler
-      onOpenChange={(nextOpen) => { if (!nextOpen) close(); }}>
+      onOpenChange={(shouldOpen) => { if (!shouldOpen) close(); }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
           <DialogTitle>{t("title")}</DialogTitle>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/dialogs/ExportDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/dialogs/ExportDialog.tsx
@@ -53,7 +53,7 @@ export default function ExportDialog(): React.JSX.Element {
   const [filename, setFilename] = useState<string>(defaultFilename);
   const [copied, setCopied] = useState<boolean>(false);
 
-  const {isOpen, open, close} = useDialog("VIEW_INVOICES__EXPORT");
+  const {isOpen, close} = useDialog("VIEW_INVOICES__EXPORT");
   const selectedInvoices = useInvoicesStore((state) => state.selectedEntities);
   const allInvoices = useInvoicesStore((state) => state.entities);
   const invoicesToExport = selectedInvoices.length > 0 ? selectedInvoices : allInvoices;
@@ -126,8 +126,8 @@ export default function ExportDialog(): React.JSX.Element {
   return (
     <Dialog
       open={isOpen}
-      // eslint-disable-next-line react/jsx-no-bind -- this is a simple fn.
-      onOpenChange={(shouldOpen) => (shouldOpen ? open() : close())}>
+      // eslint-disable-next-line react/jsx-no-bind -- inline event handler
+      onOpenChange={(nextOpen) => { if (!nextOpen) close(); }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
           <DialogTitle>{t("title")}</DialogTitle>
@@ -142,7 +142,7 @@ export default function ExportDialog(): React.JSX.Element {
               id='filename'
               placeholder={defaultFilename}
               value={filename}
-              // eslint-disable-next-line react/jsx-no-bind -- this is a simple fn.
+              // eslint-disable-next-line react/jsx-no-bind -- inline event handler
               onChange={(e) => setFilename(e.target.value)}
               className={styles["filenameInput"]}
             />
@@ -155,7 +155,7 @@ export default function ExportDialog(): React.JSX.Element {
               <h3 className={styles["sectionTitle"]}>{t("format.title")}</h3>
               <RadioGroup
                 defaultValue={exportOptions.format}
-                // eslint-disable-next-line react/jsx-no-bind -- this is a simple fn.
+                // eslint-disable-next-line react/jsx-no-bind -- inline event handler
                 onValueChange={(format) => handleOptionsChange("format", format as InvoiceExportFormat)}>
                 <div className={styles["radioRow"]}>
                   <RadioGroupItem
@@ -219,7 +219,7 @@ export default function ExportDialog(): React.JSX.Element {
                     nativeButton
                     id='include-metadata'
                     checked={exportOptions.includeMetadata}
-                    // eslint-disable-next-line react/jsx-no-bind -- this is a simple fn.
+                    // eslint-disable-next-line react/jsx-no-bind -- inline event handler
                     onCheckedChange={(checked) => handleOptionsChange("includeMetadata", checked === true)}
                   />
                   <Label htmlFor='include-metadata'>{t("options.includeMetadata")}</Label>
@@ -229,7 +229,7 @@ export default function ExportDialog(): React.JSX.Element {
                     nativeButton
                     id='include-items'
                     checked={exportOptions.includeProducts}
-                    // eslint-disable-next-line react/jsx-no-bind -- this is a simple fn.
+                    // eslint-disable-next-line react/jsx-no-bind -- inline event handler
                     onCheckedChange={(checked) => handleOptionsChange("includeProducts", checked === true)}
                   />
                   <Label htmlFor='include-items'>{t("options.includeProducts")}</Label>
@@ -239,7 +239,7 @@ export default function ExportDialog(): React.JSX.Element {
                     nativeButton
                     id='include-merchant'
                     checked={exportOptions.includeMerchant}
-                    // eslint-disable-next-line react/jsx-no-bind -- this is a simple fn.
+                    // eslint-disable-next-line react/jsx-no-bind -- inline event handler
                     onCheckedChange={(checked) => handleOptionsChange("includeMerchant", checked === true)}
                   />
                   <Label htmlFor='include-merchant'>{t("options.includeMerchant")}</Label>
@@ -254,7 +254,7 @@ export default function ExportDialog(): React.JSX.Element {
                       nativeButton
                       id='csv-include-headers'
                       checked={exportOptions.csvOptions?.includeHeaders ?? false}
-                      // eslint-disable-next-line react/jsx-no-bind -- this is a simple fn.
+                      // eslint-disable-next-line react/jsx-no-bind -- inline event handler
                       onCheckedChange={(checked) =>
                         handleOptionsChange("csvOptions", {
                           delimiter: exportOptions.csvOptions?.delimiter ?? ",",
@@ -271,7 +271,7 @@ export default function ExportDialog(): React.JSX.Element {
                       id='csv-delimiter'
                       placeholder={t("options.csv.delimiterPlaceholder")}
                       value={exportOptions.csvOptions?.delimiter ?? ","}
-                      // eslint-disable-next-line react/jsx-no-bind -- this is a simple fn.
+                      // eslint-disable-next-line react/jsx-no-bind -- inline event handler
                       onChange={(e) =>
                         handleOptionsChange("csvOptions", {
                           delimiter: e.target.value,
@@ -289,7 +289,7 @@ export default function ExportDialog(): React.JSX.Element {
                       nativeButton
                       id='json-pretty-print'
                       checked={exportOptions.jsonOptions?.prettyPrint ?? false}
-                      // eslint-disable-next-line react/jsx-no-bind -- this is a simple fn.
+                      // eslint-disable-next-line react/jsx-no-bind -- inline event handler
                       onCheckedChange={(checked) => handleOptionsChange("jsonOptions", {prettyPrint: checked === true})}
                     />
                     <Label htmlFor='json-pretty-print'>{t("options.json.prettyPrint")}</Label>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/dialogs/ExportDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/dialogs/ExportDialog.tsx
@@ -127,7 +127,7 @@ export default function ExportDialog(): React.JSX.Element {
     <Dialog
       open={isOpen}
       // eslint-disable-next-line react/jsx-no-bind -- inline event handler
-      onOpenChange={(nextOpen) => { if (!nextOpen) close(); }}>
+      onOpenChange={(shouldOpen) => { if (!shouldOpen) close(); }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
           <DialogTitle>{t("title")}</DialogTitle>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/dialogs/ExportDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/dialogs/ExportDialog.tsx
@@ -127,7 +127,9 @@ export default function ExportDialog(): React.JSX.Element {
     <Dialog
       open={isOpen}
       // eslint-disable-next-line react/jsx-no-bind -- inline event handler
-      onOpenChange={(shouldOpen) => { if (!shouldOpen) close(); }}>
+      onOpenChange={(shouldOpen) => {
+        if (!shouldOpen) close();
+      }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
           <DialogTitle>{t("title")}</DialogTitle>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/dialogs/ImportDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/dialogs/ImportDialog.tsx
@@ -116,7 +116,9 @@ export default function ImportDialog(): React.JSX.Element {
     <Dialog
       open={isOpen}
       // eslint-disable-next-line react/jsx-no-bind -- simple dialog close handler
-      onOpenChange={(shouldOpen) => { if (!shouldOpen) close(); }}>
+      onOpenChange={(shouldOpen) => {
+        if (!shouldOpen) close();
+      }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
           <DialogTitle>{t("title")}</DialogTitle>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/dialogs/ImportDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/dialogs/ImportDialog.tsx
@@ -38,7 +38,7 @@ const ACCEPT_TYPES: Record<ImportFileFormat, Accept> = {
 export default function ImportDialog(): React.JSX.Element {
   const t = useTranslations("IMS--Dialogs.importDialog");
   const [files, setFiles] = useState<File[]>([]);
-  const {isOpen, open, close} = useDialog("VIEW_INVOICES__IMPORT");
+  const {isOpen, close} = useDialog("VIEW_INVOICES__IMPORT");
   const [activeTab, setActiveTab] = useState<ImportFileFormat>("csv");
   const [uploadStatus, setUploadStatus] = useState<"idle" | "success" | "error">("idle");
 
@@ -115,8 +115,8 @@ export default function ImportDialog(): React.JSX.Element {
   return (
     <Dialog
       open={isOpen}
-      // eslint-disable-next-line react/jsx-no-bind -- this is a simple fn.
-      onOpenChange={(shouldOpen) => (shouldOpen ? open() : close())}>
+      // eslint-disable-next-line react/jsx-no-bind -- simple dialog close handler
+      onOpenChange={(nextOpen) => { if (!nextOpen) close(); }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
           <DialogTitle>{t("title")}</DialogTitle>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/dialogs/ImportDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/dialogs/ImportDialog.tsx
@@ -116,7 +116,7 @@ export default function ImportDialog(): React.JSX.Element {
     <Dialog
       open={isOpen}
       // eslint-disable-next-line react/jsx-no-bind -- simple dialog close handler
-      onOpenChange={(nextOpen) => { if (!nextOpen) close(); }}>
+      onOpenChange={(shouldOpen) => { if (!shouldOpen) close(); }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
           <DialogTitle>{t("title")}</DialogTitle>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-scans/_components/dialogs/CreateInvoiceDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-scans/_components/dialogs/CreateInvoiceDialog.tsx
@@ -46,11 +46,6 @@ import styles from "./CreateInvoiceDialog.module.scss";
 type CreationMode = "single" | "batch";
 type CreationStep = "select" | "creating" | "complete";
 
-/** Payload type for the dialog */
-interface CreateInvoicePayload {
-  selectedScans: CachedScan[];
-}
-
 /** Formats file size in human-readable format */
 function formatFileSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
@@ -129,7 +124,7 @@ export default function CreateInvoiceDialog(): React.JSX.Element {
   } = useDialog("VIEW_SCANS__CREATE_INVOICE", "add");
 
   // Get selectedScans from payload
-  const {selectedScans = []} = (payload as CreateInvoicePayload) ?? {};
+  const {selectedScans = []} = payload ?? {};
 
   // Local state for wizard steps
   const [mode, setMode] = useState<CreationMode>("single");


### PR DESCRIPTION
## Summary

Hardens the invoices domain dialog pattern (`sites/arolariu.ro/src/app/domains/invoices/_contexts/`) against the correctness and ergonomic defects diagnosed in [`docs/superpowers/specs/2026-05-18-dialog-pattern-hardening-design.md`](../tree/refactor/invoices-dialog-hardening/docs/superpowers/specs/2026-05-18-dialog-pattern-hardening-design.md). No API changes at call sites; the only consumer-visible API surface change is the removal of `useDialog().openWith` (3 call sites migrated to `useDialogs().openDialog` which is already exported).

## What changed (7 atomic commits)

| # | Commit | Scope |
|---|---|---|
| 1 | `28d05ea` | Migrate 3 `openWith` consumers (`ItemsTable`, `ShareCollaborateCard`) to `useDialogs().openDialog` |
| 2 | `2fdde75` | Rewrite `DialogContext.tsx`: split `DialogStateContext` + `DialogActionsContext`, drop the buggy `currentDialogRef`, add `DialogPayloads` compile-time registry, make `useDialog<T>` and `useDialogs().openDialog<T>` per-call generic, drop `openWith` |
| 3 | `89018d6` | Update `DialogContext.test.tsx`: delete `openWith` tests, fix outside-provider error message expectation, replace identity-mismatch test with shared-canonical-state assertion, add `useDialogs().openDialog` tests |
| 4 | `a4dfd0b` | Remove redundant `payload as X` casts in 16 dialog files; delete 4 local payload type aliases; minor registry shape corrections (`EDIT_INVOICE__SCAN` adds `scanIndex`, `VIEW_SCANS__CREATE_INVOICE` uses `CachedScan[]`) |
| 5 | `aedbdb1` | Fix Rules of Hooks violation in `ShareInvoiceDialog` (early return on null payload now sits AFTER all hooks; hook bodies defensively guard on `invoice === null`) |
| 6 | `782155d` | Simplify `onOpenChange` handlers in 12 dialogs to close-only; remove now-unused `open` destructures across 9 files |
| 7 | `dc33a33` | Lazy-load all 19 dialogs in `DialogContainer.tsx` via `next/dynamic({ssr: false})`, memoize switch on `(type, mode)`, wrap export in `React.memo` |

## Defects fixed

- **Stale `useRef` read** — `currentDialog` was exposed through `useMemo([dialogState])` but pointed at a ref. Worked by coincidence, broke when state semantics changed. Removed.
- **`isOpen` non-reactive** — was built from the ref via `useCallback([])`, so identity was stable forever. Now derived from state and re-evaluates correctly.
- **Rules of Hooks** — `ShareInvoiceDialog`'s `if (!payload) return <></>` ran before `useMemo`/`useCallback` calls. Reordered.
- **`payload: unknown` + per-consumer casts** — every dialog cast `payload as X`. Replaced with a `DialogPayloads` registry that types `payload` automatically.
- **Eager imports** — every invoice route shipped JS for all 19 dialogs. Now each dialog is its own chunk loaded on first open.

## Behavior preserved

- "No-op if another dialog is already open" — still enforced (now inside the functional setState updater).
- `useDialog(...)` callable shape — unchanged at every call site.
- One-dialog-at-a-time invariant — unchanged.

## Verification

- ✅ TypeScript: zero errors in `sites/arolariu.ro` (5,022 files)
- ✅ Vitest: 412/412 invoice-domain tests pass (12 files)
- ✅ ESLint: no errors in invoices domain
- ✅ Production build: succeeds, no warnings

Coverage at the global level remains below the 90% threshold — this is **pre-existing** (also fails on `preview`) and unrelated to this PR. Invoice domain coverage stayed at 100% for `DialogContext.tsx` / `DialogContainer.tsx`.

## Out of scope (deferred)

- Per-route `DialogType` narrowing (would require breaking changes to `useDialog`'s generic constraint per route).
- Replacing the Context with a Zustand slice (acknowledged in spec).
- Empirical bundle measurement — Next 16.2 + Turbopack doesn't emit per-route "First Load JS" in the build table; reduction will be verified via bundle analyzer post-merge.

## Test plan

1. Open `/domains/invoices/edit-invoice/<id>` — verify every dialog opens, displays payload data, and closes cleanly. Reopening should be instant (chunk cached).
2. Open `/domains/invoices/view-invoice/<id>` — verify Share, Export, ShareAnalytics dialogs.
3. Open `/domains/invoices/view-invoices` — verify Import, Export, Delete dialogs.
4. Open `/domains/invoices/view-scans` — verify CreateInvoice dialog.

---

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>