### PR TITLE
feat(view-invoices): card-based filter panel overhaul (variant J)

### DIFF
--- a/sites/arolariu.ro/messages/en.json
+++ b/sites/arolariu.ro/messages/en.json
@@ -3337,6 +3337,7 @@
         "dateRange": "Date Range",
         "dateTo": "To date",
         "defaultValue": "default",
+        "dynamicHint": "These options are populated from your invoices — only values present in your data appear here.",
         "paymentTypes": "Payment Types",
         "showResults": "Show {count, plural, one {# result} other {# results}}",
         "sortBy": "Sort By",

--- a/sites/arolariu.ro/messages/en.json
+++ b/sites/arolariu.ro/messages/en.json
@@ -3313,14 +3313,26 @@
         "amountMax": "Max amount",
         "amountMin": "Min amount",
         "amountRange": "Amount Range",
+        "anyValue": "any",
         "button": "Filters",
         "categories": "Categories",
         "category": "Category",
         "clear": "Clear all",
+        "currency": "Currency",
+        "currencyAny": "any",
         "dateFrom": "From date",
+        "datePresets": {
+          "30d": "30d",
+          "90d": "90d",
+          "all": "All time",
+          "custom": "Custom",
+          "ytd": "YTD"
+        },
         "dateRange": "Date Range",
         "dateTo": "To date",
+        "defaultValue": "default",
         "paymentTypes": "Payment Types",
+        "showResults": "Show {count, plural, one {# result} other {# results}}",
         "sortBy": "Sort By",
         "sortOptions": {
           "amountHighToLow": "Amount (high to low)",
@@ -3328,8 +3340,7 @@
           "dateNewest": "Date (newest first)",
           "dateOldest": "Date (oldest first)",
           "nameAZ": "Name (A-Z)",
-          "nameZA": "Name (Z-A)",
-          "none": "No sorting (default order)"
+          "nameZA": "Name (Z-A)"
         },
         "timeOfDay": "Time of day",
         "title": "Filters"

--- a/sites/arolariu.ro/messages/en.json
+++ b/sites/arolariu.ro/messages/en.json
@@ -3338,6 +3338,14 @@
         "dateTo": "To date",
         "defaultValue": "default",
         "dynamicHint": "These options are populated from your invoices — only values present in your data appear here.",
+        "paymentTypeLabels": {
+          "card": "Card",
+          "cash": "Cash",
+          "mobile": "Mobile",
+          "other": "Other",
+          "transfer": "Transfer",
+          "voucher": "Voucher"
+        },
         "paymentTypes": "Payment Types",
         "showResults": "Show {count, plural, one {# result} other {# results}}",
         "sortBy": "Sort By",

--- a/sites/arolariu.ro/messages/en.json
+++ b/sites/arolariu.ro/messages/en.json
@@ -3312,6 +3312,12 @@
         "activeCount": "{count} active",
         "amountMax": "Max amount",
         "amountMin": "Min amount",
+        "amountPresets": {
+          "0to50": "0-50",
+          "100to500": "100-500",
+          "500plus": "500+",
+          "50to100": "50-100"
+        },
         "amountRange": "Amount Range",
         "anyValue": "any",
         "button": "Filters",

--- a/sites/arolariu.ro/messages/fr.json
+++ b/sites/arolariu.ro/messages/fr.json
@@ -3349,7 +3349,8 @@
           "100to500": "100-500",
           "500plus": "500+",
           "50to100": "50-100"
-        }
+        },
+        "dynamicHint": "Ces options sont remplies à partir de vos factures — seules les valeurs présentes dans vos données apparaissent ici."
       },
       "placeholderPanel": "D’autres filtres seront bientôt disponibles.",
       "searchPlaceholder": "Rechercher des factures...",

--- a/sites/arolariu.ro/messages/fr.json
+++ b/sites/arolariu.ro/messages/fr.json
@@ -3343,7 +3343,13 @@
           "nameZA": "Nom (Z-A)"
         },
         "timeOfDay": "Moment de la journée",
-        "title": "Filtres"
+        "title": "Filtres",
+        "amountPresets": {
+          "0to50": "0-50",
+          "100to500": "100-500",
+          "500plus": "500+",
+          "50to100": "50-100"
+        }
       },
       "placeholderPanel": "D’autres filtres seront bientôt disponibles.",
       "searchPlaceholder": "Rechercher des factures...",

--- a/sites/arolariu.ro/messages/fr.json
+++ b/sites/arolariu.ro/messages/fr.json
@@ -3350,7 +3350,15 @@
           "500plus": "500+",
           "50to100": "50-100"
         },
-        "dynamicHint": "Ces options sont remplies à partir de vos factures — seules les valeurs présentes dans vos données apparaissent ici."
+        "dynamicHint": "Ces options sont remplies à partir de vos factures — seules les valeurs présentes dans vos données apparaissent ici.",
+        "paymentTypeLabels": {
+          "card": "Carte",
+          "cash": "Espèces",
+          "mobile": "Mobile",
+          "other": "Autre",
+          "transfer": "Virement",
+          "voucher": "Bon"
+        }
       },
       "placeholderPanel": "D’autres filtres seront bientôt disponibles.",
       "searchPlaceholder": "Rechercher des factures...",

--- a/sites/arolariu.ro/messages/fr.json
+++ b/sites/arolariu.ro/messages/fr.json
@@ -3313,14 +3313,26 @@
         "amountMax": "Montant max.",
         "amountMin": "Montant min.",
         "amountRange": "Plage de montants",
+        "anyValue": "tout",
         "button": "Filtres",
         "categories": "Catégories",
         "category": "Catégorie",
         "clear": "Tout effacer",
+        "currency": "Devise",
+        "currencyAny": "toutes",
         "dateFrom": "Date de début",
+        "datePresets": {
+          "30d": "30j",
+          "90d": "90j",
+          "all": "Tout",
+          "custom": "Personnalisé",
+          "ytd": "Année"
+        },
         "dateRange": "Plage de dates",
         "dateTo": "Date de fin",
+        "defaultValue": "défaut",
         "paymentTypes": "Types de paiement",
+        "showResults": "Afficher {count, plural, one {# résultat} other {# résultats}}",
         "sortBy": "Trier par",
         "sortOptions": {
           "amountHighToLow": "Montant (décroissant)",
@@ -3328,8 +3340,7 @@
           "dateNewest": "Date (plus récente)",
           "dateOldest": "Date (plus ancienne)",
           "nameAZ": "Nom (A-Z)",
-          "nameZA": "Nom (Z-A)",
-          "none": "Aucun"
+          "nameZA": "Nom (Z-A)"
         },
         "timeOfDay": "Moment de la journée",
         "title": "Filtres"

--- a/sites/arolariu.ro/messages/ro.json
+++ b/sites/arolariu.ro/messages/ro.json
@@ -3349,7 +3349,8 @@
           "100to500": "100-500",
           "500plus": "500+",
           "50to100": "50-100"
-        }
+        },
+        "dynamicHint": "Aceste opțiuni sunt populate din facturile tale — apar doar valorile prezente în datele tale."
       },
       "placeholderPanel": "Vor fi adăugate în curând mai multe controale de filtrare.",
       "searchPlaceholder": "Caută facturi...",

--- a/sites/arolariu.ro/messages/ro.json
+++ b/sites/arolariu.ro/messages/ro.json
@@ -3350,7 +3350,15 @@
           "500plus": "500+",
           "50to100": "50-100"
         },
-        "dynamicHint": "Aceste opțiuni sunt populate din facturile tale — apar doar valorile prezente în datele tale."
+        "dynamicHint": "Aceste opțiuni sunt populate din facturile tale — apar doar valorile prezente în datele tale.",
+        "paymentTypeLabels": {
+          "card": "Card",
+          "cash": "Numerar",
+          "mobile": "Mobil",
+          "other": "Altul",
+          "transfer": "Transfer",
+          "voucher": "Tichet"
+        }
       },
       "placeholderPanel": "Vor fi adăugate în curând mai multe controale de filtrare.",
       "searchPlaceholder": "Caută facturi...",

--- a/sites/arolariu.ro/messages/ro.json
+++ b/sites/arolariu.ro/messages/ro.json
@@ -3343,7 +3343,13 @@
           "nameZA": "Nume (Z-A)"
         },
         "timeOfDay": "Momentul zilei",
-        "title": "Filtre"
+        "title": "Filtre",
+        "amountPresets": {
+          "0to50": "0-50",
+          "100to500": "100-500",
+          "500plus": "500+",
+          "50to100": "50-100"
+        }
       },
       "placeholderPanel": "Vor fi adăugate în curând mai multe controale de filtrare.",
       "searchPlaceholder": "Caută facturi...",

--- a/sites/arolariu.ro/messages/ro.json
+++ b/sites/arolariu.ro/messages/ro.json
@@ -3313,14 +3313,26 @@
         "amountMax": "Sumă maximă",
         "amountMin": "Sumă minimă",
         "amountRange": "Interval de sumă",
+        "anyValue": "orice",
         "button": "Filtre",
         "categories": "Categorii",
         "category": "Categorie",
         "clear": "Șterge tot",
+        "currency": "Monedă",
+        "currencyAny": "orice",
         "dateFrom": "De la data",
+        "datePresets": {
+          "30d": "30z",
+          "90d": "90z",
+          "all": "Tot timpul",
+          "custom": "Personalizat",
+          "ytd": "An curent"
+        },
         "dateRange": "Interval de date",
         "dateTo": "Până la data",
+        "defaultValue": "implicit",
         "paymentTypes": "Tipuri de plată",
+        "showResults": "Afișează {count, plural, one {# rezultat} other {# rezultate}}",
         "sortBy": "Sortare după",
         "sortOptions": {
           "amountHighToLow": "Sumă (descrescător)",
@@ -3328,8 +3340,7 @@
           "dateNewest": "Dată (cele mai recente)",
           "dateOldest": "Dată (cele mai vechi)",
           "nameAZ": "Nume (A-Z)",
-          "nameZA": "Nume (Z-A)",
-          "none": "Fără sortare (ordine implicită)"
+          "nameZA": "Nume (Z-A)"
         },
         "timeOfDay": "Momentul zilei",
         "title": "Filtre"

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/FilterBar.module.scss
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/FilterBar.module.scss
@@ -439,14 +439,21 @@
   font-size: font-size('xs');
 }
 
-.datePresetRow {
+.presetRow {
   display: flex;
   gap: space(1.5);
   flex-wrap: wrap;
   margin-bottom: space(2);
 }
 
-.datePresetButton {
+.amountPresetRow {
+  display: flex;
+  gap: space(1.5);
+  flex-wrap: wrap;
+  margin-top: space(2);
+}
+
+.presetButton {
   background-color: color('background');
   border: 1px solid color('border');
   border-radius: radius('md');
@@ -466,7 +473,7 @@
   }
 }
 
-.datePresetButtonActive {
+.presetButtonActive {
   background-color: color('primary');
   color: color('primary-foreground');
   border-color: color('primary');

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/FilterBar.module.scss
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/FilterBar.module.scss
@@ -376,3 +376,134 @@
   width: 100%;
   cursor: pointer;
 }
+
+
+// ===========================================
+// NEW PANEL — variant J (2026-05-21 overhaul)
+// ===========================================
+
+.panelGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: space(3);
+
+  @include respond-below('md') {
+    grid-template-columns: 1fr;
+    gap: space(3);
+  }
+}
+
+.cardSection {
+  border: 1px solid color('border');
+  border-radius: radius('lg');
+  padding: space(3);
+  background-color: color('background');
+  @include transition(border-color, background-color);
+}
+
+.cardSectionActive {
+  border-color: color-alpha('primary', 0.3);
+  background-color: color-alpha('primary', 0.04);
+}
+
+.cardSectionHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: space(2);
+}
+
+.cardSectionTitle {
+  font-size: font-size('sm');
+  font-weight: font-weight('semibold');
+  color: color('foreground');
+  display: inline-flex;
+  align-items: center;
+  gap: space(1.5);
+}
+
+.activeValuePill {
+  background-color: color-alpha('primary', 0.1);
+  color: color('primary');
+  border: 1px solid color-alpha('primary', 0.3);
+  border-radius: radius('sm');
+  padding: space(0.5) space(2);
+  font-size: font-size('xs');
+  font-weight: font-weight('medium');
+  max-width: 12rem;
+  @include truncate;
+}
+
+.inactiveLabel {
+  color: color('muted-foreground');
+  font-size: font-size('xs');
+}
+
+.datePresetRow {
+  display: flex;
+  gap: space(1.5);
+  flex-wrap: wrap;
+  margin-bottom: space(2);
+}
+
+.datePresetButton {
+  background-color: color('background');
+  border: 1px solid color('border');
+  border-radius: radius('md');
+  padding: space(1) space(2.5);
+  font-size: font-size('xs');
+  color: color('foreground');
+  cursor: pointer;
+  @include transition(background-color, border-color);
+
+  @include respond-below('md') {
+    min-height: space(11);
+    flex: 1;
+  }
+
+  &:hover {
+    background-color: color('muted');
+  }
+}
+
+.datePresetButtonActive {
+  background-color: color('primary');
+  color: color('primary-foreground');
+  border-color: color('primary');
+
+  &:hover {
+    background-color: color('primary');
+    opacity: 0.9;
+  }
+}
+
+.amountSliderWrapper {
+  margin-top: space(2);
+  padding: 0 space(1);
+}
+
+.mobileShowResultsBar {
+  position: sticky;
+  bottom: 0;
+  background-color: color('background');
+  border-top: 1px solid color('border');
+  padding: space(3);
+  padding-bottom: calc(#{space(3)} + env(safe-area-inset-bottom, 0));
+}
+
+.mobileShowResultsButton {
+  width: 100%;
+  min-height: space(12);
+  font-size: font-size('sm');
+  font-weight: font-weight('semibold');
+}
+
+.panelHeaderActiveBadge {
+  background-color: color-alpha('primary', 0.1);
+  color: color('primary');
+  border-radius: radius('full');
+  padding: space(0.5) space(2);
+  font-size: font-size('xs');
+  font-weight: font-weight('medium');
+  margin-left: space(2);
+}

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/FilterBar.module.scss
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/FilterBar.module.scss
@@ -477,11 +477,6 @@
   }
 }
 
-.amountSliderWrapper {
-  margin-top: space(2);
-  padding: 0 space(1);
-}
-
 .mobileShowResultsBar {
   position: sticky;
   bottom: 0;

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/FilterBar.module.scss
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/FilterBar.module.scss
@@ -422,6 +422,19 @@
   gap: space(1.5);
 }
 
+.dynamicHintIcon {
+  color: color('muted-foreground');
+  cursor: help;
+  display: inline-flex;
+  align-items: center;
+  @include transition(color);
+
+  &:hover,
+  &:focus-visible {
+    color: color('foreground');
+  }
+}
+
 .activeValuePill {
   background-color: color-alpha('primary', 0.1);
   color: color('primary');

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/FilterBar.module.scss
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/FilterBar.module.scss
@@ -398,7 +398,7 @@
   border-radius: radius('lg');
   padding: space(3);
   background-color: color('background');
-  @include transition(border-color, background-color);
+  @include transition((border-color, background-color));
 }
 
 .cardSectionActive {
@@ -454,7 +454,7 @@
   font-size: font-size('xs');
   color: color('foreground');
   cursor: pointer;
-  @include transition(background-color, border-color);
+  @include transition((background-color, border-color));
 
   @include respond-below('md') {
     min-height: space(11);

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/FilterBar.module.scss
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/FilterBar.module.scss
@@ -348,6 +348,22 @@
   }
 }
 
+.chipButton {
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  cursor: pointer;
+  color: inherit;
+  border-radius: radius('full');
+
+  &:focus-visible {
+    outline: 2px solid color('primary');
+    outline-offset: 2px;
+  }
+}
+
 // ===========================================
 // PAYMENT TYPE LIST
 // ===========================================
@@ -495,6 +511,11 @@
     background-color: color('primary');
     opacity: 0.9;
   }
+}
+
+.sheetBodyScrollable {
+  flex: 1;
+  overflow-y: auto;
 }
 
 .mobileShowResultsBar {

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/FilterBar.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/FilterBar.tsx
@@ -1,14 +1,13 @@
 "use client";
 
 import {formatDate} from "@/lib/utils.generic";
+import type {Invoice} from "@/types/invoices";
 import {InvoiceCategory, PaymentType} from "@/types/invoices";
 import {
   Badge,
   Button,
   Calendar,
-  Checkbox,
   Input,
-  Label,
   Popover,
   PopoverContent,
   PopoverTrigger,
@@ -20,6 +19,7 @@ import {
   Sheet,
   SheetContent,
   SheetTrigger,
+  Slider,
   Tooltip,
   TooltipContent,
   TooltipProvider,
@@ -28,9 +28,11 @@ import {
   useWindowSize,
 } from "@arolariu/components";
 import {useLocale, useTranslations} from "next-intl";
-import {useCallback, useEffect, useState} from "react";
+import {useCallback, useEffect, useMemo, useState} from "react";
 import {TbCalendar, TbCards, TbCurrencyDollar, TbFilter, TbSearch, TbTable, TbX} from "react-icons/tb";
 import type {FilterState} from "../../_hooks/useInvoiceFilters";
+import {computePresetRange, deriveActivePreset, type DatePresetKey} from "../../_utils/datePresets";
+import {computeAvailableCategories, computeAvailableCurrencies, computeAvailablePaymentTypes} from "../../_utils/filterOptions";
 import styles from "./FilterBar.module.scss";
 
 /**
@@ -47,52 +49,42 @@ type Props = {
   viewMode: "table" | "grid";
   /** Callback when view mode changes (updates URL) */
   onViewModeChange: (mode: "table" | "grid") => void;
+  /** Full unfiltered invoice list — drives dynamic option derivation and slider bounds. */
+  invoices: ReadonlyArray<Invoice>;
+  /** Count after filters apply — drives the mobile "Show N results" CTA label. */
+  filteredCount: number;
 };
 
 /**
- * Advanced filter bar component for invoice list with URL-based state management.
+ * Advanced filter bar component for the invoice list, with URL-based state
+ * management and a card-based panel UX (variant J, spec
+ * `2026-05-21-view-invoices-filter-overhaul-design.md`).
  *
  * @remarks
- * Provides comprehensive filtering and sorting capabilities with all state synchronized
- * to URL search parameters via the parent component's `useInvoiceFilters` hook.
+ * Outer shell (search input, view toggle, mobile Sheet wrapper, desktop
+ * inline-panel container) matches the prior design. The panel internals are
+ * a 2-column card grid (single column on mobile) with six cards: Date Range,
+ * Amount Range, Currency, Categories, Payment Types, Sort By.
  *
- * **Filter Capabilities**:
- * - Debounced search input (300ms delay before updating URL)
- * - Date range filtering (from/to dates stored as ISO strings in URL)
- * - Amount range filtering (min/max amounts)
- * - Multi-select category and payment type filters
- * - Sort options (date, amount, name - ascending/descending)
- * - View mode toggle (table/grid) stored in URL
+ * **Active state**: each card highlights with a tinted background + colored
+ * border + a small active-value pill in its header when its filter is set.
  *
- * **URL Integration**:
- * - All filter changes update URL search params via `onFiltersChange` callback
- * - Date values are converted between Date objects (for Calendar) and ISO strings (for URL)
- * - Search input is debounced to avoid excessive URL updates
- * - Filter state is bookmarkable and shareable
+ * **Dynamic option lists**: Currency, Categories, Payment Types are derived
+ * from the FULL unfiltered invoice array (not the post-filter set) so that
+ * filtering down doesn't dead-end the chip rails. Cards with empty derived
+ * lists are hidden entirely.
  *
- * **Responsive Design**:
- * - Uses Popover on desktop for compact filter panel
- * - Uses Sheet (side panel) on mobile for better touch interaction
- * - Automatically adjusts filter UI based on screen size
+ * **Date presets**: 4 quick-buttons (30d / 90d / YTD / All time) control
+ * the From/To Calendar popovers as a true controlled component via
+ * `computePresetRange`. Active preset is derived from current From/To via
+ * `deriveActivePreset` — no extra URL state.
  *
- * **Performance**:
- * - Debounced search prevents excessive re-renders and URL updates
- * - Uses `useCallback` for all event handlers to avoid unnecessary re-renders
- * - Filter panel only renders when open (via Popover/Sheet)
+ * **Sort default**: defaults to "Date (newest first)"; the dropdown has no
+ * "none" option.
  *
- * @param props - Component props
- * @returns FilterBar component
- *
- * @example
- * ```tsx
- * <FilterBar
- *   filters={urlFilters}
- *   onFiltersChange={updateUrlFilters}
- *   activeFilterCount={3}
- *   viewMode="table"
- *   onViewModeChange={setViewMode}
- * />
- * ```
+ * **Mobile**: sticky "Show N results" CTA at the bottom of the Sheet —
+ * tactile thumb-reach affordance to close the sheet (filters still apply
+ * reactively as the user edits).
  */
 export default function FilterBar({
   filters,
@@ -100,6 +92,8 @@ export default function FilterBar({
   activeFilterCount,
   viewMode,
   onViewModeChange,
+  invoices,
+  filteredCount,
 }: Readonly<Props>): React.JSX.Element {
   const t = useTranslations("IMS--List.invoicesView");
   const locale = useLocale();
@@ -117,17 +111,36 @@ export default function FilterBar({
     }
   }, [debouncedSearch, filters.search, onFiltersChange]);
 
-  /**
-   * Handle search input change.
-   */
+  // ── Dynamic option lists, derived from the FULL invoice set ──
+  const availableCurrencies = useMemo(() => computeAvailableCurrencies(invoices), [invoices]);
+  const availableCategories = useMemo(() => computeAvailableCategories(invoices), [invoices]);
+  const availablePaymentTypes = useMemo(() => computeAvailablePaymentTypes(invoices), [invoices]);
+
+  // ── Slider bounds — ceiling = max(1000, ceil(highest amount / 100) * 100) ──
+  const amountMax = useMemo(() => {
+    const max = invoices.reduce((acc, inv) => Math.max(acc, inv.paymentInformation.totalCostAmount), 0);
+    return Math.max(1000, Math.ceil(max / 100) * 100);
+  }, [invoices]);
+
+  // ── Date-preset active state ──
+  const activeDatePreset = useMemo(
+    () => deriveActivePreset(filters.dateFrom, filters.dateTo, new Date()),
+    [filters.dateFrom, filters.dateTo],
+  );
+
+  // ── Per-card active predicates ──
+  const isDateActive = filters.dateFrom !== null || filters.dateTo !== null;
+  const isAmountActive = filters.amountMin !== null || filters.amountMax !== null;
+  const isCurrencyActive = filters.currencies.length > 0;
+  const isCategoryActive = filters.categories.length > 0;
+  const isPaymentActive = filters.paymentTypes.length > 0;
+  const isSortActive = !(filters.sortBy === "date" && filters.sortOrder === "desc");
+
+  // ── Handlers ──
   const handleSearchChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     setSearchInput(e.target.value);
   }, []);
 
-  /**
-   * Clear all active filters by resetting to defaults.
-   * This updates the URL to remove all filter parameters.
-   */
   const handleClearFilters = useCallback(() => {
     setSearchInput("");
     onFiltersChange({
@@ -138,32 +151,26 @@ export default function FilterBar({
       amountMax: null,
       categories: [],
       paymentTypes: [],
-      sortBy: null,
-      sortOrder: null,
+      currencies: [],
+      sortBy: "date",
+      sortOrder: "desc",
     });
   }, [onFiltersChange]);
 
-  /**
-   * Handle date range change.
-   * Converts Date objects to ISO strings for URL storage.
-   */
   const handleDateFromChange = useCallback(
     (date: Date | undefined) => {
-      onFiltersChange({dateFrom: date ? date.toISOString().split("T")[0] : null});
+      onFiltersChange({dateFrom: date ? (date.toISOString().split("T")[0] ?? null) : null});
     },
     [onFiltersChange],
   );
 
   const handleDateToChange = useCallback(
     (date: Date | undefined) => {
-      onFiltersChange({dateTo: date ? date.toISOString().split("T")[0] : null});
+      onFiltersChange({dateTo: date ? (date.toISOString().split("T")[0] ?? null) : null});
     },
     [onFiltersChange],
   );
 
-  /**
-   * Handle amount range change.
-   */
   const handleAmountMinChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const value = e.target.value ? Number.parseFloat(e.target.value) : null;
@@ -180,9 +187,17 @@ export default function FilterBar({
     [onFiltersChange],
   );
 
-  /**
-   * Handle category toggle.
-   */
+  const handleAmountSliderChange = useCallback(
+    (value: number[]) => {
+      const [min, max] = value;
+      onFiltersChange({
+        amountMin: min === 0 ? null : (min ?? null),
+        amountMax: max === amountMax ? null : (max ?? null),
+      });
+    },
+    [amountMax, onFiltersChange],
+  );
+
   const handleCategoryToggle = useCallback(
     (category: number) => {
       const newCategories = filters.categories.includes(category)
@@ -193,9 +208,6 @@ export default function FilterBar({
     [filters.categories, onFiltersChange],
   );
 
-  /**
-   * Handle payment type toggle.
-   */
   const handlePaymentTypeToggle = useCallback(
     (paymentType: number) => {
       const newPaymentTypes = filters.paymentTypes.includes(paymentType)
@@ -206,105 +218,141 @@ export default function FilterBar({
     [filters.paymentTypes, onFiltersChange],
   );
 
-  /**
-   * Handle sort change.
-   * Splits the combined value (e.g., "date-desc") into separate sortBy and sortOrder.
-   * Special value "none" clears sorting.
-   */
-  const handleSortChange = useCallback(
-    (value: string) => {
-      if (value === "none") {
-        onFiltersChange({sortBy: null, sortOrder: null});
-        return;
-      }
-      const parts = value.split("-");
-      const direction = parts.pop() as "asc" | "desc";
-      const field = parts.join("-") as Exclude<FilterState["sortBy"], null>;
-      onFiltersChange({
-        sortBy: field,
-        sortOrder: direction,
-      });
+  const handleCurrencyToggle = useCallback(
+    (code: string) => {
+      const next = filters.currencies.includes(code)
+        ? filters.currencies.filter((c) => c !== code)
+        : [...filters.currencies, code];
+      onFiltersChange({currencies: next});
+    },
+    [filters.currencies, onFiltersChange],
+  );
+
+  const handlePresetClick = useCallback(
+    (preset: DatePresetKey) => {
+      const range = computePresetRange(preset, new Date());
+      onFiltersChange({dateFrom: range.from, dateTo: range.to});
     },
     [onFiltersChange],
   );
 
-  /**
-   * Render category filter options.
-   */
-  const renderCategoryFilters = (): React.JSX.Element => {
-    const categories = [
-      {value: InvoiceCategory.GROCERY, label: t("categories.groceries")},
-      {value: InvoiceCategory.FAST_FOOD, label: t("categories.dining")},
-      {value: InvoiceCategory.HOME_CLEANING, label: t("categories.utilities")},
-      {value: InvoiceCategory.CAR_AUTO, label: t("categories.travel")},
-      {value: InvoiceCategory.OTHER, label: t("categories.other")},
-    ];
+  const handleSortChange = useCallback(
+    (value: string) => {
+      const parts = value.split("-");
+      const direction = parts.pop() as "asc" | "desc";
+      const field = parts.join("-") as Exclude<FilterState["sortBy"], null>;
+      onFiltersChange({sortBy: field, sortOrder: direction});
+    },
+    [onFiltersChange],
+  );
 
-    return (
-      <div className={styles["filterSection"]}>
-        <Label className={styles["filterLabel"]}>{t("filters.categories")}</Label>
-        <div className={styles["categoryChips"]}>
-          {categories.map((category) => (
-            <Badge
-              key={category.value}
-              variant={filters.categories.includes(category.value) ? "default" : "outline"}
-              className={styles["categoryChip"]}
-              onClick={() => handleCategoryToggle(category.value)}>
-              {category.label}
-            </Badge>
-          ))}
-        </div>
-      </div>
-    );
-  };
+  // ── Label helpers (kept inline so they pick up the right `t` namespace) ──
+  const formatCurrencyList = useCallback(
+    (codes: ReadonlyArray<string>): string =>
+      codes.length <= 2 ? codes.join(", ") : `${codes.slice(0, 2).join(", ")}, +${codes.length - 2}`,
+    [],
+  );
 
-  /**
-   * Render payment type filter options.
-   */
-  const renderPaymentTypeFilters = (): React.JSX.Element => {
-    const paymentTypes = [
-      {value: PaymentType.Cash, label: "Cash"},
-      {value: PaymentType.Card, label: "Card"},
-      {value: PaymentType.Transfer, label: "Transfer"},
-      {value: PaymentType.MobilePayment, label: "Mobile"},
-      {value: PaymentType.Voucher, label: "Voucher"},
-      {value: PaymentType.Other, label: "Other"},
-    ];
+  const getCategoryLabel = useCallback(
+    (cat: InvoiceCategory): string => {
+      switch (cat) {
+        case InvoiceCategory.GROCERY:
+          return t("categories.groceries");
+        case InvoiceCategory.FAST_FOOD:
+          return t("categories.dining");
+        case InvoiceCategory.HOME_CLEANING:
+          return t("categories.utilities");
+        case InvoiceCategory.CAR_AUTO:
+          return t("categories.travel");
+        case InvoiceCategory.OTHER:
+        case InvoiceCategory.NOT_DEFINED:
+        default:
+          return t("categories.other");
+      }
+    },
+    [t],
+  );
 
-    return (
-      <div className={styles["filterSection"]}>
-        <Label className={styles["filterLabel"]}>{t("filters.paymentTypes")}</Label>
-        <div className={styles["paymentTypeList"]}>
-          {paymentTypes.map((paymentType) => (
-            <div
-              key={paymentType.value}
-              className={styles["checkboxItem"]}>
-              <Checkbox
-                nativeButton
-                id={`payment-${paymentType.value}`}
-                checked={filters.paymentTypes.includes(paymentType.value)}
-                onCheckedChange={() => handlePaymentTypeToggle(paymentType.value)}
-              />
-              <Label
-                htmlFor={`payment-${paymentType.value}`}
-                className={styles["checkboxLabel"]}>
-                {paymentType.label}
-              </Label>
-            </div>
-          ))}
-        </div>
-      </div>
-    );
-  };
+  const getPaymentTypeLabel = useCallback((pt: PaymentType): string => {
+    switch (pt) {
+      case PaymentType.Cash:
+        return "Cash";
+      case PaymentType.Card:
+        return "Card";
+      case PaymentType.Transfer:
+        return "Transfer";
+      case PaymentType.MobilePayment:
+        return "Mobile";
+      case PaymentType.Voucher:
+        return "Voucher";
+      case PaymentType.Other:
+      case PaymentType.Unknown:
+      default:
+        return "Other";
+    }
+  }, []);
 
-  /**
-   * Render filter panel content.
-   */
+  const getSortLabel = useCallback(
+    (sortBy: FilterState["sortBy"], sortOrder: FilterState["sortOrder"]): string => {
+      if (sortBy === "date" && sortOrder === "desc") return t("filters.sortOptions.dateNewest");
+      if (sortBy === "date" && sortOrder === "asc") return t("filters.sortOptions.dateOldest");
+      if (sortBy === "amount" && sortOrder === "desc") return t("filters.sortOptions.amountHighToLow");
+      if (sortBy === "amount" && sortOrder === "asc") return t("filters.sortOptions.amountLowToHigh");
+      if (sortBy === "name" && sortOrder === "asc") return t("filters.sortOptions.nameAZ");
+      if (sortBy === "name" && sortOrder === "desc") return t("filters.sortOptions.nameZA");
+      return "";
+    },
+    [t],
+  );
+
+  const dateActivePillText = useMemo(() => {
+    if (!isDateActive) return null;
+    if (activeDatePreset === "30d") return t("filters.datePresets.30d");
+    if (activeDatePreset === "90d") return t("filters.datePresets.90d");
+    if (activeDatePreset === "ytd") return t("filters.datePresets.ytd");
+    if (filters.dateFrom && filters.dateTo)
+      return `${formatDate(filters.dateFrom, {locale})} – ${formatDate(filters.dateTo, {locale})}`;
+    if (filters.dateFrom) return `≥ ${formatDate(filters.dateFrom, {locale})}`;
+    if (filters.dateTo) return `≤ ${formatDate(filters.dateTo, {locale})}`;
+    return null;
+  }, [isDateActive, activeDatePreset, filters.dateFrom, filters.dateTo, locale, t]);
+
+  const amountActivePillText = useMemo(() => {
+    if (!isAmountActive) return null;
+    const min = filters.amountMin ?? 0;
+    const max = filters.amountMax ?? amountMax;
+    return `${min} – ${max}`;
+  }, [isAmountActive, filters.amountMin, filters.amountMax, amountMax]);
+
+  // ────────────────────────────────────────────────────────────
+  // Panel body — card grid (single-column on mobile via SCSS)
+  // ────────────────────────────────────────────────────────────
   const renderFilterPanel = (): React.JSX.Element => (
-    <div className={styles["filterPanel"]}>
-      {/* Date Range Filter */}
-      <div className={styles["filterSection"]}>
-        <Label className={styles["filterLabel"]}>{t("filters.dateRange")}</Label>
+    <div className={styles["panelGrid"]}>
+      {/* ─────── Date Range ─────── */}
+      <div className={`${styles["cardSection"]} ${isDateActive ? styles["cardSectionActive"] : ""}`}>
+        <div className={styles["cardSectionHeader"]}>
+          <span className={styles["cardSectionTitle"]}>
+            <TbCalendar /> {t("filters.dateRange")}
+          </span>
+          {dateActivePillText ? (
+            <span className={styles["activeValuePill"]}>{dateActivePillText}</span>
+          ) : (
+            <span className={styles["inactiveLabel"]}>{t("filters.anyValue")}</span>
+          )}
+        </div>
+        <div className={styles["datePresetRow"]}>
+          {(["30d", "90d", "ytd", "all"] as const).map((preset) => (
+            <button
+              key={preset}
+              type='button'
+              className={`${styles["datePresetButton"]} ${activeDatePreset === preset ? styles["datePresetButtonActive"] : ""}`}
+              // eslint-disable-next-line react/jsx-no-bind -- preset is a stable literal
+              onClick={() => handlePresetClick(preset)}>
+              {t(`filters.datePresets.${preset}`)}
+            </button>
+          ))}
+        </div>
         <div className={styles["dateRangeInputs"]}>
           <Popover>
             <PopoverTrigger
@@ -347,9 +395,18 @@ export default function FilterBar({
         </div>
       </div>
 
-      {/* Amount Range Filter */}
-      <div className={styles["filterSection"]}>
-        <Label className={styles["filterLabel"]}>{t("filters.amountRange")}</Label>
+      {/* ─────── Amount Range ─────── */}
+      <div className={`${styles["cardSection"]} ${isAmountActive ? styles["cardSectionActive"] : ""}`}>
+        <div className={styles["cardSectionHeader"]}>
+          <span className={styles["cardSectionTitle"]}>
+            <TbCurrencyDollar /> {t("filters.amountRange")}
+          </span>
+          {amountActivePillText ? (
+            <span className={styles["activeValuePill"]}>{amountActivePillText}</span>
+          ) : (
+            <span className={styles["inactiveLabel"]}>{t("filters.anyValue")}</span>
+          )}
+        </div>
         <div className={styles["amountRangeInputs"]}>
           <div className={styles["amountInputWrapper"]}>
             <TbCurrencyDollar className={styles["currencyIcon"]} />
@@ -372,25 +429,116 @@ export default function FilterBar({
             />
           </div>
         </div>
+        <div className={styles["amountSliderWrapper"]}>
+          <Slider
+            min={0}
+            max={amountMax}
+            step={1}
+            value={[filters.amountMin ?? 0, filters.amountMax ?? amountMax]}
+            onValueChange={handleAmountSliderChange}
+          />
+        </div>
       </div>
 
-      {/* Category Filter */}
-      {renderCategoryFilters()}
+      {/* ─────── Currency (dynamic) ─────── */}
+      {availableCurrencies.length > 0 && (
+        <div className={`${styles["cardSection"]} ${isCurrencyActive ? styles["cardSectionActive"] : ""}`}>
+          <div className={styles["cardSectionHeader"]}>
+            <span className={styles["cardSectionTitle"]}>💵 {t("filters.currency")}</span>
+            {isCurrencyActive ? (
+              <span className={styles["activeValuePill"]}>{formatCurrencyList(filters.currencies)}</span>
+            ) : (
+              <span className={styles["inactiveLabel"]}>{t("filters.currencyAny")}</span>
+            )}
+          </div>
+          <div className={styles["categoryChips"]}>
+            {availableCurrencies.map((code) => (
+              <Badge
+                key={code}
+                variant={filters.currencies.includes(code) ? "default" : "outline"}
+                className={styles["categoryChip"]}
+                // eslint-disable-next-line react/jsx-no-bind -- code is a stable literal
+                onClick={() => handleCurrencyToggle(code)}>
+                {code}
+              </Badge>
+            ))}
+          </div>
+        </div>
+      )}
 
-      {/* Payment Type Filter */}
-      {renderPaymentTypeFilters()}
+      {/* ─────── Categories (dynamic) ─────── */}
+      {availableCategories.length > 0 && (
+        <div className={`${styles["cardSection"]} ${isCategoryActive ? styles["cardSectionActive"] : ""}`}>
+          <div className={styles["cardSectionHeader"]}>
+            <span className={styles["cardSectionTitle"]}>📂 {t("filters.categories")}</span>
+            {isCategoryActive ? (
+              <span className={styles["activeValuePill"]}>
+                {filters.categories.map((c) => getCategoryLabel(c as InvoiceCategory)).join(", ")}
+              </span>
+            ) : (
+              <span className={styles["inactiveLabel"]}>{t("filters.anyValue")}</span>
+            )}
+          </div>
+          <div className={styles["categoryChips"]}>
+            {availableCategories.map((cat) => (
+              <Badge
+                key={cat}
+                variant={filters.categories.includes(cat) ? "default" : "outline"}
+                className={styles["categoryChip"]}
+                // eslint-disable-next-line react/jsx-no-bind -- cat is a stable enum value
+                onClick={() => handleCategoryToggle(cat)}>
+                {getCategoryLabel(cat)}
+              </Badge>
+            ))}
+          </div>
+        </div>
+      )}
 
-      {/* Sort By */}
-      <div className={styles["filterSection"]}>
-        <Label className={styles["filterLabel"]}>{t("filters.sortBy")}</Label>
+      {/* ─────── Payment Types (dynamic) ─────── */}
+      {availablePaymentTypes.length > 0 && (
+        <div className={`${styles["cardSection"]} ${isPaymentActive ? styles["cardSectionActive"] : ""}`}>
+          <div className={styles["cardSectionHeader"]}>
+            <span className={styles["cardSectionTitle"]}>💳 {t("filters.paymentTypes")}</span>
+            {isPaymentActive ? (
+              <span className={styles["activeValuePill"]}>
+                {filters.paymentTypes.map((p) => getPaymentTypeLabel(p as PaymentType)).join(", ")}
+              </span>
+            ) : (
+              <span className={styles["inactiveLabel"]}>{t("filters.anyValue")}</span>
+            )}
+          </div>
+          <div className={styles["categoryChips"]}>
+            {availablePaymentTypes.map((pt) => (
+              <Badge
+                key={pt}
+                variant={filters.paymentTypes.includes(pt) ? "default" : "outline"}
+                className={styles["categoryChip"]}
+                // eslint-disable-next-line react/jsx-no-bind -- pt is a stable enum value
+                onClick={() => handlePaymentTypeToggle(pt)}>
+                {getPaymentTypeLabel(pt)}
+              </Badge>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* ─────── Sort By ─────── */}
+      <div className={`${styles["cardSection"]} ${isSortActive ? styles["cardSectionActive"] : ""}`}>
+        <div className={styles["cardSectionHeader"]}>
+          <span className={styles["cardSectionTitle"]}>↕ {t("filters.sortBy")}</span>
+          {isSortActive ? (
+            <span className={styles["activeValuePill"]}>{getSortLabel(filters.sortBy, filters.sortOrder)}</span>
+          ) : (
+            <span className={styles["inactiveLabel"]}>{t("filters.defaultValue")}</span>
+          )}
+        </div>
         <Select
-          value={filters.sortBy && filters.sortOrder ? `${filters.sortBy}-${filters.sortOrder}` : "none"}
+          value={`${filters.sortBy}-${filters.sortOrder}`}
           onValueChange={handleSortChange}>
           <SelectTrigger className={styles["sortSelect"]}>
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value='none'>{t("filters.sortOptions.none")}</SelectItem>
             <SelectItem value='date-desc'>{t("filters.sortOptions.dateNewest")}</SelectItem>
             <SelectItem value='date-asc'>{t("filters.sortOptions.dateOldest")}</SelectItem>
             <SelectItem value='amount-desc'>{t("filters.sortOptions.amountHighToLow")}</SelectItem>
@@ -418,7 +566,7 @@ export default function FilterBar({
           />
         </div>
 
-        {/* Filter Button with Badge */}
+        {/* Filter Button — mobile opens Sheet, desktop toggles inline panel */}
         {isMobile ? (
           <Sheet
             open={isFilterOpen}
@@ -442,7 +590,14 @@ export default function FilterBar({
             />
             <SheetContent className={styles["filterSheet"]}>
               <div className={styles["sheetHeader"]}>
-                <h3 className={styles["sheetTitle"]}>{t("filters.title")}</h3>
+                <h3 className={styles["sheetTitle"]}>
+                  {t("filters.title")}
+                  {activeFilterCount > 0 && (
+                    <span className={styles["panelHeaderActiveBadge"]}>
+                      {t("filters.activeCount", {count: String(activeFilterCount)})}
+                    </span>
+                  )}
+                </h3>
                 {activeFilterCount > 0 && (
                   <Button
                     variant='ghost'
@@ -454,7 +609,15 @@ export default function FilterBar({
                   </Button>
                 )}
               </div>
-              {renderFilterPanel()}
+              <div style={{flex: 1, overflowY: "auto"}}>{renderFilterPanel()}</div>
+              <div className={styles["mobileShowResultsBar"]}>
+                <Button
+                  className={styles["mobileShowResultsButton"]}
+                  // eslint-disable-next-line react/jsx-no-bind -- inline close handler
+                  onClick={() => setIsFilterOpen(false)}>
+                  {t("filters.showResults", {count: filteredCount})}
+                </Button>
+              </div>
             </SheetContent>
           </Sheet>
         ) : (
@@ -462,6 +625,7 @@ export default function FilterBar({
             variant='outline'
             size='sm'
             className={styles["filterButton"]}
+            // eslint-disable-next-line react/jsx-no-bind -- inline toggle handler
             onClick={() => setIsFilterOpen((prev) => !prev)}
             aria-expanded={isFilterOpen}
             aria-controls='inline-filter-panel'>
@@ -500,6 +664,7 @@ export default function FilterBar({
                     variant={viewMode === "table" ? "default" : "ghost"}
                     size='sm'
                     className={styles["viewButtonLeft"]}
+                    // eslint-disable-next-line react/jsx-no-bind -- inline mode setter
                     onClick={() => onViewModeChange("table")}>
                     <TbTable className={styles["viewIcon"]} />
                   </Button>
@@ -515,6 +680,7 @@ export default function FilterBar({
                     variant={viewMode === "grid" ? "default" : "ghost"}
                     size='sm'
                     className={styles["viewButtonRight"]}
+                    // eslint-disable-next-line react/jsx-no-bind -- inline mode setter
                     onClick={() => onViewModeChange("grid")}>
                     <TbCards className={styles["viewIcon"]} />
                   </Button>
@@ -532,7 +698,14 @@ export default function FilterBar({
           id='inline-filter-panel'
           className={styles["inlineFilterPanel"]}>
           <div className={styles["inlineFilterHeader"]}>
-            <h4 className={styles["inlineFilterTitle"]}>{t("filters.title")}</h4>
+            <h4 className={styles["inlineFilterTitle"]}>
+              {t("filters.title")}
+              {activeFilterCount > 0 && (
+                <span className={styles["panelHeaderActiveBadge"]}>
+                  {t("filters.activeCount", {count: String(activeFilterCount)})}
+                </span>
+              )}
+            </h4>
             <div className={styles["inlineFilterActions"]}>
               {activeFilterCount > 0 && (
                 <Button
@@ -547,6 +720,7 @@ export default function FilterBar({
               <Button
                 variant='ghost'
                 size='sm'
+                // eslint-disable-next-line react/jsx-no-bind -- inline close handler
                 onClick={() => setIsFilterOpen(false)}
                 aria-label={t("filters.title")}
                 className={styles["clearButton"]}>
@@ -555,13 +729,6 @@ export default function FilterBar({
             </div>
           </div>
           {renderFilterPanel()}
-        </div>
-      )}
-
-      {/* Active filter count indicator */}
-      {activeFilterCount > 0 && (
-        <div className={styles["activeFiltersBar"]}>
-          <span className={styles["activeFiltersText"]}>{t("filters.activeCount", {count: String(activeFilterCount)})}</span>
         </div>
       )}
     </div>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/FilterBar.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/FilterBar.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import {formatDate} from "@/lib/utils.generic";
-import {InvoiceCategory, PaymentType, type Invoice} from "@/types/invoices";
+import {useInvoicesStore} from "@/stores";
+import {InvoiceCategory, PaymentType} from "@/types/invoices";
 import {
   Badge,
   Button,
@@ -47,8 +48,6 @@ type Props = {
   viewMode: "table" | "grid";
   /** Callback when view mode changes (updates URL) */
   onViewModeChange: (mode: "table" | "grid") => void;
-  /** Full unfiltered invoice list — drives dynamic option derivation for the multi-select cards. */
-  invoices: ReadonlyArray<Invoice>;
   /** Count after filters apply — drives the mobile "Show N results" CTA label. */
   filteredCount: number;
 };
@@ -104,12 +103,16 @@ export default function FilterBar({
   activeFilterCount,
   viewMode,
   onViewModeChange,
-  invoices,
   filteredCount,
 }: Readonly<Props>): React.JSX.Element {
   const t = useTranslations("IMS--List.invoicesView");
   const locale = useLocale();
   const {isMobile} = useWindowSize();
+  // Read full unfiltered invoice list straight from the store — matches the
+  // established pattern in this directory (BulkActionsToolbar, ExportDialog,
+  // GridView, TableView all read state.entities directly; useInvoices() is
+  // called once upstream in island.tsx and triggers the fetch).
+  const invoices = useInvoicesStore((state) => state.entities);
   const [searchInput, setSearchInput] = useState<string>(filters.search);
   const [isFilterOpen, setIsFilterOpen] = useState<boolean>(false);
 

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/FilterBar.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/FilterBar.tsx
@@ -166,18 +166,29 @@ export default function FilterBar({
     });
   }, [onFiltersChange]);
 
+  // Format a local Date as YYYY-MM-DD using local (not UTC) components so a
+  // user in a positive timezone doesn't see their picked calendar day shifted
+  // back by one. Same shape datePresets.ts uses internally for its UTC-safe
+  // ranges; here we want the LOCAL calendar day the picker actually showed.
+  const formatLocalDate = useCallback((date: Date): string => {
+    const y = date.getFullYear();
+    const m = String(date.getMonth() + 1).padStart(2, "0");
+    const d = String(date.getDate()).padStart(2, "0");
+    return `${y}-${m}-${d}`;
+  }, []);
+
   const handleDateFromChange = useCallback(
     (date: Date | undefined) => {
-      onFiltersChange({dateFrom: date ? (date.toISOString().split("T")[0] ?? null) : null});
+      onFiltersChange({dateFrom: date ? formatLocalDate(date) : null});
     },
-    [onFiltersChange],
+    [onFiltersChange, formatLocalDate],
   );
 
   const handleDateToChange = useCallback(
     (date: Date | undefined) => {
-      onFiltersChange({dateTo: date ? (date.toISOString().split("T")[0] ?? null) : null});
+      onFiltersChange({dateTo: date ? formatLocalDate(date) : null});
     },
-    [onFiltersChange],
+    [onFiltersChange, formatLocalDate],
   );
 
   const handleAmountMinChange = useCallback(
@@ -290,22 +301,25 @@ export default function FilterBar({
     [t],
   );
 
-  const getPaymentTypeLabel = useCallback((pt: PaymentType): string => {
-    switch (pt) {
-      case PaymentType.Cash:
-        return "Cash";
-      case PaymentType.Card:
-        return "Card";
-      case PaymentType.Transfer:
-        return "Transfer";
-      case PaymentType.MobilePayment:
-        return "Mobile";
-      case PaymentType.Voucher:
-        return "Voucher";
-      default:
-        return "Other";
-    }
-  }, []);
+  const getPaymentTypeLabel = useCallback(
+    (pt: PaymentType): string => {
+      switch (pt) {
+        case PaymentType.Cash:
+          return t("filters.paymentTypeLabels.cash");
+        case PaymentType.Card:
+          return t("filters.paymentTypeLabels.card");
+        case PaymentType.Transfer:
+          return t("filters.paymentTypeLabels.transfer");
+        case PaymentType.MobilePayment:
+          return t("filters.paymentTypeLabels.mobile");
+        case PaymentType.Voucher:
+          return t("filters.paymentTypeLabels.voucher");
+        default:
+          return t("filters.paymentTypeLabels.other");
+      }
+    },
+    [t],
+  );
 
   const getSortLabel = useCallback(
     (sortBy: FilterState["sortBy"], sortOrder: FilterState["sortOrder"]): string => {
@@ -382,6 +396,7 @@ export default function FilterBar({
             <button
               key={preset}
               type='button'
+              aria-pressed={activeDatePreset === preset}
               className={`${styles["presetButton"]} ${activeDatePreset === preset ? styles["presetButtonActive"] : ""}`}
               // eslint-disable-next-line react/jsx-no-bind -- preset is a stable literal
               onClick={() => handlePresetClick(preset)}>
@@ -470,6 +485,7 @@ export default function FilterBar({
             <button
               key={presetKey}
               type='button'
+              aria-pressed={activeAmountPreset === presetKey}
               className={`${styles["presetButton"]} ${activeAmountPreset === presetKey ? styles["presetButtonActive"] : ""}`}
               // eslint-disable-next-line react/jsx-no-bind -- presetKey is a stable literal
               onClick={() => handleAmountPresetClick(presetKey)}>
@@ -495,14 +511,19 @@ export default function FilterBar({
           </div>
           <div className={styles["categoryChips"]}>
             {availableCurrencies.map((code) => (
-              <Badge
+              <button
                 key={code}
-                variant={filters.currencies.includes(code) ? "default" : "outline"}
-                className={styles["categoryChip"]}
+                type='button'
+                aria-pressed={filters.currencies.includes(code)}
+                className={styles["chipButton"]}
                 // eslint-disable-next-line react/jsx-no-bind -- code is a stable literal
                 onClick={() => handleCurrencyToggle(code)}>
-                {code}
-              </Badge>
+                <Badge
+                  variant={filters.currencies.includes(code) ? "default" : "outline"}
+                  className={styles["categoryChip"]}>
+                  {code}
+                </Badge>
+              </button>
             ))}
           </div>
         </div>
@@ -526,14 +547,19 @@ export default function FilterBar({
           </div>
           <div className={styles["categoryChips"]}>
             {availableCategories.map((cat) => (
-              <Badge
+              <button
                 key={cat}
-                variant={filters.categories.includes(cat) ? "default" : "outline"}
-                className={styles["categoryChip"]}
+                type='button'
+                aria-pressed={filters.categories.includes(cat)}
+                className={styles["chipButton"]}
                 // eslint-disable-next-line react/jsx-no-bind -- cat is a stable enum value
                 onClick={() => handleCategoryToggle(cat)}>
-                {getCategoryLabel(cat)}
-              </Badge>
+                <Badge
+                  variant={filters.categories.includes(cat) ? "default" : "outline"}
+                  className={styles["categoryChip"]}>
+                  {getCategoryLabel(cat)}
+                </Badge>
+              </button>
             ))}
           </div>
         </div>
@@ -557,14 +583,19 @@ export default function FilterBar({
           </div>
           <div className={styles["categoryChips"]}>
             {availablePaymentTypes.map((pt) => (
-              <Badge
+              <button
                 key={pt}
-                variant={filters.paymentTypes.includes(pt) ? "default" : "outline"}
-                className={styles["categoryChip"]}
+                type='button'
+                aria-pressed={filters.paymentTypes.includes(pt)}
+                className={styles["chipButton"]}
                 // eslint-disable-next-line react/jsx-no-bind -- pt is a stable enum value
                 onClick={() => handlePaymentTypeToggle(pt)}>
-                {getPaymentTypeLabel(pt)}
-              </Badge>
+                <Badge
+                  variant={filters.paymentTypes.includes(pt) ? "default" : "outline"}
+                  className={styles["categoryChip"]}>
+                  {getPaymentTypeLabel(pt)}
+                </Badge>
+              </button>
             ))}
           </div>
         </div>
@@ -658,7 +689,7 @@ export default function FilterBar({
                   </Button>
                 )}
               </div>
-              <div style={{flex: 1, overflowY: "auto"}}>{renderFilterPanel()}</div>
+              <div className={styles["sheetBodyScrollable"]}>{renderFilterPanel()}</div>
               <div className={styles["mobileShowResultsBar"]}>
                 <Button
                   className={styles["mobileShowResultsButton"]}

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/FilterBar.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/FilterBar.tsx
@@ -18,7 +18,6 @@ import {
   Sheet,
   SheetContent,
   SheetTrigger,
-  Slider,
   Tooltip,
   TooltipContent,
   TooltipProvider,
@@ -48,7 +47,7 @@ type Props = {
   viewMode: "table" | "grid";
   /** Callback when view mode changes (updates URL) */
   onViewModeChange: (mode: "table" | "grid") => void;
-  /** Full unfiltered invoice list — drives dynamic option derivation and slider bounds. */
+  /** Full unfiltered invoice list — drives dynamic option derivation for the multi-select cards. */
   invoices: ReadonlyArray<Invoice>;
   /** Count after filters apply — drives the mobile "Show N results" CTA label. */
   filteredCount: number;
@@ -85,7 +84,6 @@ type Props = {
  * tactile thumb-reach affordance to close the sheet (filters still apply
  * reactively as the user edits).
  */
-// eslint-disable-next-line complexity -- top-level filter component coordinates 6 cards + 4 debounced inputs + view-mode toggle; splitting would create artificial boundaries
 export default function FilterBar({
   filters,
   onFiltersChange,
@@ -115,49 +113,6 @@ export default function FilterBar({
   const availableCurrencies = useMemo(() => computeAvailableCurrencies(invoices), [invoices]);
   const availableCategories = useMemo(() => computeAvailableCategories(invoices), [invoices]);
   const availablePaymentTypes = useMemo(() => computeAvailablePaymentTypes(invoices), [invoices]);
-
-  // ── Slider bounds — ceiling = max(1000, ceil(highest amount / 100) * 100) ──
-  const amountMax = useMemo(() => {
-    let max = 0;
-    for (const inv of invoices) {
-      if (inv.paymentInformation.totalCostAmount > max) max = inv.paymentInformation.totalCostAmount;
-    }
-    return Math.max(1000, Math.ceil(max / 100) * 100);
-  }, [invoices]);
-
-  // ── Amount slider — local "wet" state for instant thumb feedback,
-  //    debounced before pushing to URL/filters so dragging doesn't trigger
-  //    a re-render per pixel of travel.
-  const [sliderValue, setSliderValue] = useState<[number, number]>(() => [
-    filters.amountMin ?? 0,
-    filters.amountMax ?? amountMax,
-  ]);
-  const debouncedSlider = useDebounce(sliderValue, 200);
-
-  // Re-sync local slider when filters change externally (Clear all,
-  // number-input edits, etc.). Uses React's render-time setState pattern —
-  // tracking the last-seen external value and updating in render avoids
-  // the cascading-render anti-pattern of doing this from useEffect.
-  const [lastSyncedExternal, setLastSyncedExternal] = useState<[number, number]>(() => [
-    filters.amountMin ?? 0,
-    filters.amountMax ?? amountMax,
-  ]);
-  const externalMin = filters.amountMin ?? 0;
-  const externalMax = filters.amountMax ?? amountMax;
-  if (lastSyncedExternal[0] !== externalMin || lastSyncedExternal[1] !== externalMax) {
-    setLastSyncedExternal([externalMin, externalMax]);
-    setSliderValue([externalMin, externalMax]);
-  }
-
-  // Push debounced slider value to filters when it diverges from current filter state.
-  useEffect(() => {
-    const [min, max] = debouncedSlider;
-    const nextMin = min === 0 ? null : min;
-    const nextMax = max === amountMax ? null : max;
-    if (nextMin !== filters.amountMin || nextMax !== filters.amountMax) {
-      onFiltersChange({amountMin: nextMin, amountMax: nextMax});
-    }
-  }, [debouncedSlider, amountMax, filters.amountMin, filters.amountMax, onFiltersChange]);
 
   // ── Date-preset active state ──
   const activeDatePreset = useMemo(
@@ -223,11 +178,6 @@ export default function FilterBar({
     },
     [onFiltersChange],
   );
-
-  const handleAmountSliderChange = useCallback((value: number[]) => {
-    const [min = 0, max = 0] = value;
-    setSliderValue([min, max]);
-  }, []);
 
   const handleCategoryToggle = useCallback(
     (category: number) => {
@@ -346,10 +296,11 @@ export default function FilterBar({
 
   const amountActivePillText = useMemo(() => {
     if (!isAmountActive) return null;
-    const min = filters.amountMin ?? 0;
-    const max = filters.amountMax ?? amountMax;
-    return `${min} – ${max}`;
-  }, [isAmountActive, filters.amountMin, filters.amountMax, amountMax]);
+    if (filters.amountMin !== null && filters.amountMax !== null) return `${filters.amountMin} – ${filters.amountMax}`;
+    if (filters.amountMin !== null) return `≥ ${filters.amountMin}`;
+    if (filters.amountMax !== null) return `≤ ${filters.amountMax}`;
+    return null;
+  }, [isAmountActive, filters.amountMin, filters.amountMax]);
 
   // ────────────────────────────────────────────────────────────
   // Panel body — card grid (single-column on mobile via SCSS)
@@ -456,15 +407,6 @@ export default function FilterBar({
               className={styles["amountInput"]}
             />
           </div>
-        </div>
-        <div className={styles["amountSliderWrapper"]}>
-          <Slider
-            min={0}
-            max={amountMax}
-            step={1}
-            value={sliderValue}
-            onValueChange={handleAmountSliderChange}
-          />
         </div>
       </div>
 

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/FilterBar.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/FilterBar.tsx
@@ -85,6 +85,7 @@ type Props = {
  * tactile thumb-reach affordance to close the sheet (filters still apply
  * reactively as the user edits).
  */
+// eslint-disable-next-line complexity -- top-level filter component coordinates 6 cards + 4 debounced inputs + view-mode toggle; splitting would create artificial boundaries
 export default function FilterBar({
   filters,
   onFiltersChange,
@@ -123,6 +124,40 @@ export default function FilterBar({
     }
     return Math.max(1000, Math.ceil(max / 100) * 100);
   }, [invoices]);
+
+  // ── Amount slider — local "wet" state for instant thumb feedback,
+  //    debounced before pushing to URL/filters so dragging doesn't trigger
+  //    a re-render per pixel of travel.
+  const [sliderValue, setSliderValue] = useState<[number, number]>(() => [
+    filters.amountMin ?? 0,
+    filters.amountMax ?? amountMax,
+  ]);
+  const debouncedSlider = useDebounce(sliderValue, 200);
+
+  // Re-sync local slider when filters change externally (Clear all,
+  // number-input edits, etc.). Uses React's render-time setState pattern —
+  // tracking the last-seen external value and updating in render avoids
+  // the cascading-render anti-pattern of doing this from useEffect.
+  const [lastSyncedExternal, setLastSyncedExternal] = useState<[number, number]>(() => [
+    filters.amountMin ?? 0,
+    filters.amountMax ?? amountMax,
+  ]);
+  const externalMin = filters.amountMin ?? 0;
+  const externalMax = filters.amountMax ?? amountMax;
+  if (lastSyncedExternal[0] !== externalMin || lastSyncedExternal[1] !== externalMax) {
+    setLastSyncedExternal([externalMin, externalMax]);
+    setSliderValue([externalMin, externalMax]);
+  }
+
+  // Push debounced slider value to filters when it diverges from current filter state.
+  useEffect(() => {
+    const [min, max] = debouncedSlider;
+    const nextMin = min === 0 ? null : min;
+    const nextMax = max === amountMax ? null : max;
+    if (nextMin !== filters.amountMin || nextMax !== filters.amountMax) {
+      onFiltersChange({amountMin: nextMin, amountMax: nextMax});
+    }
+  }, [debouncedSlider, amountMax, filters.amountMin, filters.amountMax, onFiltersChange]);
 
   // ── Date-preset active state ──
   const activeDatePreset = useMemo(
@@ -189,16 +224,10 @@ export default function FilterBar({
     [onFiltersChange],
   );
 
-  const handleAmountSliderChange = useCallback(
-    (value: number[]) => {
-      const [min, max] = value;
-      onFiltersChange({
-        amountMin: min === 0 ? null : (min ?? null),
-        amountMax: max === amountMax ? null : (max ?? null),
-      });
-    },
-    [amountMax, onFiltersChange],
-  );
+  const handleAmountSliderChange = useCallback((value: number[]) => {
+    const [min = 0, max = 0] = value;
+    setSliderValue([min, max]);
+  }, []);
 
   const handleCategoryToggle = useCallback(
     (category: number) => {
@@ -433,7 +462,7 @@ export default function FilterBar({
             min={0}
             max={amountMax}
             step={1}
-            value={[filters.amountMin ?? 0, filters.amountMax ?? amountMax]}
+            value={sliderValue}
             onValueChange={handleAmountSliderChange}
           />
         </div>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/FilterBar.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/FilterBar.tsx
@@ -28,7 +28,7 @@ import {
 } from "@arolariu/components";
 import {useLocale, useTranslations} from "next-intl";
 import {useCallback, useEffect, useMemo, useState} from "react";
-import {TbCalendar, TbCards, TbCurrencyDollar, TbFilter, TbSearch, TbTable, TbX} from "react-icons/tb";
+import {TbCalendar, TbCards, TbCurrencyDollar, TbFilter, TbInfoCircle, TbSearch, TbTable, TbX} from "react-icons/tb";
 import type {FilterState} from "../../_hooks/useInvoiceFilters";
 import {computePresetRange, deriveActivePreset, type DatePresetKey} from "../../_utils/datePresets";
 import {computeAvailableCategories, computeAvailableCurrencies, computeAvailablePaymentTypes} from "../../_utils/filterOptions";
@@ -340,12 +340,31 @@ export default function FilterBar({
     return null;
   }, [isAmountActive, filters.amountMin, filters.amountMax]);
 
+  // Small (i) tooltip rendered next to the title of every dynamically-populated
+  // filter card (Currency, Categories, Payment Types) — explains that the chip
+  // set reflects the user's own data rather than a fixed taxonomy.
+  const dynamicHint = (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <span
+            className={styles["dynamicHintIcon"]}
+            aria-label={t("filters.dynamicHint")}>
+            <TbInfoCircle aria-hidden='true' />
+          </span>
+        }
+      />
+      <TooltipContent>{t("filters.dynamicHint")}</TooltipContent>
+    </Tooltip>
+  );
+
   // ────────────────────────────────────────────────────────────
   // Panel body — card grid (single-column on mobile via SCSS)
   // ────────────────────────────────────────────────────────────
   // eslint-disable-next-line sonarjs/cognitive-complexity, complexity -- six conditionally-rendered card sections; extracting per-card sub-components would obscure the linear visual order without simplifying logic
   const renderFilterPanel = (): React.JSX.Element => (
-    <div className={styles["panelGrid"]}>
+    <TooltipProvider>
+      <div className={styles["panelGrid"]}>
       {/* ─────── Date Range ─────── */}
       <div className={`${styles["cardSection"]} ${isDateActive ? styles["cardSectionActive"] : ""}`}>
         <div className={styles["cardSectionHeader"]}>
@@ -464,7 +483,10 @@ export default function FilterBar({
       {availableCurrencies.length > 0 && (
         <div className={`${styles["cardSection"]} ${isCurrencyActive ? styles["cardSectionActive"] : ""}`}>
           <div className={styles["cardSectionHeader"]}>
-            <span className={styles["cardSectionTitle"]}>💵 {t("filters.currency")}</span>
+            <span className={styles["cardSectionTitle"]}>
+              💵 {t("filters.currency")}
+              {dynamicHint}
+            </span>
             {isCurrencyActive ? (
               <span className={styles["activeValuePill"]}>{formatCurrencyList(filters.currencies)}</span>
             ) : (
@@ -490,7 +512,10 @@ export default function FilterBar({
       {availableCategories.length > 0 && (
         <div className={`${styles["cardSection"]} ${isCategoryActive ? styles["cardSectionActive"] : ""}`}>
           <div className={styles["cardSectionHeader"]}>
-            <span className={styles["cardSectionTitle"]}>📂 {t("filters.categories")}</span>
+            <span className={styles["cardSectionTitle"]}>
+              📂 {t("filters.categories")}
+              {dynamicHint}
+            </span>
             {isCategoryActive ? (
               <span className={styles["activeValuePill"]}>
                 {filters.categories.map((c) => getCategoryLabel(c as InvoiceCategory)).join(", ")}
@@ -518,7 +543,10 @@ export default function FilterBar({
       {availablePaymentTypes.length > 0 && (
         <div className={`${styles["cardSection"]} ${isPaymentActive ? styles["cardSectionActive"] : ""}`}>
           <div className={styles["cardSectionHeader"]}>
-            <span className={styles["cardSectionTitle"]}>💳 {t("filters.paymentTypes")}</span>
+            <span className={styles["cardSectionTitle"]}>
+              💳 {t("filters.paymentTypes")}
+              {dynamicHint}
+            </span>
             {isPaymentActive ? (
               <span className={styles["activeValuePill"]}>
                 {filters.paymentTypes.map((p) => getPaymentTypeLabel(p as PaymentType)).join(", ")}
@@ -568,7 +596,8 @@ export default function FilterBar({
           </SelectContent>
         </Select>
       </div>
-    </div>
+      </div>
+    </TooltipProvider>
   );
 
   return (

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/FilterBar.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/FilterBar.tsx
@@ -54,6 +54,20 @@ type Props = {
 };
 
 /**
+ * Quick-amount presets shown as chips beneath the Min/Max number inputs.
+ * Each preset writes both bounds to filters when clicked (or clears them
+ * when the preset is already active — tap-to-toggle).
+ */
+type AmountPresetKey = "0-50" | "50-100" | "100-500" | "500+";
+
+const AMOUNT_PRESETS = [
+  {key: "0-50", labelKey: "0to50", min: 0, max: 50},
+  {key: "50-100", labelKey: "50to100", min: 50, max: 100},
+  {key: "100-500", labelKey: "100to500", min: 100, max: 500},
+  {key: "500+", labelKey: "500plus", min: 500, max: null},
+] as const satisfies ReadonlyArray<{key: AmountPresetKey; labelKey: string; min: number; max: number | null}>;
+
+/**
  * Advanced filter bar component for the invoice list, with URL-based state
  * management and a card-based panel UX (variant J, spec
  * `2026-05-21-view-invoices-filter-overhaul-design.md`).
@@ -177,6 +191,27 @@ export default function FilterBar({
       onFiltersChange({amountMax: value});
     },
     [onFiltersChange],
+  );
+
+  // ── Amount preset (chip) active-state derivation + click handler ──
+  const activeAmountPreset = useMemo<AmountPresetKey | null>(() => {
+    for (const preset of AMOUNT_PRESETS) {
+      if (filters.amountMin === preset.min && filters.amountMax === preset.max) return preset.key;
+    }
+    return null;
+  }, [filters.amountMin, filters.amountMax]);
+
+  const handleAmountPresetClick = useCallback(
+    (presetKey: AmountPresetKey) => {
+      // Tap-to-toggle: clicking the already-active preset clears the amount filter.
+      if (activeAmountPreset === presetKey) {
+        onFiltersChange({amountMin: null, amountMax: null});
+        return;
+      }
+      const preset = AMOUNT_PRESETS.find((p) => p.key === presetKey);
+      if (preset) onFiltersChange({amountMin: preset.min, amountMax: preset.max});
+    },
+    [activeAmountPreset, onFiltersChange],
   );
 
   const handleCategoryToggle = useCallback(
@@ -320,12 +355,12 @@ export default function FilterBar({
             <span className={styles["inactiveLabel"]}>{t("filters.anyValue")}</span>
           )}
         </div>
-        <div className={styles["datePresetRow"]}>
+        <div className={styles["presetRow"]}>
           {(["30d", "90d", "ytd", "all"] as const).map((preset) => (
             <button
               key={preset}
               type='button'
-              className={`${styles["datePresetButton"]} ${activeDatePreset === preset ? styles["datePresetButtonActive"] : ""}`}
+              className={`${styles["presetButton"]} ${activeDatePreset === preset ? styles["presetButtonActive"] : ""}`}
               // eslint-disable-next-line react/jsx-no-bind -- preset is a stable literal
               onClick={() => handlePresetClick(preset)}>
               {t(`filters.datePresets.${preset}`)}
@@ -407,6 +442,18 @@ export default function FilterBar({
               className={styles["amountInput"]}
             />
           </div>
+        </div>
+        <div className={styles["amountPresetRow"]}>
+          {AMOUNT_PRESETS.map(({key: presetKey, labelKey}) => (
+            <button
+              key={presetKey}
+              type='button'
+              className={`${styles["presetButton"]} ${activeAmountPreset === presetKey ? styles["presetButtonActive"] : ""}`}
+              // eslint-disable-next-line react/jsx-no-bind -- presetKey is a stable literal
+              onClick={() => handleAmountPresetClick(presetKey)}>
+              {t(`filters.amountPresets.${labelKey}`)}
+            </button>
+          ))}
         </div>
       </div>
 

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/FilterBar.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/FilterBar.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import {formatDate} from "@/lib/utils.generic";
-import type {Invoice} from "@/types/invoices";
-import {InvoiceCategory, PaymentType} from "@/types/invoices";
+import {InvoiceCategory, PaymentType, type Invoice} from "@/types/invoices";
 import {
   Badge,
   Button,
@@ -118,7 +117,10 @@ export default function FilterBar({
 
   // ── Slider bounds — ceiling = max(1000, ceil(highest amount / 100) * 100) ──
   const amountMax = useMemo(() => {
-    const max = invoices.reduce((acc, inv) => Math.max(acc, inv.paymentInformation.totalCostAmount), 0);
+    let max = 0;
+    for (const inv of invoices) {
+      if (inv.paymentInformation.totalCostAmount > max) max = inv.paymentInformation.totalCostAmount;
+    }
     return Math.max(1000, Math.ceil(max / 100) * 100);
   }, [invoices]);
 
@@ -264,8 +266,6 @@ export default function FilterBar({
           return t("categories.utilities");
         case InvoiceCategory.CAR_AUTO:
           return t("categories.travel");
-        case InvoiceCategory.OTHER:
-        case InvoiceCategory.NOT_DEFINED:
         default:
           return t("categories.other");
       }
@@ -285,8 +285,6 @@ export default function FilterBar({
         return "Mobile";
       case PaymentType.Voucher:
         return "Voucher";
-      case PaymentType.Other:
-      case PaymentType.Unknown:
       default:
         return "Other";
     }
@@ -327,6 +325,7 @@ export default function FilterBar({
   // ────────────────────────────────────────────────────────────
   // Panel body — card grid (single-column on mobile via SCSS)
   // ────────────────────────────────────────────────────────────
+  // eslint-disable-next-line sonarjs/cognitive-complexity, complexity -- six conditionally-rendered card sections; extracting per-card sub-components would obscure the linear visual order without simplifying logic
   const renderFilterPanel = (): React.JSX.Element => (
     <div className={styles["panelGrid"]}>
       {/* ─────── Date Range ─────── */}
@@ -693,7 +692,7 @@ export default function FilterBar({
       </div>
 
       {/* Inline filter panel (desktop only) — collapses below the search bar */}
-      {!isMobile && isFilterOpen && (
+      {!isMobile && isFilterOpen ? (
         <div
           id='inline-filter-panel'
           className={styles["inlineFilterPanel"]}>
@@ -730,7 +729,7 @@ export default function FilterBar({
           </div>
           {renderFilterPanel()}
         </div>
-      )}
+      ) : null}
     </div>
   );
 }

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/InvoicesView.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/InvoicesView.tsx
@@ -181,7 +181,6 @@ export default function RenderInvoicesView({invoices}: Readonly<Props>): React.J
         activeFilterCount={activeFilterCount}
         viewMode={filters.view}
         onViewModeChange={handleViewModeChange}
-        invoices={invoices}
         filteredCount={filteredInvoices.length}
       />
       {viewContent}

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/InvoicesView.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/InvoicesView.tsx
@@ -181,6 +181,8 @@ export default function RenderInvoicesView({invoices}: Readonly<Props>): React.J
         activeFilterCount={activeFilterCount}
         viewMode={filters.view}
         onViewModeChange={handleViewModeChange}
+        invoices={invoices}
+        filteredCount={filteredInvoices.length}
       />
       {viewContent}
     </div>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_hooks/useFilteredInvoices.test.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_hooks/useFilteredInvoices.test.tsx
@@ -22,8 +22,9 @@ const createDefaultFilters = (): FilterState => ({
   amountMax: null,
   categories: [],
   paymentTypes: [],
-  sortBy: null,
-  sortOrder: null,
+  currencies: [],
+  sortBy: "date",
+  sortOrder: "desc",
   view: "table",
 });
 
@@ -1258,6 +1259,59 @@ describe("useFilteredInvoices", () => {
 
       // Assert: All invoices returned (sorted by date-desc)
       expect(result.current).toHaveLength(3);
+    });
+  });
+
+  describe("Currency filtering", () => {
+    it("excludes invoices whose currency is not in the filter set", () => {
+      const ron = new InvoiceBuilder()
+        .withName("RON Invoice")
+        .withPaymentInformation({
+          totalCostAmount: 100,
+          currency: {code: "RON", name: "Romanian Leu", symbol: "lei"},
+          transactionDate: new Date("2024-01-15"),
+          paymentType: PaymentType.Cash,
+          totalTaxAmount: 0,
+          subtotalAmount: 0,
+          tipAmount: 0,
+        })
+        .build();
+      const eur = new InvoiceBuilder()
+        .withName("EUR Invoice")
+        .withPaymentInformation({
+          totalCostAmount: 50,
+          currency: {code: "EUR", name: "Euro", symbol: "€"},
+          transactionDate: new Date("2024-02-10"),
+          paymentType: PaymentType.Card,
+          totalTaxAmount: 0,
+          subtotalAmount: 0,
+          tipAmount: 0,
+        })
+        .build();
+
+      const filters = {...createDefaultFilters(), currencies: ["RON"]};
+      const {result} = renderHook(() => useFilteredInvoices([ron, eur], filters));
+
+      expect(result.current).toHaveLength(1);
+      expect(result.current[0]?.name).toBe("RON Invoice");
+    });
+
+    it("empty currencies array means pass-through (no filter applied)", () => {
+      const ron = new InvoiceBuilder().withName("RON").build();
+      const eur = new InvoiceBuilder().withName("EUR").build();
+      const {result} = renderHook(() => useFilteredInvoices([ron, eur], createDefaultFilters()));
+      expect(result.current).toHaveLength(2);
+    });
+
+    it("treats missing currency.code as 'RON' when filtering by RON", () => {
+      const malformed = new InvoiceBuilder().withName("Malformed").build();
+      const noCode: Invoice = {
+        ...malformed,
+        paymentInformation: {...malformed.paymentInformation, currency: {code: "", name: "", symbol: ""}},
+      };
+      const filters = {...createDefaultFilters(), currencies: ["RON"]};
+      const {result} = renderHook(() => useFilteredInvoices([noCode], filters));
+      expect(result.current).toHaveLength(1);
     });
   });
 });

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_hooks/useFilteredInvoices.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_hooks/useFilteredInvoices.tsx
@@ -19,6 +19,9 @@ import type {FilterState} from "./useInvoiceFilters";
  * - Amount range: Filters by total cost amount (inclusive)
  * - Categories: Multi-select filter (OR logic)
  * - Payment types: Multi-select filter (OR logic)
+ * - Currencies: Multi-select filter (OR logic) on `invoice.paymentInformation.currency.code`,
+ *   with `"RON"` as the fallback for invoices missing a currency code (matches the
+ *   codebase-wide default in `_utils/statistics.ts`).
  *
  * **Sorting:**
  * Supports sorting by date, amount, and name with separate field and direction parameters.

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_hooks/useFilteredInvoices.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_hooks/useFilteredInvoices.tsx
@@ -96,6 +96,15 @@ export function useFilteredInvoices(invoices: ReadonlyArray<Invoice>, filters: F
       filtered = filtered.filter((invoice) => filters.paymentTypes.includes(invoice.paymentInformation.paymentType));
     }
 
+    // Apply currency filter (OR logic, like categories / paymentTypes).
+    // Falls back to "RON" for invoices missing currency.code — matches the
+    // codebase-wide default established in _utils/statistics.ts.
+    if (filters.currencies.length > 0) {
+      filtered = filtered.filter((invoice) =>
+        filters.currencies.includes(invoice.paymentInformation.currency?.code || "RON"),
+      );
+    }
+
     // Apply sorting (only if both sortBy and sortOrder are set)
     const sorted = [...filtered];
     if (filters.sortBy !== null && filters.sortOrder !== null) {

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_hooks/useInvoiceFilters.test.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_hooks/useInvoiceFilters.test.tsx
@@ -44,8 +44,9 @@ describe("useInvoiceFilters", () => {
         amountMax: null,
         categories: [],
         paymentTypes: [],
-        sortBy: null,
-        sortOrder: null,
+        currencies: [],
+        sortBy: "date",
+        sortOrder: "desc",
         view: "table",
       });
     });
@@ -436,6 +437,67 @@ describe("useInvoiceFilters", () => {
 
       // Assert
       expect(result.current.activeFilterCount).toBe(0);
+    });
+  });
+
+  describe("currencies field", () => {
+    it("parses ?cur=RON,EUR into filters.currencies", () => {
+      const mockSearchParams = new URLSearchParams("?cur=RON,EUR");
+      (useSearchParams as ReturnType<typeof vi.fn>).mockReturnValue(mockSearchParams);
+      const {result} = renderHook(() => useInvoiceFilters());
+      expect(result.current.filters.currencies).toEqual(["RON", "EUR"]);
+    });
+
+    it("defaults to empty array when ?cur is absent", () => {
+      const mockSearchParams = new URLSearchParams("");
+      (useSearchParams as ReturnType<typeof vi.fn>).mockReturnValue(mockSearchParams);
+      const {result} = renderHook(() => useInvoiceFilters());
+      expect(result.current.filters.currencies).toEqual([]);
+    });
+
+    it("writes 'cur' to URL when setFilters({currencies}) is called", () => {
+      const mockSearchParams = new URLSearchParams("");
+      (useSearchParams as ReturnType<typeof vi.fn>).mockReturnValue(mockSearchParams);
+      const {result} = renderHook(() => useInvoiceFilters());
+      result.current.setFilters({currencies: ["RON", "EUR"]});
+      const lastCall = mockReplace.mock.calls.at(-1)?.[0] as string;
+      expect(lastCall).toContain("cur=RON%2CEUR");
+    });
+
+    it("removes 'cur' from URL when setFilters({currencies: []}) is called", () => {
+      const mockSearchParams = new URLSearchParams("?cur=RON,EUR");
+      (useSearchParams as ReturnType<typeof vi.fn>).mockReturnValue(mockSearchParams);
+      const {result} = renderHook(() => useInvoiceFilters());
+      result.current.setFilters({currencies: []});
+      const lastCall = mockReplace.mock.calls.at(-1)?.[0] as string;
+      expect(lastCall).not.toContain("cur=");
+    });
+
+    it("counts non-empty currencies toward activeFilterCount", () => {
+      const mockSearchParams = new URLSearchParams("?cur=RON");
+      (useSearchParams as ReturnType<typeof vi.fn>).mockReturnValue(mockSearchParams);
+      const {result} = renderHook(() => useInvoiceFilters());
+      expect(result.current.activeFilterCount).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe("sort default flip", () => {
+    it("defaults sortBy to 'date' and sortOrder to 'desc' when both URL params are absent", () => {
+      const mockSearchParams = new URLSearchParams("");
+      (useSearchParams as ReturnType<typeof vi.fn>).mockReturnValue(mockSearchParams);
+      const {result} = renderHook(() => useInvoiceFilters());
+      expect(result.current.filters.sortBy).toBe("date");
+      expect(result.current.filters.sortOrder).toBe("desc");
+    });
+
+    it("does not write sortBy/sortOrder to URL when value matches the new default", () => {
+      const mockSearchParams = new URLSearchParams("");
+      (useSearchParams as ReturnType<typeof vi.fn>).mockReturnValue(mockSearchParams);
+      const {result} = renderHook(() => useInvoiceFilters());
+      result.current.setFilters({sortBy: "date", sortOrder: "desc"});
+      const lastCall = mockReplace.mock.calls.at(-1)?.[0] as string;
+      expect(lastCall).not.toContain("sortBy=");
+      expect(lastCall).not.toContain("sortOrder=");
     });
   });
 });

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_hooks/useInvoiceFilters.test.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_hooks/useInvoiceFilters.test.tsx
@@ -427,9 +427,10 @@ describe("useInvoiceFilters", () => {
       expect(result.current.activeFilterCount).toBe(5);
     });
 
-    it("should not count sort and view mode as active filters", () => {
+    it("should not count default sort or view mode as active filters", () => {
+      // Default sort is now date/desc — only view-mode change should NOT contribute.
       // Arrange
-      const mockSearchParams = new URLSearchParams("?sortBy=amount&sortOrder=asc&view=grid");
+      const mockSearchParams = new URLSearchParams("?view=grid");
       (useSearchParams as ReturnType<typeof vi.fn>).mockReturnValue(mockSearchParams);
 
       // Act
@@ -437,6 +438,17 @@ describe("useInvoiceFilters", () => {
 
       // Assert
       expect(result.current.activeFilterCount).toBe(0);
+    });
+
+    it("should count non-default sort as an active filter", () => {
+      // Anything other than date/desc counts toward the badge to keep the
+      // header in sync with the Sort card's active visual.
+      const mockSearchParams = new URLSearchParams("?sortBy=amount&sortOrder=asc");
+      (useSearchParams as ReturnType<typeof vi.fn>).mockReturnValue(mockSearchParams);
+
+      const {result} = renderHook(() => useInvoiceFilters());
+
+      expect(result.current.activeFilterCount).toBe(1);
     });
   });
 

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_hooks/useInvoiceFilters.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_hooks/useInvoiceFilters.tsx
@@ -30,6 +30,7 @@ export type FilterState = {
   amountMax: number | null;
   categories: number[];
   paymentTypes: number[];
+  currencies: string[];
   sortBy: "date" | "amount" | "name" | null;
   sortOrder: "asc" | "desc" | null;
   view: "table" | "grid";
@@ -155,8 +156,13 @@ export function useInvoiceFilters(): UseInvoiceFiltersReturn {
           ?.split(",")
           .map(Number)
           .filter((n) => !Number.isNaN(n)) ?? [],
-      sortBy: (searchParams.get("sortBy") as FilterState["sortBy"]) ?? null,
-      sortOrder: (searchParams.get("sortOrder") as FilterState["sortOrder"]) ?? null,
+      currencies:
+        searchParams
+          .get("cur")
+          ?.split(",")
+          .filter((c) => c.length > 0) ?? [],
+      sortBy: (searchParams.get("sortBy") as FilterState["sortBy"]) ?? "date",
+      sortOrder: (searchParams.get("sortOrder") as FilterState["sortOrder"]) ?? "desc",
       view: (searchParams.get("view") as "table" | "grid") ?? "table",
     }),
     [searchParams],
@@ -230,8 +236,15 @@ export function useInvoiceFilters(): UseInvoiceFiltersReturn {
         params.delete("pay");
       }
 
-      // Sort params: always write BOTH or NEITHER
-      if (merged.sortBy !== null && merged.sortOrder !== null) {
+      if (merged.currencies.length > 0) {
+        params.set("cur", merged.currencies.join(","));
+      } else {
+        params.delete("cur");
+      }
+
+      // Sort params: write only when value differs from the new default
+      // (default = date/desc → no params in URL keeps it clean)
+      if (merged.sortBy && merged.sortOrder && !(merged.sortBy === "date" && merged.sortOrder === "desc")) {
         params.set("sortBy", merged.sortBy);
         params.set("sortOrder", merged.sortOrder);
       } else {
@@ -285,6 +298,7 @@ export function useInvoiceFilters(): UseInvoiceFiltersReturn {
     if (filters.amountMin !== null || filters.amountMax !== null) count++;
     if (filters.categories.length > 0) count++;
     if (filters.paymentTypes.length > 0) count++;
+    if (filters.currencies.length > 0) count++;
     return count;
   }, [filters]);
 

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_hooks/useInvoiceFilters.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_hooks/useInvoiceFilters.tsx
@@ -18,8 +18,9 @@ import {useCallback, useMemo} from "react";
  * @property amountMax - Maximum amount for amount range filter
  * @property categories - Selected invoice categories (comma-separated enum values)
  * @property paymentTypes - Selected payment types (comma-separated enum values)
- * @property sortBy - Sort field (date, amount, name, or null for no sorting)
- * @property sortOrder - Sort direction (asc, desc, or null for no sorting)
+ * @property currencies - Selected ISO 4217 currency codes (comma-separated, URL key `cur`)
+ * @property sortBy - Sort field. Defaults to `"date"`.
+ * @property sortOrder - Sort direction. Defaults to `"desc"`.
  * @property view - Current view mode (table or grid)
  */
 export type FilterState = {
@@ -290,6 +291,10 @@ export function useInvoiceFilters(): UseInvoiceFiltersReturn {
    * - Amount range (if either min or max is set)
    * - Categories (if any selected)
    * - Payment types (if any selected)
+   * - Currencies (if any selected)
+   * - Sort (if non-default — anything other than date/desc)
+   *
+   * View mode is intentionally excluded — it's a UI preference, not a filter.
    */
   const activeFilterCount = useMemo(() => {
     let count = 0;
@@ -299,6 +304,10 @@ export function useInvoiceFilters(): UseInvoiceFiltersReturn {
     if (filters.categories.length > 0) count++;
     if (filters.paymentTypes.length > 0) count++;
     if (filters.currencies.length > 0) count++;
+    // Sort is "active" when not the default (date/desc). Matches the Sort card's
+    // active-visual logic in FilterBar.tsx so the header badge and the card
+    // highlight stay in sync.
+    if (!(filters.sortBy === "date" && filters.sortOrder === "desc")) count++;
     return count;
   }, [filters]);
 

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_utils/datePresets.test.ts
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_utils/datePresets.test.ts
@@ -40,8 +40,8 @@ describe("computePresetRange", () => {
 });
 
 describe("deriveActivePreset", () => {
-  it("returns null when both from and to are null", () => {
-    expect(deriveActivePreset(null, null, NOW)).toBeNull();
+  it("returns 'all' when both from and to are null (no date restriction == All time)", () => {
+    expect(deriveActivePreset(null, null, NOW)).toBe("all");
   });
 
   it("returns '30d' when from/to exactly match the 30d range", () => {

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_utils/datePresets.test.ts
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_utils/datePresets.test.ts
@@ -1,0 +1,70 @@
+/**
+ * @fileoverview Unit tests for the date-preset helpers.
+ * @module sites/arolariu.ro/src/app/domains/invoices/view-invoices/_utils/datePresets.test
+ */
+
+import {describe, expect, it} from "vitest";
+import {computePresetRange, deriveActivePreset} from "./datePresets";
+
+const NOW = new Date("2026-05-21T12:00:00.000Z");
+
+describe("computePresetRange", () => {
+  it("'30d' returns today minus 30 days through today", () => {
+    const range = computePresetRange("30d", NOW);
+    expect(range.to).toBe("2026-05-21");
+    expect(range.from).toBe("2026-04-21");
+  });
+
+  it("'90d' returns today minus 90 days through today", () => {
+    const range = computePresetRange("90d", NOW);
+    expect(range.to).toBe("2026-05-21");
+    expect(range.from).toBe("2026-02-20");
+  });
+
+  it("'ytd' returns Jan 1 of this year through today", () => {
+    const range = computePresetRange("ytd", NOW);
+    expect(range.from).toBe("2026-01-01");
+    expect(range.to).toBe("2026-05-21");
+  });
+
+  it("'ytd' on Jan 1 returns from === to", () => {
+    const jan1 = new Date("2026-01-01T12:00:00.000Z");
+    const range = computePresetRange("ytd", jan1);
+    expect(range.from).toBe("2026-01-01");
+    expect(range.to).toBe("2026-01-01");
+  });
+
+  it("'all' clears both from and to", () => {
+    expect(computePresetRange("all", NOW)).toEqual({from: null, to: null});
+  });
+});
+
+describe("deriveActivePreset", () => {
+  it("returns null when both from and to are null", () => {
+    expect(deriveActivePreset(null, null, NOW)).toBeNull();
+  });
+
+  it("returns '30d' when from/to exactly match the 30d range", () => {
+    expect(deriveActivePreset("2026-04-21", "2026-05-21", NOW)).toBe("30d");
+  });
+
+  it("returns '90d' when from/to exactly match the 90d range", () => {
+    expect(deriveActivePreset("2026-02-20", "2026-05-21", NOW)).toBe("90d");
+  });
+
+  it("returns 'ytd' when from/to exactly match the YTD range", () => {
+    expect(deriveActivePreset("2026-01-01", "2026-05-21", NOW)).toBe("ytd");
+  });
+
+  it("returns 'custom' when from/to are set but match no preset", () => {
+    expect(deriveActivePreset("2025-12-01", "2026-05-21", NOW)).toBe("custom");
+  });
+
+  it("returns 'custom' when only from is set", () => {
+    expect(deriveActivePreset("2025-12-01", null, NOW)).toBe("custom");
+  });
+
+  it("returns 'custom' when only to is set", () => {
+    expect(deriveActivePreset(null, "2026-05-21", NOW)).toBe("custom");
+  });
+});

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_utils/datePresets.ts
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_utils/datePresets.ts
@@ -1,0 +1,66 @@
+/**
+ * @fileoverview Pure helpers for the date-range quick-preset filter buttons.
+ * @module sites/arolariu.ro/src/app/domains/invoices/view-invoices/_utils/datePresets
+ *
+ * @remarks
+ * `computePresetRange` produces the {from, to} ISO date strings (YYYY-MM-DD)
+ * corresponding to each preset at a given instant. `deriveActivePreset`
+ * inverts that mapping: given the current from/to values, returns the key
+ * of the preset that exactly matches them (or "custom" / null).
+ *
+ * All dates use the UTC day boundary for stability across timezones — the
+ * existing `useFilteredInvoices` filter compares against `toSafeDate(...)`
+ * which is timezone-naive, so day-level granularity is what matters.
+ */
+
+export type DatePresetKey = "30d" | "90d" | "ytd" | "all";
+
+/**
+ * Formats a Date as a YYYY-MM-DD ISO date string (no time component).
+ */
+function toIsoDate(d: Date): string {
+  const year = d.getUTCFullYear().toString().padStart(4, "0");
+  const month = (d.getUTCMonth() + 1).toString().padStart(2, "0");
+  const day = d.getUTCDate().toString().padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+/**
+ * Returns the [from, to] ISO date range a preset represents at `now`.
+ *
+ * - "30d" → from = now − 30 days, to = now
+ * - "90d" → from = now − 90 days, to = now
+ * - "ytd" → from = January 1 of `now`'s year, to = now
+ * - "all" → from = null, to = null (clears the date filter)
+ */
+export function computePresetRange(preset: DatePresetKey, now: Date): {from: string | null; to: string | null} {
+  if (preset === "all") return {from: null, to: null};
+  const to = toIsoDate(now);
+  if (preset === "ytd") {
+    const yearStart = new Date(Date.UTC(now.getUTCFullYear(), 0, 1));
+    return {from: toIsoDate(yearStart), to};
+  }
+  const days = preset === "30d" ? 30 : 90;
+  const from = new Date(now.getTime());
+  from.setUTCDate(from.getUTCDate() - days);
+  return {from: toIsoDate(from), to};
+}
+
+/**
+ * Inverse of {@link computePresetRange}. Returns the preset key whose range
+ * exactly matches the supplied from/to (date-only equality, ignoring time),
+ * or `"custom"` when both are set but match no preset, or `null` when both
+ * are null.
+ */
+export function deriveActivePreset(
+  from: string | null,
+  to: string | null,
+  now: Date,
+): DatePresetKey | "custom" | null {
+  if (from === null && to === null) return null;
+  for (const preset of ["30d", "90d", "ytd"] as const) {
+    const range = computePresetRange(preset, now);
+    if (range.from === from && range.to === to) return preset;
+  }
+  return "custom";
+}

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_utils/datePresets.ts
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_utils/datePresets.ts
@@ -41,7 +41,7 @@ export function computePresetRange(preset: DatePresetKey, now: Date): {from: str
     return {from: toIsoDate(yearStart), to};
   }
   const days = preset === "30d" ? 30 : 90;
-  const from = new Date(now.getTime());
+  const from = new Date(now);
   from.setUTCDate(from.getUTCDate() - days);
   return {from: toIsoDate(from), to};
 }

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_utils/datePresets.ts
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_utils/datePresets.ts
@@ -57,7 +57,8 @@ export function deriveActivePreset(
   to: string | null,
   now: Date,
 ): DatePresetKey | "custom" | null {
-  if (from === null && to === null) return null;
+  // No date range set ↔ "All time" preset is active (no restriction).
+  if (from === null && to === null) return "all";
   for (const preset of ["30d", "90d", "ytd"] as const) {
     const range = computePresetRange(preset, now);
     if (range.from === from && range.to === to) return preset;

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_utils/filterOptions.test.ts
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_utils/filterOptions.test.ts
@@ -1,0 +1,120 @@
+/**
+ * @fileoverview Unit tests for the filter-option deriver helpers.
+ * @module sites/arolariu.ro/src/app/domains/invoices/view-invoices/_utils/filterOptions.test
+ */
+
+import {InvoiceBuilder} from "@/data/mocks";
+import type {Invoice} from "@/types/invoices";
+import {InvoiceCategory, PaymentType} from "@/types/invoices";
+import {describe, expect, it} from "vitest";
+import {computeAvailableCategories, computeAvailableCurrencies, computeAvailablePaymentTypes} from "./filterOptions";
+
+function makeInvoice(opts: {currency?: string; category?: InvoiceCategory; paymentType?: PaymentType}): Invoice {
+  const b = new InvoiceBuilder();
+  if (opts.category !== undefined) b.withCategory(opts.category);
+  if (opts.currency !== undefined) {
+    b.withPaymentInformation({
+      totalCostAmount: 100,
+      currency: {code: opts.currency, name: opts.currency, symbol: opts.currency},
+      transactionDate: new Date("2024-01-15"),
+      paymentType: opts.paymentType ?? PaymentType.Cash,
+      totalTaxAmount: 0,
+      subtotalAmount: 0,
+      tipAmount: 0,
+    });
+  } else if (opts.paymentType !== undefined) {
+    b.withPaymentInformation({
+      totalCostAmount: 100,
+      currency: {code: "RON", name: "Romanian Leu", symbol: "lei"},
+      transactionDate: new Date("2024-01-15"),
+      paymentType: opts.paymentType,
+      totalTaxAmount: 0,
+      subtotalAmount: 0,
+      tipAmount: 0,
+    });
+  }
+  return b.build();
+}
+
+describe("computeAvailableCurrencies", () => {
+  it("returns an empty list for no invoices", () => {
+    expect(computeAvailableCurrencies([])).toEqual([]);
+  });
+
+  it("returns a single-item list for one invoice", () => {
+    const invoices = [makeInvoice({currency: "EUR"})];
+    expect(computeAvailableCurrencies(invoices)).toEqual(["EUR"]);
+  });
+
+  it("dedupes repeated currencies", () => {
+    const invoices = [makeInvoice({currency: "EUR"}), makeInvoice({currency: "EUR"})];
+    expect(computeAvailableCurrencies(invoices)).toEqual(["EUR"]);
+  });
+
+  it("orders by frequency descending", () => {
+    const invoices = [
+      makeInvoice({currency: "USD"}),
+      makeInvoice({currency: "RON"}),
+      makeInvoice({currency: "RON"}),
+      makeInvoice({currency: "RON"}),
+      makeInvoice({currency: "EUR"}),
+      makeInvoice({currency: "EUR"}),
+    ];
+    expect(computeAvailableCurrencies(invoices)).toEqual(["RON", "EUR", "USD"]);
+  });
+
+  it("breaks ties alphabetically", () => {
+    const invoices = [makeInvoice({currency: "USD"}), makeInvoice({currency: "EUR"}), makeInvoice({currency: "GBP"})];
+    expect(computeAvailableCurrencies(invoices)).toEqual(["EUR", "GBP", "USD"]);
+  });
+
+  it("falls back to RON when currency.code is missing", () => {
+    const invoice = makeInvoice({currency: "EUR"});
+    const invoiceMissing: Invoice = {
+      ...invoice,
+      paymentInformation: {...invoice.paymentInformation, currency: {code: "", name: "", symbol: ""}},
+    };
+    expect(computeAvailableCurrencies([invoiceMissing])).toEqual(["RON"]);
+  });
+});
+
+describe("computeAvailableCategories", () => {
+  it("returns an empty list for no invoices", () => {
+    expect(computeAvailableCategories([])).toEqual([]);
+  });
+
+  it("dedupes repeated categories and orders by frequency", () => {
+    const invoices = [
+      makeInvoice({category: InvoiceCategory.FAST_FOOD}),
+      makeInvoice({category: InvoiceCategory.GROCERY}),
+      makeInvoice({category: InvoiceCategory.GROCERY}),
+      makeInvoice({category: InvoiceCategory.GROCERY}),
+    ];
+    expect(computeAvailableCategories(invoices)).toEqual([InvoiceCategory.GROCERY, InvoiceCategory.FAST_FOOD]);
+  });
+
+  it("breaks ties by enum ordinal (numeric value asc)", () => {
+    const invoices = [
+      makeInvoice({category: InvoiceCategory.OTHER}),
+      makeInvoice({category: InvoiceCategory.GROCERY}),
+      makeInvoice({category: InvoiceCategory.FAST_FOOD}),
+    ];
+    expect(computeAvailableCategories(invoices)).toEqual([InvoiceCategory.GROCERY, InvoiceCategory.FAST_FOOD, InvoiceCategory.OTHER]);
+  });
+});
+
+describe("computeAvailablePaymentTypes", () => {
+  it("returns an empty list for no invoices", () => {
+    expect(computeAvailablePaymentTypes([])).toEqual([]);
+  });
+
+  it("dedupes and orders by frequency then ordinal", () => {
+    const invoices = [
+      makeInvoice({paymentType: PaymentType.Card}),
+      makeInvoice({paymentType: PaymentType.Card}),
+      makeInvoice({paymentType: PaymentType.Cash}),
+      makeInvoice({paymentType: PaymentType.Transfer}),
+    ];
+    expect(computeAvailablePaymentTypes(invoices)).toEqual([PaymentType.Card, PaymentType.Cash, PaymentType.Transfer]);
+  });
+});

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_utils/filterOptions.ts
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_utils/filterOptions.ts
@@ -13,8 +13,7 @@
  * enum values used by category and payment type).
  */
 
-import type {Invoice} from "@/types/invoices";
-import type {InvoiceCategory, PaymentType} from "@/types/invoices";
+import type {Invoice, InvoiceCategory, PaymentType} from "@/types/invoices";
 
 const DEFAULT_CURRENCY_CODE = "RON";
 
@@ -36,7 +35,7 @@ export function computeAvailableCurrencies(invoices: ReadonlyArray<Invoice>): Re
   const codes = invoices.map((i) => i.paymentInformation.currency?.code || DEFAULT_CURRENCY_CODE);
   const freq = buildFrequencyMap(codes);
   return [...freq.entries()]
-    .sort((a, b) => {
+    .toSorted((a, b) => {
       const freqDelta = b[1] - a[1];
       if (freqDelta !== 0) return freqDelta;
       return a[0].localeCompare(b[0]);
@@ -53,7 +52,7 @@ export function computeAvailableCategories(invoices: ReadonlyArray<Invoice>): Re
   const values = invoices.map((i) => i.category);
   const freq = buildFrequencyMap(values);
   return [...freq.entries()]
-    .sort((a, b) => {
+    .toSorted((a, b) => {
       const freqDelta = b[1] - a[1];
       if (freqDelta !== 0) return freqDelta;
       return (a[0] as number) - (b[0] as number);
@@ -69,7 +68,7 @@ export function computeAvailablePaymentTypes(invoices: ReadonlyArray<Invoice>): 
   const values = invoices.map((i) => i.paymentInformation.paymentType);
   const freq = buildFrequencyMap(values);
   return [...freq.entries()]
-    .sort((a, b) => {
+    .toSorted((a, b) => {
       const freqDelta = b[1] - a[1];
       if (freqDelta !== 0) return freqDelta;
       return (a[0] as number) - (b[0] as number);

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_utils/filterOptions.ts
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_utils/filterOptions.ts
@@ -1,0 +1,78 @@
+/**
+ * @fileoverview Pure derivers for the available filter-option lists shown in
+ * the invoice filter panel.
+ * @module sites/arolariu.ro/src/app/domains/invoices/view-invoices/_utils/filterOptions
+ *
+ * @remarks
+ * All three helpers operate on the FULL (unfiltered) invoice array. This is a
+ * deliberate UX decision so that filtering down to (say) Cash doesn't hide the
+ * Card chip — the user can always switch between any value they've ever used.
+ *
+ * Ordering: frequency-desc primary; ties broken by the natural tie-break for
+ * the data type (alphabetic for currency codes, ascending numeric for the
+ * enum values used by category and payment type).
+ */
+
+import type {Invoice} from "@/types/invoices";
+import type {InvoiceCategory, PaymentType} from "@/types/invoices";
+
+const DEFAULT_CURRENCY_CODE = "RON";
+
+function buildFrequencyMap<K>(values: Iterable<K>): Map<K, number> {
+  const map = new Map<K, number>();
+  for (const v of values) {
+    map.set(v, (map.get(v) ?? 0) + 1);
+  }
+  return map;
+}
+
+/**
+ * Returns the unique ISO 4217 currency codes present in the user's invoices,
+ * ordered by frequency descending with ties broken alphabetically. Invoices
+ * whose `currency.code` is empty are bucketed under `"RON"` (matches the
+ * codebase-wide default established in `_utils/statistics.ts`).
+ */
+export function computeAvailableCurrencies(invoices: ReadonlyArray<Invoice>): ReadonlyArray<string> {
+  const codes = invoices.map((i) => i.paymentInformation.currency?.code || DEFAULT_CURRENCY_CODE);
+  const freq = buildFrequencyMap(codes);
+  return [...freq.entries()]
+    .sort((a, b) => {
+      const freqDelta = b[1] - a[1];
+      if (freqDelta !== 0) return freqDelta;
+      return a[0].localeCompare(b[0]);
+    })
+    .map(([code]) => code);
+}
+
+/**
+ * Returns the unique `InvoiceCategory` enum values present in the user's
+ * invoices, ordered by frequency descending with ties broken by ascending
+ * enum ordinal (numeric value).
+ */
+export function computeAvailableCategories(invoices: ReadonlyArray<Invoice>): ReadonlyArray<InvoiceCategory> {
+  const values = invoices.map((i) => i.category);
+  const freq = buildFrequencyMap(values);
+  return [...freq.entries()]
+    .sort((a, b) => {
+      const freqDelta = b[1] - a[1];
+      if (freqDelta !== 0) return freqDelta;
+      return (a[0] as number) - (b[0] as number);
+    })
+    .map(([cat]) => cat);
+}
+
+/**
+ * Returns the unique `PaymentType` enum values present in the user's invoices,
+ * ordered by frequency descending with ties broken by ascending enum ordinal.
+ */
+export function computeAvailablePaymentTypes(invoices: ReadonlyArray<Invoice>): ReadonlyArray<PaymentType> {
+  const values = invoices.map((i) => i.paymentInformation.paymentType);
+  const freq = buildFrequencyMap(values);
+  return [...freq.entries()]
+    .sort((a, b) => {
+      const freqDelta = b[1] - a[1];
+      if (freqDelta !== 0) return freqDelta;
+      return (a[0] as number) - (b[0] as number);
+    })
+    .map(([pt]) => pt);
+}


### PR DESCRIPTION
## Summary

Reworks the **view-invoices filter panel** end-to-end (variant **J** of the brainstorm). The bar now uses a **card-based 2-column panel** (single column on mobile), a new **Currency filter**, **dynamic option lists** populated from the user's own invoices, and **date-range quick presets** that control the From/To pickers. The default sort is now `Date (newest first)`.

Closes the design exploration in `docs/superpowers/specs/2026-05-21-view-invoices-filter-overhaul-design.md` and follows the plan in `docs/superpowers/plans/2026-05-21-view-invoices-filter-overhaul.md`.

## What changed (per commit)

1. **`filterOptions.ts`** (new) — pure derivers for the available currency codes, categories, and payment types based on the full unfiltered invoice array. Frequency-desc sort, alphabetic/ordinal tie-break, `"RON"` fallback for empty currency. **+11 Vitest tests.**
2. **`datePresets.ts`** (new) — `computePresetRange("30d" | "90d" | "ytd" | "all")` and `deriveActivePreset(from, to, now)`. UTC day boundaries to avoid TZ drift. **+12 Vitest tests.**
3. **`useInvoiceFilters`** — adds `currencies: string[]` to `FilterState` (URL key `cur`), flips default sort to `"date"/"desc"`. **+6 tests.**
4. **`useFilteredInvoices`** — applies the currency filter (`i.paymentInformation.currency?.code || "RON"` ∈ selected). **+3 tests.**
5. **i18n** — adds `filters.currency`, `filters.currencyAny`, `filters.anyValue`, `filters.defaultValue`, `filters.datePresets.{30d,90d,ytd,all,custom}`, and `filters.showResults` (ICU plural). Removes `sortOptions.none`. All three locales (en/ro/fr).
6. **`FilterBar.module.scss`** — new card classes (`panelGrid`, `cardSection`, `cardSectionActive`, `cardSectionHeader`, `activeValuePill`, `datePresetButton[Active]`, `mobileShowResultsBar`, `amountSliderWrapper`, etc.).
7. **`FilterBar.tsx`** — full rewrite:
   - Six card sections: Date Range, Amount Range, Currency, Categories, Payment Types, Sort By.
   - Active sections get a tinted background + colored border + an active-value pill in the section header.
   - Date Range card has four preset buttons (30d / 90d / YTD / All time) that control the From/To Calendar popovers.
   - Amount Range card adds the `@arolariu/components` `Slider` as a dual-thumb range slider (ceiling = `max(1000, ceil(highestAmount / 100) * 100)`).
   - Currency / Categories / Payment Types lists are derived dynamically; the whole card is hidden when its derived list is empty.
   - Categories and Payment Types now use the same Badge-chip pattern as Currency.
   - Sort By: `"none"` SelectItem removed; default is Date (newest).
   - Header `N active` badge counts all active sections.
   - Mobile Sheet body is now a flex column: scrollable middle + sticky `Show N results` CTA at the bottom (tap closes the sheet).
   - New props: `invoices` (drives dynamic lists + slider) and `filteredCount` (drives the CTA label). `InvoicesView` passes both.
8. **`FilterBar.tsx` lint sweep** — combined duplicate imports, `toSorted` over `sort`, `for-of` over `reduce`, removed useless switch cases, ternary over leaked-render. Net: FilterBar.tsx now has **0** lint errors (down from 7 baseline).

## Verification

- `npm run test:unit`: **2059 / 2059 passing** (105 test files). Coverage: 99.8% statements, 96.81% branches, 99.73% functions, 99.96% lines.
- `npx eslint` over touched files: 6 errors total, all pre-existing on `preview` (4 in `useInvoiceFilters.tsx` cognitive-complexity + no-negated-condition, 2 in `useFilteredInvoices.tsx` prefer-destructuring + default-case). **0 new errors.**
- `npx tsc --noEmit`: clean for all touched files.
- E2E (Playwright) intentionally not run on this branch per workflow policy.

## Smoke-test checklist (for the reviewer)

When testing locally, verify:

1. Default view: sort = `Date (newest first)`, the Sort card is **not** highlighted as active.
2. Picking a different sort highlights the Sort card with active-value pill.
3. Currency card appears only when invoices have ≥1 currency code; multi-select chips toggle correctly.
4. Categories / Payment Types cards only show the values actually present in the user's invoices.
5. Clicking `30d` / `90d` / `YTD` populates From/To in the Calendar popovers (controlled-style).
6. Active preset button has the active visual.
7. Amount slider thumbs match Min/Max inputs in both directions.
8. Mobile (Sheet) view: panel scrolls, `Show N results` CTA is sticky at the bottom; tapping closes the sheet.
9. URL bookmark + reload preserves all filter state including `cur`.
10. `Clear all` resets every section including currency.

## Visual

The chosen design (J) is the **card-based 2-column** variant from the second visual round. See `docs/superpowers/specs/2026-05-21-view-invoices-filter-overhaul-design.md` for the design rationale and prior alternatives that were rejected.

---

🤖 Generated with [GitHub Copilot CLI](https://github.com/cli/cli)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
