### PR TITLE
perf(view-scans): defer off-screen ScanCard mounts to fix mobile freeze

### DIFF
--- a/sites/arolariu.ro/src/app/domains/invoices/_components/DeferredMount.test.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_components/DeferredMount.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * @fileoverview Unit tests for the DeferredMount primitive.
+ * @module sites/arolariu.ro/src/app/domains/invoices/_components/DeferredMount.test
+ *
+ * @remarks
+ * Pins the IntersectionObserver contract for DeferredMount:
+ * 1. Initial render shows the placeholder, not the children.
+ * 2. On first intersection, children replace the placeholder and the
+ *    observer disconnects.
+ * 3. When IntersectionObserver is unavailable, children render immediately
+ *    (graceful degradation for very old WebViews).
+ */
+
+import {act, render} from "@testing-library/react";
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
+import DeferredMount from "./DeferredMount";
+
+type Callback = (entries: ReadonlyArray<{isIntersecting: boolean}>) => void;
+
+const {observerInstances, originalIntersectionObserver} = vi.hoisted(() => ({
+  observerInstances: [] as Array<{
+    callback: Callback;
+    observe: ReturnType<typeof vi.fn>;
+    disconnect: ReturnType<typeof vi.fn>;
+    observedElement: Element | null;
+  }>,
+  originalIntersectionObserver: globalThis.IntersectionObserver as
+    | typeof IntersectionObserver
+    | undefined,
+}));
+
+function installIntersectionObserverMock(): void {
+  observerInstances.length = 0;
+
+  class MockIntersectionObserver {
+    public observe: ReturnType<typeof vi.fn>;
+    public disconnect: ReturnType<typeof vi.fn>;
+    public observedElement: Element | null = null;
+    public readonly callback: Callback;
+
+    constructor(callback: Callback) {
+      this.callback = callback;
+      const instance = {
+        callback,
+        observe: vi.fn((el: Element) => {
+          this.observedElement = el;
+          instance.observedElement = el;
+        }),
+        disconnect: vi.fn(),
+        observedElement: null as Element | null,
+      };
+      this.observe = instance.observe;
+      this.disconnect = instance.disconnect;
+      observerInstances.push(instance);
+    }
+  }
+
+  Object.defineProperty(globalThis, "IntersectionObserver", {
+    value: MockIntersectionObserver,
+    writable: true,
+    configurable: true,
+  });
+}
+
+function uninstallIntersectionObserverMock(): void {
+  if (originalIntersectionObserver) {
+    Object.defineProperty(globalThis, "IntersectionObserver", {
+      value: originalIntersectionObserver,
+      writable: true,
+      configurable: true,
+    });
+  } else {
+    // @ts-expect-error -- intentional delete for the unavailable-runtime test
+    delete globalThis.IntersectionObserver;
+  }
+}
+
+describe("DeferredMount", () => {
+  beforeEach(() => {
+    installIntersectionObserverMock();
+  });
+
+  afterEach(() => {
+    uninstallIntersectionObserverMock();
+    vi.clearAllMocks();
+  });
+
+  it("renders the placeholder and not the children before intersection", () => {
+    const {queryByText} = render(
+      <DeferredMount placeholder={<span>shimmer</span>}>
+        <span>real card</span>
+      </DeferredMount>,
+    );
+
+    expect(queryByText("shimmer")).not.toBeNull();
+    expect(queryByText("real card")).toBeNull();
+    expect(observerInstances).toHaveLength(1);
+    expect(observerInstances[0]!.observe).toHaveBeenCalledTimes(1);
+  });
+
+  it("swaps placeholder for children when intersection fires, then disconnects", () => {
+    const {queryByText} = render(
+      <DeferredMount placeholder={<span>shimmer</span>}>
+        <span>real card</span>
+      </DeferredMount>,
+    );
+
+    const instance = observerInstances[0]!;
+
+    act(() => {
+      instance.callback([{isIntersecting: true}]);
+    });
+
+    expect(queryByText("real card")).not.toBeNull();
+    expect(queryByText("shimmer")).toBeNull();
+    // disconnect may be called more than once: once inside the callback when
+    // intersection fires, and once as the useEffect cleanup when the
+    // `activated` dependency change re-runs the effect. The contract we
+    // care about is "disconnect was called" — IntersectionObserver tolerates
+    // redundant disconnect calls.
+    expect(instance.disconnect).toHaveBeenCalled();
+  });
+
+  it("renders children immediately when IntersectionObserver is unavailable", () => {
+    uninstallIntersectionObserverMock();
+    // @ts-expect-error -- intentional delete to simulate ancient runtime
+    delete globalThis.IntersectionObserver;
+
+    const {queryByText} = render(
+      <DeferredMount placeholder={<span>shimmer</span>}>
+        <span>real card</span>
+      </DeferredMount>,
+    );
+
+    expect(queryByText("real card")).not.toBeNull();
+    expect(queryByText("shimmer")).toBeNull();
+  });
+});

--- a/sites/arolariu.ro/src/app/domains/invoices/_components/DeferredMount.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_components/DeferredMount.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+/**
+ * @fileoverview Reusable IntersectionObserver-driven deferred mount wrapper.
+ * @module sites/arolariu.ro/src/app/domains/invoices/_components/DeferredMount
+ *
+ * @remarks
+ * Renders {@link Props.placeholder} until its container intersects (or
+ * approaches) the viewport, then swaps to {@link Props.children} and
+ * disconnects the observer. Once activated, stays mounted for the rest of the
+ * page's lifetime (no re-shimmer on scroll-out) — appropriate for bounded
+ * lists where memory cost is acceptable in exchange for stable UX.
+ *
+ * Falls back to immediate activation when {@link IntersectionObserver} is
+ * unavailable (graceful degradation for ancient WebViews); the primary
+ * browser matrix targeted by Next.js 16 ships it natively.
+ */
+
+import {useEffect, useRef, useState} from "react";
+
+/**
+ * Props for the DeferredMount component.
+ */
+type Props = Readonly<{
+  /** Rendered until the container intersects the viewport. */
+  placeholder: React.ReactNode;
+  /** Rendered after the first intersection. */
+  children: React.ReactNode;
+  /**
+   * Optional class applied to the wrapper element so callers can size the
+   * placeholder and final children identically to avoid scroll jump.
+   */
+  className?: string;
+}>;
+
+// One viewport-worth of prefetch ahead of the scroll position — cards
+// activate before the user actually sees them, so the swap is invisible.
+const ROOT_MARGIN = "200px";
+
+/**
+ * Defers mounting of its children until the wrapper enters the viewport.
+ *
+ * @param props - {@link Props}
+ * @returns A wrapper element rendering either the placeholder or the children.
+ */
+export default function DeferredMount({
+  placeholder,
+  children,
+  className,
+}: Props): React.JSX.Element {
+  const ref = useRef<HTMLDivElement>(null);
+  const [activated, setActivated] = useState(false);
+
+  useEffect(() => {
+    if (activated) return;
+    const el = ref.current;
+    if (!el) return;
+
+    if (typeof IntersectionObserver === "undefined") {
+      setActivated(true);
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            setActivated(true);
+            observer.disconnect();
+            return;
+          }
+        }
+      },
+      {rootMargin: ROOT_MARGIN},
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [activated]);
+
+  return (
+    <div ref={ref} className={className}>
+      {activated ? children : placeholder}
+    </div>
+  );
+}

--- a/sites/arolariu.ro/src/app/domains/invoices/_components/DeferredMount.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_components/DeferredMount.tsx
@@ -49,17 +49,16 @@ export default function DeferredMount({
   className,
 }: Props): React.JSX.Element {
   const ref = useRef<HTMLDivElement>(null);
-  const [activated, setActivated] = useState(false);
+  // When IntersectionObserver is unavailable (very old WebViews), activate
+  // immediately via the initializer so the effect never has to setState
+  // synchronously — keeps react-hooks/set-state-in-effect happy and avoids
+  // an unnecessary first-render → effect → re-render cycle in the fallback path.
+  const [activated, setActivated] = useState(() => typeof IntersectionObserver === "undefined");
 
   useEffect(() => {
     if (activated) return;
     const el = ref.current;
     if (!el) return;
-
-    if (typeof IntersectionObserver === "undefined") {
-      setActivated(true);
-      return;
-    }
 
     const observer = new IntersectionObserver(
       (entries) => {
@@ -79,7 +78,9 @@ export default function DeferredMount({
   }, [activated]);
 
   return (
-    <div ref={ref} className={className}>
+    <div
+      ref={ref}
+      className={className}>
       {activated ? children : placeholder}
     </div>
   );

--- a/sites/arolariu.ro/src/app/domains/invoices/_components/ScanCard.module.scss
+++ b/sites/arolariu.ro/src/app/domains/invoices/_components/ScanCard.module.scss
@@ -62,6 +62,10 @@
 }
 
 .imagePreview {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
   object-fit: cover;
 }
 
@@ -259,6 +263,10 @@
 }
 
 .previewImage {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
   object-fit: contain;
 }
 

--- a/sites/arolariu.ro/src/app/domains/invoices/_components/ScanCard.shimmers.module.scss
+++ b/sites/arolariu.ro/src/app/domains/invoices/_components/ScanCard.shimmers.module.scss
@@ -1,0 +1,43 @@
+// ===========================================
+// SCAN CARD SHIMMER STYLES
+// ===========================================
+//
+// Placeholder skeleton rules used by <CardShimmer> in ScanCard.shimmers.tsx,
+// rendered both in the pre-hydration loading grid and inside <DeferredMount>
+// for off-screen cards.
+//
+// Colocated with ScanCard.shimmers.tsx so the shimmer is a fully
+// self-contained component (markup + styles in the same folder).
+
+@use '../../../../styles/abstracts' as *;
+
+.skeletonCard {
+  display: flex;
+  flex-direction: column;
+  gap: space(2);
+}
+
+.skeletonImage {
+  aspect-ratio: 4 / 3;
+  width: 100%;
+  border-radius: radius('md');
+}
+
+.skeletonInfo {
+  display: flex;
+  flex-direction: column;
+  gap: space(2);
+  padding-inline: space(2);
+}
+
+.skeletonName {
+  height: space(4);
+  width: 70%;
+  border-radius: radius('sm');
+}
+
+.skeletonMeta {
+  height: space(3);
+  width: 50%;
+  border-radius: radius('sm');
+}

--- a/sites/arolariu.ro/src/app/domains/invoices/_components/ScanCard.shimmers.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_components/ScanCard.shimmers.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+/**
+ * @fileoverview Shimmer placeholders for the ScanCard component.
+ * @module sites/arolariu.ro/src/app/domains/invoices/_components/ScanCard.shimmers
+ *
+ * @remarks
+ * Colocated with ScanCard.tsx so the shimmer styles + markup live together
+ * as a single self-contained unit. The shimmer is rendered in two places
+ * today:
+ *
+ * 1. **Pre-hydration loading grid** — `ScansGrid` shows a fixed set of
+ *    shimmers before the Zustand store has hydrated from IndexedDB.
+ * 2. **Deferred-mount placeholder** — inside `<DeferredMount>` as the
+ *    placeholder for cards not yet scrolled into the viewport.
+ *
+ * Sharing one component keeps the visual layout consistent across both
+ * call sites.
+ */
+
+import {Skeleton} from "@arolariu/components";
+import styles from "./ScanCard.shimmers.module.scss";
+
+/**
+ * Skeleton placeholder matching a ScanCard's outer dimensions (4:3 preview
+ * image + two text lines for the file name and meta row).
+ */
+export function CardShimmer(): React.JSX.Element {
+  return (
+    <div className={styles["skeletonCard"]}>
+      <Skeleton className={styles["skeletonImage"]} />
+      <div className={styles["skeletonInfo"]}>
+        <Skeleton className={styles["skeletonName"]} />
+        <Skeleton className={styles["skeletonMeta"]} />
+      </div>
+    </div>
+  );
+}

--- a/sites/arolariu.ro/src/app/domains/invoices/_components/ScanCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_components/ScanCard.tsx
@@ -35,7 +35,6 @@ import {
 } from "@arolariu/components";
 import {motion} from "motion/react";
 import {useTranslations} from "next-intl";
-import Image from "next/image";
 import {useCallback, useEffect, useRef, useState} from "react";
 import {
   TbCheck,
@@ -283,14 +282,13 @@ export default function ScanCard({scan, isSelected, onToggleSelect}: Readonly<Sc
               </div>
             ) : (
               <>
-                <Image
+                {/* eslint-disable-next-line @next/next/no-img-element -- plain <img> chosen over next/image; see spec 2026-05-21-view-scans-deferred-mount-design.md */}
+                <img
                   src={scan.blobUrl}
                   alt={scan.name}
-                  fill
                   className={styles["imagePreview"]}
                   loading='lazy'
-                  sizes='(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw'
-                  unoptimized
+                  decoding='async'
                 />
                 {/* Preview overlay icon for images - use zoom icon */}
                 <div className={styles["previewOverlay"]}>
@@ -462,12 +460,12 @@ export default function ScanCard({scan, isSelected, onToggleSelect}: Readonly<Sc
             </div>
           ) : (
             <div className={styles["previewImageContainer"]}>
-              <Image
+              {/* eslint-disable-next-line @next/next/no-img-element -- plain <img> chosen over next/image; see spec 2026-05-21-view-scans-deferred-mount-design.md */}
+              <img
                 src={scan.blobUrl}
                 alt={scan.name}
-                fill
                 className={styles["previewImage"]}
-                unoptimized
+                decoding='async'
               />
             </div>
           )}

--- a/sites/arolariu.ro/src/app/domains/invoices/view-scans/_components/ScansGrid.module.scss
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-scans/_components/ScansGrid.module.scss
@@ -6,36 +6,11 @@
 // ===========================================
 // LOADING SKELETON GRID
 // ===========================================
-.skeletonCard {
-  display: flex;
-  flex-direction: column;
-  gap: space(2);
-}
-
-.skeletonImage {
-  aspect-ratio: 4 / 3;
-  width: 100%;
-  border-radius: radius('md');
-}
-
-.skeletonInfo {
-  display: flex;
-  flex-direction: column;
-  gap: space(2);
-  padding-inline: space(2);
-}
-
-.skeletonName {
-  height: space(4);
-  width: 70%;
-  border-radius: radius('sm');
-}
-
-.skeletonMeta {
-  height: space(3);
-  width: 50%;
-  border-radius: radius('sm');
-}
+//
+// Per-card shimmer rules moved to ScanCard.shimmers.module.scss (colocated
+// with the shimmer component). The legacy `.skeletonGrid` / `.skeletonItem`
+// block below remains for backwards compatibility with any consumer that
+// still references it.
 
 // Legacy skeleton grid (deprecated, keeping for backwards compatibility)
 .skeletonGrid {

--- a/sites/arolariu.ro/src/app/domains/invoices/view-scans/_components/ScansGrid.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-scans/_components/ScansGrid.tsx
@@ -6,7 +6,7 @@
  */
 
 import type {CachedScan} from "@/types/scans";
-import {Button, Skeleton, useIsMobile} from "@arolariu/components";
+import {Button, useIsMobile} from "@arolariu/components";
 import {AnimatePresence, motion} from "motion/react";
 import {useTranslations} from "next-intl";
 import {useCallback, useEffect, useState} from "react";
@@ -14,6 +14,7 @@ import {TbCamera, TbChevronLeft, TbChevronRight} from "react-icons/tb";
 import DeferredMount from "../../_components/DeferredMount";
 import EmptyState from "../../_components/EmptyState";
 import ScanCard from "../../_components/ScanCard";
+import {CardShimmer} from "../../_components/ScanCard.shimmers";
 import {useScans} from "../_hooks/useScans";
 import styles from "./ScansGrid.module.scss";
 
@@ -46,26 +47,6 @@ function ScanCardWrapper({scan, isSelected, onToggleSelection}: Readonly<ScanCar
       isSelected={isSelected}
       onToggleSelect={handleToggle}
     />
-  );
-}
-
-/**
- * Shimmer placeholder matching a ScanCard's outer dimensions.
- *
- * @remarks
- * Used in two places: (1) inside the pre-hydration loading grid (multiple
- * shimmers), and (2) inside <DeferredMount> as the placeholder for off-screen
- * cards. Sharing one component keeps the visual layout consistent.
- */
-function CardShimmer(): React.JSX.Element {
-  return (
-    <div className={styles["skeletonCard"]}>
-      <Skeleton className={styles["skeletonImage"]} />
-      <div className={styles["skeletonInfo"]}>
-        <Skeleton className={styles["skeletonName"]} />
-        <Skeleton className={styles["skeletonMeta"]} />
-      </div>
-    </div>
   );
 }
 

--- a/sites/arolariu.ro/src/app/domains/invoices/view-scans/_components/ScansGrid.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-scans/_components/ScansGrid.tsx
@@ -6,11 +6,12 @@
  */
 
 import type {CachedScan} from "@/types/scans";
-import {Button, Skeleton} from "@arolariu/components";
+import {Button, Skeleton, useIsMobile} from "@arolariu/components";
 import {AnimatePresence, motion} from "motion/react";
 import {useTranslations} from "next-intl";
 import {useCallback, useEffect, useState} from "react";
 import {TbCamera, TbChevronLeft, TbChevronRight} from "react-icons/tb";
+import DeferredMount from "../../_components/DeferredMount";
 import EmptyState from "../../_components/EmptyState";
 import ScanCard from "../../_components/ScanCard";
 import {useScans} from "../_hooks/useScans";
@@ -49,6 +50,26 @@ function ScanCardWrapper({scan, isSelected, onToggleSelection}: Readonly<ScanCar
 }
 
 /**
+ * Shimmer placeholder matching a ScanCard's outer dimensions.
+ *
+ * @remarks
+ * Used in two places: (1) inside the pre-hydration loading grid (multiple
+ * shimmers), and (2) inside <DeferredMount> as the placeholder for off-screen
+ * cards. Sharing one component keeps the visual layout consistent.
+ */
+function CardShimmer(): React.JSX.Element {
+  return (
+    <div className={styles["skeletonCard"]}>
+      <Skeleton className={styles["skeletonImage"]} />
+      <div className={styles["skeletonInfo"]}>
+        <Skeleton className={styles["skeletonName"]} />
+        <Skeleton className={styles["skeletonMeta"]} />
+      </div>
+    </div>
+  );
+}
+
+/**
  * Grid display for scans with selection support.
  */
 export default function ScansGrid(): React.JSX.Element {
@@ -56,16 +77,7 @@ export default function ScansGrid(): React.JSX.Element {
   const {scans, selectedScans, hasHydrated, isSyncing, toggleSelection} = useScans();
   const [page, setPage] = useState(0);
 
-  // Detect mobile viewport
-  const [isMobile, setIsMobile] = useState(false);
-  useEffect(() => {
-    const checkMobile = (): void => {
-      setIsMobile(window.innerWidth < 768);
-    };
-    checkMobile();
-    window.addEventListener("resize", checkMobile);
-    return () => window.removeEventListener("resize", checkMobile);
-  }, []);
+  const isMobile = useIsMobile();
 
   /**
    * Filter out scans without required fields.
@@ -95,15 +107,7 @@ export default function ScansGrid(): React.JSX.Element {
     return (
       <div className={styles["scansGrid"]}>
         {SKELETON_KEYS.map((skeletonKey) => (
-          <div
-            key={skeletonKey}
-            className={styles["skeletonCard"]}>
-            <Skeleton className={styles["skeletonImage"]} />
-            <div className={styles["skeletonInfo"]}>
-              <Skeleton className={styles["skeletonName"]} />
-              <Skeleton className={styles["skeletonMeta"]} />
-            </div>
-          </div>
+          <CardShimmer key={skeletonKey} />
         ))}
       </div>
     );
@@ -139,11 +143,13 @@ export default function ScansGrid(): React.JSX.Element {
               animate={{opacity: 1}}
               exit={{opacity: 0}}
               transition={{duration: 0.15, ease: "easeOut"}}>
-              <ScanCardWrapper
-                scan={scan}
-                isSelected={selectedScans.some((s) => s.id === scan.id)}
-                onToggleSelection={toggleSelection}
-              />
+              <DeferredMount placeholder={<CardShimmer />}>
+                <ScanCardWrapper
+                  scan={scan}
+                  isSelected={selectedScans.some((s) => s.id === scan.id)}
+                  onToggleSelection={toggleSelection}
+                />
+              </DeferredMount>
             </motion.div>
           ))}
         </AnimatePresence>


### PR DESCRIPTION
## Problem

On `/domains/invoices/view-scans`, the page freezes on mount when many scans are cached in IndexedDB — especially on mobile. With ~50 cards rendering simultaneously, each mounting a `next/image` preview, a hidden `Dialog` preview, plus `DropdownMenu` and `AlertDialog` subtrees, the main thread chokes before first interaction.

At the realistic worst-case scale (~100 scans per user), this is a **render and mount cost** problem, not a data-volume problem.

## Fix

Introduce a reusable `<DeferredMount>` primitive that uses `IntersectionObserver` to delay mounting of off-screen children. `ScansGrid` wraps each grid card in `<DeferredMount placeholder={<CardShimmer />}>` — so only the first ~5-10 cards actually mount on first paint; the rest are sized shimmers until the user scrolls them near the viewport (`rootMargin: 200px` gives invisible prefetch).

Also drops `next/image` in `ScanCard` (both call sites had `unoptimized` set anyway, so layout/CDN behavior is unchanged) and the duplicate `window.innerWidth` resize listener in `ScansGrid` (replaced with `useIsMobile` from `@arolariu/components`, which `island.tsx` already uses).

## Out of scope (intentional, per design)

- No `useScans()` API change.
- No `useMemo` on derived arrays (`readyScans`, `validScans`, `paginatedScans`).
- No `React.memo` on `ScanCard`.
- No `ScanCard.tsx` file split.
- No server-side pagination, no virtualization library, no thumbnail variants.
- The `view-invoices` grid-view image-burst (separately noted) is a planned follow-up that reuses `<DeferredMount>`.

Spec: `docs/superpowers/specs/2026-05-21-view-scans-deferred-mount-design.md` (local, gitignored)
Plan: `docs/superpowers/plans/2026-05-21-view-scans-deferred-mount.md` (local, gitignored)

## Changes

| File | Change |
|------|--------|
| `_components/DeferredMount.tsx` (new) | IntersectionObserver-driven wrapper; `rootMargin: 200px`; stays-mounted-once-activated; fallback to immediate activation when `IntersectionObserver` unavailable. |
| `_components/DeferredMount.test.tsx` (new) | 3 Vitest cases: placeholder-first, swaps-on-intersection-+-disconnects, IO-unavailable-fallback. Mocks `IntersectionObserver` globally. |
| `_components/ScanCard.tsx` | 2x `<Image>` → plain `<img loading="lazy" decoding="async">`; drop `next/image` import. |
| `_components/ScanCard.module.scss` | Add `position: absolute; inset: 0; width/height: 100%` to `.imagePreview` and `.previewImage` (replaces `next/image fill` layout). |
| `view-scans/_components/ScansGrid.tsx` | Drop manual resize listener → use `useIsMobile`. Extract `<CardShimmer>` (single source of skeleton truth, used by both pre-hydration grid and deferred placeholder). Wrap each card in `<DeferredMount>`. |

Net: 2 new files + 3 modified. +270/-33 LoC.

## Verification

- `npm run test:unit`: all tests pass (3 new tests for DeferredMount + 0 regressions). Coverage 99.79% statements, 96.74% branches.
- `npx eslint` on modified files: 0 new errors (38 pre-existing on `ScanCard.tsx` + `ScansGrid.tsx` confirmed identical on `preview` — unrelated tech debt). 0 errors on new files.
- `next build`: succeeds; `/domains/invoices/view-scans` route renders.
- Manual smoke test on local dev: confirmed by author. No freeze on mobile-emulated DevTools; cards activate progressively on scroll; no layout jump on shimmer→card swap; preview/dropdown/delete still work.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>