### PR TITLE
feat(apphost): persist Azurite blob data across F5 restarts

### DIFF
--- a/tooling/AppHost/Aspire/AzuriteBootstrap.cs
+++ b/tooling/AppHost/Aspire/AzuriteBootstrap.cs
@@ -21,9 +21,14 @@ using Microsoft.Extensions.Logging;
 /// Azurite ships with no default CORS rules and no containers; without this hook every
 /// preflight OPTIONS fails with "No 'Access-Control-Allow-Origin' header is present on the
 /// requested resource", and the first upload to a missing container 404s with
-/// <c>ContainerNotFound</c>. CORS service-properties don't survive a container restart in
-/// the default ephemeral-volume configuration, so the rules must be re-applied on every
-/// AppHost run; the container check is idempotent and cheap.
+/// <c>ContainerNotFound</c>. With the named data volume in place (see <c>Program.cs</c>'s
+/// Azurite <c>WithDataVolume</c> call), Azurite now persists service-properties and
+/// containers across restarts in <c>/data/__azurite_db_blob__.json</c> and
+/// <c>__blobstorage__/</c> — but this bootstrap still runs on every AppHost startup as
+/// defense in depth: it recovers a fresh-volume state (e.g. after <c>docker volume rm
+/// arolariu-azurite-data</c>) without manual intervention, and both operations
+/// (CORS replace, <c>CreateIfNotExistsAsync</c>) are idempotent so the cost on a warm
+/// volume is negligible.
 /// </para>
 ///
 /// <para>

--- a/tooling/AppHost/Constants.cs
+++ b/tooling/AppHost/Constants.cs
@@ -29,6 +29,7 @@ internal static class Constants
   public const string SqlDataVolume = "arolariu-mssql-data";
   public const string CosmosDataVolume = "arolariu-cosmos-data";
   public const string RedisDataVolume = "arolariu-redis-data";
+  public const string AzuriteDataVolume = "arolariu-azurite-data";
 
   // ── Fixed dev ports — match infra/Local/Storage/docker-compose.yml ──
   public const int ApiPort = 5000;

--- a/tooling/AppHost/Program.cs
+++ b/tooling/AppHost/Program.cs
@@ -132,7 +132,13 @@ var cosmosMerchants = cosmosPrimaryDb.AddContainer(
 var storage = builder
     .AddAzureStorage("storage")
     .RunAsEmulator(emulator => emulator
-        .WithBlobPort(Constants.AzuriteBlobPort))
+        .WithBlobPort(Constants.AzuriteBlobPort)
+        // Persist Azurite's workspace (mounted at /data inside the container)
+        // across F5 restarts — uploaded blobs, the 'invoices' container, and CORS
+        // service-properties all survive container destruction. Without this,
+        // every restart began with an empty namespace and AzuriteBootstrap had
+        // to re-create the container from scratch on each run.
+        .WithDataVolume(Constants.AzuriteDataVolume))
     // Bypass DCP on the blob endpoint (same rationale as SQL/Cosmos above): the
     // AzuriteBootstrap helper below and exp's config.aspire.json both connect to
     // hardcoded localhost:10000 — DCP would map that to a random host port and


### PR DESCRIPTION
Closes the persistence gap for the Aspire-managed Azurite emulator so uploaded blobs and the `invoices` container survive F5 restarts, matching the existing semantics for SQL, Cosmos, and Redis.

## Changes

1. `tooling/AppHost/Constants.cs` — new `AzuriteDataVolume` constant (`arolariu-azurite-data`), following the existing `arolariu-<service>-data` naming convention.
2. `tooling/AppHost/Program.cs` — chained `WithDataVolume(Constants.AzuriteDataVolume)` into the Azurite `RunAsEmulator` lambda. Aspire 13.x mounts this at `/data` inside the container (Azurite's workspace).
3. `tooling/AppHost/Aspire/AzuriteBootstrap.cs` — corrected a now-stale XML doc comment that claimed CORS service-properties don't survive container restarts. With the data volume, they do; the bootstrap is kept as defense-in-depth (idempotent CORS replace + `CreateIfNotExistsAsync` for `invoices`).

## Verification

- `dotnet build tooling/AppHost` — 0 warnings, 0 errors.
- `dotnet test tooling/AppHost.Tests` — 4/4 pass, no regressions.
- Manual smoke test: `docker volume rm arolariu-azurite-data` → F5 → upload blob → stop → F5 → blob still present. Confirmed.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>