### PR TITLE
refactor(website): reorganize message tree

### DIFF
--- a/docs/superpowers/plans/2026-05-26-message-tree-hierarchy-redesign.md
+++ b/docs/superpowers/plans/2026-05-26-message-tree-hierarchy-redesign.md
@@ -1,0 +1,1045 @@
+# Message Tree Hierarchy Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reorganize `sites/arolariu.ro/messages/{en,ro,fr}.json` into a strict UI-surface-first hierarchy while preserving locale parity and selector-based translation call sites.
+
+**Architecture:** Keep one authored JSON file per locale and add a deterministic migration toolchain under `scripts/migrations/message-tree/`. The migration is driven by a generated old-path → new-path map, then applies that map to all locale catalogs and selector call sites. Validation becomes part of i18n generation/typecheck so only approved top-level buckets and lower-camel-case paths survive.
+
+**Tech Stack:** Node.js >=24, TypeScript scripts executed directly with `node`, Next.js 16, next-intl, next-intl-selector, npm workspaces, Vitest unit tests.
+
+---
+
+## File structure
+
+**Message catalogs**
+
+- Modify: `sites/arolariu.ro/messages/en.json`
+- Modify: `sites/arolariu.ro/messages/ro.json`
+- Modify: `sites/arolariu.ro/messages/fr.json`
+- Generated/observed: `sites/arolariu.ro/messages/en.d.json.ts`
+- Do not modify: `sites/arolariu.ro/messages/*.json.bak`
+
+**Migration tooling**
+
+- Create: `scripts/migrations/message-tree/treeUtils.ts` — JSON tree flattening, unflattening, object sorting, path utilities.
+- Create: `scripts/migrations/message-tree/taxonomy.ts` — allowed buckets, segment rules, seed rename rules, and taxonomy validation.
+- Create: `scripts/migrations/message-tree/report.ts` — inventory report for before/after shape.
+- Create: `scripts/migrations/message-tree/generateKeyMap.ts` — deterministic old-path to new-path map generator.
+- Create: `scripts/migrations/message-tree/applyCatalogMap.ts` — applies key map to `en`, `ro`, and `fr` catalogs.
+- Create: `scripts/migrations/message-tree/rewriteCallSites.ts` — rewrites selector lambdas and `selectorFromPath(...)` string literals.
+- Create: `scripts/migrations/message-tree/validateMessages.ts` — validates locale parity and strict taxonomy.
+- Create: `scripts/migrations/message-tree/key-map.json` — committed generated migration map.
+- Create: `scripts/migrations/message-tree/reports/before.json` and `after.json` — committed migration reports.
+
+**Existing tooling integration**
+
+- Modify: `scripts/generate.i18n.ts` — invoke or reuse taxonomy validation after parity validation.
+- Modify: `sites/arolariu.ro/scripts/typecheck.ts` only if taxonomy validation should run during website typecheck; otherwise keep validation in `npm run generate:i18n`.
+
+**Call sites**
+
+- Modify selector call sites under:
+  - `sites/arolariu.ro/src/**/*.ts`
+  - `sites/arolariu.ro/src/**/*.tsx`
+  - `sites/arolariu.ro/emails/**/*.ts`
+  - `sites/arolariu.ro/emails/**/*.tsx`
+  - `sites/arolariu.ro/vitest.setup.ts`
+
+**Verification boundary**
+
+- Allowed: `npm --workspace @arolariu/website run typecheck`, `npm run test:unit`, `npm run build:website`, and targeted Node migration scripts.
+- Not allowed: ESLint, Playwright, E2E tests, Storybook tests, full `npm run test`, or other full-suite commands.
+
+**Working tree caution**
+
+- Do not stage unrelated existing changes:
+  - `.vscode/settings.json`
+  - `sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_dialogs/RecipeDialog.stories.tsx`
+
+---
+
+### Task 1: Build message-tree utility foundation
+
+**Files:**
+- Create: `scripts/migrations/message-tree/treeUtils.ts`
+- Test via: `node -e` smoke checks
+
+- [ ] **Step 1: Create `treeUtils.ts`**
+
+Create `scripts/migrations/message-tree/treeUtils.ts`:
+
+```ts
+import fs from "node:fs";
+import path from "node:path";
+
+export type MessageLeaf = string;
+export type MessageTree = {
+  readonly [key: string]: MessageLeaf | MessageTree;
+};
+
+export type FlatMessages = ReadonlyMap<string, MessageLeaf>;
+
+export const localeNames = ["en", "ro", "fr"] as const;
+export type LocaleName = (typeof localeNames)[number];
+
+export function getRepositoryRoot(startDirectory: string = process.cwd()): string {
+  let currentDirectory = startDirectory;
+  while (!fs.existsSync(path.join(currentDirectory, "package.json")) || !fs.existsSync(path.join(currentDirectory, "sites", "arolariu.ro"))) {
+    const parentDirectory = path.dirname(currentDirectory);
+    if (parentDirectory === currentDirectory) {
+      throw new Error("Could not locate repository root.");
+    }
+    currentDirectory = parentDirectory;
+  }
+  return currentDirectory;
+}
+
+export function getMessagesDirectory(repositoryRoot: string = getRepositoryRoot()): string {
+  return path.join(repositoryRoot, "sites", "arolariu.ro", "messages");
+}
+
+export function readMessageTree(locale: LocaleName, messagesDirectory: string = getMessagesDirectory()): MessageTree {
+  return JSON.parse(fs.readFileSync(path.join(messagesDirectory, `${locale}.json`), "utf8")) as MessageTree;
+}
+
+export function writeMessageTree(locale: LocaleName, tree: MessageTree, messagesDirectory: string = getMessagesDirectory()): void {
+  fs.writeFileSync(path.join(messagesDirectory, `${locale}.json`), `${JSON.stringify(sortTree(tree), null, 2)}\n`);
+}
+
+export function flattenMessages(tree: MessageTree, prefix: string = ""): Map<string, MessageLeaf> {
+  const result = new Map<string, MessageLeaf>();
+  for (const [key, value] of Object.entries(tree)) {
+    const nextPath = prefix ? `${prefix}.${key}` : key;
+    if (typeof value === "string") {
+      result.set(nextPath, value);
+    } else {
+      for (const [childPath, childValue] of flattenMessages(value, nextPath)) {
+        result.set(childPath, childValue);
+      }
+    }
+  }
+  return result;
+}
+
+export function unflattenMessages(flatMessages: ReadonlyMap<string, MessageLeaf>): MessageTree {
+  const root: Record<string, MessageLeaf | Record<string, unknown>> = {};
+  for (const [messagePath, value] of flatMessages) {
+    const segments = messagePath.split(".");
+    let pointer: Record<string, MessageLeaf | Record<string, unknown>> = root;
+    for (const [index, segment] of segments.entries()) {
+      if (index === segments.length - 1) {
+        pointer[segment] = value;
+      } else {
+        const existing = pointer[segment];
+        if (typeof existing === "string") {
+          throw new Error(`Cannot create nested path "${messagePath}" because "${segments.slice(0, index + 1).join(".")}" is already a leaf.`);
+        }
+        pointer[segment] = existing ?? {};
+        pointer = pointer[segment] as Record<string, MessageLeaf | Record<string, unknown>>;
+      }
+    }
+  }
+  return root as MessageTree;
+}
+
+export function sortTree(tree: MessageTree): MessageTree {
+  return Object.fromEntries(
+    Object.entries(tree)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, value]) => [key, typeof value === "string" ? value : sortTree(value)]),
+  ) as MessageTree;
+}
+
+export function getPathDepth(messagePath: string): number {
+  return messagePath.split(".").length;
+}
+
+export function isLowerCamelCase(segment: string): boolean {
+  return /^[a-z][A-Za-z0-9]*$/u.test(segment);
+}
+
+export function replacePrefix(messagePath: string, oldPrefix: string, newPrefix: string): string {
+  if (messagePath === oldPrefix) return newPrefix;
+  if (messagePath.startsWith(`${oldPrefix}.`)) return `${newPrefix}${messagePath.slice(oldPrefix.length)}`;
+  return messagePath;
+}
+```
+
+- [ ] **Step 2: Run smoke check**
+
+Run:
+
+```powershell
+Set-Location 'C:\Users\aolariu\source\repos\arolariu\arolariu.ro'
+node -e "import('./scripts/migrations/message-tree/treeUtils.ts').then((m)=>{const t={A:{b:'c'}}; const f=m.flattenMessages(t); if(f.get('A.b')!=='c') throw new Error('flatten failed'); const u=m.unflattenMessages(f); if(u.A.b!=='c') throw new Error('unflatten failed'); console.log('tree utils ok');})"
+```
+
+Expected: `tree utils ok`.
+
+- [ ] **Step 3: Commit utility foundation**
+
+Run:
+
+```powershell
+Set-Location 'C:\Users\aolariu\source\repos\arolariu\arolariu.ro'
+git add scripts\migrations\message-tree\treeUtils.ts
+git commit -m "chore: add message tree utilities" -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+Expected: commit contains only `treeUtils.ts`.
+
+---
+
+### Task 2: Add strict taxonomy definitions and validator
+
+**Files:**
+- Create: `scripts/migrations/message-tree/taxonomy.ts`
+- Create: `scripts/migrations/message-tree/validateMessages.ts`
+- Modify: `scripts/generate.i18n.ts`
+
+- [ ] **Step 1: Create taxonomy rules**
+
+Create `scripts/migrations/message-tree/taxonomy.ts`:
+
+```ts
+import {flattenMessages, isLowerCamelCase, localeNames, readMessageTree, type LocaleName, type MessageTree} from "./treeUtils.ts";
+
+export const allowedTopLevelBuckets = [
+  "app",
+  "pages",
+  "sections",
+  "components",
+  "dialogs",
+  "cards",
+  "forms",
+  "tables",
+  "toasts",
+  "emails",
+  "shared",
+] as const;
+
+export type TopLevelBucket = (typeof allowedTopLevelBuckets)[number];
+
+export type ValidationIssue = Readonly<{
+  locale: LocaleName;
+  path: string;
+  message: string;
+}>;
+
+export function validateMessageTaxonomy(locale: LocaleName, tree: MessageTree): ValidationIssue[] {
+  const issues: ValidationIssue[] = [];
+  const flat = flattenMessages(tree);
+
+  for (const messagePath of flat.keys()) {
+    const segments = messagePath.split(".");
+    const topLevel = segments[0] ?? "";
+    if (!allowedTopLevelBuckets.includes(topLevel as TopLevelBucket)) {
+      issues.push({locale, path: messagePath, message: `Top-level bucket "${topLevel}" is not allowed.`});
+    }
+
+    for (const segment of segments) {
+      if (segment.includes("IMS--")) {
+        issues.push({locale, path: messagePath, message: `Segment "${segment}" contains the retired IMS-- prefix.`});
+      }
+      if (!isLowerCamelCase(segment)) {
+        issues.push({locale, path: messagePath, message: `Segment "${segment}" must be lower camelCase.`});
+      }
+    }
+
+    const value = flat.get(messagePath);
+    if (locale === "en" && value?.trim().length === 0) {
+      issues.push({locale, path: messagePath, message: "English source messages must not be empty."});
+    }
+  }
+
+  return issues;
+}
+
+export function validateLocaleParity(): ValidationIssue[] {
+  const [baseLocale, ...targetLocales] = localeNames;
+  const baseFlat = flattenMessages(readMessageTree(baseLocale));
+  const issues: ValidationIssue[] = [];
+
+  for (const locale of targetLocales) {
+    const currentFlat = flattenMessages(readMessageTree(locale));
+    for (const key of baseFlat.keys()) {
+      if (!currentFlat.has(key)) {
+        issues.push({locale, path: key, message: "Missing key from target locale."});
+      }
+    }
+    for (const key of currentFlat.keys()) {
+      if (!baseFlat.has(key)) {
+        issues.push({locale, path: key, message: "Extra key not present in English source locale."});
+      }
+    }
+  }
+
+  return issues;
+}
+
+export function validateAllMessages(): ValidationIssue[] {
+  return [
+    ...localeNames.flatMap((locale) => validateMessageTaxonomy(locale, readMessageTree(locale))),
+    ...validateLocaleParity(),
+  ];
+}
+```
+
+- [ ] **Step 2: Create validator CLI**
+
+Create `scripts/migrations/message-tree/validateMessages.ts`:
+
+```ts
+import {validateAllMessages} from "./taxonomy.ts";
+
+const issues = validateAllMessages();
+if (issues.length > 0) {
+  console.error(`[message-tree] Found ${issues.length} message taxonomy issue(s).`);
+  for (const issue of issues.slice(0, 200)) {
+    console.error(`- ${issue.locale}:${issue.path} — ${issue.message}`);
+  }
+  if (issues.length > 200) {
+    console.error(`[message-tree] ${issues.length - 200} additional issue(s) omitted.`);
+  }
+  process.exit(1);
+}
+
+console.info("[message-tree] Message taxonomy validation passed.");
+```
+
+- [ ] **Step 3: Run validator before migration and confirm it fails**
+
+Run:
+
+```powershell
+Set-Location 'C:\Users\aolariu\source\repos\arolariu\arolariu.ro'
+node scripts\migrations\message-tree\validateMessages.ts
+```
+
+Expected: FAIL with issues for current top-level buckets such as `About` and `IMS--Dialogs`. This confirms the validator catches current drift.
+
+- [ ] **Step 4: Integrate validator into generation only after migration**
+
+Do not wire the validator into `scripts/generate.i18n.ts` yet, because the current catalog must fail. Add integration in Task 9 after the catalog is rewritten.
+
+- [ ] **Step 5: Commit validator tooling**
+
+Run:
+
+```powershell
+Set-Location 'C:\Users\aolariu\source\repos\arolariu\arolariu.ro'
+git add scripts\migrations\message-tree\taxonomy.ts scripts\migrations\message-tree\validateMessages.ts
+git commit -m "chore: add message tree taxonomy validator" -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+Expected: commit contains only taxonomy validator files.
+
+---
+
+### Task 3: Add inventory report script
+
+**Files:**
+- Create: `scripts/migrations/message-tree/report.ts`
+- Create: `scripts/migrations/message-tree/reports/before.json`
+
+- [ ] **Step 1: Create report script**
+
+Create `scripts/migrations/message-tree/report.ts`:
+
+```ts
+import fs from "node:fs";
+import path from "node:path";
+import {flattenMessages, getMessagesDirectory, getPathDepth, getRepositoryRoot, localeNames, readMessageTree} from "./treeUtils.ts";
+import {allowedTopLevelBuckets} from "./taxonomy.ts";
+
+type BucketReport = Readonly<{
+  bucket: string;
+  leaves: number;
+  maxDepth: number;
+  childCount: number;
+}>;
+
+type LocaleReport = Readonly<{
+  locale: string;
+  topLevelCount: number;
+  leafCount: number;
+  maxDepth: number;
+  allowedBucketLeaves: number;
+  retiredPrefixLeaves: number;
+  buckets: readonly BucketReport[];
+}>;
+
+function buildLocaleReport(locale: (typeof localeNames)[number]): LocaleReport {
+  const tree = readMessageTree(locale);
+  const flat = flattenMessages(tree);
+  const buckets = Object.entries(tree).map(([bucket, value]) => {
+    const branchFlat = typeof value === "string" ? new Map([[bucket, value]]) : flattenMessages(value, bucket);
+    const paths = [...branchFlat.keys()];
+    return {
+      bucket,
+      leaves: paths.length,
+      maxDepth: Math.max(...paths.map(getPathDepth)),
+      childCount: typeof value === "string" ? 0 : Object.keys(value).length,
+    };
+  });
+
+  return {
+    locale,
+    topLevelCount: Object.keys(tree).length,
+    leafCount: flat.size,
+    maxDepth: Math.max(...[...flat.keys()].map(getPathDepth)),
+    allowedBucketLeaves: [...flat.keys()].filter((key) => allowedTopLevelBuckets.some((bucket) => key === bucket || key.startsWith(`${bucket}.`))).length,
+    retiredPrefixLeaves: [...flat.keys()].filter((key) => key.includes("IMS--")).length,
+    buckets: buckets.sort((left, right) => right.leaves - left.leaves),
+  };
+}
+
+const report = {
+  generatedAt: new Date().toISOString(),
+  messagesDirectory: path.relative(getRepositoryRoot(), getMessagesDirectory()),
+  locales: localeNames.map(buildLocaleReport),
+};
+
+const outputPath = process.argv[2];
+if (outputPath) {
+  fs.mkdirSync(path.dirname(outputPath), {recursive: true});
+  fs.writeFileSync(outputPath, `${JSON.stringify(report, null, 2)}\n`);
+}
+
+console.log(JSON.stringify(report, null, 2));
+```
+
+- [ ] **Step 2: Generate before report**
+
+Run:
+
+```powershell
+Set-Location 'C:\Users\aolariu\source\repos\arolariu\arolariu.ro'
+node scripts\migrations\message-tree\report.ts scripts\migrations\message-tree\reports\before.json
+```
+
+Expected: output shows `leafCount` 3326 for each locale and non-zero `retiredPrefixLeaves`.
+
+- [ ] **Step 3: Commit report tooling and before report**
+
+Run:
+
+```powershell
+Set-Location 'C:\Users\aolariu\source\repos\arolariu\arolariu.ro'
+git add scripts\migrations\message-tree\report.ts scripts\migrations\message-tree\reports\before.json
+git commit -m "chore: add message tree inventory report" -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+Expected: commit includes report script and `before.json`.
+
+---
+
+### Task 4: Generate the old-path to new-path key map
+
+**Files:**
+- Create: `scripts/migrations/message-tree/generateKeyMap.ts`
+- Create: `scripts/migrations/message-tree/key-map.json`
+
+- [ ] **Step 1: Create key-map generator**
+
+Create `scripts/migrations/message-tree/generateKeyMap.ts`:
+
+```ts
+import fs from "node:fs";
+import path from "node:path";
+import {flattenMessages, getRepositoryRoot, readMessageTree} from "./treeUtils.ts";
+import {allowedTopLevelBuckets} from "./taxonomy.ts";
+
+type KeyMapEntry = Readonly<{
+  oldPath: string;
+  newPath: string;
+  reason: string;
+}>;
+
+const explicitPrefixRules: ReadonlyArray<readonly [oldPrefix: string, newPrefix: string, reason: string]> = [
+  ["Navigation", "app.navigation", "app shell navigation"],
+  ["Footer", "app.footer", "app shell footer"],
+  ["Commander", "app.commander", "global command palette"],
+  ["Errors", "app.errors", "global error and not-found copy"],
+  ["Common.accessibility", "shared.accessibility", "shared accessibility labels"],
+  ["Common.enums", "shared.enums", "shared enum labels"],
+  ["Home", "pages.home", "home page and homepage sections"],
+  ["Domains", "pages.domains", "domains landing page"],
+  ["About.Hub", "pages.about.hub", "about hub page"],
+  ["About.Author.metadata", "pages.about.author.metadata", "author page metadata"],
+  ["About.Author", "sections.about.author", "author page sections"],
+  ["About.Platform.metadata", "pages.about.platform.metadata", "platform page metadata"],
+  ["About.Platform", "sections.about.platform", "platform page sections"],
+  ["Profile.metadata", "pages.profile.metadata", "profile page metadata"],
+  ["Profile", "pages.profile", "profile page content and settings"],
+  ["Auth", "pages.auth", "authentication pages"],
+  ["Legal.PrivacyPolicy.metadata", "pages.legal.privacyPolicy.metadata", "privacy metadata"],
+  ["Legal.PrivacyPolicy", "sections.legal.privacyPolicy", "privacy policy content"],
+  ["Legal.TermsOfService.metadata", "pages.legal.termsOfService.metadata", "terms metadata"],
+  ["Legal.TermsOfService", "sections.legal.termsOfService", "terms content"],
+  ["Acknowledgements.metadata", "pages.legal.acknowledgements.metadata", "acknowledgements metadata"],
+  ["Acknowledgements", "sections.legal.acknowledgements", "acknowledgements content"],
+  ["EULA", "pages.legal.eula", "end user license agreement"],
+  ["email", "emails", "email templates"],
+  ["IMS--Dialogs", "dialogs.invoices", "invoice dialogs"],
+  ["IMS--Cards", "cards.invoices", "invoice cards"],
+  ["IMS--Stats", "cards.invoices.statistics", "invoice statistics widgets"],
+  ["IMS--Hooks", "toasts.invoices", "user-visible hook feedback"],
+  ["IMS--Common", "shared.invoices", "shared invoice labels"],
+  ["IMS--Landing", "pages.invoices.landing", "invoice landing page"],
+  ["IMS--Create", "forms.invoices.createInvoice", "create-invoice flow"],
+  ["IMS--Edit", "pages.invoices.editInvoice", "edit-invoice experience"],
+  ["IMS--List.metadata", "pages.invoices.viewInvoices.metadata", "view-invoices metadata"],
+  ["IMS--List.invoicesView.filters", "forms.invoices.filters", "invoice list filters"],
+  ["IMS--List.invoicesView.table", "tables.invoices.list", "invoice list table"],
+  ["IMS--List", "pages.invoices.viewInvoices", "view-invoices page"],
+  ["IMS--ViewScans", "pages.invoices.viewScans", "view-scans page"],
+  ["IMS--UploadScans", "pages.invoices.uploadScans", "upload-scans page"],
+  ["IMS--View.metadata", "pages.invoices.viewInvoice.metadata", "view-invoice metadata"],
+  ["IMS--View.timelineItem", "sections.invoices.timeline.item", "invoice timeline item"],
+  ["IMS--View", "pages.invoices.viewInvoice", "view-invoice page"],
+];
+
+function lowerCamel(segment: string): string {
+  const cleaned = segment
+    .replace(/^IMS--/u, "")
+    .replace(/[_\s-]+(.)?/gu, (_match, next: string | undefined) => (next ? next.toUpperCase() : ""))
+    .replace(/[^A-Za-z0-9]/gu, "");
+  if (!cleaned) return "unknown";
+  return `${cleaned[0]!.toLowerCase()}${cleaned.slice(1)}`;
+}
+
+function normalizePath(messagePath: string): string {
+  return messagePath.split(".").map(lowerCamel).join(".");
+}
+
+function mapPath(oldPath: string): KeyMapEntry {
+  const matchingRule = explicitPrefixRules
+    .filter(([oldPrefix]) => oldPath === oldPrefix || oldPath.startsWith(`${oldPrefix}.`))
+    .sort((left, right) => right[0].length - left[0].length)[0];
+
+  if (matchingRule) {
+    const [oldPrefix, newPrefix, reason] = matchingRule;
+    const suffix = oldPath === oldPrefix ? "" : oldPath.slice(oldPrefix.length);
+    return {oldPath, newPath: normalizePath(`${newPrefix}${suffix}`), reason};
+  }
+
+  const currentTopLevel = oldPath.split(".")[0] ?? "";
+  const fallbackPrefix = allowedTopLevelBuckets.includes(currentTopLevel as (typeof allowedTopLevelBuckets)[number]) ? "" : "shared.legacy.";
+  return {oldPath, newPath: normalizePath(`${fallbackPrefix}${oldPath}`), reason: "fallback normalized legacy path"};
+}
+
+const flat = flattenMessages(readMessageTree("en"));
+const entries = [...flat.keys()].map(mapPath).sort((left, right) => left.oldPath.localeCompare(right.oldPath));
+const duplicates = new Map<string, string[]>();
+for (const entry of entries) {
+  duplicates.set(entry.newPath, [...(duplicates.get(entry.newPath) ?? []), entry.oldPath]);
+}
+const duplicateEntries = [...duplicates.entries()].filter(([, oldPaths]) => oldPaths.length > 1);
+if (duplicateEntries.length > 0) {
+  console.error("[message-tree] Duplicate target paths detected:");
+  for (const [newPath, oldPaths] of duplicateEntries.slice(0, 50)) {
+    console.error(`- ${newPath}: ${oldPaths.join(", ")}`);
+  }
+  process.exit(1);
+}
+
+const outputPath = path.join(getRepositoryRoot(), "scripts", "migrations", "message-tree", "key-map.json");
+fs.writeFileSync(outputPath, `${JSON.stringify(entries, null, 2)}\n`);
+console.info(`[message-tree] Wrote ${entries.length} mappings to ${path.relative(getRepositoryRoot(), outputPath)}.`);
+```
+
+- [ ] **Step 2: Generate key map**
+
+Run:
+
+```powershell
+Set-Location 'C:\Users\aolariu\source\repos\arolariu\arolariu.ro'
+node scripts\migrations\message-tree\generateKeyMap.ts
+```
+
+Expected: `Wrote 3326 mappings`.
+
+- [ ] **Step 3: Inspect map for forbidden paths**
+
+Run:
+
+```powershell
+Set-Location 'C:\Users\aolariu\source\repos\arolariu\arolariu.ro'
+rg '"newPath": "(About|IMS--|Profile|email|Legal|Navigation|Footer|Common|EULA|Acknowledgements|Auth|Domains|Home)' scripts\migrations\message-tree\key-map.json -n
+rg 'IMS--|--|\\s' scripts\migrations\message-tree\key-map.json -n
+```
+
+Expected: no matches for old top-level paths or `IMS--` in `newPath` values.
+
+- [ ] **Step 4: Commit key map generator and map**
+
+Run:
+
+```powershell
+Set-Location 'C:\Users\aolariu\source\repos\arolariu\arolariu.ro'
+git add scripts\migrations\message-tree\generateKeyMap.ts scripts\migrations\message-tree\key-map.json
+git commit -m "chore: generate message tree key map" -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+Expected: commit contains the generator and `key-map.json`.
+
+---
+
+### Task 5: Apply key map to locale catalogs
+
+**Files:**
+- Create: `scripts/migrations/message-tree/applyCatalogMap.ts`
+- Modify: `sites/arolariu.ro/messages/en.json`
+- Modify: `sites/arolariu.ro/messages/ro.json`
+- Modify: `sites/arolariu.ro/messages/fr.json`
+
+- [ ] **Step 1: Create catalog rewrite script**
+
+Create `scripts/migrations/message-tree/applyCatalogMap.ts`:
+
+```ts
+import fs from "node:fs";
+import path from "node:path";
+import {flattenMessages, getRepositoryRoot, localeNames, readMessageTree, unflattenMessages, writeMessageTree} from "./treeUtils.ts";
+
+type KeyMapEntry = Readonly<{
+  oldPath: string;
+  newPath: string;
+  reason: string;
+}>;
+
+const repositoryRoot = getRepositoryRoot();
+const keyMap = JSON.parse(
+  fs.readFileSync(path.join(repositoryRoot, "scripts", "migrations", "message-tree", "key-map.json"), "utf8"),
+) as readonly KeyMapEntry[];
+
+for (const locale of localeNames) {
+  const oldFlat = flattenMessages(readMessageTree(locale));
+  const newFlat = new Map<string, string>();
+
+  for (const entry of keyMap) {
+    const value = oldFlat.get(entry.oldPath);
+    if (value === undefined) {
+      throw new Error(`[message-tree] ${locale} is missing old path ${entry.oldPath}`);
+    }
+    newFlat.set(entry.newPath, value);
+  }
+
+  if (newFlat.size !== oldFlat.size) {
+    throw new Error(`[message-tree] ${locale} leaf count changed from ${oldFlat.size} to ${newFlat.size}`);
+  }
+
+  writeMessageTree(locale, unflattenMessages(newFlat));
+  console.info(`[message-tree] Rewrote ${locale}.json with ${newFlat.size} leaves.`);
+}
+```
+
+- [ ] **Step 2: Apply map to catalogs**
+
+Run:
+
+```powershell
+Set-Location 'C:\Users\aolariu\source\repos\arolariu\arolariu.ro'
+node scripts\migrations\message-tree\applyCatalogMap.ts
+```
+
+Expected: rewrites `en`, `ro`, and `fr` with `3326 leaves`.
+
+- [ ] **Step 3: Run taxonomy validator**
+
+Run:
+
+```powershell
+Set-Location 'C:\Users\aolariu\source\repos\arolariu\arolariu.ro'
+node scripts\migrations\message-tree\validateMessages.ts
+```
+
+Expected: `Message taxonomy validation passed.`
+
+- [ ] **Step 4: Commit catalog rewrite**
+
+Run:
+
+```powershell
+Set-Location 'C:\Users\aolariu\source\repos\arolariu\arolariu.ro'
+git add scripts\migrations\message-tree\applyCatalogMap.ts sites\arolariu.ro\messages\en.json sites\arolariu.ro\messages\ro.json sites\arolariu.ro\messages\fr.json
+git commit -m "refactor: reorganize message catalogs by ui surface" -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+Expected: commit includes the apply script and the three locale catalogs only.
+
+---
+
+### Task 6: Rewrite selector call sites
+
+**Files:**
+- Create: `scripts/migrations/message-tree/rewriteCallSites.ts`
+- Modify: `sites/arolariu.ro/src/**/*.ts`
+- Modify: `sites/arolariu.ro/src/**/*.tsx`
+- Modify: `sites/arolariu.ro/emails/**/*.ts`
+- Modify: `sites/arolariu.ro/emails/**/*.tsx`
+- Modify: `sites/arolariu.ro/vitest.setup.ts`
+
+- [ ] **Step 1: Create call-site rewrite script**
+
+Create `scripts/migrations/message-tree/rewriteCallSites.ts`:
+
+```ts
+import fs from "node:fs";
+import path from "node:path";
+import {getRepositoryRoot} from "./treeUtils.ts";
+
+type KeyMapEntry = Readonly<{
+  oldPath: string;
+  newPath: string;
+  reason: string;
+}>;
+
+const repositoryRoot = getRepositoryRoot();
+const roots = [
+  path.join(repositoryRoot, "sites", "arolariu.ro", "src"),
+  path.join(repositoryRoot, "sites", "arolariu.ro", "emails"),
+  path.join(repositoryRoot, "sites", "arolariu.ro", "vitest.setup.ts"),
+];
+const keyMap = JSON.parse(
+  fs.readFileSync(path.join(repositoryRoot, "scripts", "migrations", "message-tree", "key-map.json"), "utf8"),
+) as readonly KeyMapEntry[];
+const sortedMap = [...keyMap].sort((left, right) => right.oldPath.length - left.oldPath.length);
+
+function collectFiles(targetPath: string): string[] {
+  if (fs.statSync(targetPath).isFile()) return [targetPath];
+  return fs.readdirSync(targetPath, {withFileTypes: true}).flatMap((entry) => {
+    const fullPath = path.join(targetPath, entry.name);
+    if (entry.isDirectory()) return collectFiles(fullPath);
+    return /\.(ts|tsx)$/u.test(fullPath) ? [fullPath] : [];
+  });
+}
+
+function rewriteText(input: string): string {
+  let output = input;
+  for (const entry of sortedMap) {
+    output = output.split(entry.oldPath).join(entry.newPath);
+
+    const bracketPath = entry.oldPath
+      .split(".")
+      .map((segment, index) => (index === 0 && /[^A-Za-z_$]/u.test(segment) ? `["${segment}"]` : `.${segment}`))
+      .join("")
+      .replace(/^\./u, "");
+    const newDotPath = entry.newPath
+      .split(".")
+      .map((segment) => `.${segment}`)
+      .join("")
+      .replace(/^\./u, "");
+    output = output.split(`m.${bracketPath}`).join(`m.${newDotPath}`);
+    output = output.split(`m[\"${entry.oldPath.split(".")[0]}\"]`).join(`m.${entry.newPath.split(".")[0]}`);
+  }
+  return output;
+}
+
+let changedCount = 0;
+for (const filePath of roots.flatMap(collectFiles)) {
+  const oldText = fs.readFileSync(filePath, "utf8");
+  const newText = rewriteText(oldText);
+  if (newText !== oldText) {
+    fs.writeFileSync(filePath, newText);
+    changedCount += 1;
+  }
+}
+
+console.info(`[message-tree] Rewrote ${changedCount} call-site file(s).`);
+```
+
+- [ ] **Step 2: Run call-site rewrite**
+
+Run:
+
+```powershell
+Set-Location 'C:\Users\aolariu\source\repos\arolariu\arolariu.ro'
+node scripts\migrations\message-tree\rewriteCallSites.ts
+```
+
+Expected: outputs changed call-site count.
+
+- [ ] **Step 3: Scan for old path references**
+
+Run:
+
+```powershell
+Set-Location 'C:\Users\aolariu\source\repos\arolariu\arolariu.ro'
+rg 'IMS--|m\\.About|m\\.Profile|m\\.Legal|m\\.Navigation|m\\.Footer|selectorFromPath\\("(About|Profile|IMS--|email\\.)' sites\arolariu.ro\src sites\arolariu.ro\emails sites\arolariu.ro\vitest.setup.ts -n --glob '*.{ts,tsx}'
+```
+
+Expected: no matches, except comments that are intentionally updated in Task 8.
+
+- [ ] **Step 4: Run website typecheck**
+
+Run:
+
+```powershell
+Set-Location 'C:\Users\aolariu\source\repos\arolariu\arolariu.ro\sites\arolariu.ro'
+npm run typecheck
+```
+
+Expected: typecheck passes. If it fails, use the first failing selector path to add or correct a mapping in `key-map.json`, rerun Tasks 5 and 6, and rerun typecheck.
+
+- [ ] **Step 5: Commit call-site rewrite**
+
+Run:
+
+```powershell
+Set-Location 'C:\Users\aolariu\source\repos\arolariu\arolariu.ro'
+git add scripts\migrations\message-tree\rewriteCallSites.ts sites\arolariu.ro\src sites\arolariu.ro\emails sites\arolariu.ro\vitest.setup.ts
+git commit -m "refactor: update translation selectors for new message tree" -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+Expected: commit includes rewrite script and call-site changes.
+
+---
+
+### Task 7: Generate after report and compare inventory
+
+**Files:**
+- Create: `scripts/migrations/message-tree/reports/after.json`
+
+- [ ] **Step 1: Generate after report**
+
+Run:
+
+```powershell
+Set-Location 'C:\Users\aolariu\source\repos\arolariu\arolariu.ro'
+node scripts\migrations\message-tree\report.ts scripts\migrations\message-tree\reports\after.json
+```
+
+Expected: each locale still has `leafCount` 3326, `retiredPrefixLeaves` 0, and only allowed top-level buckets.
+
+- [ ] **Step 2: Compare before and after reports**
+
+Run:
+
+```powershell
+Set-Location 'C:\Users\aolariu\source\repos\arolariu\arolariu.ro'
+node -e "const fs=require('node:fs'); const before=JSON.parse(fs.readFileSync('scripts/migrations/message-tree/reports/before.json','utf8')); const after=JSON.parse(fs.readFileSync('scripts/migrations/message-tree/reports/after.json','utf8')); for (let i=0;i<after.locales.length;i++){ if(before.locales[i].leafCount!==after.locales[i].leafCount) throw new Error('leaf count changed for '+after.locales[i].locale); if(after.locales[i].retiredPrefixLeaves!==0) throw new Error('retired prefixes remain for '+after.locales[i].locale); } console.log('message tree reports match expected migration invariants');"
+```
+
+Expected: `message tree reports match expected migration invariants`.
+
+- [ ] **Step 3: Commit after report**
+
+Run:
+
+```powershell
+Set-Location 'C:\Users\aolariu\source\repos\arolariu\arolariu.ro'
+git add scripts\migrations\message-tree\reports\after.json
+git commit -m "chore: record message tree after report" -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+Expected: commit includes only `after.json`.
+
+---
+
+### Task 8: Update documentation comments and RFC-adjacent examples
+
+**Files:**
+- Modify: `sites/arolariu.ro/src/i18n/request.ts` only if comments mention old tree paths
+- Modify: `sites/arolariu.ro/src/app/globals.ts` only if comments mention old tree paths
+- Modify: `scripts/generate.i18n.ts`
+- Modify: relevant comments in touched call-site files
+
+- [ ] **Step 1: Search documentation for old hierarchy names**
+
+Run:
+
+```powershell
+Set-Location 'C:\Users\aolariu\source\repos\arolariu\arolariu.ro'
+rg 'IMS--|About\\.Platform|About\\.Author|email\\.welcome|Navigation\\.|Domains\\.services|Legal\\.PrivacyPolicy' sites\arolariu.ro scripts docs\rfc -n --glob '*.{ts,tsx,md}'
+```
+
+Expected: matches are only historical docs or comments requiring updates.
+
+- [ ] **Step 2: Update comments that instruct future development**
+
+For active code comments, replace examples like:
+
+```ts
+t((m) => m["IMS--List"].metadata.title)
+```
+
+with:
+
+```ts
+t((m) => m.pages.invoices.viewInvoices.metadata.title)
+```
+
+For email examples, replace:
+
+```ts
+t(selectorFromPath("email.welcome.subject"))
+```
+
+with:
+
+```ts
+t(selectorFromPath("emails.account.welcome.subject"))
+```
+
+- [ ] **Step 3: Commit comment/docs updates**
+
+Run:
+
+```powershell
+Set-Location 'C:\Users\aolariu\source\repos\arolariu\arolariu.ro'
+git add sites\arolariu.ro scripts docs\rfc
+git restore --staged -- .vscode\settings.json
+git commit -m "docs: update message tree examples" -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+Expected: commit contains only comments/documentation related to message hierarchy.
+
+---
+
+### Task 9: Integrate taxonomy validation with i18n generation
+
+**Files:**
+- Modify: `scripts/generate.i18n.ts`
+
+- [ ] **Step 1: Import taxonomy validator**
+
+At the top of `scripts/generate.i18n.ts`, add:
+
+```ts
+import {validateAllMessages} from "./migrations/message-tree/taxonomy.ts";
+```
+
+- [ ] **Step 2: Add validation function**
+
+Near the existing validation helpers in `scripts/generate.i18n.ts`, add:
+
+```ts
+function validateMessageTreeTaxonomy(): void {
+  const issues = validateAllMessages();
+  if (issues.length === 0) {
+    console.info("[arolariu.ro::generate:i18n] Message tree taxonomy validation passed.");
+    return;
+  }
+
+  console.error(`[arolariu.ro::generate:i18n] Found ${issues.length} message tree taxonomy issue(s).`);
+  for (const issue of issues.slice(0, 200)) {
+    console.error(`[arolariu.ro::generate:i18n] ${issue.locale}:${issue.path} — ${issue.message}`);
+  }
+  throw new Error("[arolariu.ro::generate:i18n] Message tree taxonomy validation failed.");
+}
+```
+
+- [ ] **Step 3: Invoke taxonomy validation**
+
+In the main generation flow, after existing locale parity checks complete, call:
+
+```ts
+validateMessageTreeTaxonomy();
+```
+
+- [ ] **Step 4: Run i18n generation**
+
+Run:
+
+```powershell
+Set-Location 'C:\Users\aolariu\source\repos\arolariu\arolariu.ro'
+npm run generate:i18n
+```
+
+Expected: command succeeds and logs taxonomy validation passed.
+
+- [ ] **Step 5: Commit generation integration**
+
+Run:
+
+```powershell
+Set-Location 'C:\Users\aolariu\source\repos\arolariu\arolariu.ro'
+git add scripts\generate.i18n.ts
+git commit -m "chore: enforce message tree taxonomy during i18n generation" -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+Expected: commit includes only `scripts/generate.i18n.ts`.
+
+---
+
+### Task 10: Final verification and handoff
+
+**Files:**
+- Read: git status and final diff
+
+- [ ] **Step 1: Run final typecheck**
+
+Run:
+
+```powershell
+Set-Location 'C:\Users\aolariu\source\repos\arolariu\arolariu.ro\sites\arolariu.ro'
+npm run typecheck
+```
+
+Expected: typecheck passes.
+
+- [ ] **Step 2: Run allowed unit tests**
+
+Run:
+
+```powershell
+Set-Location 'C:\Users\aolariu\source\repos\arolariu\arolariu.ro'
+npm run test:unit
+```
+
+Expected: unit tests pass. Do not run `npm run test`.
+
+- [ ] **Step 3: Run website build**
+
+Run:
+
+```powershell
+Set-Location 'C:\Users\aolariu\source\repos\arolariu\arolariu.ro'
+npm run build:website
+```
+
+Expected: website build succeeds.
+
+- [ ] **Step 4: Final old-reference scan**
+
+Run:
+
+```powershell
+Set-Location 'C:\Users\aolariu\source\repos\arolariu\arolariu.ro'
+rg 'IMS--|m\\.About|m\\.Profile|m\\.Legal|m\\.Navigation|m\\.Footer|selectorFromPath\\("(About|Profile|IMS--|email\\.)' sites\arolariu.ro\src sites\arolariu.ro\emails sites\arolariu.ro\messages scripts\migrations\message-tree -n --glob '*.{ts,tsx,json}'
+```
+
+Expected: no matches except `key-map.json`, `reports/before.json`, and migration scripts that intentionally mention old paths.
+
+- [ ] **Step 5: Check final working tree**
+
+Run:
+
+```powershell
+Set-Location 'C:\Users\aolariu\source\repos\arolariu\arolariu.ro'
+git --no-pager status --short
+git --no-pager diff --stat
+```
+
+Expected: only pre-existing unrelated changes remain if they were not part of this migration:
+
+```text
+ M .vscode/settings.json
+ D sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_dialogs/RecipeDialog.stories.tsx
+```
+
+- [ ] **Step 6: Commit final verification fixes if needed**
+
+Run only if final verification required code changes:
+
+```powershell
+Set-Location 'C:\Users\aolariu\source\repos\arolariu\arolariu.ro'
+git add sites\arolariu.ro scripts\migrations\message-tree scripts\generate.i18n.ts
+git restore --staged -- .vscode\settings.json sites\arolariu.ro\src\app\domains\invoices\edit-invoice\[id]\_dialogs\RecipeDialog.stories.tsx
+git commit -m "refactor: complete message tree hierarchy migration" -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+Expected: no unrelated files are staged.

--- a/docs/superpowers/specs/2026-05-26-message-tree-hierarchy-design.md
+++ b/docs/superpowers/specs/2026-05-26-message-tree-hierarchy-design.md
@@ -1,0 +1,196 @@
+# Message Tree Hierarchy Redesign
+
+## Context
+
+The `sites/arolariu.ro/messages/` directory currently contains one authored JSON catalog per locale:
+
+- `en.json` — English source of truth
+- `ro.json` — Romanian catalog
+- `fr.json` — French catalog
+
+`en.d.json.ts` is generated from `en.json` via the `next-intl` `createMessagesDeclaration` setting in `sites/arolariu.ro/next.config.ts`. Runtime loading stays centralized in `src/i18n/request.ts`, and `src/app/globals.ts` wires the English message shape into `next-intl` `AppConfig`.
+
+The current catalogs are structurally aligned across all three locales:
+
+- 26 top-level keys per locale
+- 3,326 leaves per locale
+- Maximum tree depth of 6
+- 1,787 leaves under `IMS--*` prefixes
+- 1,539 leaves outside `IMS--*`
+
+Large current top-level groups include `About` (570 leaves), `IMS--Dialogs` (450), `email` (382), `IMS--Cards` (319), `IMS--View` (224), `Profile` (208), `IMS--List` (146), and `IMS--Edit` (132). This shape is functional but hard to discover because it mixes route names, product-domain labels, implementation-era prefixes, UI-surface groups, and email template groups at the same level.
+
+## Goals
+
+1. Keep one authored JSON file per locale.
+2. Replace mixed top-level namespaces with a strict UI-surface-first hierarchy.
+3. Make message paths predictable from the kind of UI being edited.
+4. Preserve exact locale parity across `en`, `ro`, and `fr`.
+5. Preserve selector-based `next-intl-selector` call sites and generated message typing.
+6. Add taxonomy validation so the old drift does not return.
+
+## Non-goals
+
+- Do not split catalogs into per-domain files.
+- Do not change supported locales.
+- Do not change runtime locale resolution, cookie behavior, or `NextIntlClientProvider` wiring.
+- Do not introduce a new i18n library.
+- Do not rewrite copy content for tone, language quality, or translation accuracy as part of the hierarchy migration.
+
+## Target top-level buckets
+
+The new tree uses strict UI-surface buckets. The first segment answers: “what UI surface owns this copy?”
+
+| Bucket | Purpose |
+| --- | --- |
+| `app` | App shell and cross-route chrome: navigation, footer, commander, global errors, not-found, app-level accessibility copy. |
+| `pages` | Page-level route copy and metadata: titles, subtitles, page descriptions, SEO metadata. |
+| `sections` | Reusable page sections that are not generic components: hero, feature, stats, legal article, timeline, platform/about sections. |
+| `components` | Shared reusable components and presentation primitives that are not tied to a page/domain. |
+| `dialogs` | Modal/dialog/sheet copy grouped by domain and dialog name. |
+| `cards` | Card and widget copy grouped by domain and card name. |
+| `forms` | Fields, validation labels, placeholders, helper text, steppers, filters, and form-specific errors. |
+| `tables` | Table/list headers, row actions, bulk actions, table empty states, and table-specific labels. |
+| `toasts` | Transient success, error, loading, and promise-toast messages. |
+| `emails` | React Email template copy grouped by category and template name. |
+| `shared` | Domain-neutral enums, actions, statuses, accessibility labels, fallbacks, formatting words, and reusable phrases. |
+
+No other top-level buckets are allowed after the migration.
+
+## Naming rules
+
+All path segments use lower camelCase. Symbolic prefixes such as `IMS--` are removed.
+
+Stable path shapes:
+
+```text
+pages.<area>.<page>.metadata.title
+pages.<area>.<page>.metadata.description
+pages.<area>.<page>.title
+pages.<area>.<page>.subtitle
+
+sections.<area>.<sectionName>.title
+sections.<area>.<sectionName>.description
+sections.<area>.<sectionName>.items.<itemKey>.title
+
+dialogs.<domain>.<dialogName>.title
+dialogs.<domain>.<dialogName>.description
+dialogs.<domain>.<dialogName>.actions.<actionName>
+dialogs.<domain>.<dialogName>.states.<stateName>.title
+dialogs.<domain>.<dialogName>.toasts.<eventName>.<status>
+
+cards.<domain>.<cardName>.title
+cards.<domain>.<cardName>.description
+cards.<domain>.<cardName>.metrics.<metricName>.label
+cards.<domain>.<cardName>.states.<stateName>.description
+
+forms.<domain>.<formName>.fields.<fieldName>.label
+forms.<domain>.<formName>.fields.<fieldName>.placeholder
+forms.<domain>.<formName>.fields.<fieldName>.helper
+forms.<domain>.<formName>.fields.<fieldName>.errors.<errorName>
+
+tables.<domain>.<tableName>.columns.<columnName>
+tables.<domain>.<tableName>.rows.actions.<actionName>
+tables.<domain>.<tableName>.empty.title
+
+toasts.<domain>.<featureName>.<eventName>.<status>
+
+emails.<category>.<templateName>.subject
+emails.<category>.<templateName>.preview
+emails.<category>.<templateName>.heading
+emails.<category>.<templateName>.body.<blockName>
+emails.<category>.<templateName>.cta.<actionName>
+emails.<category>.<templateName>.signOff.<lineName>
+
+shared.actions.<actionName>
+shared.status.<statusName>
+shared.accessibility.<labelName>
+shared.enums.<enumName>.<memberName>
+shared.fallbacks.<fallbackName>
+```
+
+Leaf names should be semantic (`title`, `description`, `label`, `helper`, `empty.title`, `actions.save`) rather than implementation-specific (`cardTitleBase`, `buttonText2`, `fooString`).
+
+## High-level migration mapping
+
+| Current group | Target bucket strategy |
+| --- | --- |
+| `IMS--Dialogs` | `dialogs.invoices.*` |
+| `IMS--Cards` | `cards.invoices.*` |
+| `IMS--Create` | Split into `pages.invoices.create`, `forms.invoices.createInvoice`, and `toasts.invoices.createInvoice`. |
+| `IMS--Edit` | Split into `pages.invoices.edit`, `forms.invoices.editInvoice`, `cards.invoices.*`, and `sections.invoices.*`. |
+| `IMS--List` | Split into `pages.invoices.viewInvoices`, `forms.invoices.filters`, `tables.invoices.list`, and `toasts.invoices.*`. |
+| `IMS--View` | Split into `pages.invoices.viewInvoice`, `cards.invoices.*`, `sections.invoices.timeline`, and `dialogs.invoices.*`. |
+| `IMS--ViewScans` | Split into `pages.invoices.viewScans`, `cards.invoices.scan`, `dialogs.invoices.*`, and `toasts.invoices.scans`. |
+| `IMS--UploadScans` | Split into `pages.invoices.uploadScans`, `forms.invoices.uploadScans`, `sections.invoices.uploadScans`, and `toasts.invoices.scans`. |
+| `IMS--Stats` | `cards.invoices.statistics.*` and `sections.invoices.statistics.*` depending on visual role. |
+| `IMS--Common` | `shared.*`, `forms.invoices.*`, or `toasts.invoices.*` depending on usage. |
+| `IMS--Hooks` | `toasts.invoices.*` for user-visible hook feedback; otherwise colocate under owning surface. |
+| `About` | `pages.about.*`, `sections.about.*`, and `cards.about.*`. |
+| `Home` | `pages.home.*` and `sections.home.*`. |
+| `Domains` | `pages.domains.*` and `sections.domains.*`. |
+| `Profile` | `pages.profile.*`, `forms.profile.*`, `cards.profile.*`, and `toasts.profile.*`. |
+| `Legal`, `EULA`, `Acknowledgements` | `pages.legal.*`, `sections.legal.*`, and `tables.legal.*` where applicable. |
+| `Auth` | `pages.auth.*`, `forms.auth.*`, and `sections.auth.*`. |
+| `Navigation`, `Footer`, `Commander`, `Errors`, `Common` | `app.*`, `components.*`, or `shared.*` depending on ownership. |
+| `email` | `emails.*`, normalized by category and template name. |
+
+## Migration tooling
+
+The implementation should create `scripts/migrations/message-tree/` with:
+
+1. A deterministic old-path to new-path key map.
+2. A message-tree rewrite script that applies the same key map to `en.json`, `ro.json`, and `fr.json`.
+3. A selector call-site rewrite script that updates:
+   - direct selector lambdas, e.g. `m["IMS--Cards"].healthScore.title`
+   - dynamic `selectorFromPath("...")` calls
+   - email template selectors
+4. A report command that prints before/after:
+   - leaf count
+   - maximum depth
+   - bucket counts
+   - locale parity
+   - remaining old prefixes
+   - remaining disallowed top-level buckets
+
+The key map is the source of truth for the migration. It must be reviewed before mass rewriting catalogs and call sites.
+
+## Validation rules
+
+Upgrade `scripts/generate.i18n.ts` or add a companion validator invoked by generation/typecheck to enforce:
+
+- allowed top-level buckets only
+- lower camelCase path segments
+- no `IMS--` prefixes
+- exact `en/ro/fr` key parity
+- no extra keys in target locales
+- no missing keys in target locales
+- no object/leaf type mismatches between locales
+- no empty English source leaves
+- no empty target-locale leaves except explicitly accepted translator placeholders
+- common actions/statuses/accessibility labels live under `shared` unless intentionally surface-specific
+
+## Verification boundary
+
+Use the approved verification boundary from the selector migration:
+
+- website typecheck, including import guard
+- `npm run test:unit`
+- `npm run build:website`
+
+Do not run ESLint, Playwright, E2E tests, Storybook tests, full `npm run test`, or other full-suite commands unless explicitly re-approved.
+
+## Risks
+
+- This is a broad rename across 3,326 leaves and hundreds of selector call sites.
+- Dynamic `selectorFromPath(...)` paths need special handling because static selector-lambda rewriting will not catch all runtime-composed paths.
+- A strict UI-bucket taxonomy improves discovery but can separate feature copy across multiple buckets. The mitigation is consistent second/third segments, e.g. `dialogs.invoices.share`, `cards.invoices.sharing`, `toasts.invoices.share`.
+- Existing uncommitted working-tree changes must not be included in spec or implementation commits unless they are explicitly part of the hierarchy work.
+
+## Approved decisions
+
+- Keep one authored JSON file per locale.
+- Use strict UI-surface top-level buckets.
+- Use lower camelCase and remove `IMS--` prefixes.
+- Keep current runtime i18n wiring intact.
+- Codemod the migration through a reviewed key map.

--- a/scripts/generate.i18n.ts
+++ b/scripts/generate.i18n.ts
@@ -77,7 +77,7 @@ function loadTranslationFile(filePath: string, verbose: boolean = false): Messag
  * @param keyNamespace The translation key to lookup.
  *
  * @example
- * extractMessageValue(messages, "Domains.services.title")
+ * extractMessageValue(messages, "pages.domains.services.title")
  * // > The above invocation will try to return the value of the key "title" from the "services" object, which is a child of the "Domains" object.
  *
  * @remarks The function will treat non-existent values as an empty string.
@@ -242,7 +242,7 @@ function areMessageValuesEqual(baseTranslationMessage: Message, currentTranslati
  * The keys are extracted recursively, so if the value of a key is another MessageFormat object, the function will extract the keys from that object as well.
  *
  * Whenever a key is a string, the function will add it to the keys array.
- * Whenever a key is a MessageFormat object, the function will recursively call itself with the value of the key, and append a dot (.) to the key - e.g. "Domains.services."
+ * Whenever a key is a MessageFormat object, the function will recursively call itself with the value of the key, and append a dot (.) to the key - e.g. "pages.domains.services."
  * @param messages
  * @returns
  */

--- a/scripts/generate.i18n.ts
+++ b/scripts/generate.i18n.ts
@@ -22,6 +22,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import {styleText} from "node:util";
+import {validateAllMessages} from "./migrations/message-tree/taxonomy.ts";
 
 /**
  * Represents either a plain string message or a message formatted with `MessageFormat`.
@@ -379,6 +380,20 @@ function validateLocale(
   return missingKeys.length;
 }
 
+function validateMessageTreeTaxonomy(): void {
+  const issues = validateAllMessages();
+  if (issues.length === 0) {
+    console.info("[arolariu.ro::generate:i18n] Message tree taxonomy validation passed.");
+    return;
+  }
+
+  console.error(`[arolariu.ro::generate:i18n] Found ${issues.length} message tree taxonomy issue(s).`);
+  for (const issue of issues.slice(0, 200)) {
+    console.error(`[arolariu.ro::generate:i18n] ${issue.locale}:${issue.path} — ${issue.message}`);
+  }
+  throw new Error("[arolariu.ro::generate:i18n] Message tree taxonomy validation failed.");
+}
+
 /**
  * This is the main function of the script.
  * Validates all supported locales (Romanian and French) against the English source of truth.
@@ -416,6 +431,8 @@ export async function main(verbose: boolean = false): Promise<number> {
     localeResults[locale] = missingCount;
     totalMissingKeys += missingCount;
   }
+
+  validateMessageTreeTaxonomy();
 
   // Summary output
   console.log(styleText("green", "\n✨ i18n synchronization completed."));

--- a/scripts/migrations/message-tree/applyCatalogMap.ts
+++ b/scripts/migrations/message-tree/applyCatalogMap.ts
@@ -1,0 +1,34 @@
+import fs from "node:fs";
+import path from "node:path";
+import {flattenMessages, getRepositoryRoot, localeNames, readMessageTree, unflattenMessages, writeMessageTree} from "./treeUtils.ts";
+
+type KeyMapEntry = Readonly<{
+  oldPath: string;
+  newPath: string;
+  reason: string;
+}>;
+
+const repositoryRoot = getRepositoryRoot();
+const keyMap = JSON.parse(
+  fs.readFileSync(path.join(repositoryRoot, "scripts", "migrations", "message-tree", "key-map.json"), "utf8"),
+) as readonly KeyMapEntry[];
+
+for (const locale of localeNames) {
+  const oldFlat = flattenMessages(readMessageTree(locale));
+  const newFlat = new Map<string, string>();
+
+  for (const entry of keyMap) {
+    const value = oldFlat.get(entry.oldPath);
+    if (value === undefined) {
+      throw new Error(`[message-tree] ${locale} is missing old path ${entry.oldPath}`);
+    }
+    newFlat.set(entry.newPath, value);
+  }
+
+  if (newFlat.size !== oldFlat.size) {
+    throw new Error(`[message-tree] ${locale} leaf count changed from ${oldFlat.size} to ${newFlat.size}`);
+  }
+
+  writeMessageTree(locale, unflattenMessages(newFlat));
+  console.info(`[message-tree] Rewrote ${locale}.json with ${newFlat.size} leaves.`);
+}

--- a/scripts/migrations/message-tree/generateKeyMap.ts
+++ b/scripts/migrations/message-tree/generateKeyMap.ts
@@ -1,0 +1,102 @@
+import fs from "node:fs";
+import path from "node:path";
+import {flattenMessages, getRepositoryRoot, readMessageTree} from "./treeUtils.ts";
+import {allowedTopLevelBuckets} from "./taxonomy.ts";
+
+type KeyMapEntry = Readonly<{
+  oldPath: string;
+  newPath: string;
+  reason: string;
+}>;
+
+const explicitPrefixRules: ReadonlyArray<readonly [oldPrefix: string, newPrefix: string, reason: string]> = [
+  ["Navigation", "app.navigation", "app shell navigation"],
+  ["Footer", "app.footer", "app shell footer"],
+  ["Commander", "app.commander", "global command palette"],
+  ["Errors", "app.errors", "global error and not-found copy"],
+  ["Common.accessibility", "shared.accessibility", "shared accessibility labels"],
+  ["Common.enums", "shared.enums", "shared enum labels"],
+  ["Home", "pages.home", "home page and homepage sections"],
+  ["Domains", "pages.domains", "domains landing page"],
+  ["About.Hub", "pages.about.hub", "about hub page"],
+  ["About.Author.metadata", "pages.about.author.metadata", "author page metadata"],
+  ["About.Author", "sections.about.author", "author page sections"],
+  ["About.Platform.metadata", "pages.about.platform.metadata", "platform page metadata"],
+  ["About.Platform", "sections.about.platform", "platform page sections"],
+  ["Profile.metadata", "pages.profile.metadata", "profile page metadata"],
+  ["Profile", "pages.profile", "profile page content and settings"],
+  ["Auth", "pages.auth", "authentication pages"],
+  ["Legal.PrivacyPolicy.metadata", "pages.legal.privacyPolicy.metadata", "privacy metadata"],
+  ["Legal.PrivacyPolicy", "sections.legal.privacyPolicy", "privacy policy content"],
+  ["Legal.TermsOfService.metadata", "pages.legal.termsOfService.metadata", "terms metadata"],
+  ["Legal.TermsOfService", "sections.legal.termsOfService", "terms content"],
+  ["Acknowledgements.metadata", "pages.legal.acknowledgements.metadata", "acknowledgements metadata"],
+  ["Acknowledgements", "sections.legal.acknowledgements", "acknowledgements content"],
+  ["EULA", "pages.legal.eula", "end user license agreement"],
+  ["email", "emails", "email templates"],
+  ["IMS--Dialogs", "dialogs.invoices", "invoice dialogs"],
+  ["IMS--Cards", "cards.invoices", "invoice cards"],
+  ["IMS--Stats", "cards.invoices.statistics", "invoice statistics widgets"],
+  ["IMS--Hooks", "toasts.invoices", "user-visible hook feedback"],
+  ["IMS--Common", "shared.invoices", "shared invoice labels"],
+  ["IMS--Landing", "pages.invoices.landing", "invoice landing page"],
+  ["IMS--Create", "forms.invoices.createInvoice", "create-invoice flow"],
+  ["IMS--Edit", "pages.invoices.editInvoice", "edit-invoice experience"],
+  ["IMS--List.metadata", "pages.invoices.viewInvoices.metadata", "view-invoices metadata"],
+  ["IMS--List.invoicesView.filters", "forms.invoices.filters", "invoice list filters"],
+  ["IMS--List.invoicesView.table", "tables.invoices.list", "invoice list table"],
+  ["IMS--List", "pages.invoices.viewInvoices", "view-invoices page"],
+  ["IMS--ViewScans", "pages.invoices.viewScans", "view-scans page"],
+  ["IMS--UploadScans", "pages.invoices.uploadScans", "upload-scans page"],
+  ["IMS--View.metadata", "pages.invoices.viewInvoice.metadata", "view-invoice metadata"],
+  ["IMS--View.timelineItem", "sections.invoices.timeline.item", "invoice timeline item"],
+  ["IMS--View", "pages.invoices.viewInvoice", "view-invoice page"],
+];
+
+function lowerCamel(segment: string): string {
+  const cleaned = segment
+    .replace(/^IMS--/u, "")
+    .replace(/[_\s-]+(.)?/gu, (_match, next: string | undefined) => (next ? next.toUpperCase() : ""))
+    .replace(/[^A-Za-z0-9]/gu, "");
+  if (!cleaned) return "unknown";
+  return `${cleaned[0]!.toLowerCase()}${cleaned.slice(1)}`;
+}
+
+function normalizePath(messagePath: string): string {
+  return messagePath.split(".").map(lowerCamel).join(".");
+}
+
+function mapPath(oldPath: string): KeyMapEntry {
+  const matchingRule = explicitPrefixRules
+    .filter(([oldPrefix]) => oldPath === oldPrefix || oldPath.startsWith(`${oldPrefix}.`))
+    .sort((left, right) => right[0].length - left[0].length)[0];
+
+  if (matchingRule) {
+    const [oldPrefix, newPrefix, reason] = matchingRule;
+    const suffix = oldPath === oldPrefix ? "" : oldPath.slice(oldPrefix.length);
+    return {oldPath, newPath: normalizePath(`${newPrefix}${suffix}`), reason};
+  }
+
+  const currentTopLevel = oldPath.split(".")[0] ?? "";
+  const fallbackPrefix = allowedTopLevelBuckets.includes(currentTopLevel as (typeof allowedTopLevelBuckets)[number]) ? "" : "shared.legacy.";
+  return {oldPath, newPath: normalizePath(`${fallbackPrefix}${oldPath}`), reason: "fallback normalized legacy path"};
+}
+
+const flat = flattenMessages(readMessageTree("en"));
+const entries = [...flat.keys()].map(mapPath).sort((left, right) => left.oldPath.localeCompare(right.oldPath));
+const duplicates = new Map<string, string[]>();
+for (const entry of entries) {
+  duplicates.set(entry.newPath, [...(duplicates.get(entry.newPath) ?? []), entry.oldPath]);
+}
+const duplicateEntries = [...duplicates.entries()].filter(([, oldPaths]) => oldPaths.length > 1);
+if (duplicateEntries.length > 0) {
+  console.error("[message-tree] Duplicate target paths detected:");
+  for (const [newPath, oldPaths] of duplicateEntries.slice(0, 50)) {
+    console.error(`- ${newPath}: ${oldPaths.join(", ")}`);
+  }
+  process.exit(1);
+}
+
+const outputPath = path.join(getRepositoryRoot(), "scripts", "migrations", "message-tree", "key-map.json");
+fs.writeFileSync(outputPath, `${JSON.stringify(entries, null, 2)}\n`);
+console.info(`[message-tree] Wrote ${entries.length} mappings to ${path.relative(getRepositoryRoot(), outputPath)}.`);

--- a/scripts/migrations/message-tree/generateKeyMap.ts
+++ b/scripts/migrations/message-tree/generateKeyMap.ts
@@ -54,11 +54,19 @@ const explicitPrefixRules: ReadonlyArray<readonly [oldPrefix: string, newPrefix:
 ];
 
 function lowerCamel(segment: string): string {
+  if (/^\d+$/u.test(segment)) {
+    return `item${segment}`;
+  }
+
   const cleaned = segment
     .replace(/^IMS--/u, "")
     .replace(/[_\s-]+(.)?/gu, (_match, next: string | undefined) => (next ? next.toUpperCase() : ""))
     .replace(/[^A-Za-z0-9]/gu, "");
   if (!cleaned) return "unknown";
+  if (/^\d/u.test(cleaned)) {
+    return `value${cleaned[0]!.toUpperCase()}${cleaned.slice(1)}`;
+  }
+
   return `${cleaned[0]!.toLowerCase()}${cleaned.slice(1)}`;
 }
 

--- a/scripts/migrations/message-tree/key-map.json
+++ b/scripts/migrations/message-tree/key-map.json
@@ -1,0 +1,16632 @@
+[
+  {
+    "oldPath": "About.Author.Biography.FifthPoint",
+    "newPath": "sections.about.author.biography.fifthPoint",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Biography.FirstPoint",
+    "newPath": "sections.about.author.biography.firstPoint",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Biography.FourthPoint",
+    "newPath": "sections.about.author.biography.fourthPoint",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Biography.SecondPoint",
+    "newPath": "sections.about.author.biography.secondPoint",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Biography.ThirdPoint",
+    "newPath": "sections.about.author.biography.thirdPoint",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Biography.title",
+    "newPath": "sections.about.author.biography.title",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.ab730.code",
+    "newPath": "sections.about.author.certifications.certificates.ab730.code",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.ab730.coreSkills",
+    "newPath": "sections.about.author.certifications.certificates.ab730.coreSkills",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.ab730.description",
+    "newPath": "sections.about.author.certifications.certificates.ab730.description",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.ab730.issuer",
+    "newPath": "sections.about.author.certifications.certificates.ab730.issuer",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.ab730.issuerDate",
+    "newPath": "sections.about.author.certifications.certificates.ab730.issuerDate",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.ab730.link",
+    "newPath": "sections.about.author.certifications.certificates.ab730.link",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.ab730.name",
+    "newPath": "sections.about.author.certifications.certificates.ab730.name",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.ab731.code",
+    "newPath": "sections.about.author.certifications.certificates.ab731.code",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.ab731.coreSkills",
+    "newPath": "sections.about.author.certifications.certificates.ab731.coreSkills",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.ab731.description",
+    "newPath": "sections.about.author.certifications.certificates.ab731.description",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.ab731.issuer",
+    "newPath": "sections.about.author.certifications.certificates.ab731.issuer",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.ab731.issuerDate",
+    "newPath": "sections.about.author.certifications.certificates.ab731.issuerDate",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.ab731.link",
+    "newPath": "sections.about.author.certifications.certificates.ab731.link",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.ab731.name",
+    "newPath": "sections.about.author.certifications.certificates.ab731.name",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.ai900.code",
+    "newPath": "sections.about.author.certifications.certificates.ai900.code",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.ai900.coreSkills",
+    "newPath": "sections.about.author.certifications.certificates.ai900.coreSkills",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.ai900.description",
+    "newPath": "sections.about.author.certifications.certificates.ai900.description",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.ai900.issuer",
+    "newPath": "sections.about.author.certifications.certificates.ai900.issuer",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.ai900.issuerDate",
+    "newPath": "sections.about.author.certifications.certificates.ai900.issuerDate",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.ai900.link",
+    "newPath": "sections.about.author.certifications.certificates.ai900.link",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.ai900.name",
+    "newPath": "sections.about.author.certifications.certificates.ai900.name",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.az900.code",
+    "newPath": "sections.about.author.certifications.certificates.az900.code",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.az900.coreSkills",
+    "newPath": "sections.about.author.certifications.certificates.az900.coreSkills",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.az900.description",
+    "newPath": "sections.about.author.certifications.certificates.az900.description",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.az900.issuer",
+    "newPath": "sections.about.author.certifications.certificates.az900.issuer",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.az900.issuerDate",
+    "newPath": "sections.about.author.certifications.certificates.az900.issuerDate",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.az900.link",
+    "newPath": "sections.about.author.certifications.certificates.az900.link",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.az900.name",
+    "newPath": "sections.about.author.certifications.certificates.az900.name",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.gh100.code",
+    "newPath": "sections.about.author.certifications.certificates.gh100.code",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.gh100.coreSkills",
+    "newPath": "sections.about.author.certifications.certificates.gh100.coreSkills",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.gh100.description",
+    "newPath": "sections.about.author.certifications.certificates.gh100.description",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.gh100.issuer",
+    "newPath": "sections.about.author.certifications.certificates.gh100.issuer",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.gh100.issuerDate",
+    "newPath": "sections.about.author.certifications.certificates.gh100.issuerDate",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.gh100.link",
+    "newPath": "sections.about.author.certifications.certificates.gh100.link",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.gh100.name",
+    "newPath": "sections.about.author.certifications.certificates.gh100.name",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.gh200.code",
+    "newPath": "sections.about.author.certifications.certificates.gh200.code",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.gh200.coreSkills",
+    "newPath": "sections.about.author.certifications.certificates.gh200.coreSkills",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.gh200.description",
+    "newPath": "sections.about.author.certifications.certificates.gh200.description",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.gh200.issuer",
+    "newPath": "sections.about.author.certifications.certificates.gh200.issuer",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.gh200.issuerDate",
+    "newPath": "sections.about.author.certifications.certificates.gh200.issuerDate",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.gh200.link",
+    "newPath": "sections.about.author.certifications.certificates.gh200.link",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.gh200.name",
+    "newPath": "sections.about.author.certifications.certificates.gh200.name",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.gh300.code",
+    "newPath": "sections.about.author.certifications.certificates.gh300.code",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.gh300.coreSkills",
+    "newPath": "sections.about.author.certifications.certificates.gh300.coreSkills",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.gh300.description",
+    "newPath": "sections.about.author.certifications.certificates.gh300.description",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.gh300.issuer",
+    "newPath": "sections.about.author.certifications.certificates.gh300.issuer",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.gh300.issuerDate",
+    "newPath": "sections.about.author.certifications.certificates.gh300.issuerDate",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.gh300.link",
+    "newPath": "sections.about.author.certifications.certificates.gh300.link",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.gh300.name",
+    "newPath": "sections.about.author.certifications.certificates.gh300.name",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.gh900.code",
+    "newPath": "sections.about.author.certifications.certificates.gh900.code",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.gh900.coreSkills",
+    "newPath": "sections.about.author.certifications.certificates.gh900.coreSkills",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.gh900.description",
+    "newPath": "sections.about.author.certifications.certificates.gh900.description",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.gh900.issuer",
+    "newPath": "sections.about.author.certifications.certificates.gh900.issuer",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.gh900.issuerDate",
+    "newPath": "sections.about.author.certifications.certificates.gh900.issuerDate",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.gh900.link",
+    "newPath": "sections.about.author.certifications.certificates.gh900.link",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.gh900.name",
+    "newPath": "sections.about.author.certifications.certificates.gh900.name",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.sc900.code",
+    "newPath": "sections.about.author.certifications.certificates.sc900.code",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.sc900.coreSkills",
+    "newPath": "sections.about.author.certifications.certificates.sc900.coreSkills",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.sc900.description",
+    "newPath": "sections.about.author.certifications.certificates.sc900.description",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.sc900.issuer",
+    "newPath": "sections.about.author.certifications.certificates.sc900.issuer",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.sc900.issuerDate",
+    "newPath": "sections.about.author.certifications.certificates.sc900.issuerDate",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.sc900.link",
+    "newPath": "sections.about.author.certifications.certificates.sc900.link",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.certificates.sc900.name",
+    "newPath": "sections.about.author.certifications.certificates.sc900.name",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.coreSkillsLabel",
+    "newPath": "sections.about.author.certifications.coreSkillsLabel",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.subtitle",
+    "newPath": "sections.about.author.certifications.subtitle",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.title",
+    "newPath": "sections.about.author.certifications.title",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Certifications.viewCertification",
+    "newPath": "sections.about.author.certifications.viewCertification",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Competencies.competences.agileMethodologies.description",
+    "newPath": "sections.about.author.competencies.competences.agileMethodologies.description",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Competencies.competences.agileMethodologies.title",
+    "newPath": "sections.about.author.competencies.competences.agileMethodologies.title",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Competencies.competences.algorithmicSkills.description",
+    "newPath": "sections.about.author.competencies.competences.algorithmicSkills.description",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Competencies.competences.algorithmicSkills.title",
+    "newPath": "sections.about.author.competencies.competences.algorithmicSkills.title",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Competencies.competences.customerCentric.description",
+    "newPath": "sections.about.author.competencies.competences.customerCentric.description",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Competencies.competences.customerCentric.title",
+    "newPath": "sections.about.author.competencies.competences.customerCentric.title",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Competencies.competences.domainDrivenDesign.description",
+    "newPath": "sections.about.author.competencies.competences.domainDrivenDesign.description",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Competencies.competences.domainDrivenDesign.title",
+    "newPath": "sections.about.author.competencies.competences.domainDrivenDesign.title",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Competencies.competences.engineeringExcellence.description",
+    "newPath": "sections.about.author.competencies.competences.engineeringExcellence.description",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Competencies.competences.engineeringExcellence.title",
+    "newPath": "sections.about.author.competencies.competences.engineeringExcellence.title",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Competencies.competences.testDrivenDevelopment.description",
+    "newPath": "sections.about.author.competencies.competences.testDrivenDevelopment.description",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Competencies.competences.testDrivenDevelopment.title",
+    "newPath": "sections.about.author.competencies.competences.testDrivenDevelopment.title",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Competencies.subtitle",
+    "newPath": "sections.about.author.competencies.subtitle",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Competencies.title",
+    "newPath": "sections.about.author.competencies.title",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Contact.collaborate.discipline1",
+    "newPath": "sections.about.author.contact.collaborate.discipline1",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Contact.collaborate.discipline2",
+    "newPath": "sections.about.author.contact.collaborate.discipline2",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Contact.collaborate.discipline3",
+    "newPath": "sections.about.author.contact.collaborate.discipline3",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Contact.collaborate.discipline4",
+    "newPath": "sections.about.author.contact.collaborate.discipline4",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Contact.collaborate.footer",
+    "newPath": "sections.about.author.contact.collaborate.footer",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Contact.collaborate.subtitle",
+    "newPath": "sections.about.author.contact.collaborate.subtitle",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Contact.collaborate.title",
+    "newPath": "sections.about.author.contact.collaborate.title",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Contact.footer",
+    "newPath": "sections.about.author.contact.footer",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Contact.socials.footer",
+    "newPath": "sections.about.author.contact.socials.footer",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Contact.socials.subtitle",
+    "newPath": "sections.about.author.contact.socials.subtitle",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Contact.socials.title",
+    "newPath": "sections.about.author.contact.socials.title",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Contact.subtitle",
+    "newPath": "sections.about.author.contact.subtitle",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Contact.title",
+    "newPath": "sections.about.author.contact.title",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Education.subtitle",
+    "newPath": "sections.about.author.education.subtitle",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Education.title",
+    "newPath": "sections.about.author.education.title",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Education.university.aseBucharest.aboutTheProgram_cta",
+    "newPath": "sections.about.author.education.university.aseBucharest.aboutTheProgramCta",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Education.university.aseBucharest.aboutTheProgram_description",
+    "newPath": "sections.about.author.education.university.aseBucharest.aboutTheProgramDescription",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Education.university.aseBucharest.aboutTheProgram_learnings",
+    "newPath": "sections.about.author.education.university.aseBucharest.aboutTheProgramLearnings",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Education.university.aseBucharest.aboutTheProgram_learnings_title",
+    "newPath": "sections.about.author.education.university.aseBucharest.aboutTheProgramLearningsTitle",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Education.university.aseBucharest.aboutTheProgram_title",
+    "newPath": "sections.about.author.education.university.aseBucharest.aboutTheProgramTitle",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Education.university.aseBucharest.degree",
+    "newPath": "sections.about.author.education.university.aseBucharest.degree",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Education.university.aseBucharest.description",
+    "newPath": "sections.about.author.education.university.aseBucharest.description",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Education.university.aseBucharest.institution",
+    "newPath": "sections.about.author.education.university.aseBucharest.institution",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Education.university.aseBucharest.keyCourses",
+    "newPath": "sections.about.author.education.university.aseBucharest.keyCourses",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Education.university.aseBucharest.keyCourses_title",
+    "newPath": "sections.about.author.education.university.aseBucharest.keyCoursesTitle",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Education.university.aseBucharest.location",
+    "newPath": "sections.about.author.education.university.aseBucharest.location",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Education.university.aseBucharest.period",
+    "newPath": "sections.about.author.education.university.aseBucharest.period",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Education.university.aseBucharest.status",
+    "newPath": "sections.about.author.education.university.aseBucharest.status",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Education.university.malmoSweden.aboutTheProgram_cta",
+    "newPath": "sections.about.author.education.university.malmoSweden.aboutTheProgramCta",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Education.university.malmoSweden.aboutTheProgram_description",
+    "newPath": "sections.about.author.education.university.malmoSweden.aboutTheProgramDescription",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Education.university.malmoSweden.aboutTheProgram_learnings",
+    "newPath": "sections.about.author.education.university.malmoSweden.aboutTheProgramLearnings",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Education.university.malmoSweden.aboutTheProgram_learnings_title",
+    "newPath": "sections.about.author.education.university.malmoSweden.aboutTheProgramLearningsTitle",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Education.university.malmoSweden.aboutTheProgram_title",
+    "newPath": "sections.about.author.education.university.malmoSweden.aboutTheProgramTitle",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Education.university.malmoSweden.degree",
+    "newPath": "sections.about.author.education.university.malmoSweden.degree",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Education.university.malmoSweden.description",
+    "newPath": "sections.about.author.education.university.malmoSweden.description",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Education.university.malmoSweden.institution",
+    "newPath": "sections.about.author.education.university.malmoSweden.institution",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Education.university.malmoSweden.keyCourses",
+    "newPath": "sections.about.author.education.university.malmoSweden.keyCourses",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Education.university.malmoSweden.keyCourses_title",
+    "newPath": "sections.about.author.education.university.malmoSweden.keyCoursesTitle",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Education.university.malmoSweden.location",
+    "newPath": "sections.about.author.education.university.malmoSweden.location",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Education.university.malmoSweden.period",
+    "newPath": "sections.about.author.education.university.malmoSweden.period",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Education.university.malmoSweden.status",
+    "newPath": "sections.about.author.education.university.malmoSweden.status",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Experiences.achievementsLabel",
+    "newPath": "sections.about.author.experiences.achievementsLabel",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Experiences.intel.achievements",
+    "newPath": "sections.about.author.experiences.intel.achievements",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Experiences.intel.company",
+    "newPath": "sections.about.author.experiences.intel.company",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Experiences.intel.description",
+    "newPath": "sections.about.author.experiences.intel.description",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Experiences.intel.location",
+    "newPath": "sections.about.author.experiences.intel.location",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Experiences.intel.period",
+    "newPath": "sections.about.author.experiences.intel.period",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Experiences.intel.responsibilites",
+    "newPath": "sections.about.author.experiences.intel.responsibilites",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Experiences.intel.techAndSkills",
+    "newPath": "sections.about.author.experiences.intel.techAndSkills",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Experiences.intel.title",
+    "newPath": "sections.about.author.experiences.intel.title",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Experiences.microsoft1.achievements",
+    "newPath": "sections.about.author.experiences.microsoft1.achievements",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Experiences.microsoft1.company",
+    "newPath": "sections.about.author.experiences.microsoft1.company",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Experiences.microsoft1.description",
+    "newPath": "sections.about.author.experiences.microsoft1.description",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Experiences.microsoft1.location",
+    "newPath": "sections.about.author.experiences.microsoft1.location",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Experiences.microsoft1.period",
+    "newPath": "sections.about.author.experiences.microsoft1.period",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Experiences.microsoft1.responsibilites",
+    "newPath": "sections.about.author.experiences.microsoft1.responsibilites",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Experiences.microsoft1.techAndSkills",
+    "newPath": "sections.about.author.experiences.microsoft1.techAndSkills",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Experiences.microsoft1.title",
+    "newPath": "sections.about.author.experiences.microsoft1.title",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Experiences.microsoft2.achievements",
+    "newPath": "sections.about.author.experiences.microsoft2.achievements",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Experiences.microsoft2.company",
+    "newPath": "sections.about.author.experiences.microsoft2.company",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Experiences.microsoft2.description",
+    "newPath": "sections.about.author.experiences.microsoft2.description",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Experiences.microsoft2.location",
+    "newPath": "sections.about.author.experiences.microsoft2.location",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Experiences.microsoft2.period",
+    "newPath": "sections.about.author.experiences.microsoft2.period",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Experiences.microsoft2.responsibilites",
+    "newPath": "sections.about.author.experiences.microsoft2.responsibilites",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Experiences.microsoft2.techAndSkills",
+    "newPath": "sections.about.author.experiences.microsoft2.techAndSkills",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Experiences.microsoft2.title",
+    "newPath": "sections.about.author.experiences.microsoft2.title",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Experiences.microsoft3.achievements",
+    "newPath": "sections.about.author.experiences.microsoft3.achievements",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Experiences.microsoft3.company",
+    "newPath": "sections.about.author.experiences.microsoft3.company",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Experiences.microsoft3.description",
+    "newPath": "sections.about.author.experiences.microsoft3.description",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Experiences.microsoft3.location",
+    "newPath": "sections.about.author.experiences.microsoft3.location",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Experiences.microsoft3.period",
+    "newPath": "sections.about.author.experiences.microsoft3.period",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Experiences.microsoft3.responsibilites",
+    "newPath": "sections.about.author.experiences.microsoft3.responsibilites",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Experiences.microsoft3.techAndSkills",
+    "newPath": "sections.about.author.experiences.microsoft3.techAndSkills",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Experiences.microsoft3.title",
+    "newPath": "sections.about.author.experiences.microsoft3.title",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Experiences.responsibilitiesLabel",
+    "newPath": "sections.about.author.experiences.responsibilitiesLabel",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Experiences.subtitle",
+    "newPath": "sections.about.author.experiences.subtitle",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Experiences.techSkillsLabel",
+    "newPath": "sections.about.author.experiences.techSkillsLabel",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Experiences.title",
+    "newPath": "sections.about.author.experiences.title",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Experiences.ubisoft.achievements",
+    "newPath": "sections.about.author.experiences.ubisoft.achievements",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Experiences.ubisoft.company",
+    "newPath": "sections.about.author.experiences.ubisoft.company",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Experiences.ubisoft.description",
+    "newPath": "sections.about.author.experiences.ubisoft.description",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Experiences.ubisoft.location",
+    "newPath": "sections.about.author.experiences.ubisoft.location",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Experiences.ubisoft.period",
+    "newPath": "sections.about.author.experiences.ubisoft.period",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Experiences.ubisoft.responsibilites",
+    "newPath": "sections.about.author.experiences.ubisoft.responsibilites",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Experiences.ubisoft.techAndSkills",
+    "newPath": "sections.about.author.experiences.ubisoft.techAndSkills",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Experiences.ubisoft.title",
+    "newPath": "sections.about.author.experiences.ubisoft.title",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.metadata.description",
+    "newPath": "pages.about.author.metadata.description",
+    "reason": "author page metadata"
+  },
+  {
+    "oldPath": "About.Author.metadata.title",
+    "newPath": "pages.about.author.metadata.title",
+    "reason": "author page metadata"
+  },
+  {
+    "oldPath": "About.Author.Perspectives.perspectiveFromX.author",
+    "newPath": "sections.about.author.perspectives.perspectiveFromX.author",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Perspectives.perspectiveFromX.avatar",
+    "newPath": "sections.about.author.perspectives.perspectiveFromX.avatar",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Perspectives.perspectiveFromX.company",
+    "newPath": "sections.about.author.perspectives.perspectiveFromX.company",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Perspectives.perspectiveFromX.position",
+    "newPath": "sections.about.author.perspectives.perspectiveFromX.position",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Perspectives.perspectiveFromX.quote",
+    "newPath": "sections.about.author.perspectives.perspectiveFromX.quote",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Perspectives.perspectiveFromXX.author",
+    "newPath": "sections.about.author.perspectives.perspectiveFromXX.author",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Perspectives.perspectiveFromXX.avatar",
+    "newPath": "sections.about.author.perspectives.perspectiveFromXX.avatar",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Perspectives.perspectiveFromXX.company",
+    "newPath": "sections.about.author.perspectives.perspectiveFromXX.company",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Perspectives.perspectiveFromXX.position",
+    "newPath": "sections.about.author.perspectives.perspectiveFromXX.position",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Perspectives.perspectiveFromXX.quote",
+    "newPath": "sections.about.author.perspectives.perspectiveFromXX.quote",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Perspectives.perspectiveFromXY.author",
+    "newPath": "sections.about.author.perspectives.perspectiveFromXY.author",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Perspectives.perspectiveFromXY.avatar",
+    "newPath": "sections.about.author.perspectives.perspectiveFromXY.avatar",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Perspectives.perspectiveFromXY.company",
+    "newPath": "sections.about.author.perspectives.perspectiveFromXY.company",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Perspectives.perspectiveFromXY.position",
+    "newPath": "sections.about.author.perspectives.perspectiveFromXY.position",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Perspectives.perspectiveFromXY.quote",
+    "newPath": "sections.about.author.perspectives.perspectiveFromXY.quote",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Perspectives.perspectiveFromXZ.author",
+    "newPath": "sections.about.author.perspectives.perspectiveFromXZ.author",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Perspectives.perspectiveFromXZ.avatar",
+    "newPath": "sections.about.author.perspectives.perspectiveFromXZ.avatar",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Perspectives.perspectiveFromXZ.company",
+    "newPath": "sections.about.author.perspectives.perspectiveFromXZ.company",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Perspectives.perspectiveFromXZ.position",
+    "newPath": "sections.about.author.perspectives.perspectiveFromXZ.position",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Perspectives.perspectiveFromXZ.quote",
+    "newPath": "sections.about.author.perspectives.perspectiveFromXZ.quote",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Perspectives.perspectiveFromY.author",
+    "newPath": "sections.about.author.perspectives.perspectiveFromY.author",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Perspectives.perspectiveFromY.avatar",
+    "newPath": "sections.about.author.perspectives.perspectiveFromY.avatar",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Perspectives.perspectiveFromY.company",
+    "newPath": "sections.about.author.perspectives.perspectiveFromY.company",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Perspectives.perspectiveFromY.position",
+    "newPath": "sections.about.author.perspectives.perspectiveFromY.position",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Perspectives.perspectiveFromY.quote",
+    "newPath": "sections.about.author.perspectives.perspectiveFromY.quote",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Perspectives.perspectiveFromYX.author",
+    "newPath": "sections.about.author.perspectives.perspectiveFromYX.author",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Perspectives.perspectiveFromYX.avatar",
+    "newPath": "sections.about.author.perspectives.perspectiveFromYX.avatar",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Perspectives.perspectiveFromYX.company",
+    "newPath": "sections.about.author.perspectives.perspectiveFromYX.company",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Perspectives.perspectiveFromYX.position",
+    "newPath": "sections.about.author.perspectives.perspectiveFromYX.position",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Perspectives.perspectiveFromYX.quote",
+    "newPath": "sections.about.author.perspectives.perspectiveFromYX.quote",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Perspectives.perspectiveFromYY.author",
+    "newPath": "sections.about.author.perspectives.perspectiveFromYY.author",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Perspectives.perspectiveFromYY.avatar",
+    "newPath": "sections.about.author.perspectives.perspectiveFromYY.avatar",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Perspectives.perspectiveFromYY.company",
+    "newPath": "sections.about.author.perspectives.perspectiveFromYY.company",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Perspectives.perspectiveFromYY.position",
+    "newPath": "sections.about.author.perspectives.perspectiveFromYY.position",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Perspectives.perspectiveFromYY.quote",
+    "newPath": "sections.about.author.perspectives.perspectiveFromYY.quote",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Perspectives.perspectiveFromYZ.author",
+    "newPath": "sections.about.author.perspectives.perspectiveFromYZ.author",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Perspectives.perspectiveFromYZ.avatar",
+    "newPath": "sections.about.author.perspectives.perspectiveFromYZ.avatar",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Perspectives.perspectiveFromYZ.company",
+    "newPath": "sections.about.author.perspectives.perspectiveFromYZ.company",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Perspectives.perspectiveFromYZ.position",
+    "newPath": "sections.about.author.perspectives.perspectiveFromYZ.position",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Perspectives.perspectiveFromYZ.quote",
+    "newPath": "sections.about.author.perspectives.perspectiveFromYZ.quote",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Perspectives.perspectiveFromZ.author",
+    "newPath": "sections.about.author.perspectives.perspectiveFromZ.author",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Perspectives.perspectiveFromZ.avatar",
+    "newPath": "sections.about.author.perspectives.perspectiveFromZ.avatar",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Perspectives.perspectiveFromZ.company",
+    "newPath": "sections.about.author.perspectives.perspectiveFromZ.company",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Perspectives.perspectiveFromZ.position",
+    "newPath": "sections.about.author.perspectives.perspectiveFromZ.position",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Perspectives.perspectiveFromZ.quote",
+    "newPath": "sections.about.author.perspectives.perspectiveFromZ.quote",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Perspectives.subtitle",
+    "newPath": "sections.about.author.perspectives.subtitle",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.Perspectives.title",
+    "newPath": "sections.about.author.perspectives.title",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.subtitle",
+    "newPath": "sections.about.author.subtitle",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.Author.title",
+    "newPath": "sections.about.author.title",
+    "reason": "author page sections"
+  },
+  {
+    "oldPath": "About.cards.author.cta",
+    "newPath": "shared.legacy.about.cards.author.cta",
+    "reason": "fallback normalized legacy path"
+  },
+  {
+    "oldPath": "About.cards.author.subtitle",
+    "newPath": "shared.legacy.about.cards.author.subtitle",
+    "reason": "fallback normalized legacy path"
+  },
+  {
+    "oldPath": "About.cards.author.title",
+    "newPath": "shared.legacy.about.cards.author.title",
+    "reason": "fallback normalized legacy path"
+  },
+  {
+    "oldPath": "About.cards.platform.cta",
+    "newPath": "shared.legacy.about.cards.platform.cta",
+    "reason": "fallback normalized legacy path"
+  },
+  {
+    "oldPath": "About.cards.platform.subtitle",
+    "newPath": "shared.legacy.about.cards.platform.subtitle",
+    "reason": "fallback normalized legacy path"
+  },
+  {
+    "oldPath": "About.cards.platform.title",
+    "newPath": "shared.legacy.about.cards.platform.title",
+    "reason": "fallback normalized legacy path"
+  },
+  {
+    "oldPath": "About.footer",
+    "newPath": "shared.legacy.about.footer",
+    "reason": "fallback normalized legacy path"
+  },
+  {
+    "oldPath": "About.Hub.cta.footer",
+    "newPath": "pages.about.hub.cta.footer",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.cta.primary",
+    "newPath": "pages.about.hub.cta.primary",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.cta.secondary",
+    "newPath": "pages.about.hub.cta.secondary",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.cta.subtitle",
+    "newPath": "pages.about.hub.cta.subtitle",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.cta.title",
+    "newPath": "pages.about.hub.cta.title",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.faq.questions.q1.answer",
+    "newPath": "pages.about.hub.faq.questions.q1.answer",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.faq.questions.q1.question",
+    "newPath": "pages.about.hub.faq.questions.q1.question",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.faq.questions.q2.answer",
+    "newPath": "pages.about.hub.faq.questions.q2.answer",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.faq.questions.q2.question",
+    "newPath": "pages.about.hub.faq.questions.q2.question",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.faq.questions.q3.answer",
+    "newPath": "pages.about.hub.faq.questions.q3.answer",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.faq.questions.q3.question",
+    "newPath": "pages.about.hub.faq.questions.q3.question",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.faq.questions.q4.answer",
+    "newPath": "pages.about.hub.faq.questions.q4.answer",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.faq.questions.q4.question",
+    "newPath": "pages.about.hub.faq.questions.q4.question",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.faq.subtitle",
+    "newPath": "pages.about.hub.faq.subtitle",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.faq.title",
+    "newPath": "pages.about.hub.faq.title",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.hero.badge",
+    "newPath": "pages.about.hub.hero.badge",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.hero.ctaPrimary",
+    "newPath": "pages.about.hub.hero.ctaPrimary",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.hero.ctaSecondary",
+    "newPath": "pages.about.hub.hero.ctaSecondary",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.hero.subtitle",
+    "newPath": "pages.about.hub.hero.subtitle",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.hero.title",
+    "newPath": "pages.about.hub.hero.title",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.mission.description",
+    "newPath": "pages.about.hub.mission.description",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.mission.pillars.innovation.description",
+    "newPath": "pages.about.hub.mission.pillars.innovation.description",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.mission.pillars.innovation.title",
+    "newPath": "pages.about.hub.mission.pillars.innovation.title",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.mission.pillars.openness.description",
+    "newPath": "pages.about.hub.mission.pillars.openness.description",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.mission.pillars.openness.title",
+    "newPath": "pages.about.hub.mission.pillars.openness.title",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.mission.pillars.quality.description",
+    "newPath": "pages.about.hub.mission.pillars.quality.description",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.mission.pillars.quality.title",
+    "newPath": "pages.about.hub.mission.pillars.quality.title",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.mission.statement",
+    "newPath": "pages.about.hub.mission.statement",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.mission.title",
+    "newPath": "pages.about.hub.mission.title",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.navigation.author.cta",
+    "newPath": "pages.about.hub.navigation.author.cta",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.navigation.author.features.0",
+    "newPath": "pages.about.hub.navigation.author.features.0",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.navigation.author.features.1",
+    "newPath": "pages.about.hub.navigation.author.features.1",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.navigation.author.features.2",
+    "newPath": "pages.about.hub.navigation.author.features.2",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.navigation.author.subtitle",
+    "newPath": "pages.about.hub.navigation.author.subtitle",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.navigation.author.title",
+    "newPath": "pages.about.hub.navigation.author.title",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.navigation.platform.cta",
+    "newPath": "pages.about.hub.navigation.platform.cta",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.navigation.platform.features.0",
+    "newPath": "pages.about.hub.navigation.platform.features.0",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.navigation.platform.features.1",
+    "newPath": "pages.about.hub.navigation.platform.features.1",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.navigation.platform.features.2",
+    "newPath": "pages.about.hub.navigation.platform.features.2",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.navigation.platform.subtitle",
+    "newPath": "pages.about.hub.navigation.platform.subtitle",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.navigation.platform.title",
+    "newPath": "pages.about.hub.navigation.platform.title",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.navigation.subtitle",
+    "newPath": "pages.about.hub.navigation.subtitle",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.navigation.title",
+    "newPath": "pages.about.hub.navigation.title",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.stats.items.linesOfCode.description",
+    "newPath": "pages.about.hub.stats.items.linesOfCode.description",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.stats.items.linesOfCode.label",
+    "newPath": "pages.about.hub.stats.items.linesOfCode.label",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.stats.items.linesOfCode.value",
+    "newPath": "pages.about.hub.stats.items.linesOfCode.value",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.stats.items.technologies.description",
+    "newPath": "pages.about.hub.stats.items.technologies.description",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.stats.items.technologies.label",
+    "newPath": "pages.about.hub.stats.items.technologies.label",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.stats.items.technologies.value",
+    "newPath": "pages.about.hub.stats.items.technologies.value",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.stats.items.testCoverage.description",
+    "newPath": "pages.about.hub.stats.items.testCoverage.description",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.stats.items.testCoverage.label",
+    "newPath": "pages.about.hub.stats.items.testCoverage.label",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.stats.items.testCoverage.value",
+    "newPath": "pages.about.hub.stats.items.testCoverage.value",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.stats.items.yearsActive.description",
+    "newPath": "pages.about.hub.stats.items.yearsActive.description",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.stats.items.yearsActive.label",
+    "newPath": "pages.about.hub.stats.items.yearsActive.label",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.stats.items.yearsActive.value",
+    "newPath": "pages.about.hub.stats.items.yearsActive.value",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.stats.subtitle",
+    "newPath": "pages.about.hub.stats.subtitle",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.stats.title",
+    "newPath": "pages.about.hub.stats.title",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.values.items.accessibility.description",
+    "newPath": "pages.about.hub.values.items.accessibility.description",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.values.items.accessibility.title",
+    "newPath": "pages.about.hub.values.items.accessibility.title",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.values.items.community.description",
+    "newPath": "pages.about.hub.values.items.community.description",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.values.items.community.title",
+    "newPath": "pages.about.hub.values.items.community.title",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.values.items.engineering.description",
+    "newPath": "pages.about.hub.values.items.engineering.description",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.values.items.engineering.title",
+    "newPath": "pages.about.hub.values.items.engineering.title",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.values.items.learning.description",
+    "newPath": "pages.about.hub.values.items.learning.description",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.values.items.learning.title",
+    "newPath": "pages.about.hub.values.items.learning.title",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.values.items.performance.description",
+    "newPath": "pages.about.hub.values.items.performance.description",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.values.items.performance.title",
+    "newPath": "pages.about.hub.values.items.performance.title",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.values.items.privacy.description",
+    "newPath": "pages.about.hub.values.items.privacy.description",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.values.items.privacy.title",
+    "newPath": "pages.about.hub.values.items.privacy.title",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.values.subtitle",
+    "newPath": "pages.about.hub.values.subtitle",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.Hub.values.title",
+    "newPath": "pages.about.hub.values.title",
+    "reason": "about hub page"
+  },
+  {
+    "oldPath": "About.metadata.description",
+    "newPath": "shared.legacy.about.metadata.description",
+    "reason": "fallback normalized legacy path"
+  },
+  {
+    "oldPath": "About.metadata.title",
+    "newPath": "shared.legacy.about.metadata.title",
+    "reason": "fallback normalized legacy path"
+  },
+  {
+    "oldPath": "About.Platform.architecture.badge",
+    "newPath": "sections.about.platform.architecture.badge",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.architecture.description",
+    "newPath": "sections.about.platform.architecture.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.architecture.layers.ai.description",
+    "newPath": "sections.about.platform.architecture.layers.ai.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.architecture.layers.ai.name",
+    "newPath": "sections.about.platform.architecture.layers.ai.name",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.architecture.layers.ai.technologies",
+    "newPath": "sections.about.platform.architecture.layers.ai.technologies",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.architecture.layers.api.description",
+    "newPath": "sections.about.platform.architecture.layers.api.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.architecture.layers.api.name",
+    "newPath": "sections.about.platform.architecture.layers.api.name",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.architecture.layers.api.technologies",
+    "newPath": "sections.about.platform.architecture.layers.api.technologies",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.architecture.layers.auth.description",
+    "newPath": "sections.about.platform.architecture.layers.auth.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.architecture.layers.auth.name",
+    "newPath": "sections.about.platform.architecture.layers.auth.name",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.architecture.layers.auth.technologies",
+    "newPath": "sections.about.platform.architecture.layers.auth.technologies",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.architecture.layers.cdn.description",
+    "newPath": "sections.about.platform.architecture.layers.cdn.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.architecture.layers.cdn.name",
+    "newPath": "sections.about.platform.architecture.layers.cdn.name",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.architecture.layers.cdn.technologies",
+    "newPath": "sections.about.platform.architecture.layers.cdn.technologies",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.architecture.layers.client.description",
+    "newPath": "sections.about.platform.architecture.layers.client.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.architecture.layers.client.name",
+    "newPath": "sections.about.platform.architecture.layers.client.name",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.architecture.layers.client.technologies",
+    "newPath": "sections.about.platform.architecture.layers.client.technologies",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.architecture.layers.data.description",
+    "newPath": "sections.about.platform.architecture.layers.data.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.architecture.layers.data.name",
+    "newPath": "sections.about.platform.architecture.layers.data.name",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.architecture.layers.data.technologies",
+    "newPath": "sections.about.platform.architecture.layers.data.technologies",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.architecture.layers.infra.description",
+    "newPath": "sections.about.platform.architecture.layers.infra.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.architecture.layers.infra.name",
+    "newPath": "sections.about.platform.architecture.layers.infra.name",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.architecture.layers.infra.technologies",
+    "newPath": "sections.about.platform.architecture.layers.infra.technologies",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.architecture.layers.services.description",
+    "newPath": "sections.about.platform.architecture.layers.services.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.architecture.layers.services.name",
+    "newPath": "sections.about.platform.architecture.layers.services.name",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.architecture.layers.services.technologies",
+    "newPath": "sections.about.platform.architecture.layers.services.technologies",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.architecture.principles.appRouter.description",
+    "newPath": "sections.about.platform.architecture.principles.appRouter.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.architecture.principles.appRouter.title",
+    "newPath": "sections.about.platform.architecture.principles.appRouter.title",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.architecture.principles.cloudNative.description",
+    "newPath": "sections.about.platform.architecture.principles.cloudNative.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.architecture.principles.cloudNative.title",
+    "newPath": "sections.about.platform.architecture.principles.cloudNative.title",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.architecture.principles.rsc.description",
+    "newPath": "sections.about.platform.architecture.principles.rsc.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.architecture.principles.rsc.title",
+    "newPath": "sections.about.platform.architecture.principles.rsc.title",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.architecture.title",
+    "newPath": "sections.about.platform.architecture.title",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.architecture.titleHighlight",
+    "newPath": "sections.about.platform.architecture.titleHighlight",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.callToAction.cta.createAccount",
+    "newPath": "sections.about.platform.callToAction.cta.createAccount",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.callToAction.cta.exploreApplications",
+    "newPath": "sections.about.platform.callToAction.cta.exploreApplications",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.callToAction.description",
+    "newPath": "sections.about.platform.callToAction.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.callToAction.footer",
+    "newPath": "sections.about.platform.callToAction.footer",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.callToAction.footerRole",
+    "newPath": "sections.about.platform.callToAction.footerRole",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.callToAction.links.getInTouch",
+    "newPath": "sections.about.platform.callToAction.links.getInTouch",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.callToAction.links.meetAuthor",
+    "newPath": "sections.about.platform.callToAction.links.meetAuthor",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.callToAction.links.viewSource",
+    "newPath": "sections.about.platform.callToAction.links.viewSource",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.callToAction.title",
+    "newPath": "sections.about.platform.callToAction.title",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.callToAction.titleHighlight",
+    "newPath": "sections.about.platform.callToAction.titleHighlight",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.callToAction.trust.freeToUse.description",
+    "newPath": "sections.about.platform.callToAction.trust.freeToUse.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.callToAction.trust.freeToUse.title",
+    "newPath": "sections.about.platform.callToAction.trust.freeToUse.title",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.callToAction.trust.openSource.description",
+    "newPath": "sections.about.platform.callToAction.trust.openSource.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.callToAction.trust.openSource.title",
+    "newPath": "sections.about.platform.callToAction.trust.openSource.title",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.callToAction.trust.privacyFirst.description",
+    "newPath": "sections.about.platform.callToAction.trust.privacyFirst.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.callToAction.trust.privacyFirst.title",
+    "newPath": "sections.about.platform.callToAction.trust.privacyFirst.title",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.features.badge",
+    "newPath": "sections.about.platform.features.badge",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.features.description",
+    "newPath": "sections.about.platform.features.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.features.items.ai.description",
+    "newPath": "sections.about.platform.features.items.ai.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.features.items.ai.longDescription",
+    "newPath": "sections.about.platform.features.items.ai.longDescription",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.features.items.ai.tags",
+    "newPath": "sections.about.platform.features.items.ai.tags",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.features.items.ai.title",
+    "newPath": "sections.about.platform.features.items.ai.title",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.features.items.analytics.description",
+    "newPath": "sections.about.platform.features.items.analytics.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.features.items.analytics.longDescription",
+    "newPath": "sections.about.platform.features.items.analytics.longDescription",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.features.items.analytics.tags",
+    "newPath": "sections.about.platform.features.items.analytics.tags",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.features.items.analytics.title",
+    "newPath": "sections.about.platform.features.items.analytics.title",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.features.items.auth.description",
+    "newPath": "sections.about.platform.features.items.auth.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.features.items.auth.longDescription",
+    "newPath": "sections.about.platform.features.items.auth.longDescription",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.features.items.auth.tags",
+    "newPath": "sections.about.platform.features.items.auth.tags",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.features.items.auth.title",
+    "newPath": "sections.about.platform.features.items.auth.title",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.features.items.budgets.description",
+    "newPath": "sections.about.platform.features.items.budgets.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.features.items.budgets.longDescription",
+    "newPath": "sections.about.platform.features.items.budgets.longDescription",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.features.items.budgets.tags",
+    "newPath": "sections.about.platform.features.items.budgets.tags",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.features.items.budgets.title",
+    "newPath": "sections.about.platform.features.items.budgets.title",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.features.items.i18n.description",
+    "newPath": "sections.about.platform.features.items.i18n.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.features.items.i18n.longDescription",
+    "newPath": "sections.about.platform.features.items.i18n.longDescription",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.features.items.i18n.tags",
+    "newPath": "sections.about.platform.features.items.i18n.tags",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.features.items.i18n.title",
+    "newPath": "sections.about.platform.features.items.i18n.title",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.features.items.invoices.description",
+    "newPath": "sections.about.platform.features.items.invoices.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.features.items.invoices.longDescription",
+    "newPath": "sections.about.platform.features.items.invoices.longDescription",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.features.items.invoices.tags",
+    "newPath": "sections.about.platform.features.items.invoices.tags",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.features.items.invoices.title",
+    "newPath": "sections.about.platform.features.items.invoices.title",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.features.items.merchants.description",
+    "newPath": "sections.about.platform.features.items.merchants.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.features.items.merchants.longDescription",
+    "newPath": "sections.about.platform.features.items.merchants.longDescription",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.features.items.merchants.tags",
+    "newPath": "sections.about.platform.features.items.merchants.tags",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.features.items.merchants.title",
+    "newPath": "sections.about.platform.features.items.merchants.title",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.features.items.recipes.description",
+    "newPath": "sections.about.platform.features.items.recipes.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.features.items.recipes.longDescription",
+    "newPath": "sections.about.platform.features.items.recipes.longDescription",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.features.items.recipes.tags",
+    "newPath": "sections.about.platform.features.items.recipes.tags",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.features.items.recipes.title",
+    "newPath": "sections.about.platform.features.items.recipes.title",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.features.items.security.description",
+    "newPath": "sections.about.platform.features.items.security.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.features.items.security.longDescription",
+    "newPath": "sections.about.platform.features.items.security.longDescription",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.features.items.security.tags",
+    "newPath": "sections.about.platform.features.items.security.tags",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.features.items.security.title",
+    "newPath": "sections.about.platform.features.items.security.title",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.features.modal.close",
+    "newPath": "sections.about.platform.features.modal.close",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.features.modal.exploreFeature",
+    "newPath": "sections.about.platform.features.modal.exploreFeature",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.features.title",
+    "newPath": "sections.about.platform.features.title",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.features.titleHighlight",
+    "newPath": "sections.about.platform.features.titleHighlight",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.hero.cta.exploreFeatures",
+    "newPath": "sections.about.platform.hero.cta.exploreFeatures",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.hero.cta.viewSource",
+    "newPath": "sections.about.platform.hero.cta.viewSource",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.hero.description",
+    "newPath": "sections.about.platform.hero.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.hero.scrollIndicator",
+    "newPath": "sections.about.platform.hero.scrollIndicator",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.hero.stats.countries",
+    "newPath": "sections.about.platform.hero.stats.countries",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.hero.stats.linesOfCode",
+    "newPath": "sections.about.platform.hero.stats.linesOfCode",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.hero.stats.projects",
+    "newPath": "sections.about.platform.hero.stats.projects",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.hero.stats.techStack",
+    "newPath": "sections.about.platform.hero.stats.techStack",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.hero.statusBadge",
+    "newPath": "sections.about.platform.hero.statusBadge",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.hero.subtitle",
+    "newPath": "sections.about.platform.hero.subtitle",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.hero.title",
+    "newPath": "sections.about.platform.hero.title",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.hero.trust.freeForever",
+    "newPath": "sections.about.platform.hero.trust.freeForever",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.hero.trust.openSource",
+    "newPath": "sections.about.platform.hero.trust.openSource",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.hero.trust.privacyFirst",
+    "newPath": "sections.about.platform.hero.trust.privacyFirst",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.metadata.description",
+    "newPath": "pages.about.platform.metadata.description",
+    "reason": "platform page metadata"
+  },
+  {
+    "oldPath": "About.Platform.metadata.title",
+    "newPath": "pages.about.platform.metadata.title",
+    "reason": "platform page metadata"
+  },
+  {
+    "oldPath": "About.Platform.statistics.badge",
+    "newPath": "sections.about.platform.statistics.badge",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.statistics.description",
+    "newPath": "sections.about.platform.statistics.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.statistics.items.apis.description",
+    "newPath": "sections.about.platform.statistics.items.apis.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.statistics.items.apis.label",
+    "newPath": "sections.about.platform.statistics.items.apis.label",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.statistics.items.apis.suffix",
+    "newPath": "sections.about.platform.statistics.items.apis.suffix",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.statistics.items.apis.value",
+    "newPath": "sections.about.platform.statistics.items.apis.value",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.statistics.items.commits.description",
+    "newPath": "sections.about.platform.statistics.items.commits.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.statistics.items.commits.label",
+    "newPath": "sections.about.platform.statistics.items.commits.label",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.statistics.items.commits.suffix",
+    "newPath": "sections.about.platform.statistics.items.commits.suffix",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.statistics.items.commits.value",
+    "newPath": "sections.about.platform.statistics.items.commits.value",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.statistics.items.contributors.description",
+    "newPath": "sections.about.platform.statistics.items.contributors.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.statistics.items.contributors.label",
+    "newPath": "sections.about.platform.statistics.items.contributors.label",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.statistics.items.contributors.suffix",
+    "newPath": "sections.about.platform.statistics.items.contributors.suffix",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.statistics.items.contributors.value",
+    "newPath": "sections.about.platform.statistics.items.contributors.value",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.statistics.items.countries.description",
+    "newPath": "sections.about.platform.statistics.items.countries.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.statistics.items.countries.label",
+    "newPath": "sections.about.platform.statistics.items.countries.label",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.statistics.items.countries.suffix",
+    "newPath": "sections.about.platform.statistics.items.countries.suffix",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.statistics.items.countries.value",
+    "newPath": "sections.about.platform.statistics.items.countries.value",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.statistics.items.linesOfCode.description",
+    "newPath": "sections.about.platform.statistics.items.linesOfCode.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.statistics.items.linesOfCode.label",
+    "newPath": "sections.about.platform.statistics.items.linesOfCode.label",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.statistics.items.linesOfCode.suffix",
+    "newPath": "sections.about.platform.statistics.items.linesOfCode.suffix",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.statistics.items.linesOfCode.value",
+    "newPath": "sections.about.platform.statistics.items.linesOfCode.value",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.statistics.items.projects.description",
+    "newPath": "sections.about.platform.statistics.items.projects.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.statistics.items.projects.label",
+    "newPath": "sections.about.platform.statistics.items.projects.label",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.statistics.items.projects.suffix",
+    "newPath": "sections.about.platform.statistics.items.projects.suffix",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.statistics.items.projects.value",
+    "newPath": "sections.about.platform.statistics.items.projects.value",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.statistics.items.stars.description",
+    "newPath": "sections.about.platform.statistics.items.stars.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.statistics.items.stars.label",
+    "newPath": "sections.about.platform.statistics.items.stars.label",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.statistics.items.stars.suffix",
+    "newPath": "sections.about.platform.statistics.items.stars.suffix",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.statistics.items.stars.value",
+    "newPath": "sections.about.platform.statistics.items.stars.value",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.statistics.items.users.description",
+    "newPath": "sections.about.platform.statistics.items.users.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.statistics.items.users.label",
+    "newPath": "sections.about.platform.statistics.items.users.label",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.statistics.items.users.suffix",
+    "newPath": "sections.about.platform.statistics.items.users.suffix",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.statistics.items.users.value",
+    "newPath": "sections.about.platform.statistics.items.users.value",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.statistics.title",
+    "newPath": "sections.about.platform.statistics.title",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.statistics.titleHighlight",
+    "newPath": "sections.about.platform.statistics.titleHighlight",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.badge",
+    "newPath": "sections.about.platform.techStack.badge",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.categories.backend.description",
+    "newPath": "sections.about.platform.techStack.categories.backend.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.categories.backend.name",
+    "newPath": "sections.about.platform.techStack.categories.backend.name",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.categories.cloud.description",
+    "newPath": "sections.about.platform.techStack.categories.cloud.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.categories.cloud.name",
+    "newPath": "sections.about.platform.techStack.categories.cloud.name",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.categories.frontend.description",
+    "newPath": "sections.about.platform.techStack.categories.frontend.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.categories.frontend.name",
+    "newPath": "sections.about.platform.techStack.categories.frontend.name",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.categories.tooling.description",
+    "newPath": "sections.about.platform.techStack.categories.tooling.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.categories.tooling.name",
+    "newPath": "sections.about.platform.techStack.categories.tooling.name",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.description",
+    "newPath": "sections.about.platform.techStack.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.stats.coverage.description",
+    "newPath": "sections.about.platform.techStack.stats.coverage.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.stats.coverage.label",
+    "newPath": "sections.about.platform.techStack.stats.coverage.label",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.stats.coverage.value",
+    "newPath": "sections.about.platform.techStack.stats.coverage.value",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.stats.security.description",
+    "newPath": "sections.about.platform.techStack.stats.security.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.stats.security.label",
+    "newPath": "sections.about.platform.techStack.stats.security.label",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.stats.security.value",
+    "newPath": "sections.about.platform.techStack.stats.security.value",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.stats.technologies.description",
+    "newPath": "sections.about.platform.techStack.stats.technologies.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.stats.technologies.label",
+    "newPath": "sections.about.platform.techStack.stats.technologies.label",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.stats.technologies.value",
+    "newPath": "sections.about.platform.techStack.stats.technologies.value",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.stats.typescript.description",
+    "newPath": "sections.about.platform.techStack.stats.typescript.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.stats.typescript.label",
+    "newPath": "sections.about.platform.techStack.stats.typescript.label",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.stats.typescript.value",
+    "newPath": "sections.about.platform.techStack.stats.typescript.value",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.technologies.aspnet.description",
+    "newPath": "sections.about.platform.techStack.technologies.aspnet.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.technologies.aspnet.name",
+    "newPath": "sections.about.platform.techStack.technologies.aspnet.name",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.technologies.azure.description",
+    "newPath": "sections.about.platform.techStack.technologies.azure.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.technologies.azure.name",
+    "newPath": "sections.about.platform.techStack.technologies.azure.name",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.technologies.azureDevops.description",
+    "newPath": "sections.about.platform.techStack.technologies.azureDevops.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.technologies.azureDevops.name",
+    "newPath": "sections.about.platform.techStack.technologies.azureDevops.name",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.technologies.azuresql.description",
+    "newPath": "sections.about.platform.techStack.technologies.azuresql.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.technologies.azuresql.name",
+    "newPath": "sections.about.platform.techStack.technologies.azuresql.name",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.technologies.bicep.description",
+    "newPath": "sections.about.platform.techStack.technologies.bicep.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.technologies.bicep.name",
+    "newPath": "sections.about.platform.techStack.technologies.bicep.name",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.technologies.cosmosdb.description",
+    "newPath": "sections.about.platform.techStack.technologies.cosmosdb.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.technologies.cosmosdb.name",
+    "newPath": "sections.about.platform.techStack.technologies.cosmosdb.name",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.technologies.docker.description",
+    "newPath": "sections.about.platform.techStack.technologies.docker.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.technologies.docker.name",
+    "newPath": "sections.about.platform.techStack.technologies.docker.name",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.technologies.dotnet.description",
+    "newPath": "sections.about.platform.techStack.technologies.dotnet.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.technologies.dotnet.name",
+    "newPath": "sections.about.platform.techStack.technologies.dotnet.name",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.technologies.eslint.description",
+    "newPath": "sections.about.platform.techStack.technologies.eslint.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.technologies.eslint.name",
+    "newPath": "sections.about.platform.techStack.technologies.eslint.name",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.technologies.git.description",
+    "newPath": "sections.about.platform.techStack.technologies.git.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.technologies.git.name",
+    "newPath": "sections.about.platform.techStack.technologies.git.name",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.technologies.githubActions.description",
+    "newPath": "sections.about.platform.techStack.technologies.githubActions.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.technologies.githubActions.name",
+    "newPath": "sections.about.platform.techStack.technologies.githubActions.name",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.technologies.motion.description",
+    "newPath": "sections.about.platform.techStack.technologies.motion.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.technologies.motion.name",
+    "newPath": "sections.about.platform.techStack.technologies.motion.name",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.technologies.nextjs.description",
+    "newPath": "sections.about.platform.techStack.technologies.nextjs.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.technologies.nextjs.name",
+    "newPath": "sections.about.platform.techStack.technologies.nextjs.name",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.technologies.nodejs.description",
+    "newPath": "sections.about.platform.techStack.technologies.nodejs.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.technologies.nodejs.name",
+    "newPath": "sections.about.platform.techStack.technologies.nodejs.name",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.technologies.playwright.description",
+    "newPath": "sections.about.platform.techStack.technologies.playwright.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.technologies.playwright.name",
+    "newPath": "sections.about.platform.techStack.technologies.playwright.name",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.technologies.pnpm.description",
+    "newPath": "sections.about.platform.techStack.technologies.pnpm.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.technologies.pnpm.name",
+    "newPath": "sections.about.platform.techStack.technologies.pnpm.name",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.technologies.prettier.description",
+    "newPath": "sections.about.platform.techStack.technologies.prettier.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.technologies.prettier.name",
+    "newPath": "sections.about.platform.techStack.technologies.prettier.name",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.technologies.react.description",
+    "newPath": "sections.about.platform.techStack.technologies.react.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.technologies.react.name",
+    "newPath": "sections.about.platform.techStack.technologies.react.name",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.technologies.redis.description",
+    "newPath": "sections.about.platform.techStack.technologies.redis.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.technologies.redis.name",
+    "newPath": "sections.about.platform.techStack.technologies.redis.name",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.technologies.scss.description",
+    "newPath": "sections.about.platform.techStack.technologies.scss.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.technologies.scss.name",
+    "newPath": "sections.about.platform.techStack.technologies.scss.name",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.technologies.typescript.description",
+    "newPath": "sections.about.platform.techStack.technologies.typescript.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.technologies.typescript.name",
+    "newPath": "sections.about.platform.techStack.technologies.typescript.name",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.technologies.vercel.description",
+    "newPath": "sections.about.platform.techStack.technologies.vercel.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.technologies.vercel.name",
+    "newPath": "sections.about.platform.techStack.technologies.vercel.name",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.technologies.vitest.description",
+    "newPath": "sections.about.platform.techStack.technologies.vitest.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.technologies.vitest.name",
+    "newPath": "sections.about.platform.techStack.technologies.vitest.name",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.technologies.zustand.description",
+    "newPath": "sections.about.platform.techStack.technologies.zustand.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.technologies.zustand.name",
+    "newPath": "sections.about.platform.techStack.technologies.zustand.name",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.title",
+    "newPath": "sections.about.platform.techStack.title",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.techStack.titleHighlight",
+    "newPath": "sections.about.platform.techStack.titleHighlight",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.timeline.badge",
+    "newPath": "sections.about.platform.timeline.badge",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.timeline.collapseHint",
+    "newPath": "sections.about.platform.timeline.collapseHint",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.timeline.description",
+    "newPath": "sections.about.platform.timeline.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.timeline.events.ai.date",
+    "newPath": "sections.about.platform.timeline.events.ai.date",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.timeline.events.ai.description",
+    "newPath": "sections.about.platform.timeline.events.ai.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.timeline.events.ai.details",
+    "newPath": "sections.about.platform.timeline.events.ai.details",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.timeline.events.ai.tags",
+    "newPath": "sections.about.platform.timeline.events.ai.tags",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.timeline.events.ai.title",
+    "newPath": "sections.about.platform.timeline.events.ai.title",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.timeline.events.backend.date",
+    "newPath": "sections.about.platform.timeline.events.backend.date",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.timeline.events.backend.description",
+    "newPath": "sections.about.platform.timeline.events.backend.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.timeline.events.backend.details",
+    "newPath": "sections.about.platform.timeline.events.backend.details",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.timeline.events.backend.tags",
+    "newPath": "sections.about.platform.timeline.events.backend.tags",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.timeline.events.backend.title",
+    "newPath": "sections.about.platform.timeline.events.backend.title",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.timeline.events.expansion.date",
+    "newPath": "sections.about.platform.timeline.events.expansion.date",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.timeline.events.expansion.description",
+    "newPath": "sections.about.platform.timeline.events.expansion.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.timeline.events.expansion.details",
+    "newPath": "sections.about.platform.timeline.events.expansion.details",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.timeline.events.expansion.tags",
+    "newPath": "sections.about.platform.timeline.events.expansion.tags",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.timeline.events.expansion.title",
+    "newPath": "sections.about.platform.timeline.events.expansion.title",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.timeline.events.inception.date",
+    "newPath": "sections.about.platform.timeline.events.inception.date",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.timeline.events.inception.description",
+    "newPath": "sections.about.platform.timeline.events.inception.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.timeline.events.inception.details",
+    "newPath": "sections.about.platform.timeline.events.inception.details",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.timeline.events.inception.tags",
+    "newPath": "sections.about.platform.timeline.events.inception.tags",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.timeline.events.inception.title",
+    "newPath": "sections.about.platform.timeline.events.inception.title",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.timeline.events.launch.date",
+    "newPath": "sections.about.platform.timeline.events.launch.date",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.timeline.events.launch.description",
+    "newPath": "sections.about.platform.timeline.events.launch.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.timeline.events.launch.details",
+    "newPath": "sections.about.platform.timeline.events.launch.details",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.timeline.events.launch.tags",
+    "newPath": "sections.about.platform.timeline.events.launch.tags",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.timeline.events.launch.title",
+    "newPath": "sections.about.platform.timeline.events.launch.title",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.timeline.events.nextjs.date",
+    "newPath": "sections.about.platform.timeline.events.nextjs.date",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.timeline.events.nextjs.description",
+    "newPath": "sections.about.platform.timeline.events.nextjs.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.timeline.events.nextjs.details",
+    "newPath": "sections.about.platform.timeline.events.nextjs.details",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.timeline.events.nextjs.tags",
+    "newPath": "sections.about.platform.timeline.events.nextjs.tags",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.timeline.events.nextjs.title",
+    "newPath": "sections.about.platform.timeline.events.nextjs.title",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.timeline.events.present.date",
+    "newPath": "sections.about.platform.timeline.events.present.date",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.timeline.events.present.description",
+    "newPath": "sections.about.platform.timeline.events.present.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.timeline.events.present.details",
+    "newPath": "sections.about.platform.timeline.events.present.details",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.timeline.events.present.tags",
+    "newPath": "sections.about.platform.timeline.events.present.tags",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.timeline.events.present.title",
+    "newPath": "sections.about.platform.timeline.events.present.title",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.timeline.events.prototype.date",
+    "newPath": "sections.about.platform.timeline.events.prototype.date",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.timeline.events.prototype.description",
+    "newPath": "sections.about.platform.timeline.events.prototype.description",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.timeline.events.prototype.details",
+    "newPath": "sections.about.platform.timeline.events.prototype.details",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.timeline.events.prototype.tags",
+    "newPath": "sections.about.platform.timeline.events.prototype.tags",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.timeline.events.prototype.title",
+    "newPath": "sections.about.platform.timeline.events.prototype.title",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.timeline.expandHint",
+    "newPath": "sections.about.platform.timeline.expandHint",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.timeline.futureIndicator",
+    "newPath": "sections.about.platform.timeline.futureIndicator",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.timeline.keyAchievements",
+    "newPath": "sections.about.platform.timeline.keyAchievements",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.timeline.title",
+    "newPath": "sections.about.platform.timeline.title",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.Platform.timeline.titleHighlight",
+    "newPath": "sections.about.platform.timeline.titleHighlight",
+    "reason": "platform page sections"
+  },
+  {
+    "oldPath": "About.subtitle",
+    "newPath": "shared.legacy.about.subtitle",
+    "reason": "fallback normalized legacy path"
+  },
+  {
+    "oldPath": "About.title",
+    "newPath": "shared.legacy.about.title",
+    "reason": "fallback normalized legacy path"
+  },
+  {
+    "oldPath": "Acknowledgements.contributors.items.c1.description",
+    "newPath": "sections.legal.acknowledgements.contributors.items.c1.description",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.contributors.items.c1.name",
+    "newPath": "sections.legal.acknowledgements.contributors.items.c1.name",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.contributors.items.c1.packages",
+    "newPath": "sections.legal.acknowledgements.contributors.items.c1.packages",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.contributors.items.c2.description",
+    "newPath": "sections.legal.acknowledgements.contributors.items.c2.description",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.contributors.items.c2.name",
+    "newPath": "sections.legal.acknowledgements.contributors.items.c2.name",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.contributors.items.c2.packages",
+    "newPath": "sections.legal.acknowledgements.contributors.items.c2.packages",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.contributors.items.c3.description",
+    "newPath": "sections.legal.acknowledgements.contributors.items.c3.description",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.contributors.items.c3.name",
+    "newPath": "sections.legal.acknowledgements.contributors.items.c3.name",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.contributors.items.c3.packages",
+    "newPath": "sections.legal.acknowledgements.contributors.items.c3.packages",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.contributors.items.c4.description",
+    "newPath": "sections.legal.acknowledgements.contributors.items.c4.description",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.contributors.items.c4.name",
+    "newPath": "sections.legal.acknowledgements.contributors.items.c4.name",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.contributors.items.c4.packages",
+    "newPath": "sections.legal.acknowledgements.contributors.items.c4.packages",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.contributors.packages",
+    "newPath": "sections.legal.acknowledgements.contributors.packages",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.contributors.subtitle",
+    "newPath": "sections.legal.acknowledgements.contributors.subtitle",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.contributors.title",
+    "newPath": "sections.legal.acknowledgements.contributors.title",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.hero.badge",
+    "newPath": "sections.legal.acknowledgements.hero.badge",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.hero.lastUpdate",
+    "newPath": "sections.legal.acknowledgements.hero.lastUpdate",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.hero.subtitle",
+    "newPath": "sections.legal.acknowledgements.hero.subtitle",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.hero.title",
+    "newPath": "sections.legal.acknowledgements.hero.title",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.lastUpdate",
+    "newPath": "sections.legal.acknowledgements.lastUpdate",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.licenses.apache",
+    "newPath": "sections.legal.acknowledgements.licenses.apache",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.licenses.apacheDescription",
+    "newPath": "sections.legal.acknowledgements.licenses.apacheDescription",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.licenses.gpl",
+    "newPath": "sections.legal.acknowledgements.licenses.gpl",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.licenses.gplDescription",
+    "newPath": "sections.legal.acknowledgements.licenses.gplDescription",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.licenses.mit",
+    "newPath": "sections.legal.acknowledgements.licenses.mit",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.licenses.mitDescription",
+    "newPath": "sections.legal.acknowledgements.licenses.mitDescription",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.licenses.other",
+    "newPath": "sections.legal.acknowledgements.licenses.other",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.licenses.otherDescription",
+    "newPath": "sections.legal.acknowledgements.licenses.otherDescription",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.licenses.packages",
+    "newPath": "sections.legal.acknowledgements.licenses.packages",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.licenses.title",
+    "newPath": "sections.legal.acknowledgements.licenses.title",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.metadata.description",
+    "newPath": "pages.legal.acknowledgements.metadata.description",
+    "reason": "acknowledgements metadata"
+  },
+  {
+    "oldPath": "Acknowledgements.metadata.title",
+    "newPath": "pages.legal.acknowledgements.metadata.title",
+    "reason": "acknowledgements metadata"
+  },
+  {
+    "oldPath": "Acknowledgements.packages.subtitle",
+    "newPath": "sections.legal.acknowledgements.packages.subtitle",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.packages.title",
+    "newPath": "sections.legal.acknowledgements.packages.title",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.packagesScreen.badge.development",
+    "newPath": "sections.legal.acknowledgements.packagesScreen.badge.development",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.packagesScreen.badge.production",
+    "newPath": "sections.legal.acknowledgements.packagesScreen.badge.production",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.packagesScreen.card.dependencies",
+    "newPath": "sections.legal.acknowledgements.packagesScreen.card.dependencies",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.packagesScreen.card.license",
+    "newPath": "sections.legal.acknowledgements.packagesScreen.card.license",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.packagesScreen.card.viewDependencies",
+    "newPath": "sections.legal.acknowledgements.packagesScreen.card.viewDependencies",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.packagesScreen.card.website",
+    "newPath": "sections.legal.acknowledgements.packagesScreen.card.website",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.packagesScreen.dialog.dependencies",
+    "newPath": "sections.legal.acknowledgements.packagesScreen.dialog.dependencies",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.packagesScreen.dialog.dependenciesCount",
+    "newPath": "sections.legal.acknowledgements.packagesScreen.dialog.dependenciesCount",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.packagesScreen.emptyState.subtitle",
+    "newPath": "sections.legal.acknowledgements.packagesScreen.emptyState.subtitle",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.packagesScreen.emptyState.title",
+    "newPath": "sections.legal.acknowledgements.packagesScreen.emptyState.title",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.packagesScreen.filters.allPackages",
+    "newPath": "sections.legal.acknowledgements.packagesScreen.filters.allPackages",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.packagesScreen.filters.ascending",
+    "newPath": "sections.legal.acknowledgements.packagesScreen.filters.ascending",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.packagesScreen.filters.dependenciesCount",
+    "newPath": "sections.legal.acknowledgements.packagesScreen.filters.dependenciesCount",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.packagesScreen.filters.descending",
+    "newPath": "sections.legal.acknowledgements.packagesScreen.filters.descending",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.packagesScreen.filters.developmentOnly",
+    "newPath": "sections.legal.acknowledgements.packagesScreen.filters.developmentOnly",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.packagesScreen.filters.filterByType",
+    "newPath": "sections.legal.acknowledgements.packagesScreen.filters.filterByType",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.packagesScreen.filters.name",
+    "newPath": "sections.legal.acknowledgements.packagesScreen.filters.name",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.packagesScreen.filters.packageType",
+    "newPath": "sections.legal.acknowledgements.packagesScreen.filters.packageType",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.packagesScreen.filters.productionOnly",
+    "newPath": "sections.legal.acknowledgements.packagesScreen.filters.productionOnly",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.packagesScreen.filters.sortBy",
+    "newPath": "sections.legal.acknowledgements.packagesScreen.filters.sortBy",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.packagesScreen.filters.sortDirection",
+    "newPath": "sections.legal.acknowledgements.packagesScreen.filters.sortDirection",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.packagesScreen.openSource.description",
+    "newPath": "sections.legal.acknowledgements.packagesScreen.openSource.description",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.packagesScreen.openSource.title",
+    "newPath": "sections.legal.acknowledgements.packagesScreen.openSource.title",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.packagesScreen.search.placeholder",
+    "newPath": "sections.legal.acknowledgements.packagesScreen.search.placeholder",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.packagesScreen.table.dependencies",
+    "newPath": "sections.legal.acknowledgements.packagesScreen.table.dependencies",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.packagesScreen.table.description",
+    "newPath": "sections.legal.acknowledgements.packagesScreen.table.description",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.packagesScreen.table.license",
+    "newPath": "sections.legal.acknowledgements.packagesScreen.table.license",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.packagesScreen.table.package",
+    "newPath": "sections.legal.acknowledgements.packagesScreen.table.package",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.packagesScreen.table.type",
+    "newPath": "sections.legal.acknowledgements.packagesScreen.table.type",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.packagesScreen.table.version",
+    "newPath": "sections.legal.acknowledgements.packagesScreen.table.version",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.packagesScreen.table.website",
+    "newPath": "sections.legal.acknowledgements.packagesScreen.table.website",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.packagesScreen.views.gridView",
+    "newPath": "sections.legal.acknowledgements.packagesScreen.views.gridView",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.packagesScreen.views.tableView",
+    "newPath": "sections.legal.acknowledgements.packagesScreen.views.tableView",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.stats.development.description",
+    "newPath": "sections.legal.acknowledgements.stats.development.description",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.stats.development.label",
+    "newPath": "sections.legal.acknowledgements.stats.development.label",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.stats.development.value",
+    "newPath": "sections.legal.acknowledgements.stats.development.value",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.stats.mitLicense.description",
+    "newPath": "sections.legal.acknowledgements.stats.mitLicense.description",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.stats.mitLicense.label",
+    "newPath": "sections.legal.acknowledgements.stats.mitLicense.label",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.stats.mitLicense.value",
+    "newPath": "sections.legal.acknowledgements.stats.mitLicense.value",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.stats.production.description",
+    "newPath": "sections.legal.acknowledgements.stats.production.description",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.stats.production.label",
+    "newPath": "sections.legal.acknowledgements.stats.production.label",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.stats.production.value",
+    "newPath": "sections.legal.acknowledgements.stats.production.value",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.stats.subtitle",
+    "newPath": "sections.legal.acknowledgements.stats.subtitle",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.stats.title",
+    "newPath": "sections.legal.acknowledgements.stats.title",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.stats.total.description",
+    "newPath": "sections.legal.acknowledgements.stats.total.description",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.stats.total.label",
+    "newPath": "sections.legal.acknowledgements.stats.total.label",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.stats.total.value",
+    "newPath": "sections.legal.acknowledgements.stats.total.value",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Acknowledgements.title",
+    "newPath": "sections.legal.acknowledgements.title",
+    "reason": "acknowledgements content"
+  },
+  {
+    "oldPath": "Auth.Button.login",
+    "newPath": "pages.auth.button.login",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.Button.logout",
+    "newPath": "pages.auth.button.logout",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.Island.callToAction",
+    "newPath": "pages.auth.island.callToAction",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.Island.description",
+    "newPath": "pages.auth.island.description",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.Island.footer",
+    "newPath": "pages.auth.island.footer",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.Island.hero.badge",
+    "newPath": "pages.auth.island.hero.badge",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.Island.hero.subtitle",
+    "newPath": "pages.auth.island.hero.subtitle",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.Island.hero.title",
+    "newPath": "pages.auth.island.hero.title",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.Island.signIn.bullets.first",
+    "newPath": "pages.auth.island.signIn.bullets.first",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.Island.signIn.bullets.second",
+    "newPath": "pages.auth.island.signIn.bullets.second",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.Island.signIn.bullets.third",
+    "newPath": "pages.auth.island.signIn.bullets.third",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.Island.signIn.cta",
+    "newPath": "pages.auth.island.signIn.cta",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.Island.signIn.description",
+    "newPath": "pages.auth.island.signIn.description",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.Island.signIn.illustrationAlt",
+    "newPath": "pages.auth.island.signIn.illustrationAlt",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.Island.signIn.secondaryAction",
+    "newPath": "pages.auth.island.signIn.secondaryAction",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.Island.signIn.secondaryPrompt",
+    "newPath": "pages.auth.island.signIn.secondaryPrompt",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.Island.signIn.title",
+    "newPath": "pages.auth.island.signIn.title",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.Island.signUp.bullets.first",
+    "newPath": "pages.auth.island.signUp.bullets.first",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.Island.signUp.bullets.second",
+    "newPath": "pages.auth.island.signUp.bullets.second",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.Island.signUp.bullets.third",
+    "newPath": "pages.auth.island.signUp.bullets.third",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.Island.signUp.cta",
+    "newPath": "pages.auth.island.signUp.cta",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.Island.signUp.description",
+    "newPath": "pages.auth.island.signUp.description",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.Island.signUp.illustrationAlt",
+    "newPath": "pages.auth.island.signUp.illustrationAlt",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.Island.signUp.secondaryAction",
+    "newPath": "pages.auth.island.signUp.secondaryAction",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.Island.signUp.secondaryPrompt",
+    "newPath": "pages.auth.island.signUp.secondaryPrompt",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.Island.signUp.title",
+    "newPath": "pages.auth.island.signUp.title",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.Island.step1",
+    "newPath": "pages.auth.island.step1",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.Island.step2",
+    "newPath": "pages.auth.island.step2",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.Island.title",
+    "newPath": "pages.auth.island.title",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.Island.trust.oauth",
+    "newPath": "pages.auth.island.trust.oauth",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.Island.trust.privacy",
+    "newPath": "pages.auth.island.trust.privacy",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.Island.trust.session",
+    "newPath": "pages.auth.island.trust.session",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.metadata.description",
+    "newPath": "pages.auth.metadata.description",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.metadata.title",
+    "newPath": "pages.auth.metadata.title",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.SignIn.bullets.first",
+    "newPath": "pages.auth.signIn.bullets.first",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.SignIn.bullets.second",
+    "newPath": "pages.auth.signIn.bullets.second",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.SignIn.bullets.third",
+    "newPath": "pages.auth.signIn.bullets.third",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.SignIn.footer",
+    "newPath": "pages.auth.signIn.footer",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.SignIn.form.kicker",
+    "newPath": "pages.auth.signIn.form.kicker",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.SignIn.form.secondaryAction",
+    "newPath": "pages.auth.signIn.form.secondaryAction",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.SignIn.form.secondaryPrompt",
+    "newPath": "pages.auth.signIn.form.secondaryPrompt",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.SignIn.hero.subtitle",
+    "newPath": "pages.auth.signIn.hero.subtitle",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.SignIn.hero.title",
+    "newPath": "pages.auth.signIn.hero.title",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.SignIn.illustrationAlt",
+    "newPath": "pages.auth.signIn.illustrationAlt",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.SignIn.metadata.description",
+    "newPath": "pages.auth.signIn.metadata.description",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.SignIn.metadata.title",
+    "newPath": "pages.auth.signIn.metadata.title",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.SignUp.bullets.first",
+    "newPath": "pages.auth.signUp.bullets.first",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.SignUp.bullets.second",
+    "newPath": "pages.auth.signUp.bullets.second",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.SignUp.bullets.third",
+    "newPath": "pages.auth.signUp.bullets.third",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.SignUp.footer",
+    "newPath": "pages.auth.signUp.footer",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.SignUp.form.kicker",
+    "newPath": "pages.auth.signUp.form.kicker",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.SignUp.form.secondaryAction",
+    "newPath": "pages.auth.signUp.form.secondaryAction",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.SignUp.form.secondaryPrompt",
+    "newPath": "pages.auth.signUp.form.secondaryPrompt",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.SignUp.hero.subtitle",
+    "newPath": "pages.auth.signUp.hero.subtitle",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.SignUp.hero.title",
+    "newPath": "pages.auth.signUp.hero.title",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.SignUp.illustrationAlt",
+    "newPath": "pages.auth.signUp.illustrationAlt",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.SignUp.metadata.description",
+    "newPath": "pages.auth.signUp.metadata.description",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Auth.SignUp.metadata.title",
+    "newPath": "pages.auth.signUp.metadata.title",
+    "reason": "authentication pages"
+  },
+  {
+    "oldPath": "Commander.groups.accessibility",
+    "newPath": "app.commander.groups.accessibility",
+    "reason": "global command palette"
+  },
+  {
+    "oldPath": "Commander.groups.fun",
+    "newPath": "app.commander.groups.fun",
+    "reason": "global command palette"
+  },
+  {
+    "oldPath": "Commander.groups.language",
+    "newPath": "app.commander.groups.language",
+    "reason": "global command palette"
+  },
+  {
+    "oldPath": "Commander.groups.links",
+    "newPath": "app.commander.groups.links",
+    "reason": "global command palette"
+  },
+  {
+    "oldPath": "Commander.groups.navigation",
+    "newPath": "app.commander.groups.navigation",
+    "reason": "global command palette"
+  },
+  {
+    "oldPath": "Commander.groups.theme",
+    "newPath": "app.commander.groups.theme",
+    "reason": "global command palette"
+  },
+  {
+    "oldPath": "Commander.items.dark",
+    "newPath": "app.commander.items.dark",
+    "reason": "global command palette"
+  },
+  {
+    "oldPath": "Commander.items.disco",
+    "newPath": "app.commander.items.disco",
+    "reason": "global command palette"
+  },
+  {
+    "oldPath": "Commander.items.english",
+    "newPath": "app.commander.items.english",
+    "reason": "global command palette"
+  },
+  {
+    "oldPath": "Commander.items.fontDyslexic",
+    "newPath": "app.commander.items.fontDyslexic",
+    "reason": "global command palette"
+  },
+  {
+    "oldPath": "Commander.items.fontNormal",
+    "newPath": "app.commander.items.fontNormal",
+    "reason": "global command palette"
+  },
+  {
+    "oldPath": "Commander.items.french",
+    "newPath": "app.commander.items.french",
+    "reason": "global command palette"
+  },
+  {
+    "oldPath": "Commander.items.github",
+    "newPath": "app.commander.items.github",
+    "reason": "global command palette"
+  },
+  {
+    "oldPath": "Commander.items.homepage",
+    "newPath": "app.commander.items.homepage",
+    "reason": "global command palette"
+  },
+  {
+    "oldPath": "Commander.items.light",
+    "newPath": "app.commander.items.light",
+    "reason": "global command palette"
+  },
+  {
+    "oldPath": "Commander.items.matrix",
+    "newPath": "app.commander.items.matrix",
+    "reason": "global command palette"
+  },
+  {
+    "oldPath": "Commander.items.rainbow",
+    "newPath": "app.commander.items.rainbow",
+    "reason": "global command palette"
+  },
+  {
+    "oldPath": "Commander.items.romanian",
+    "newPath": "app.commander.items.romanian",
+    "reason": "global command palette"
+  },
+  {
+    "oldPath": "Commander.items.system",
+    "newPath": "app.commander.items.system",
+    "reason": "global command palette"
+  },
+  {
+    "oldPath": "Commander.noResults",
+    "newPath": "app.commander.noResults",
+    "reason": "global command palette"
+  },
+  {
+    "oldPath": "Commander.placeholder",
+    "newPath": "app.commander.placeholder",
+    "reason": "global command palette"
+  },
+  {
+    "oldPath": "Common.accessibility.logoAlt",
+    "newPath": "shared.accessibility.logoAlt",
+    "reason": "shared accessibility labels"
+  },
+  {
+    "oldPath": "Common.accessibility.toggleTheme",
+    "newPath": "shared.accessibility.toggleTheme",
+    "reason": "shared accessibility labels"
+  },
+  {
+    "oldPath": "Common.states.forbidden.callToAction",
+    "newPath": "shared.legacy.common.states.forbidden.callToAction",
+    "reason": "fallback normalized legacy path"
+  },
+  {
+    "oldPath": "Common.states.forbidden.description",
+    "newPath": "shared.legacy.common.states.forbidden.description",
+    "reason": "fallback normalized legacy path"
+  },
+  {
+    "oldPath": "Common.states.forbidden.title",
+    "newPath": "shared.legacy.common.states.forbidden.title",
+    "reason": "fallback normalized legacy path"
+  },
+  {
+    "oldPath": "Domains.metadata.description",
+    "newPath": "pages.domains.metadata.description",
+    "reason": "domains landing page"
+  },
+  {
+    "oldPath": "Domains.metadata.title",
+    "newPath": "pages.domains.metadata.title",
+    "reason": "domains landing page"
+  },
+  {
+    "oldPath": "Domains.services.callToAction",
+    "newPath": "pages.domains.services.callToAction",
+    "reason": "domains landing page"
+  },
+  {
+    "oldPath": "Domains.services.invoices.card.description",
+    "newPath": "pages.domains.services.invoices.card.description",
+    "reason": "domains landing page"
+  },
+  {
+    "oldPath": "Domains.services.invoices.card.imageAlt",
+    "newPath": "pages.domains.services.invoices.card.imageAlt",
+    "reason": "domains landing page"
+  },
+  {
+    "oldPath": "Domains.services.invoices.card.title",
+    "newPath": "pages.domains.services.invoices.card.title",
+    "reason": "domains landing page"
+  },
+  {
+    "oldPath": "Domains.subtitle",
+    "newPath": "pages.domains.subtitle",
+    "reason": "domains landing page"
+  },
+  {
+    "oldPath": "Domains.title",
+    "newPath": "pages.domains.title",
+    "reason": "domains landing page"
+  },
+  {
+    "oldPath": "email.accountInactivity.badge",
+    "newPath": "emails.accountInactivity.badge",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.accountInactivity.cta.primary",
+    "newPath": "emails.accountInactivity.cta.primary",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.accountInactivity.cta.secondary",
+    "newPath": "emails.accountInactivity.cta.secondary",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.accountInactivity.footnote",
+    "newPath": "emails.accountInactivity.footnote",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.accountInactivity.greeting",
+    "newPath": "emails.accountInactivity.greeting",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.accountInactivity.heading",
+    "newPath": "emails.accountInactivity.heading",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.accountInactivity.intro",
+    "newPath": "emails.accountInactivity.intro",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.accountInactivity.preview",
+    "newPath": "emails.accountInactivity.preview",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.accountInactivity.signOff.line1",
+    "newPath": "emails.accountInactivity.signOff.line1",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.accountInactivity.signOff.line2",
+    "newPath": "emails.accountInactivity.signOff.line2",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.accountInactivity.subject",
+    "newPath": "emails.accountInactivity.subject",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.accountInactivity.supportPrompt",
+    "newPath": "emails.accountInactivity.supportPrompt",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.accountInactivity.timeline.daysValue",
+    "newPath": "emails.accountInactivity.timeline.daysValue",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.accountInactivity.timeline.inactiveFor",
+    "newPath": "emails.accountInactivity.timeline.inactiveFor",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.accountInactivity.timeline.timeRemaining",
+    "newPath": "emails.accountInactivity.timeline.timeRemaining",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.accountInactivity.timeline.title",
+    "newPath": "emails.accountInactivity.timeline.title",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.accountInactivity.whatThisMeans.bullet1",
+    "newPath": "emails.accountInactivity.whatThisMeans.bullet1",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.accountInactivity.whatThisMeans.bullet2",
+    "newPath": "emails.accountInactivity.whatThisMeans.bullet2",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.accountInactivity.whatThisMeans.bullet3",
+    "newPath": "emails.accountInactivity.whatThisMeans.bullet3",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.accountInactivity.whatThisMeans.title",
+    "newPath": "emails.accountInactivity.whatThisMeans.title",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.firstInvoiceUploaded.badge",
+    "newPath": "emails.firstInvoiceUploaded.badge",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.firstInvoiceUploaded.body",
+    "newPath": "emails.firstInvoiceUploaded.body",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.firstInvoiceUploaded.ctaPrimary",
+    "newPath": "emails.firstInvoiceUploaded.ctaPrimary",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.firstInvoiceUploaded.ctaSecondary",
+    "newPath": "emails.firstInvoiceUploaded.ctaSecondary",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.firstInvoiceUploaded.featuresToExplore.0",
+    "newPath": "emails.firstInvoiceUploaded.featuresToExplore.0",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.firstInvoiceUploaded.featuresToExplore.1",
+    "newPath": "emails.firstInvoiceUploaded.featuresToExplore.1",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.firstInvoiceUploaded.featuresToExplore.2",
+    "newPath": "emails.firstInvoiceUploaded.featuresToExplore.2",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.firstInvoiceUploaded.featuresToExplore.3",
+    "newPath": "emails.firstInvoiceUploaded.featuresToExplore.3",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.firstInvoiceUploaded.featuresToExploreTitle",
+    "newPath": "emails.firstInvoiceUploaded.featuresToExploreTitle",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.firstInvoiceUploaded.feedbackPrompt",
+    "newPath": "emails.firstInvoiceUploaded.feedbackPrompt",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.firstInvoiceUploaded.greeting",
+    "newPath": "emails.firstInvoiceUploaded.greeting",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.firstInvoiceUploaded.heading",
+    "newPath": "emails.firstInvoiceUploaded.heading",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.firstInvoiceUploaded.intro",
+    "newPath": "emails.firstInvoiceUploaded.intro",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.firstInvoiceUploaded.invoiceSummary.invoiceName",
+    "newPath": "emails.firstInvoiceUploaded.invoiceSummary.invoiceName",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.firstInvoiceUploaded.invoiceSummary.status",
+    "newPath": "emails.firstInvoiceUploaded.invoiceSummary.status",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.firstInvoiceUploaded.invoiceSummary.uploaded",
+    "newPath": "emails.firstInvoiceUploaded.invoiceSummary.uploaded",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.firstInvoiceUploaded.invoiceSummaryTitle",
+    "newPath": "emails.firstInvoiceUploaded.invoiceSummaryTitle",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.firstInvoiceUploaded.preview",
+    "newPath": "emails.firstInvoiceUploaded.preview",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.firstInvoiceUploaded.signOff.line1",
+    "newPath": "emails.firstInvoiceUploaded.signOff.line1",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.firstInvoiceUploaded.signOff.line2",
+    "newPath": "emails.firstInvoiceUploaded.signOff.line2",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.firstInvoiceUploaded.statusValue",
+    "newPath": "emails.firstInvoiceUploaded.statusValue",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.firstInvoiceUploaded.subject",
+    "newPath": "emails.firstInvoiceUploaded.subject",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.firstInvoiceUploaded.untitledFallback",
+    "newPath": "emails.firstInvoiceUploaded.untitledFallback",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.firstInvoiceUploaded.whatHappensNext.0",
+    "newPath": "emails.firstInvoiceUploaded.whatHappensNext.0",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.firstInvoiceUploaded.whatHappensNext.1",
+    "newPath": "emails.firstInvoiceUploaded.whatHappensNext.1",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.firstInvoiceUploaded.whatHappensNext.2",
+    "newPath": "emails.firstInvoiceUploaded.whatHappensNext.2",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.firstInvoiceUploaded.whatHappensNextTitle",
+    "newPath": "emails.firstInvoiceUploaded.whatHappensNextTitle",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.incompleteInvoice.analyzedOnLabel",
+    "newPath": "emails.incompleteInvoice.analyzedOnLabel",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.incompleteInvoice.badge",
+    "newPath": "emails.incompleteInvoice.badge",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.incompleteInvoice.bodyText",
+    "newPath": "emails.incompleteInvoice.bodyText",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.incompleteInvoice.feedback",
+    "newPath": "emails.incompleteInvoice.feedback",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.incompleteInvoice.greeting",
+    "newPath": "emails.incompleteInvoice.greeting",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.incompleteInvoice.heading",
+    "newPath": "emails.incompleteInvoice.heading",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.incompleteInvoice.intro",
+    "newPath": "emails.incompleteInvoice.intro",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.incompleteInvoice.invoiceDetailsTitle",
+    "newPath": "emails.incompleteInvoice.invoiceDetailsTitle",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.incompleteInvoice.invoiceLabel",
+    "newPath": "emails.incompleteInvoice.invoiceLabel",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.incompleteInvoice.missingFields.category.label",
+    "newPath": "emails.incompleteInvoice.missingFields.category.label",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.incompleteInvoice.missingFields.category.suggestion",
+    "newPath": "emails.incompleteInvoice.missingFields.category.suggestion",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.incompleteInvoice.missingFields.items.label",
+    "newPath": "emails.incompleteInvoice.missingFields.items.label",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.incompleteInvoice.missingFields.items.suggestion",
+    "newPath": "emails.incompleteInvoice.missingFields.items.suggestion",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.incompleteInvoice.missingFields.merchant.label",
+    "newPath": "emails.incompleteInvoice.missingFields.merchant.label",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.incompleteInvoice.missingFields.merchant.suggestion",
+    "newPath": "emails.incompleteInvoice.missingFields.merchant.suggestion",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.incompleteInvoice.missingFields.payment.label",
+    "newPath": "emails.incompleteInvoice.missingFields.payment.label",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.incompleteInvoice.missingFields.payment.suggestion",
+    "newPath": "emails.incompleteInvoice.missingFields.payment.suggestion",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.incompleteInvoice.missingFields.unknown.label",
+    "newPath": "emails.incompleteInvoice.missingFields.unknown.label",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.incompleteInvoice.missingFields.unknown.suggestion",
+    "newPath": "emails.incompleteInvoice.missingFields.unknown.suggestion",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.incompleteInvoice.missingFieldsLabel",
+    "newPath": "emails.incompleteInvoice.missingFieldsLabel",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.incompleteInvoice.preview",
+    "newPath": "emails.incompleteInvoice.preview",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.incompleteInvoice.primaryCta",
+    "newPath": "emails.incompleteInvoice.primaryCta",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.incompleteInvoice.secondaryCta",
+    "newPath": "emails.incompleteInvoice.secondaryCta",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.incompleteInvoice.signOff.line1",
+    "newPath": "emails.incompleteInvoice.signOff.line1",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.incompleteInvoice.signOff.line2",
+    "newPath": "emails.incompleteInvoice.signOff.line2",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.incompleteInvoice.subject",
+    "newPath": "emails.incompleteInvoice.subject",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.incompleteInvoice.tips.0",
+    "newPath": "emails.incompleteInvoice.tips.0",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.incompleteInvoice.tips.1",
+    "newPath": "emails.incompleteInvoice.tips.1",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.incompleteInvoice.tips.2",
+    "newPath": "emails.incompleteInvoice.tips.2",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.incompleteInvoice.tips.3",
+    "newPath": "emails.incompleteInvoice.tips.3",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.incompleteInvoice.tipsTitle",
+    "newPath": "emails.incompleteInvoice.tipsTitle",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.incompleteInvoice.whatsMissingTitle",
+    "newPath": "emails.incompleteInvoice.whatsMissingTitle",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceAnalyzed.badge",
+    "newPath": "emails.invoiceAnalyzed.badge",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceAnalyzed.body",
+    "newPath": "emails.invoiceAnalyzed.body",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceAnalyzed.ctaPrimary",
+    "newPath": "emails.invoiceAnalyzed.ctaPrimary",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceAnalyzed.feedbackPrompt",
+    "newPath": "emails.invoiceAnalyzed.feedbackPrompt",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceAnalyzed.greeting",
+    "newPath": "emails.invoiceAnalyzed.greeting",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceAnalyzed.heading",
+    "newPath": "emails.invoiceAnalyzed.heading",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceAnalyzed.intro",
+    "newPath": "emails.invoiceAnalyzed.intro",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceAnalyzed.preview",
+    "newPath": "emails.invoiceAnalyzed.preview",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceAnalyzed.signOff.line1",
+    "newPath": "emails.invoiceAnalyzed.signOff.line1",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceAnalyzed.signOff.line2",
+    "newPath": "emails.invoiceAnalyzed.signOff.line2",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceAnalyzed.subject",
+    "newPath": "emails.invoiceAnalyzed.subject",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceAnalyzed.summary.invoiceName",
+    "newPath": "emails.invoiceAnalyzed.summary.invoiceName",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceAnalyzed.summary.itemsDetected",
+    "newPath": "emails.invoiceAnalyzed.summary.itemsDetected",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceAnalyzed.summary.merchantId",
+    "newPath": "emails.invoiceAnalyzed.summary.merchantId",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceAnalyzed.summary.notIdentified",
+    "newPath": "emails.invoiceAnalyzed.summary.notIdentified",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceAnalyzed.summary.totalAmount",
+    "newPath": "emails.invoiceAnalyzed.summary.totalAmount",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceAnalyzed.summaryTitle",
+    "newPath": "emails.invoiceAnalyzed.summaryTitle",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceAnalyzed.whatWasAnalyzed.0",
+    "newPath": "emails.invoiceAnalyzed.whatWasAnalyzed.0",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceAnalyzed.whatWasAnalyzed.1",
+    "newPath": "emails.invoiceAnalyzed.whatWasAnalyzed.1",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceAnalyzed.whatWasAnalyzed.2",
+    "newPath": "emails.invoiceAnalyzed.whatWasAnalyzed.2",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceAnalyzed.whatWasAnalyzed.3",
+    "newPath": "emails.invoiceAnalyzed.whatWasAnalyzed.3",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceAnalyzed.whatWasAnalyzed.4",
+    "newPath": "emails.invoiceAnalyzed.whatWasAnalyzed.4",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceAnalyzed.whatWasAnalyzedTitle",
+    "newPath": "emails.invoiceAnalyzed.whatWasAnalyzedTitle",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceDeleted.badge",
+    "newPath": "emails.invoiceDeleted.badge",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceDeleted.body",
+    "newPath": "emails.invoiceDeleted.body",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceDeleted.ctaPrimary",
+    "newPath": "emails.invoiceDeleted.ctaPrimary",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceDeleted.details.invoice",
+    "newPath": "emails.invoiceDeleted.details.invoice",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceDeleted.details.invoiceId",
+    "newPath": "emails.invoiceDeleted.details.invoiceId",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceDeleted.details.status",
+    "newPath": "emails.invoiceDeleted.details.status",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceDeleted.detailsTitle",
+    "newPath": "emails.invoiceDeleted.detailsTitle",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceDeleted.greeting",
+    "newPath": "emails.invoiceDeleted.greeting",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceDeleted.heading",
+    "newPath": "emails.invoiceDeleted.heading",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceDeleted.intro",
+    "newPath": "emails.invoiceDeleted.intro",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceDeleted.placeholder",
+    "newPath": "emails.invoiceDeleted.placeholder",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceDeleted.preview",
+    "newPath": "emails.invoiceDeleted.preview",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceDeleted.signOff.line1",
+    "newPath": "emails.invoiceDeleted.signOff.line1",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceDeleted.signOff.line2",
+    "newPath": "emails.invoiceDeleted.signOff.line2",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceDeleted.statusValue",
+    "newPath": "emails.invoiceDeleted.statusValue",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceDeleted.subject",
+    "newPath": "emails.invoiceDeleted.subject",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceDeleted.whatYouShouldKnow.0",
+    "newPath": "emails.invoiceDeleted.whatYouShouldKnow.0",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceDeleted.whatYouShouldKnow.1",
+    "newPath": "emails.invoiceDeleted.whatYouShouldKnow.1",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceDeleted.whatYouShouldKnow.2",
+    "newPath": "emails.invoiceDeleted.whatYouShouldKnow.2",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceDeleted.whatYouShouldKnow.3",
+    "newPath": "emails.invoiceDeleted.whatYouShouldKnow.3",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceDeleted.whatYouShouldKnowTitle",
+    "newPath": "emails.invoiceDeleted.whatYouShouldKnowTitle",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceInactivity.badge.14",
+    "newPath": "emails.invoiceInactivity.badge.14",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceInactivity.badge.3",
+    "newPath": "emails.invoiceInactivity.badge.3",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceInactivity.badge.30",
+    "newPath": "emails.invoiceInactivity.badge.30",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceInactivity.badge.7",
+    "newPath": "emails.invoiceInactivity.badge.7",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceInactivity.cta.primary",
+    "newPath": "emails.invoiceInactivity.cta.primary",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceInactivity.cta.secondary",
+    "newPath": "emails.invoiceInactivity.cta.secondary",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceInactivity.greeting",
+    "newPath": "emails.invoiceInactivity.greeting",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceInactivity.heading.14",
+    "newPath": "emails.invoiceInactivity.heading.14",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceInactivity.heading.3",
+    "newPath": "emails.invoiceInactivity.heading.3",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceInactivity.heading.30",
+    "newPath": "emails.invoiceInactivity.heading.30",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceInactivity.heading.7",
+    "newPath": "emails.invoiceInactivity.heading.7",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceInactivity.helpPrompt",
+    "newPath": "emails.invoiceInactivity.helpPrompt",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceInactivity.important.message",
+    "newPath": "emails.invoiceInactivity.important.message",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceInactivity.important.title",
+    "newPath": "emails.invoiceInactivity.important.title",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceInactivity.intro.14",
+    "newPath": "emails.invoiceInactivity.intro.14",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceInactivity.intro.3",
+    "newPath": "emails.invoiceInactivity.intro.3",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceInactivity.intro.30",
+    "newPath": "emails.invoiceInactivity.intro.30",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceInactivity.intro.7",
+    "newPath": "emails.invoiceInactivity.intro.7",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceInactivity.preview",
+    "newPath": "emails.invoiceInactivity.preview",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceInactivity.signOff.line1",
+    "newPath": "emails.invoiceInactivity.signOff.line1",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceInactivity.signOff.line2",
+    "newPath": "emails.invoiceInactivity.signOff.line2",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceInactivity.status.daysWithoutUpload",
+    "newPath": "emails.invoiceInactivity.status.daysWithoutUpload",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceInactivity.status.lastUpload",
+    "newPath": "emails.invoiceInactivity.status.lastUpload",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceInactivity.status.title",
+    "newPath": "emails.invoiceInactivity.status.title",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceInactivity.subject",
+    "newPath": "emails.invoiceInactivity.subject",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceInactivity.tip.message",
+    "newPath": "emails.invoiceInactivity.tip.message",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceInactivity.tip.title",
+    "newPath": "emails.invoiceInactivity.tip.title",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceInactivity.whyWorthIt.bullet1",
+    "newPath": "emails.invoiceInactivity.whyWorthIt.bullet1",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceInactivity.whyWorthIt.bullet2",
+    "newPath": "emails.invoiceInactivity.whyWorthIt.bullet2",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceInactivity.whyWorthIt.bullet3",
+    "newPath": "emails.invoiceInactivity.whyWorthIt.bullet3",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceInactivity.whyWorthIt.title",
+    "newPath": "emails.invoiceInactivity.whyWorthIt.title",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceMadePublic.accessValue",
+    "newPath": "emails.invoiceMadePublic.accessValue",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceMadePublic.badge",
+    "newPath": "emails.invoiceMadePublic.badge",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceMadePublic.ctaPrimary",
+    "newPath": "emails.invoiceMadePublic.ctaPrimary",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceMadePublic.details.access",
+    "newPath": "emails.invoiceMadePublic.details.access",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceMadePublic.details.created",
+    "newPath": "emails.invoiceMadePublic.details.created",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceMadePublic.details.invoiceId",
+    "newPath": "emails.invoiceMadePublic.details.invoiceId",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceMadePublic.details.invoiceName",
+    "newPath": "emails.invoiceMadePublic.details.invoiceName",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceMadePublic.details.merchant",
+    "newPath": "emails.invoiceMadePublic.details.merchant",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceMadePublic.details.total",
+    "newPath": "emails.invoiceMadePublic.details.total",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceMadePublic.detailsTitle",
+    "newPath": "emails.invoiceMadePublic.detailsTitle",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceMadePublic.directLinkLabel",
+    "newPath": "emails.invoiceMadePublic.directLinkLabel",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceMadePublic.feedbackPrompt",
+    "newPath": "emails.invoiceMadePublic.feedbackPrompt",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceMadePublic.greeting",
+    "newPath": "emails.invoiceMadePublic.greeting",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceMadePublic.heading",
+    "newPath": "emails.invoiceMadePublic.heading",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceMadePublic.howToShare.0",
+    "newPath": "emails.invoiceMadePublic.howToShare.0",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceMadePublic.howToShare.1",
+    "newPath": "emails.invoiceMadePublic.howToShare.1",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceMadePublic.howToShare.2",
+    "newPath": "emails.invoiceMadePublic.howToShare.2",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceMadePublic.howToShareTitle",
+    "newPath": "emails.invoiceMadePublic.howToShareTitle",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceMadePublic.intro",
+    "newPath": "emails.invoiceMadePublic.intro",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceMadePublic.preview",
+    "newPath": "emails.invoiceMadePublic.preview",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceMadePublic.privacyNoticeBody",
+    "newPath": "emails.invoiceMadePublic.privacyNoticeBody",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceMadePublic.privacyNoticeTitle",
+    "newPath": "emails.invoiceMadePublic.privacyNoticeTitle",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceMadePublic.qrAlt",
+    "newPath": "emails.invoiceMadePublic.qrAlt",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceMadePublic.qrSubText",
+    "newPath": "emails.invoiceMadePublic.qrSubText",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceMadePublic.qrTitle",
+    "newPath": "emails.invoiceMadePublic.qrTitle",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceMadePublic.signOff.line1",
+    "newPath": "emails.invoiceMadePublic.signOff.line1",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceMadePublic.signOff.line2",
+    "newPath": "emails.invoiceMadePublic.signOff.line2",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceMadePublic.subject",
+    "newPath": "emails.invoiceMadePublic.subject",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceShared.badge",
+    "newPath": "emails.invoiceShared.badge",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceShared.body",
+    "newPath": "emails.invoiceShared.body",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceShared.ctaPrimary",
+    "newPath": "emails.invoiceShared.ctaPrimary",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceShared.details.invoiceId",
+    "newPath": "emails.invoiceShared.details.invoiceId",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceShared.details.sharedBy",
+    "newPath": "emails.invoiceShared.details.sharedBy",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceShared.detailsTitle",
+    "newPath": "emails.invoiceShared.detailsTitle",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceShared.feedbackPrompt",
+    "newPath": "emails.invoiceShared.feedbackPrompt",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceShared.greeting",
+    "newPath": "emails.invoiceShared.greeting",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceShared.heading",
+    "newPath": "emails.invoiceShared.heading",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceShared.intro",
+    "newPath": "emails.invoiceShared.intro",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceShared.preview",
+    "newPath": "emails.invoiceShared.preview",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceShared.signOff.line1",
+    "newPath": "emails.invoiceShared.signOff.line1",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceShared.signOff.line2",
+    "newPath": "emails.invoiceShared.signOff.line2",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceShared.subject",
+    "newPath": "emails.invoiceShared.subject",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceShared.whatYouCanDo.0",
+    "newPath": "emails.invoiceShared.whatYouCanDo.0",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceShared.whatYouCanDo.1",
+    "newPath": "emails.invoiceShared.whatYouCanDo.1",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceShared.whatYouCanDo.2",
+    "newPath": "emails.invoiceShared.whatYouCanDo.2",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceShared.whatYouCanDoTitle",
+    "newPath": "emails.invoiceShared.whatYouCanDoTitle",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceStats.badge",
+    "newPath": "emails.invoiceStats.badge",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceStats.body",
+    "newPath": "emails.invoiceStats.body",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceStats.breakdownCardTitle",
+    "newPath": "emails.invoiceStats.breakdownCardTitle",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceStats.breakdownNote",
+    "newPath": "emails.invoiceStats.breakdownNote",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceStats.breakdownTableTitle",
+    "newPath": "emails.invoiceStats.breakdownTableTitle",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceStats.ctaPrimary",
+    "newPath": "emails.invoiceStats.ctaPrimary",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceStats.ctaSecondary",
+    "newPath": "emails.invoiceStats.ctaSecondary",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceStats.donutChartAlt",
+    "newPath": "emails.invoiceStats.donutChartAlt",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceStats.donutChartTitle",
+    "newPath": "emails.invoiceStats.donutChartTitle",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceStats.feedbackPrompt",
+    "newPath": "emails.invoiceStats.feedbackPrompt",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceStats.frequencyLabel",
+    "newPath": "emails.invoiceStats.frequencyLabel",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceStats.greeting",
+    "newPath": "emails.invoiceStats.greeting",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceStats.heading",
+    "newPath": "emails.invoiceStats.heading",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceStats.intro",
+    "newPath": "emails.invoiceStats.intro",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceStats.metrics.averagePerInvoice",
+    "newPath": "emails.invoiceStats.metrics.averagePerInvoice",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceStats.metrics.invoices",
+    "newPath": "emails.invoiceStats.metrics.invoices",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceStats.metrics.scans",
+    "newPath": "emails.invoiceStats.metrics.scans",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceStats.metrics.totalSpend",
+    "newPath": "emails.invoiceStats.metrics.totalSpend",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceStats.noDataFallback",
+    "newPath": "emails.invoiceStats.noDataFallback",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceStats.preview",
+    "newPath": "emails.invoiceStats.preview",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceStats.reportDetails.currency",
+    "newPath": "emails.invoiceStats.reportDetails.currency",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceStats.reportDetails.period",
+    "newPath": "emails.invoiceStats.reportDetails.period",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceStats.reportDetailsTitle",
+    "newPath": "emails.invoiceStats.reportDetailsTitle",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceStats.signOff.line1",
+    "newPath": "emails.invoiceStats.signOff.line1",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceStats.signOff.line2",
+    "newPath": "emails.invoiceStats.signOff.line2",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceStats.subject",
+    "newPath": "emails.invoiceStats.subject",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceStats.title",
+    "newPath": "emails.invoiceStats.title",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceStats.topCategoriesTitle",
+    "newPath": "emails.invoiceStats.topCategoriesTitle",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceStats.topMerchantsTitle",
+    "newPath": "emails.invoiceStats.topMerchantsTitle",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceUnshared.badge",
+    "newPath": "emails.invoiceUnshared.badge",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceUnshared.body",
+    "newPath": "emails.invoiceUnshared.body",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceUnshared.ctaPrimary",
+    "newPath": "emails.invoiceUnshared.ctaPrimary",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceUnshared.ctaSecondary",
+    "newPath": "emails.invoiceUnshared.ctaSecondary",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceUnshared.details.accessRevoked",
+    "newPath": "emails.invoiceUnshared.details.accessRevoked",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceUnshared.details.invoiceId",
+    "newPath": "emails.invoiceUnshared.details.invoiceId",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceUnshared.details.notProvided",
+    "newPath": "emails.invoiceUnshared.details.notProvided",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceUnshared.details.revokedAt",
+    "newPath": "emails.invoiceUnshared.details.revokedAt",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceUnshared.details.revokedBy",
+    "newPath": "emails.invoiceUnshared.details.revokedBy",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceUnshared.details.yourAccess",
+    "newPath": "emails.invoiceUnshared.details.yourAccess",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceUnshared.detailsTitle",
+    "newPath": "emails.invoiceUnshared.detailsTitle",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceUnshared.feedbackPrompt",
+    "newPath": "emails.invoiceUnshared.feedbackPrompt",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceUnshared.greeting",
+    "newPath": "emails.invoiceUnshared.greeting",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceUnshared.heading",
+    "newPath": "emails.invoiceUnshared.heading",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceUnshared.intro",
+    "newPath": "emails.invoiceUnshared.intro",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceUnshared.preview",
+    "newPath": "emails.invoiceUnshared.preview",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceUnshared.signOff.line1",
+    "newPath": "emails.invoiceUnshared.signOff.line1",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceUnshared.signOff.line2",
+    "newPath": "emails.invoiceUnshared.signOff.line2",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceUnshared.subject",
+    "newPath": "emails.invoiceUnshared.subject",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceUnshared.whatThisMeans.0",
+    "newPath": "emails.invoiceUnshared.whatThisMeans.0",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceUnshared.whatThisMeans.1",
+    "newPath": "emails.invoiceUnshared.whatThisMeans.1",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceUnshared.whatThisMeans.2",
+    "newPath": "emails.invoiceUnshared.whatThisMeans.2",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.invoiceUnshared.whatThisMeansTitle",
+    "newPath": "emails.invoiceUnshared.whatThisMeansTitle",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.layout.allRightsReserved",
+    "newPath": "emails.layout.allRightsReserved",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.layout.buttonFallback",
+    "newPath": "emails.layout.buttonFallback",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.layout.managePreferences",
+    "newPath": "emails.layout.managePreferences",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.layout.secondaryFallback",
+    "newPath": "emails.layout.secondaryFallback",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.layout.tagline",
+    "newPath": "emails.layout.tagline",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.layout.unsubscribe",
+    "newPath": "emails.layout.unsubscribe",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.newsletterSubscribed.badge",
+    "newPath": "emails.newsletterSubscribed.badge",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.newsletterSubscribed.body",
+    "newPath": "emails.newsletterSubscribed.body",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.newsletterSubscribed.ctaPrimary",
+    "newPath": "emails.newsletterSubscribed.ctaPrimary",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.newsletterSubscribed.feedbackPrompt",
+    "newPath": "emails.newsletterSubscribed.feedbackPrompt",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.newsletterSubscribed.greeting",
+    "newPath": "emails.newsletterSubscribed.greeting",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.newsletterSubscribed.heading",
+    "newPath": "emails.newsletterSubscribed.heading",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.newsletterSubscribed.intro",
+    "newPath": "emails.newsletterSubscribed.intro",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.newsletterSubscribed.preview",
+    "newPath": "emails.newsletterSubscribed.preview",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.newsletterSubscribed.signOff.line1",
+    "newPath": "emails.newsletterSubscribed.signOff.line1",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.newsletterSubscribed.signOff.line2",
+    "newPath": "emails.newsletterSubscribed.signOff.line2",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.newsletterSubscribed.subject",
+    "newPath": "emails.newsletterSubscribed.subject",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.newsletterSubscribed.whatToExpect.0",
+    "newPath": "emails.newsletterSubscribed.whatToExpect.0",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.newsletterSubscribed.whatToExpect.1",
+    "newPath": "emails.newsletterSubscribed.whatToExpect.1",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.newsletterSubscribed.whatToExpect.2",
+    "newPath": "emails.newsletterSubscribed.whatToExpect.2",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.newsletterSubscribed.whatToExpectTitle",
+    "newPath": "emails.newsletterSubscribed.whatToExpectTitle",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.newsletterUnsubscribed.badge",
+    "newPath": "emails.newsletterUnsubscribed.badge",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.newsletterUnsubscribed.body",
+    "newPath": "emails.newsletterUnsubscribed.body",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.newsletterUnsubscribed.ctaPrimary",
+    "newPath": "emails.newsletterUnsubscribed.ctaPrimary",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.newsletterUnsubscribed.ctaSecondary",
+    "newPath": "emails.newsletterUnsubscribed.ctaSecondary",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.newsletterUnsubscribed.feedbackPrompt",
+    "newPath": "emails.newsletterUnsubscribed.feedbackPrompt",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.newsletterUnsubscribed.greeting",
+    "newPath": "emails.newsletterUnsubscribed.greeting",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.newsletterUnsubscribed.heading",
+    "newPath": "emails.newsletterUnsubscribed.heading",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.newsletterUnsubscribed.intro",
+    "newPath": "emails.newsletterUnsubscribed.intro",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.newsletterUnsubscribed.preview",
+    "newPath": "emails.newsletterUnsubscribed.preview",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.newsletterUnsubscribed.signOff.line1",
+    "newPath": "emails.newsletterUnsubscribed.signOff.line1",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.newsletterUnsubscribed.signOff.line2",
+    "newPath": "emails.newsletterUnsubscribed.signOff.line2",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.newsletterUnsubscribed.subject",
+    "newPath": "emails.newsletterUnsubscribed.subject",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.newsletterUnsubscribed.whatHappensNext.0",
+    "newPath": "emails.newsletterUnsubscribed.whatHappensNext.0",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.newsletterUnsubscribed.whatHappensNext.1",
+    "newPath": "emails.newsletterUnsubscribed.whatHappensNext.1",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.newsletterUnsubscribed.whatHappensNext.2",
+    "newPath": "emails.newsletterUnsubscribed.whatHappensNext.2",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.newsletterUnsubscribed.whatHappensNextTitle",
+    "newPath": "emails.newsletterUnsubscribed.whatHappensNextTitle",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.spendingAlert.badge",
+    "newPath": "emails.spendingAlert.badge",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.spendingAlert.chartAlt",
+    "newPath": "emails.spendingAlert.chartAlt",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.spendingAlert.chartTitle",
+    "newPath": "emails.spendingAlert.chartTitle",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.spendingAlert.ctaPrimary",
+    "newPath": "emails.spendingAlert.ctaPrimary",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.spendingAlert.detailsLabels.budget",
+    "newPath": "emails.spendingAlert.detailsLabels.budget",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.spendingAlert.detailsLabels.category",
+    "newPath": "emails.spendingAlert.detailsLabels.category",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.spendingAlert.detailsLabels.period",
+    "newPath": "emails.spendingAlert.detailsLabels.period",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.spendingAlert.detailsLabels.spent",
+    "newPath": "emails.spendingAlert.detailsLabels.spent",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.spendingAlert.detailsTitle",
+    "newPath": "emails.spendingAlert.detailsTitle",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.spendingAlert.feedbackPrompt",
+    "newPath": "emails.spendingAlert.feedbackPrompt",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.spendingAlert.greeting",
+    "newPath": "emails.spendingAlert.greeting",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.spendingAlert.heading",
+    "newPath": "emails.spendingAlert.heading",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.spendingAlert.intro",
+    "newPath": "emails.spendingAlert.intro",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.spendingAlert.metricsLabels.budgetLimit",
+    "newPath": "emails.spendingAlert.metricsLabels.budgetLimit",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.spendingAlert.metricsLabels.currentSpending",
+    "newPath": "emails.spendingAlert.metricsLabels.currentSpending",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.spendingAlert.metricsLabels.remaining",
+    "newPath": "emails.spendingAlert.metricsLabels.remaining",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.spendingAlert.metricsLabels.threshold",
+    "newPath": "emails.spendingAlert.metricsLabels.threshold",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.spendingAlert.notificationsLink",
+    "newPath": "emails.spendingAlert.notificationsLink",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.spendingAlert.notificationsParagraph",
+    "newPath": "emails.spendingAlert.notificationsParagraph",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.spendingAlert.overBudgetValue",
+    "newPath": "emails.spendingAlert.overBudgetValue",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.spendingAlert.overBudgetWarning",
+    "newPath": "emails.spendingAlert.overBudgetWarning",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.spendingAlert.preview",
+    "newPath": "emails.spendingAlert.preview",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.spendingAlert.signOff.line1",
+    "newPath": "emails.spendingAlert.signOff.line1",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.spendingAlert.signOff.line2",
+    "newPath": "emails.spendingAlert.signOff.line2",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.spendingAlert.subject",
+    "newPath": "emails.spendingAlert.subject",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.spendingAlert.tipsOnTrack.0",
+    "newPath": "emails.spendingAlert.tipsOnTrack.0",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.spendingAlert.tipsOnTrack.1",
+    "newPath": "emails.spendingAlert.tipsOnTrack.1",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.spendingAlert.tipsOnTrack.2",
+    "newPath": "emails.spendingAlert.tipsOnTrack.2",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.spendingAlert.tipsOverBudget.0",
+    "newPath": "emails.spendingAlert.tipsOverBudget.0",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.spendingAlert.tipsOverBudget.1",
+    "newPath": "emails.spendingAlert.tipsOverBudget.1",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.spendingAlert.tipsOverBudget.2",
+    "newPath": "emails.spendingAlert.tipsOverBudget.2",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.spendingAlert.tipsTitle",
+    "newPath": "emails.spendingAlert.tipsTitle",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.unanalyzedInvoices.analysisProvidedTitle",
+    "newPath": "emails.unanalyzedInvoices.analysisProvidedTitle",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.unanalyzedInvoices.analysisProvides.0",
+    "newPath": "emails.unanalyzedInvoices.analysisProvides.0",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.unanalyzedInvoices.analysisProvides.1",
+    "newPath": "emails.unanalyzedInvoices.analysisProvides.1",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.unanalyzedInvoices.analysisProvides.2",
+    "newPath": "emails.unanalyzedInvoices.analysisProvides.2",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.unanalyzedInvoices.analysisProvides.3",
+    "newPath": "emails.unanalyzedInvoices.analysisProvides.3",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.unanalyzedInvoices.analysisProvides.4",
+    "newPath": "emails.unanalyzedInvoices.analysisProvides.4",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.unanalyzedInvoices.andMore",
+    "newPath": "emails.unanalyzedInvoices.andMore",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.unanalyzedInvoices.badge",
+    "newPath": "emails.unanalyzedInvoices.badge",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.unanalyzedInvoices.bodyText",
+    "newPath": "emails.unanalyzedInvoices.bodyText",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.unanalyzedInvoices.feedback",
+    "newPath": "emails.unanalyzedInvoices.feedback",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.unanalyzedInvoices.greeting",
+    "newPath": "emails.unanalyzedInvoices.greeting",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.unanalyzedInvoices.heading",
+    "newPath": "emails.unanalyzedInvoices.heading",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.unanalyzedInvoices.intro",
+    "newPath": "emails.unanalyzedInvoices.intro",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.unanalyzedInvoices.invoicesAwaitingTitle",
+    "newPath": "emails.unanalyzedInvoices.invoicesAwaitingTitle",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.unanalyzedInvoices.preview",
+    "newPath": "emails.unanalyzedInvoices.preview",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.unanalyzedInvoices.primaryCta",
+    "newPath": "emails.unanalyzedInvoices.primaryCta",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.unanalyzedInvoices.signOff.line1",
+    "newPath": "emails.unanalyzedInvoices.signOff.line1",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.unanalyzedInvoices.signOff.line2",
+    "newPath": "emails.unanalyzedInvoices.signOff.line2",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.unanalyzedInvoices.subject",
+    "newPath": "emails.unanalyzedInvoices.subject",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.unanalyzedInvoices.uploadedDate",
+    "newPath": "emails.unanalyzedInvoices.uploadedDate",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.weeklyUploadReminder.badge",
+    "newPath": "emails.weeklyUploadReminder.badge",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.weeklyUploadReminder.bodyText",
+    "newPath": "emails.weeklyUploadReminder.bodyText",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.weeklyUploadReminder.feedback",
+    "newPath": "emails.weeklyUploadReminder.feedback",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.weeklyUploadReminder.greeting",
+    "newPath": "emails.weeklyUploadReminder.greeting",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.weeklyUploadReminder.heading",
+    "newPath": "emails.weeklyUploadReminder.heading",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.weeklyUploadReminder.intro",
+    "newPath": "emails.weeklyUploadReminder.intro",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.weeklyUploadReminder.metricsLabels.lastWeek",
+    "newPath": "emails.weeklyUploadReminder.metricsLabels.lastWeek",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.weeklyUploadReminder.metricsLabels.thisWeek",
+    "newPath": "emails.weeklyUploadReminder.metricsLabels.thisWeek",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.weeklyUploadReminder.metricsLabels.totalInvoices",
+    "newPath": "emails.weeklyUploadReminder.metricsLabels.totalInvoices",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.weeklyUploadReminder.metricsLabels.totalTracked",
+    "newPath": "emails.weeklyUploadReminder.metricsLabels.totalTracked",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.weeklyUploadReminder.preview",
+    "newPath": "emails.weeklyUploadReminder.preview",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.weeklyUploadReminder.primaryCta",
+    "newPath": "emails.weeklyUploadReminder.primaryCta",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.weeklyUploadReminder.quickTips.0",
+    "newPath": "emails.weeklyUploadReminder.quickTips.0",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.weeklyUploadReminder.quickTips.1",
+    "newPath": "emails.weeklyUploadReminder.quickTips.1",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.weeklyUploadReminder.quickTips.2",
+    "newPath": "emails.weeklyUploadReminder.quickTips.2",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.weeklyUploadReminder.quickTipsTitle",
+    "newPath": "emails.weeklyUploadReminder.quickTipsTitle",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.weeklyUploadReminder.secondaryCta",
+    "newPath": "emails.weeklyUploadReminder.secondaryCta",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.weeklyUploadReminder.signOff.line1",
+    "newPath": "emails.weeklyUploadReminder.signOff.line1",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.weeklyUploadReminder.signOff.line2",
+    "newPath": "emails.weeklyUploadReminder.signOff.line2",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.weeklyUploadReminder.subject",
+    "newPath": "emails.weeklyUploadReminder.subject",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.welcome.badge",
+    "newPath": "emails.welcome.badge",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.welcome.body",
+    "newPath": "emails.welcome.body",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.welcome.ctaPrimary",
+    "newPath": "emails.welcome.ctaPrimary",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.welcome.ctaSecondary",
+    "newPath": "emails.welcome.ctaSecondary",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.welcome.feedbackPrompt",
+    "newPath": "emails.welcome.feedbackPrompt",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.welcome.greeting",
+    "newPath": "emails.welcome.greeting",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.welcome.heading",
+    "newPath": "emails.welcome.heading",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.welcome.howItWorks.0",
+    "newPath": "emails.welcome.howItWorks.0",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.welcome.howItWorks.1",
+    "newPath": "emails.welcome.howItWorks.1",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.welcome.howItWorks.2",
+    "newPath": "emails.welcome.howItWorks.2",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.welcome.howItWorksTitle",
+    "newPath": "emails.welcome.howItWorksTitle",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.welcome.intro",
+    "newPath": "emails.welcome.intro",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.welcome.preview",
+    "newPath": "emails.welcome.preview",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.welcome.signOff.line1",
+    "newPath": "emails.welcome.signOff.line1",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.welcome.signOff.line2",
+    "newPath": "emails.welcome.signOff.line2",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.welcome.subject",
+    "newPath": "emails.welcome.subject",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.welcome.whatYouCanDo.0",
+    "newPath": "emails.welcome.whatYouCanDo.0",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.welcome.whatYouCanDo.1",
+    "newPath": "emails.welcome.whatYouCanDo.1",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.welcome.whatYouCanDo.2",
+    "newPath": "emails.welcome.whatYouCanDo.2",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.welcome.whatYouCanDo.3",
+    "newPath": "emails.welcome.whatYouCanDo.3",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "email.welcome.whatYouCanDoTitle",
+    "newPath": "emails.welcome.whatYouCanDoTitle",
+    "reason": "email templates"
+  },
+  {
+    "oldPath": "Errors.globalError.actions.step1",
+    "newPath": "app.errors.globalError.actions.step1",
+    "reason": "global error and not-found copy"
+  },
+  {
+    "oldPath": "Errors.globalError.actions.step2",
+    "newPath": "app.errors.globalError.actions.step2",
+    "reason": "global error and not-found copy"
+  },
+  {
+    "oldPath": "Errors.globalError.actions.step3",
+    "newPath": "app.errors.globalError.actions.step3",
+    "reason": "global error and not-found copy"
+  },
+  {
+    "oldPath": "Errors.globalError.actions.whatCanYouDoTitle",
+    "newPath": "app.errors.globalError.actions.whatCanYouDoTitle",
+    "reason": "global error and not-found copy"
+  },
+  {
+    "oldPath": "Errors.globalError.buttons.copied",
+    "newPath": "app.errors.globalError.buttons.copied",
+    "reason": "global error and not-found copy"
+  },
+  {
+    "oldPath": "Errors.globalError.buttons.copyErrorId",
+    "newPath": "app.errors.globalError.buttons.copyErrorId",
+    "reason": "global error and not-found copy"
+  },
+  {
+    "oldPath": "Errors.globalError.buttons.copyErrorIdTitle",
+    "newPath": "app.errors.globalError.buttons.copyErrorIdTitle",
+    "reason": "global error and not-found copy"
+  },
+  {
+    "oldPath": "Errors.globalError.buttons.returnHome",
+    "newPath": "app.errors.globalError.buttons.returnHome",
+    "reason": "global error and not-found copy"
+  },
+  {
+    "oldPath": "Errors.globalError.buttons.tryAgain",
+    "newPath": "app.errors.globalError.buttons.tryAgain",
+    "reason": "global error and not-found copy"
+  },
+  {
+    "oldPath": "Errors.globalError.copyErrorConsoleMessage",
+    "newPath": "app.errors.globalError.copyErrorConsoleMessage",
+    "reason": "global error and not-found copy"
+  },
+  {
+    "oldPath": "Errors.globalError.details.errorIdLabel",
+    "newPath": "app.errors.globalError.details.errorIdLabel",
+    "reason": "global error and not-found copy"
+  },
+  {
+    "oldPath": "Errors.globalError.details.genericDescription",
+    "newPath": "app.errors.globalError.details.genericDescription",
+    "reason": "global error and not-found copy"
+  },
+  {
+    "oldPath": "Errors.globalError.details.title",
+    "newPath": "app.errors.globalError.details.title",
+    "reason": "global error and not-found copy"
+  },
+  {
+    "oldPath": "Errors.globalError.details.unknownError",
+    "newPath": "app.errors.globalError.details.unknownError",
+    "reason": "global error and not-found copy"
+  },
+  {
+    "oldPath": "Errors.globalError.details.whatHappenedTitle",
+    "newPath": "app.errors.globalError.details.whatHappenedTitle",
+    "reason": "global error and not-found copy"
+  },
+  {
+    "oldPath": "Errors.globalError.diagnostics.loading",
+    "newPath": "app.errors.globalError.diagnostics.loading",
+    "reason": "global error and not-found copy"
+  },
+  {
+    "oldPath": "Errors.globalError.diagnostics.scanLabel",
+    "newPath": "app.errors.globalError.diagnostics.scanLabel",
+    "reason": "global error and not-found copy"
+  },
+  {
+    "oldPath": "Errors.globalError.diagnostics.stackTraceLabel",
+    "newPath": "app.errors.globalError.diagnostics.stackTraceLabel",
+    "reason": "global error and not-found copy"
+  },
+  {
+    "oldPath": "Errors.globalError.diagnostics.technicalSummary",
+    "newPath": "app.errors.globalError.diagnostics.technicalSummary",
+    "reason": "global error and not-found copy"
+  },
+  {
+    "oldPath": "Errors.globalError.hero.subtitle",
+    "newPath": "app.errors.globalError.hero.subtitle",
+    "reason": "global error and not-found copy"
+  },
+  {
+    "oldPath": "Errors.globalError.hero.title",
+    "newPath": "app.errors.globalError.hero.title",
+    "reason": "global error and not-found copy"
+  },
+  {
+    "oldPath": "Errors.globalError.metadata.title",
+    "newPath": "app.errors.globalError.metadata.title",
+    "reason": "global error and not-found copy"
+  },
+  {
+    "oldPath": "Errors.globalError.support.contactPrefix",
+    "newPath": "app.errors.globalError.support.contactPrefix",
+    "reason": "global error and not-found copy"
+  },
+  {
+    "oldPath": "Errors.globalError.support.includeErrorId",
+    "newPath": "app.errors.globalError.support.includeErrorId",
+    "reason": "global error and not-found copy"
+  },
+  {
+    "oldPath": "Errors.notFound.additionalInfo",
+    "newPath": "app.errors.notFound.additionalInfo",
+    "reason": "global error and not-found copy"
+  },
+  {
+    "oldPath": "Errors.notFound.buttons.returnButton",
+    "newPath": "app.errors.notFound.buttons.returnButton",
+    "reason": "global error and not-found copy"
+  },
+  {
+    "oldPath": "Errors.notFound.buttons.submitErrorButton",
+    "newPath": "app.errors.notFound.buttons.submitErrorButton",
+    "reason": "global error and not-found copy"
+  },
+  {
+    "oldPath": "Errors.notFound.falsePositive",
+    "newPath": "app.errors.notFound.falsePositive",
+    "reason": "global error and not-found copy"
+  },
+  {
+    "oldPath": "Errors.notFound.subtitle",
+    "newPath": "app.errors.notFound.subtitle",
+    "reason": "global error and not-found copy"
+  },
+  {
+    "oldPath": "Errors.notFound.title",
+    "newPath": "app.errors.notFound.title",
+    "reason": "global error and not-found copy"
+  },
+  {
+    "oldPath": "EULA.accept",
+    "newPath": "pages.legal.eula.accept",
+    "reason": "end user license agreement"
+  },
+  {
+    "oldPath": "EULA.content",
+    "newPath": "pages.legal.eula.content",
+    "reason": "end user license agreement"
+  },
+  {
+    "oldPath": "EULA.cookiesPolicy.cookies.analytics.checkbox",
+    "newPath": "pages.legal.eula.cookiesPolicy.cookies.analytics.checkbox",
+    "reason": "end user license agreement"
+  },
+  {
+    "oldPath": "EULA.cookiesPolicy.cookies.analytics.description",
+    "newPath": "pages.legal.eula.cookiesPolicy.cookies.analytics.description",
+    "reason": "end user license agreement"
+  },
+  {
+    "oldPath": "EULA.cookiesPolicy.cookies.analytics.title",
+    "newPath": "pages.legal.eula.cookiesPolicy.cookies.analytics.title",
+    "reason": "end user license agreement"
+  },
+  {
+    "oldPath": "EULA.cookiesPolicy.cookies.cta",
+    "newPath": "pages.legal.eula.cookiesPolicy.cookies.cta",
+    "reason": "end user license agreement"
+  },
+  {
+    "oldPath": "EULA.cookiesPolicy.cookies.essential.checkbox",
+    "newPath": "pages.legal.eula.cookiesPolicy.cookies.essential.checkbox",
+    "reason": "end user license agreement"
+  },
+  {
+    "oldPath": "EULA.cookiesPolicy.cookies.essential.description",
+    "newPath": "pages.legal.eula.cookiesPolicy.cookies.essential.description",
+    "reason": "end user license agreement"
+  },
+  {
+    "oldPath": "EULA.cookiesPolicy.cookies.essential.title",
+    "newPath": "pages.legal.eula.cookiesPolicy.cookies.essential.title",
+    "reason": "end user license agreement"
+  },
+  {
+    "oldPath": "EULA.cookiesPolicy.subtitle",
+    "newPath": "pages.legal.eula.cookiesPolicy.subtitle",
+    "reason": "end user license agreement"
+  },
+  {
+    "oldPath": "EULA.cookiesPolicy.title",
+    "newPath": "pages.legal.eula.cookiesPolicy.title",
+    "reason": "end user license agreement"
+  },
+  {
+    "oldPath": "EULA.language",
+    "newPath": "pages.legal.eula.language",
+    "reason": "end user license agreement"
+  },
+  {
+    "oldPath": "EULA.privacyPolicy.cta",
+    "newPath": "pages.legal.eula.privacyPolicy.cta",
+    "reason": "end user license agreement"
+  },
+  {
+    "oldPath": "EULA.privacyPolicy.subtitle",
+    "newPath": "pages.legal.eula.privacyPolicy.subtitle",
+    "reason": "end user license agreement"
+  },
+  {
+    "oldPath": "EULA.privacyPolicy.title",
+    "newPath": "pages.legal.eula.privacyPolicy.title",
+    "reason": "end user license agreement"
+  },
+  {
+    "oldPath": "EULA.subtitle",
+    "newPath": "pages.legal.eula.subtitle",
+    "reason": "end user license agreement"
+  },
+  {
+    "oldPath": "EULA.termsOfService.cta",
+    "newPath": "pages.legal.eula.termsOfService.cta",
+    "reason": "end user license agreement"
+  },
+  {
+    "oldPath": "EULA.termsOfService.subtitle",
+    "newPath": "pages.legal.eula.termsOfService.subtitle",
+    "reason": "end user license agreement"
+  },
+  {
+    "oldPath": "EULA.termsOfService.title",
+    "newPath": "pages.legal.eula.termsOfService.title",
+    "reason": "end user license agreement"
+  },
+  {
+    "oldPath": "EULA.title",
+    "newPath": "pages.legal.eula.title",
+    "reason": "end user license agreement"
+  },
+  {
+    "oldPath": "Footer.accessibility.brandTitle",
+    "newPath": "app.footer.accessibility.brandTitle",
+    "reason": "app shell footer"
+  },
+  {
+    "oldPath": "Footer.accessibility.goHome",
+    "newPath": "app.footer.accessibility.goHome",
+    "reason": "app shell footer"
+  },
+  {
+    "oldPath": "Footer.accessibility.logoAlt",
+    "newPath": "app.footer.accessibility.logoAlt",
+    "reason": "app shell footer"
+  },
+  {
+    "oldPath": "Footer.builtOn",
+    "newPath": "app.footer.builtOn",
+    "reason": "app shell footer"
+  },
+  {
+    "oldPath": "Footer.commitSha",
+    "newPath": "app.footer.commitSha",
+    "reason": "app shell footer"
+  },
+  {
+    "oldPath": "Footer.copyright",
+    "newPath": "app.footer.copyright",
+    "reason": "app shell footer"
+  },
+  {
+    "oldPath": "Footer.navigation.about",
+    "newPath": "app.footer.navigation.about",
+    "reason": "app shell footer"
+  },
+  {
+    "oldPath": "Footer.navigation.acknowledgements",
+    "newPath": "app.footer.navigation.acknowledgements",
+    "reason": "app shell footer"
+  },
+  {
+    "oldPath": "Footer.navigation.privacyPolicy",
+    "newPath": "app.footer.navigation.privacyPolicy",
+    "reason": "app shell footer"
+  },
+  {
+    "oldPath": "Footer.navigation.subdomains",
+    "newPath": "app.footer.navigation.subdomains",
+    "reason": "app shell footer"
+  },
+  {
+    "oldPath": "Footer.navigation.termsOfService",
+    "newPath": "app.footer.navigation.termsOfService",
+    "reason": "app shell footer"
+  },
+  {
+    "oldPath": "Footer.navigation.what",
+    "newPath": "app.footer.navigation.what",
+    "reason": "app shell footer"
+  },
+  {
+    "oldPath": "Footer.socialLinks.github",
+    "newPath": "app.footer.socialLinks.github",
+    "reason": "app shell footer"
+  },
+  {
+    "oldPath": "Footer.socialLinks.linkedin",
+    "newPath": "app.footer.socialLinks.linkedin",
+    "reason": "app shell footer"
+  },
+  {
+    "oldPath": "Footer.sourceCode",
+    "newPath": "app.footer.sourceCode",
+    "reason": "app shell footer"
+  },
+  {
+    "oldPath": "Footer.sourceCodeAnchor",
+    "newPath": "app.footer.sourceCodeAnchor",
+    "reason": "app shell footer"
+  },
+  {
+    "oldPath": "Footer.subtitle",
+    "newPath": "app.footer.subtitle",
+    "reason": "app shell footer"
+  },
+  {
+    "oldPath": "Home.appreciation",
+    "newPath": "pages.home.appreciation",
+    "reason": "home page and homepage sections"
+  },
+  {
+    "oldPath": "Home.cta",
+    "newPath": "pages.home.cta",
+    "reason": "home page and homepage sections"
+  },
+  {
+    "oldPath": "Home.featuresTab.azure.description",
+    "newPath": "pages.home.featuresTab.azure.description",
+    "reason": "home page and homepage sections"
+  },
+  {
+    "oldPath": "Home.featuresTab.azure.title",
+    "newPath": "pages.home.featuresTab.azure.title",
+    "reason": "home page and homepage sections"
+  },
+  {
+    "oldPath": "Home.featuresTab.csharp.description",
+    "newPath": "pages.home.featuresTab.csharp.description",
+    "reason": "home page and homepage sections"
+  },
+  {
+    "oldPath": "Home.featuresTab.csharp.title",
+    "newPath": "pages.home.featuresTab.csharp.title",
+    "reason": "home page and homepage sections"
+  },
+  {
+    "oldPath": "Home.featuresTab.description",
+    "newPath": "pages.home.featuresTab.description",
+    "reason": "home page and homepage sections"
+  },
+  {
+    "oldPath": "Home.featuresTab.githubActions.description",
+    "newPath": "pages.home.featuresTab.githubActions.description",
+    "reason": "home page and homepage sections"
+  },
+  {
+    "oldPath": "Home.featuresTab.githubActions.title",
+    "newPath": "pages.home.featuresTab.githubActions.title",
+    "reason": "home page and homepage sections"
+  },
+  {
+    "oldPath": "Home.featuresTab.learnMoreBtn",
+    "newPath": "pages.home.featuresTab.learnMoreBtn",
+    "reason": "home page and homepage sections"
+  },
+  {
+    "oldPath": "Home.featuresTab.nextJs.description",
+    "newPath": "pages.home.featuresTab.nextJs.description",
+    "reason": "home page and homepage sections"
+  },
+  {
+    "oldPath": "Home.featuresTab.nextJs.title",
+    "newPath": "pages.home.featuresTab.nextJs.title",
+    "reason": "home page and homepage sections"
+  },
+  {
+    "oldPath": "Home.featuresTab.otel.description",
+    "newPath": "pages.home.featuresTab.otel.description",
+    "reason": "home page and homepage sections"
+  },
+  {
+    "oldPath": "Home.featuresTab.otel.title",
+    "newPath": "pages.home.featuresTab.otel.title",
+    "reason": "home page and homepage sections"
+  },
+  {
+    "oldPath": "Home.featuresTab.svelte.description",
+    "newPath": "pages.home.featuresTab.svelte.description",
+    "reason": "home page and homepage sections"
+  },
+  {
+    "oldPath": "Home.featuresTab.svelte.title",
+    "newPath": "pages.home.featuresTab.svelte.title",
+    "reason": "home page and homepage sections"
+  },
+  {
+    "oldPath": "Home.featuresTab.title",
+    "newPath": "pages.home.featuresTab.title",
+    "reason": "home page and homepage sections"
+  },
+  {
+    "oldPath": "Home.subtitle",
+    "newPath": "pages.home.subtitle",
+    "reason": "home page and homepage sections"
+  },
+  {
+    "oldPath": "Home.technologyTab.badgeTitle",
+    "newPath": "pages.home.technologyTab.badgeTitle",
+    "reason": "home page and homepage sections"
+  },
+  {
+    "oldPath": "Home.technologyTab.description",
+    "newPath": "pages.home.technologyTab.description",
+    "reason": "home page and homepage sections"
+  },
+  {
+    "oldPath": "Home.technologyTab.learnMoreBtn",
+    "newPath": "pages.home.technologyTab.learnMoreBtn",
+    "reason": "home page and homepage sections"
+  },
+  {
+    "oldPath": "Home.technologyTab.points.point1",
+    "newPath": "pages.home.technologyTab.points.point1",
+    "reason": "home page and homepage sections"
+  },
+  {
+    "oldPath": "Home.technologyTab.points.point2",
+    "newPath": "pages.home.technologyTab.points.point2",
+    "reason": "home page and homepage sections"
+  },
+  {
+    "oldPath": "Home.technologyTab.points.point3",
+    "newPath": "pages.home.technologyTab.points.point3",
+    "reason": "home page and homepage sections"
+  },
+  {
+    "oldPath": "Home.technologyTab.title",
+    "newPath": "pages.home.technologyTab.title",
+    "reason": "home page and homepage sections"
+  },
+  {
+    "oldPath": "Home.title",
+    "newPath": "pages.home.title",
+    "reason": "home page and homepage sections"
+  },
+  {
+    "oldPath": "IMS--Cards.budgetImpactCard.dailyAllowance",
+    "newPath": "cards.invoices.budgetImpactCard.dailyAllowance",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.budgetImpactCard.dailyAllowanceValue",
+    "newPath": "cards.invoices.budgetImpactCard.dailyAllowanceValue",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.budgetImpactCard.daysLeft",
+    "newPath": "cards.invoices.budgetImpactCard.daysLeft",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.budgetImpactCard.inMonth",
+    "newPath": "cards.invoices.budgetImpactCard.inMonth",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.budgetImpactCard.invoiceUsed",
+    "newPath": "cards.invoices.budgetImpactCard.invoiceUsed",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.budgetImpactCard.monthlyBudget",
+    "newPath": "cards.invoices.budgetImpactCard.monthlyBudget",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.budgetImpactCard.ofMonthlyBudget",
+    "newPath": "cards.invoices.budgetImpactCard.ofMonthlyBudget",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.budgetImpactCard.overBudget",
+    "newPath": "cards.invoices.budgetImpactCard.overBudget",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.budgetImpactCard.remaining",
+    "newPath": "cards.invoices.budgetImpactCard.remaining",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.budgetImpactCard.spent",
+    "newPath": "cards.invoices.budgetImpactCard.spent",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.budgetImpactCard.title",
+    "newPath": "cards.invoices.budgetImpactCard.title",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.categorySuggestionCard.description",
+    "newPath": "cards.invoices.categorySuggestionCard.description",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.categorySuggestionCard.gamification",
+    "newPath": "cards.invoices.categorySuggestionCard.gamification",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.categorySuggestionCard.moreCategories",
+    "newPath": "cards.invoices.categorySuggestionCard.moreCategories",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.categorySuggestionCard.title",
+    "newPath": "cards.invoices.categorySuggestionCard.title",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.comparisonStatsCard.avgValue",
+    "newPath": "cards.invoices.comparisonStatsCard.avgValue",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.comparisonStatsCard.itemCount",
+    "newPath": "cards.invoices.comparisonStatsCard.itemCount",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.comparisonStatsCard.itemCountComparison",
+    "newPath": "cards.invoices.comparisonStatsCard.itemCountComparison",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.comparisonStatsCard.maxValue",
+    "newPath": "cards.invoices.comparisonStatsCard.maxValue",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.comparisonStatsCard.minValue",
+    "newPath": "cards.invoices.comparisonStatsCard.minValue",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.comparisonStatsCard.positionInRange",
+    "newPath": "cards.invoices.comparisonStatsCard.positionInRange",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.comparisonStatsCard.sameStore",
+    "newPath": "cards.invoices.comparisonStatsCard.sameStore",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.comparisonStatsCard.sameStoreComparison",
+    "newPath": "cards.invoices.comparisonStatsCard.sameStoreComparison",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.comparisonStatsCard.subtitle",
+    "newPath": "cards.invoices.comparisonStatsCard.subtitle",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.comparisonStatsCard.thisValue",
+    "newPath": "cards.invoices.comparisonStatsCard.thisValue",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.comparisonStatsCard.title",
+    "newPath": "cards.invoices.comparisonStatsCard.title",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.comparisonStatsCard.vsAverage",
+    "newPath": "cards.invoices.comparisonStatsCard.vsAverage",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.diningCard.challenge.descriptionPrefix",
+    "newPath": "cards.invoices.diningCard.challenge.descriptionPrefix",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.diningCard.challenge.descriptionSuffix",
+    "newPath": "cards.invoices.diningCard.challenge.descriptionSuffix",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.diningCard.challenge.title",
+    "newPath": "cards.invoices.diningCard.challenge.title",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.diningCard.estimatedNutrition.calories",
+    "newPath": "cards.invoices.diningCard.estimatedNutrition.calories",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.diningCard.estimatedNutrition.caloriesValue",
+    "newPath": "cards.invoices.diningCard.estimatedNutrition.caloriesValue",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.diningCard.estimatedNutrition.carbs",
+    "newPath": "cards.invoices.diningCard.estimatedNutrition.carbs",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.diningCard.estimatedNutrition.carbsValue",
+    "newPath": "cards.invoices.diningCard.estimatedNutrition.carbsValue",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.diningCard.estimatedNutrition.protein",
+    "newPath": "cards.invoices.diningCard.estimatedNutrition.protein",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.diningCard.estimatedNutrition.proteinValue",
+    "newPath": "cards.invoices.diningCard.estimatedNutrition.proteinValue",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.diningCard.estimatedNutrition.sodium",
+    "newPath": "cards.invoices.diningCard.estimatedNutrition.sodium",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.diningCard.estimatedNutrition.title",
+    "newPath": "cards.invoices.diningCard.estimatedNutrition.title",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.diningCard.habits.avgSpend",
+    "newPath": "cards.invoices.diningCard.habits.avgSpend",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.diningCard.habits.favorite",
+    "newPath": "cards.invoices.diningCard.habits.favorite",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.diningCard.habits.frequency",
+    "newPath": "cards.invoices.diningCard.habits.frequency",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.diningCard.habits.frequencyDiff",
+    "newPath": "cards.invoices.diningCard.habits.frequencyDiff",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.diningCard.habits.frequencyValue",
+    "newPath": "cards.invoices.diningCard.habits.frequencyValue",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.diningCard.habits.title",
+    "newPath": "cards.invoices.diningCard.habits.title",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.diningCard.habits.visits",
+    "newPath": "cards.invoices.diningCard.habits.visits",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.diningCard.sodium.high",
+    "newPath": "cards.invoices.diningCard.sodium.high",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.diningCard.sodium.low",
+    "newPath": "cards.invoices.diningCard.sodium.low",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.diningCard.sodium.medium",
+    "newPath": "cards.invoices.diningCard.sodium.medium",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.diningCard.swaps.caloriesSaved",
+    "newPath": "cards.invoices.diningCard.swaps.caloriesSaved",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.diningCard.swaps.grilled",
+    "newPath": "cards.invoices.diningCard.swaps.grilled",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.diningCard.swaps.moneySaved",
+    "newPath": "cards.invoices.diningCard.swaps.moneySaved",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.diningCard.swaps.salad",
+    "newPath": "cards.invoices.diningCard.swaps.salad",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.diningCard.swaps.title",
+    "newPath": "cards.invoices.diningCard.swaps.title",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.diningCard.swaps.water",
+    "newPath": "cards.invoices.diningCard.swaps.water",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.diningCard.title",
+    "newPath": "cards.invoices.diningCard.title",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.generalExpenseCard.aria.changeCategory",
+    "newPath": "cards.invoices.generalExpenseCard.aria.changeCategory",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.generalExpenseCard.aria.confirmCategory",
+    "newPath": "cards.invoices.generalExpenseCard.aria.confirmCategory",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.generalExpenseCard.aria.export",
+    "newPath": "cards.invoices.generalExpenseCard.aria.export",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.generalExpenseCard.aria.organize",
+    "newPath": "cards.invoices.generalExpenseCard.aria.organize",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.generalExpenseCard.budgetCategories.electronics",
+    "newPath": "cards.invoices.generalExpenseCard.budgetCategories.electronics",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.generalExpenseCard.budgetCategories.entertainment",
+    "newPath": "cards.invoices.generalExpenseCard.budgetCategories.entertainment",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.generalExpenseCard.budgetCategories.shopping",
+    "newPath": "cards.invoices.generalExpenseCard.budgetCategories.shopping",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.generalExpenseCard.buttons.change",
+    "newPath": "cards.invoices.generalExpenseCard.buttons.change",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.generalExpenseCard.buttons.correct",
+    "newPath": "cards.invoices.generalExpenseCard.buttons.correct",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.generalExpenseCard.buttons.export",
+    "newPath": "cards.invoices.generalExpenseCard.buttons.export",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.generalExpenseCard.buttons.organize",
+    "newPath": "cards.invoices.generalExpenseCard.buttons.organize",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.generalExpenseCard.confidence",
+    "newPath": "cards.invoices.generalExpenseCard.confidence",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.generalExpenseCard.detectedCategory",
+    "newPath": "cards.invoices.generalExpenseCard.detectedCategory",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.generalExpenseCard.nearLimitAlert",
+    "newPath": "cards.invoices.generalExpenseCard.nearLimitAlert",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.generalExpenseCard.options.businessExpense",
+    "newPath": "cards.invoices.generalExpenseCard.options.businessExpense",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.generalExpenseCard.options.insuranceInventory",
+    "newPath": "cards.invoices.generalExpenseCard.options.insuranceInventory",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.generalExpenseCard.options.trackWarranty",
+    "newPath": "cards.invoices.generalExpenseCard.options.trackWarranty",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.generalExpenseCard.sections.autoDetectedCategory",
+    "newPath": "cards.invoices.generalExpenseCard.sections.autoDetectedCategory",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.generalExpenseCard.sections.budgetImpact",
+    "newPath": "cards.invoices.generalExpenseCard.sections.budgetImpact",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.generalExpenseCard.sections.similarPurchases",
+    "newPath": "cards.invoices.generalExpenseCard.sections.similarPurchases",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.generalExpenseCard.sections.taxBusiness",
+    "newPath": "cards.invoices.generalExpenseCard.sections.taxBusiness",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.generalExpenseCard.title",
+    "newPath": "cards.invoices.generalExpenseCard.title",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.generalExpenseCard.vatReclaimable",
+    "newPath": "cards.invoices.generalExpenseCard.vatReclaimable",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.homeInventoryCard.bulk.description",
+    "newPath": "cards.invoices.homeInventoryCard.bulk.description",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.homeInventoryCard.bulk.title",
+    "newPath": "cards.invoices.homeInventoryCard.bulk.title",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.homeInventoryCard.eco.productsWithEcoLabels",
+    "newPath": "cards.invoices.homeInventoryCard.eco.productsWithEcoLabels",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.homeInventoryCard.eco.recyclablePackaging",
+    "newPath": "cards.invoices.homeInventoryCard.eco.recyclablePackaging",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.homeInventoryCard.eco.tip",
+    "newPath": "cards.invoices.homeInventoryCard.eco.tip",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.homeInventoryCard.eco.title",
+    "newPath": "cards.invoices.homeInventoryCard.eco.title",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.homeInventoryCard.stockLevels.daysRemaining",
+    "newPath": "cards.invoices.homeInventoryCard.stockLevels.daysRemaining",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.homeInventoryCard.stockLevels.title",
+    "newPath": "cards.invoices.homeInventoryCard.stockLevels.title",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.homeInventoryCard.supplyNames.dishSoap",
+    "newPath": "cards.invoices.homeInventoryCard.supplyNames.dishSoap",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.homeInventoryCard.supplyNames.floorCleaner",
+    "newPath": "cards.invoices.homeInventoryCard.supplyNames.floorCleaner",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.homeInventoryCard.supplyNames.laundryDetergent",
+    "newPath": "cards.invoices.homeInventoryCard.supplyNames.laundryDetergent",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.homeInventoryCard.supplyNames.paperProducts",
+    "newPath": "cards.invoices.homeInventoryCard.supplyNames.paperProducts",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.homeInventoryCard.title",
+    "newPath": "cards.invoices.homeInventoryCard.title",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.imageCard.aria.expandImage",
+    "newPath": "cards.invoices.imageCard.aria.expandImage",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.imageCard.buttons.addScan",
+    "newPath": "cards.invoices.imageCard.buttons.addScan",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.imageCard.buttons.expand",
+    "newPath": "cards.invoices.imageCard.buttons.expand",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.imageCard.buttons.next",
+    "newPath": "cards.invoices.imageCard.buttons.next",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.imageCard.buttons.previous",
+    "newPath": "cards.invoices.imageCard.buttons.previous",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.imageCard.buttons.remove",
+    "newPath": "cards.invoices.imageCard.buttons.remove",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.imageCard.dialogTitle",
+    "newPath": "cards.invoices.imageCard.dialogTitle",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.imageCard.dialogTitleWithIndex",
+    "newPath": "cards.invoices.imageCard.dialogTitleWithIndex",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.imageCard.scanAlt",
+    "newPath": "cards.invoices.imageCard.scanAlt",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.imageCard.scanAltFullSize",
+    "newPath": "cards.invoices.imageCard.scanAltFullSize",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.imageCard.title",
+    "newPath": "cards.invoices.imageCard.title",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.imageCard.titleWithIndex",
+    "newPath": "cards.invoices.imageCard.titleWithIndex",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.imageCard.tooltips.addScan",
+    "newPath": "cards.invoices.imageCard.tooltips.addScan",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.imageCard.tooltips.expand",
+    "newPath": "cards.invoices.imageCard.tooltips.expand",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.imageCard.tooltips.next",
+    "newPath": "cards.invoices.imageCard.tooltips.next",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.imageCard.tooltips.previous",
+    "newPath": "cards.invoices.imageCard.tooltips.previous",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.imageCard.tooltips.remove",
+    "newPath": "cards.invoices.imageCard.tooltips.remove",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.invoiceCard.descriptionPlaceholder",
+    "newPath": "cards.invoices.invoiceCard.descriptionPlaceholder",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.invoiceCard.fromMerchant",
+    "newPath": "cards.invoices.invoiceCard.fromMerchant",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.invoiceCard.importantBadge",
+    "newPath": "cards.invoices.invoiceCard.importantBadge",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.invoiceCard.labels.category",
+    "newPath": "cards.invoices.invoiceCard.labels.category",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.invoiceCard.labels.dateUtc",
+    "newPath": "cards.invoices.invoiceCard.labels.dateUtc",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.invoiceCard.labels.hours",
+    "newPath": "cards.invoices.invoiceCard.labels.hours",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.invoiceCard.labels.minutes",
+    "newPath": "cards.invoices.invoiceCard.labels.minutes",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.invoiceCard.labels.paymentMethod",
+    "newPath": "cards.invoices.invoiceCard.labels.paymentMethod",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.invoiceCard.labels.totalAmount",
+    "newPath": "cards.invoices.invoiceCard.labels.totalAmount",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.invoiceCard.labels.utc",
+    "newPath": "cards.invoices.invoiceCard.labels.utc",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.invoiceCard.markImportant",
+    "newPath": "cards.invoices.invoiceCard.markImportant",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.invoiceCard.placeholders.selectCategory",
+    "newPath": "cards.invoices.invoiceCard.placeholders.selectCategory",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.invoiceCard.placeholders.selectPaymentType",
+    "newPath": "cards.invoices.invoiceCard.placeholders.selectPaymentType",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.invoiceCard.title",
+    "newPath": "cards.invoices.invoiceCard.title",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.invoiceCard.tooltips.markFavorite",
+    "newPath": "cards.invoices.invoiceCard.tooltips.markFavorite",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.invoiceCard.tooltips.unmarkFavorite",
+    "newPath": "cards.invoices.invoiceCard.tooltips.unmarkFavorite",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.invoiceDetailsCard.itemsTitle",
+    "newPath": "cards.invoices.invoiceDetailsCard.itemsTitle",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.invoiceDetailsCard.labels.category",
+    "newPath": "cards.invoices.invoiceDetailsCard.labels.category",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.invoiceDetailsCard.labels.countryRegion",
+    "newPath": "cards.invoices.invoiceDetailsCard.labels.countryRegion",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.invoiceDetailsCard.labels.dateUtc",
+    "newPath": "cards.invoices.invoiceDetailsCard.labels.dateUtc",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.invoiceDetailsCard.labels.payment",
+    "newPath": "cards.invoices.invoiceDetailsCard.labels.payment",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.invoiceDetailsCard.labels.receiptType",
+    "newPath": "cards.invoices.invoiceDetailsCard.labels.receiptType",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.invoiceDetailsCard.labels.ronEquivalent",
+    "newPath": "cards.invoices.invoiceDetailsCard.labels.ronEquivalent",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.invoiceDetailsCard.labels.subtotal",
+    "newPath": "cards.invoices.invoiceDetailsCard.labels.subtotal",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.invoiceDetailsCard.labels.tip",
+    "newPath": "cards.invoices.invoiceDetailsCard.labels.tip",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.invoiceDetailsCard.labels.totalAmount",
+    "newPath": "cards.invoices.invoiceDetailsCard.labels.totalAmount",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.invoiceDetailsCard.pagination.next",
+    "newPath": "cards.invoices.invoiceDetailsCard.pagination.next",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.invoiceDetailsCard.pagination.pageOf",
+    "newPath": "cards.invoices.invoiceDetailsCard.pagination.pageOf",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.invoiceDetailsCard.pagination.previous",
+    "newPath": "cards.invoices.invoiceDetailsCard.pagination.previous",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.invoiceDetailsCard.sections.paymentMethods",
+    "newPath": "cards.invoices.invoiceDetailsCard.sections.paymentMethods",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.invoiceDetailsCard.sections.taxBreakdown",
+    "newPath": "cards.invoices.invoiceDetailsCard.sections.taxBreakdown",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.invoiceDetailsCard.table.grandTotal",
+    "newPath": "cards.invoices.invoiceDetailsCard.table.grandTotal",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.invoiceDetailsCard.table.item",
+    "newPath": "cards.invoices.invoiceDetailsCard.table.item",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.invoiceDetailsCard.table.price",
+    "newPath": "cards.invoices.invoiceDetailsCard.table.price",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.invoiceDetailsCard.table.qty",
+    "newPath": "cards.invoices.invoiceDetailsCard.table.qty",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.invoiceDetailsCard.table.total",
+    "newPath": "cards.invoices.invoiceDetailsCard.table.total",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.invoiceDetailsCard.table.unit",
+    "newPath": "cards.invoices.invoiceDetailsCard.table.unit",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.invoiceDetailsCard.taxLabels.net",
+    "newPath": "cards.invoices.invoiceDetailsCard.taxLabels.net",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.invoiceDetailsCard.taxLabels.tax",
+    "newPath": "cards.invoices.invoiceDetailsCard.taxLabels.tax",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.invoiceDetailsCard.title",
+    "newPath": "cards.invoices.invoiceDetailsCard.title",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.invoiceDetailsCard.tooltips.exchangeRate",
+    "newPath": "cards.invoices.invoiceDetailsCard.tooltips.exchangeRate",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.merchantCard.addressLabel",
+    "newPath": "cards.invoices.merchantCard.addressLabel",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.merchantCard.buttons.viewAllReceipts",
+    "newPath": "cards.invoices.merchantCard.buttons.viewAllReceipts",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.merchantCard.buttons.viewMerchantDetails",
+    "newPath": "cards.invoices.merchantCard.buttons.viewMerchantDetails",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.merchantCard.noMerchantLinked",
+    "newPath": "cards.invoices.merchantCard.noMerchantLinked",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.merchantCard.title",
+    "newPath": "cards.invoices.merchantCard.title",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.merchantCard.tooltips.viewAllReceipts",
+    "newPath": "cards.invoices.merchantCard.tooltips.viewAllReceipts",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.merchantCard.tooltips.viewMerchantDetails",
+    "newPath": "cards.invoices.merchantCard.tooltips.viewMerchantDetails",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.merchantInfoCard.categoryDistribution",
+    "newPath": "cards.invoices.merchantInfoCard.categoryDistribution",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.merchantInfoCard.noMerchantLinked",
+    "newPath": "cards.invoices.merchantInfoCard.noMerchantLinked",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.merchantInfoCard.spendingHistory",
+    "newPath": "cards.invoices.merchantInfoCard.spendingHistory",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.merchantInfoCard.stats.avgSpend",
+    "newPath": "cards.invoices.merchantInfoCard.stats.avgSpend",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.merchantInfoCard.stats.daysAgo",
+    "newPath": "cards.invoices.merchantInfoCard.stats.daysAgo",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.merchantInfoCard.stats.visits",
+    "newPath": "cards.invoices.merchantInfoCard.stats.visits",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.merchantInfoCard.title",
+    "newPath": "cards.invoices.merchantInfoCard.title",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.merchantInfoCard.viewAllInvoices",
+    "newPath": "cards.invoices.merchantInfoCard.viewAllInvoices",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.merchantInfoCard.viewAllReceipts",
+    "newPath": "cards.invoices.merchantInfoCard.viewAllReceipts",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.merchantInfoCard.viewOnMap",
+    "newPath": "cards.invoices.merchantInfoCard.viewOnMap",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.nutritionCard.allergens.foundInItems",
+    "newPath": "cards.invoices.nutritionCard.allergens.foundInItems",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.nutritionCard.allergens.title",
+    "newPath": "cards.invoices.nutritionCard.allergens.title",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.nutritionCard.composition.dairyOther",
+    "newPath": "cards.invoices.nutritionCard.composition.dairyOther",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.nutritionCard.composition.processed",
+    "newPath": "cards.invoices.nutritionCard.composition.processed",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.nutritionCard.composition.title",
+    "newPath": "cards.invoices.nutritionCard.composition.title",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.nutritionCard.composition.wholeFoods",
+    "newPath": "cards.invoices.nutritionCard.composition.wholeFoods",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.nutritionCard.foodGroups.fruits",
+    "newPath": "cards.invoices.nutritionCard.foodGroups.fruits",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.nutritionCard.foodGroups.grains",
+    "newPath": "cards.invoices.nutritionCard.foodGroups.grains",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.nutritionCard.foodGroups.itemsCount",
+    "newPath": "cards.invoices.nutritionCard.foodGroups.itemsCount",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.nutritionCard.foodGroups.protein",
+    "newPath": "cards.invoices.nutritionCard.foodGroups.protein",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.nutritionCard.foodGroups.vegetables",
+    "newPath": "cards.invoices.nutritionCard.foodGroups.vegetables",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.nutritionCard.score.excellent",
+    "newPath": "cards.invoices.nutritionCard.score.excellent",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.nutritionCard.score.fair",
+    "newPath": "cards.invoices.nutritionCard.score.fair",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.nutritionCard.score.good",
+    "newPath": "cards.invoices.nutritionCard.score.good",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.nutritionCard.score.needsWork",
+    "newPath": "cards.invoices.nutritionCard.score.needsWork",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.nutritionCard.score.title",
+    "newPath": "cards.invoices.nutritionCard.score.title",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.nutritionCard.suggestions.addFruits",
+    "newPath": "cards.invoices.nutritionCard.suggestions.addFruits",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.nutritionCard.suggestions.addFruitsAndVegetables",
+    "newPath": "cards.invoices.nutritionCard.suggestions.addFruitsAndVegetables",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.nutritionCard.suggestions.addVegetables",
+    "newPath": "cards.invoices.nutritionCard.suggestions.addVegetables",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.nutritionCard.suggestions.greatBalance",
+    "newPath": "cards.invoices.nutritionCard.suggestions.greatBalance",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.nutritionCard.suggestions.swapProcessed",
+    "newPath": "cards.invoices.nutritionCard.suggestions.swapProcessed",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.nutritionCard.title",
+    "newPath": "cards.invoices.nutritionCard.title",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.receiptScanCard.buttons.expand",
+    "newPath": "cards.invoices.receiptScanCard.buttons.expand",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.receiptScanCard.buttons.nextScan",
+    "newPath": "cards.invoices.receiptScanCard.buttons.nextScan",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.receiptScanCard.buttons.previousScan",
+    "newPath": "cards.invoices.receiptScanCard.buttons.previousScan",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.receiptScanCard.controls.download",
+    "newPath": "cards.invoices.receiptScanCard.controls.download",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.receiptScanCard.controls.fullScreen",
+    "newPath": "cards.invoices.receiptScanCard.controls.fullScreen",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.receiptScanCard.controls.reset",
+    "newPath": "cards.invoices.receiptScanCard.controls.reset",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.receiptScanCard.controls.rotate",
+    "newPath": "cards.invoices.receiptScanCard.controls.rotate",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.receiptScanCard.controls.toggleZoom",
+    "newPath": "cards.invoices.receiptScanCard.controls.toggleZoom",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.receiptScanCard.controls.zoomIn",
+    "newPath": "cards.invoices.receiptScanCard.controls.zoomIn",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.receiptScanCard.controls.zoomOut",
+    "newPath": "cards.invoices.receiptScanCard.controls.zoomOut",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.receiptScanCard.dialogTitle",
+    "newPath": "cards.invoices.receiptScanCard.dialogTitle",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.receiptScanCard.dialogTitleWithIndex",
+    "newPath": "cards.invoices.receiptScanCard.dialogTitleWithIndex",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.receiptScanCard.navigation.next",
+    "newPath": "cards.invoices.receiptScanCard.navigation.next",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.receiptScanCard.navigation.of",
+    "newPath": "cards.invoices.receiptScanCard.navigation.of",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.receiptScanCard.navigation.previous",
+    "newPath": "cards.invoices.receiptScanCard.navigation.previous",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.receiptScanCard.scanAlt",
+    "newPath": "cards.invoices.receiptScanCard.scanAlt",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.receiptScanCard.scanAltFullSize",
+    "newPath": "cards.invoices.receiptScanCard.scanAltFullSize",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.receiptScanCard.title",
+    "newPath": "cards.invoices.receiptScanCard.title",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.receiptScanCard.titleWithIndex",
+    "newPath": "cards.invoices.receiptScanCard.titleWithIndex",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.receiptScanCard.tooltips.expand",
+    "newPath": "cards.invoices.receiptScanCard.tooltips.expand",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.receiptScanCard.tooltips.nextScan",
+    "newPath": "cards.invoices.receiptScanCard.tooltips.nextScan",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.receiptScanCard.tooltips.previousScan",
+    "newPath": "cards.invoices.receiptScanCard.tooltips.previousScan",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.recipeCard.buttons.viewRecipe",
+    "newPath": "cards.invoices.recipeCard.buttons.viewRecipe",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.recipeCard.buttons.visitReference",
+    "newPath": "cards.invoices.recipeCard.buttons.visitReference",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.recipeCard.complexity.easy",
+    "newPath": "cards.invoices.recipeCard.complexity.easy",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.recipeCard.complexity.hard",
+    "newPath": "cards.invoices.recipeCard.complexity.hard",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.recipeCard.complexity.normal",
+    "newPath": "cards.invoices.recipeCard.complexity.normal",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.recipeCard.complexity.unknown",
+    "newPath": "cards.invoices.recipeCard.complexity.unknown",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.recipeCard.dropdown.delete",
+    "newPath": "cards.invoices.recipeCard.dropdown.delete",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.recipeCard.dropdown.edit",
+    "newPath": "cards.invoices.recipeCard.dropdown.edit",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.recipeCard.dropdown.markAsFavorite",
+    "newPath": "cards.invoices.recipeCard.dropdown.markAsFavorite",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.recipeCard.dropdown.share",
+    "newPath": "cards.invoices.recipeCard.dropdown.share",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.recipeCard.dropdown.view",
+    "newPath": "cards.invoices.recipeCard.dropdown.view",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.recipeCard.ingredients.additionalLabel",
+    "newPath": "cards.invoices.recipeCard.ingredients.additionalLabel",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.recipeCard.ingredients.label",
+    "newPath": "cards.invoices.recipeCard.ingredients.label",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.recipeCard.ingredients.more",
+    "newPath": "cards.invoices.recipeCard.ingredients.more",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.recipeCard.timing.cookLabel",
+    "newPath": "cards.invoices.recipeCard.timing.cookLabel",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.recipeCard.timing.cookTooltip",
+    "newPath": "cards.invoices.recipeCard.timing.cookTooltip",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.recipeCard.timing.prepLabel",
+    "newPath": "cards.invoices.recipeCard.timing.prepLabel",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.recipeCard.timing.prepTooltip",
+    "newPath": "cards.invoices.recipeCard.timing.prepTooltip",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.seasonalInsightsCard.insights.holidaySeason.description",
+    "newPath": "cards.invoices.seasonalInsightsCard.insights.holidaySeason.description",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.seasonalInsightsCard.insights.holidaySeason.title",
+    "newPath": "cards.invoices.seasonalInsightsCard.insights.holidaySeason.title",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.seasonalInsightsCard.insights.insufficientData.description",
+    "newPath": "cards.invoices.seasonalInsightsCard.insights.insufficientData.description",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.seasonalInsightsCard.insights.insufficientData.title",
+    "newPath": "cards.invoices.seasonalInsightsCard.insights.insufficientData.title",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.seasonalInsightsCard.insights.normalPattern.description",
+    "newPath": "cards.invoices.seasonalInsightsCard.insights.normalPattern.description",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.seasonalInsightsCard.insights.normalPattern.title",
+    "newPath": "cards.invoices.seasonalInsightsCard.insights.normalPattern.title",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.seasonalInsightsCard.insights.spike.description",
+    "newPath": "cards.invoices.seasonalInsightsCard.insights.spike.description",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.seasonalInsightsCard.insights.spike.title",
+    "newPath": "cards.invoices.seasonalInsightsCard.insights.spike.title",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.seasonalInsightsCard.insights.stockUpTip.description",
+    "newPath": "cards.invoices.seasonalInsightsCard.insights.stockUpTip.description",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.seasonalInsightsCard.insights.stockUpTip.title",
+    "newPath": "cards.invoices.seasonalInsightsCard.insights.stockUpTip.title",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.seasonalInsightsCard.month.spendingSoFar",
+    "newPath": "cards.invoices.seasonalInsightsCard.month.spendingSoFar",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.seasonalInsightsCard.month.vsAverage",
+    "newPath": "cards.invoices.seasonalInsightsCard.month.vsAverage",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.seasonalInsightsCard.title",
+    "newPath": "cards.invoices.seasonalInsightsCard.title",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.sharingCard.buttons.manageSharing",
+    "newPath": "cards.invoices.sharingCard.buttons.manageSharing",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.sharingCard.buttons.markAsPrivate",
+    "newPath": "cards.invoices.sharingCard.buttons.markAsPrivate",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.sharingCard.buttons.revokingAccess",
+    "newPath": "cards.invoices.sharingCard.buttons.revokingAccess",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.sharingCard.buttons.shareInvoice",
+    "newPath": "cards.invoices.sharingCard.buttons.shareInvoice",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.sharingCard.emptyShared.private",
+    "newPath": "cards.invoices.sharingCard.emptyShared.private",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.sharingCard.emptyShared.public",
+    "newPath": "cards.invoices.sharingCard.emptyShared.public",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.sharingCard.owner",
+    "newPath": "cards.invoices.sharingCard.owner",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.sharingCard.ownerAvatarAlt",
+    "newPath": "cards.invoices.sharingCard.ownerAvatarAlt",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.sharingCard.publicInvoice.description",
+    "newPath": "cards.invoices.sharingCard.publicInvoice.description",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.sharingCard.publicInvoice.title",
+    "newPath": "cards.invoices.sharingCard.publicInvoice.title",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.sharingCard.sharedWith",
+    "newPath": "cards.invoices.sharingCard.sharedWith",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.sharingCard.title",
+    "newPath": "cards.invoices.sharingCard.title",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.sharingCard.toasts.removeAccessComingSoon.description",
+    "newPath": "cards.invoices.sharingCard.toasts.removeAccessComingSoon.description",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.sharingCard.toasts.removeAccessComingSoon.title",
+    "newPath": "cards.invoices.sharingCard.toasts.removeAccessComingSoon.title",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.sharingCard.toasts.revoke.error",
+    "newPath": "cards.invoices.sharingCard.toasts.revoke.error",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.sharingCard.toasts.revoke.loading",
+    "newPath": "cards.invoices.sharingCard.toasts.revoke.loading",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.sharingCard.toasts.revoke.success",
+    "newPath": "cards.invoices.sharingCard.toasts.revoke.success",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.sharingCard.tooltips.manageSharing",
+    "newPath": "cards.invoices.sharingCard.tooltips.manageSharing",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.sharingCard.tooltips.markAsPrivate",
+    "newPath": "cards.invoices.sharingCard.tooltips.markAsPrivate",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.sharingCard.tooltips.removeAccess",
+    "newPath": "cards.invoices.sharingCard.tooltips.removeAccess",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.sharingCard.tooltips.shareInvoice",
+    "newPath": "cards.invoices.sharingCard.tooltips.shareInvoice",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.sharingCard.userWithId",
+    "newPath": "cards.invoices.sharingCard.userWithId",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.shoppingCalendarCard.insights.days",
+    "newPath": "cards.invoices.shoppingCalendarCard.insights.days",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.shoppingCalendarCard.insights.mostActiveOn",
+    "newPath": "cards.invoices.shoppingCalendarCard.insights.mostActiveOn",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.shoppingCalendarCard.insights.onAverage",
+    "newPath": "cards.invoices.shoppingCalendarCard.insights.onAverage",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.shoppingCalendarCard.insights.perTrip",
+    "newPath": "cards.invoices.shoppingCalendarCard.insights.perTrip",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.shoppingCalendarCard.insights.shopEveryPrefix",
+    "newPath": "cards.invoices.shoppingCalendarCard.insights.shopEveryPrefix",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.shoppingCalendarCard.insights.spendingPrefix",
+    "newPath": "cards.invoices.shoppingCalendarCard.insights.spendingPrefix",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.shoppingCalendarCard.insights.weekdayLabel",
+    "newPath": "cards.invoices.shoppingCalendarCard.insights.weekdayLabel",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.shoppingCalendarCard.legend.less",
+    "newPath": "cards.invoices.shoppingCalendarCard.legend.less",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.shoppingCalendarCard.legend.more",
+    "newPath": "cards.invoices.shoppingCalendarCard.legend.more",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.shoppingCalendarCard.stats.monthTotal",
+    "newPath": "cards.invoices.shoppingCalendarCard.stats.monthTotal",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.shoppingCalendarCard.stats.shoppingDays",
+    "newPath": "cards.invoices.shoppingCalendarCard.stats.shoppingDays",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.shoppingCalendarCard.title",
+    "newPath": "cards.invoices.shoppingCalendarCard.title",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.shoppingCalendarCard.tooltip.basedOnCachedInvoices",
+    "newPath": "cards.invoices.shoppingCalendarCard.tooltip.basedOnCachedInvoices",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.shoppingCalendarCard.tooltip.currentInvoice",
+    "newPath": "cards.invoices.shoppingCalendarCard.tooltip.currentInvoice",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.shoppingCalendarCard.tooltip.currentInvoiceOnly",
+    "newPath": "cards.invoices.shoppingCalendarCard.tooltip.currentInvoiceOnly",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.shoppingCalendarCard.tooltip.invoiceCount",
+    "newPath": "cards.invoices.shoppingCalendarCard.tooltip.invoiceCount",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.shoppingCalendarCard.tooltip.more",
+    "newPath": "cards.invoices.shoppingCalendarCard.tooltip.more",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.shoppingCalendarCard.tooltip.vsAverage",
+    "newPath": "cards.invoices.shoppingCalendarCard.tooltip.vsAverage",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.summaryStatsCard.description",
+    "newPath": "cards.invoices.summaryStatsCard.description",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.summaryStatsCard.extremes.highest",
+    "newPath": "cards.invoices.summaryStatsCard.extremes.highest",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.summaryStatsCard.extremes.lowest",
+    "newPath": "cards.invoices.summaryStatsCard.extremes.lowest",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.summaryStatsCard.stats.averagePrice.description",
+    "newPath": "cards.invoices.summaryStatsCard.stats.averagePrice.description",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.summaryStatsCard.stats.averagePrice.label",
+    "newPath": "cards.invoices.summaryStatsCard.stats.averagePrice.label",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.summaryStatsCard.stats.categories.description",
+    "newPath": "cards.invoices.summaryStatsCard.stats.categories.description",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.summaryStatsCard.stats.categories.label",
+    "newPath": "cards.invoices.summaryStatsCard.stats.categories.label",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.summaryStatsCard.stats.taxRate.description",
+    "newPath": "cards.invoices.summaryStatsCard.stats.taxRate.description",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.summaryStatsCard.stats.taxRate.label",
+    "newPath": "cards.invoices.summaryStatsCard.stats.taxRate.label",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.summaryStatsCard.stats.totalItems.description",
+    "newPath": "cards.invoices.summaryStatsCard.stats.totalItems.description",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.summaryStatsCard.stats.totalItems.label",
+    "newPath": "cards.invoices.summaryStatsCard.stats.totalItems.label",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.summaryStatsCard.title",
+    "newPath": "cards.invoices.summaryStatsCard.title",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.vehicleCard.buttons.addVehicle",
+    "newPath": "cards.invoices.vehicleCard.buttons.addVehicle",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.vehicleCard.buttons.fullReport",
+    "newPath": "cards.invoices.vehicleCard.buttons.fullReport",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.vehicleCard.chart.amount",
+    "newPath": "cards.invoices.vehicleCard.chart.amount",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.vehicleCard.chart.title",
+    "newPath": "cards.invoices.vehicleCard.chart.title",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.vehicleCard.details.liters",
+    "newPath": "cards.invoices.vehicleCard.details.liters",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.vehicleCard.details.notSet",
+    "newPath": "cards.invoices.vehicleCard.details.notSet",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.vehicleCard.details.pricePerLiter",
+    "newPath": "cards.invoices.vehicleCard.details.pricePerLiter",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.vehicleCard.details.station",
+    "newPath": "cards.invoices.vehicleCard.details.station",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.vehicleCard.details.vehicle",
+    "newPath": "cards.invoices.vehicleCard.details.vehicle",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.vehicleCard.expenseType",
+    "newPath": "cards.invoices.vehicleCard.expenseType",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.vehicleCard.maintenance.title",
+    "newPath": "cards.invoices.vehicleCard.maintenance.title",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.vehicleCard.months.dec",
+    "newPath": "cards.invoices.vehicleCard.months.dec",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.vehicleCard.months.nov",
+    "newPath": "cards.invoices.vehicleCard.months.nov",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.vehicleCard.months.oct",
+    "newPath": "cards.invoices.vehicleCard.months.oct",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.vehicleCard.months.sep",
+    "newPath": "cards.invoices.vehicleCard.months.sep",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.vehicleCard.reminders.oilChange",
+    "newPath": "cards.invoices.vehicleCard.reminders.oilChange",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.vehicleCard.reminders.tireRotation",
+    "newPath": "cards.invoices.vehicleCard.reminders.tireRotation",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.vehicleCard.stats.costPerKm",
+    "newPath": "cards.invoices.vehicleCard.stats.costPerKm",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.vehicleCard.stats.estimated",
+    "newPath": "cards.invoices.vehicleCard.stats.estimated",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.vehicleCard.stats.fillUps",
+    "newPath": "cards.invoices.vehicleCard.stats.fillUps",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.vehicleCard.stats.fuelPrice",
+    "newPath": "cards.invoices.vehicleCard.stats.fuelPrice",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.vehicleCard.stats.thisMonth",
+    "newPath": "cards.invoices.vehicleCard.stats.thisMonth",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.vehicleCard.stats.thisMonthSuffix",
+    "newPath": "cards.invoices.vehicleCard.stats.thisMonthSuffix",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.vehicleCard.tip.perLiter",
+    "newPath": "cards.invoices.vehicleCard.tip.perLiter",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.vehicleCard.tip.title",
+    "newPath": "cards.invoices.vehicleCard.tip.title",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Cards.vehicleCard.title",
+    "newPath": "cards.invoices.vehicleCard.title",
+    "reason": "invoice cards"
+  },
+  {
+    "oldPath": "IMS--Common.commandPalette.actions.createInvoice",
+    "newPath": "shared.invoices.commandPalette.actions.createInvoice",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.commandPalette.actions.uploadScans",
+    "newPath": "shared.invoices.commandPalette.actions.uploadScans",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.commandPalette.actions.viewAll",
+    "newPath": "shared.invoices.commandPalette.actions.viewAll",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.commandPalette.actions.viewStatistics",
+    "newPath": "shared.invoices.commandPalette.actions.viewStatistics",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.commandPalette.groups.quickActions",
+    "newPath": "shared.invoices.commandPalette.groups.quickActions",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.commandPalette.groups.recentInvoices",
+    "newPath": "shared.invoices.commandPalette.groups.recentInvoices",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.commandPalette.groups.searchResults",
+    "newPath": "shared.invoices.commandPalette.groups.searchResults",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.commandPalette.noResults",
+    "newPath": "shared.invoices.commandPalette.noResults",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.commandPalette.placeholder",
+    "newPath": "shared.invoices.commandPalette.placeholder",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.invoiceHeader.buttons.analyzeWithAi",
+    "newPath": "shared.invoices.invoiceHeader.buttons.analyzeWithAi",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.invoiceHeader.buttons.delete",
+    "newPath": "shared.invoices.invoiceHeader.buttons.delete",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.invoiceHeader.buttons.discard",
+    "newPath": "shared.invoices.invoiceHeader.buttons.discard",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.invoiceHeader.buttons.edit",
+    "newPath": "shared.invoices.invoiceHeader.buttons.edit",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.invoiceHeader.buttons.export",
+    "newPath": "shared.invoices.invoiceHeader.buttons.export",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.invoiceHeader.buttons.print",
+    "newPath": "shared.invoices.invoiceHeader.buttons.print",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.invoiceHeader.buttons.save",
+    "newPath": "shared.invoices.invoiceHeader.buttons.save",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.invoiceHeader.buttons.saving",
+    "newPath": "shared.invoices.invoiceHeader.buttons.saving",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.invoiceHeader.id",
+    "newPath": "shared.invoices.invoiceHeader.id",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.invoiceHeader.tooltips.analyzeSpendingPatterns",
+    "newPath": "shared.invoices.invoiceHeader.tooltips.analyzeSpendingPatterns",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.invoiceHeader.tooltips.delete",
+    "newPath": "shared.invoices.invoiceHeader.tooltips.delete",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.invoiceHeader.tooltips.deleteInvoicePermanently",
+    "newPath": "shared.invoices.invoiceHeader.tooltips.deleteInvoicePermanently",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.invoiceHeader.tooltips.discardAllPendingChanges",
+    "newPath": "shared.invoices.invoiceHeader.tooltips.discardAllPendingChanges",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.invoiceHeader.tooltips.edit",
+    "newPath": "shared.invoices.invoiceHeader.tooltips.edit",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.invoiceHeader.tooltips.export",
+    "newPath": "shared.invoices.invoiceHeader.tooltips.export",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.invoiceHeader.tooltips.importantInvoice",
+    "newPath": "shared.invoices.invoiceHeader.tooltips.importantInvoice",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.invoiceHeader.tooltips.print",
+    "newPath": "shared.invoices.invoiceHeader.tooltips.print",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.invoiceHeader.tooltips.printInvoiceWithAllDetails",
+    "newPath": "shared.invoices.invoiceHeader.tooltips.printInvoiceWithAllDetails",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.invoiceHeader.tooltips.saveAllPendingChanges",
+    "newPath": "shared.invoices.invoiceHeader.tooltips.saveAllPendingChanges",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.invoicesNotFound.cta",
+    "newPath": "shared.invoices.invoicesNotFound.cta",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.invoicesNotFound.description",
+    "newPath": "shared.invoices.invoicesNotFound.description",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.invoicesNotFound.title",
+    "newPath": "shared.invoices.invoicesNotFound.title",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.loadingInvoices.description",
+    "newPath": "shared.invoices.loadingInvoices.description",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.loadingInvoices.title",
+    "newPath": "shared.invoices.loadingInvoices.title",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.mobileNav.ariaLabel",
+    "newPath": "shared.invoices.mobileNav.ariaLabel",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.mobileNav.home",
+    "newPath": "shared.invoices.mobileNav.home",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.mobileNav.invoices",
+    "newPath": "shared.invoices.mobileNav.invoices",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.mobileNav.profile",
+    "newPath": "shared.invoices.mobileNav.profile",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.mobileNav.scan",
+    "newPath": "shared.invoices.mobileNav.scan",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.notifications.markAllRead",
+    "newPath": "shared.invoices.notifications.markAllRead",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.notifications.noNotifications",
+    "newPath": "shared.invoices.notifications.noNotifications",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.notifications.timeAgo.days",
+    "newPath": "shared.invoices.notifications.timeAgo.days",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.notifications.timeAgo.hours",
+    "newPath": "shared.invoices.notifications.timeAgo.hours",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.notifications.timeAgo.minutes",
+    "newPath": "shared.invoices.notifications.timeAgo.minutes",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.notifications.timeAgo.now",
+    "newPath": "shared.invoices.notifications.timeAgo.now",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.notifications.title",
+    "newPath": "shared.invoices.notifications.title",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.notifications.types.analysisComplete",
+    "newPath": "shared.invoices.notifications.types.analysisComplete",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.notifications.types.invoiceCreated",
+    "newPath": "shared.invoices.notifications.types.invoiceCreated",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.notifications.types.monthlyReport",
+    "newPath": "shared.invoices.notifications.types.monthlyReport",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.onboarding.back",
+    "newPath": "shared.invoices.onboarding.back",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.onboarding.dontShowAgain",
+    "newPath": "shared.invoices.onboarding.dontShowAgain",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.onboarding.getStarted",
+    "newPath": "shared.invoices.onboarding.getStarted",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.onboarding.next",
+    "newPath": "shared.invoices.onboarding.next",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.onboarding.skip",
+    "newPath": "shared.invoices.onboarding.skip",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.onboarding.stepOf",
+    "newPath": "shared.invoices.onboarding.stepOf",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.onboarding.steps.analyze.description",
+    "newPath": "shared.invoices.onboarding.steps.analyze.description",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.onboarding.steps.analyze.title",
+    "newPath": "shared.invoices.onboarding.steps.analyze.title",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.onboarding.steps.track.description",
+    "newPath": "shared.invoices.onboarding.steps.track.description",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.onboarding.steps.track.title",
+    "newPath": "shared.invoices.onboarding.steps.track.title",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.onboarding.steps.upload.description",
+    "newPath": "shared.invoices.onboarding.steps.upload.description",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.onboarding.steps.upload.title",
+    "newPath": "shared.invoices.onboarding.steps.upload.title",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.preferences.currency",
+    "newPath": "shared.invoices.preferences.currency",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.preferences.defaultView",
+    "newPath": "shared.invoices.preferences.defaultView",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.preferences.pageSize",
+    "newPath": "shared.invoices.preferences.pageSize",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.preferences.save",
+    "newPath": "shared.invoices.preferences.save",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.preferences.saved",
+    "newPath": "shared.invoices.preferences.saved",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.preferences.showStats",
+    "newPath": "shared.invoices.preferences.showStats",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.preferences.sortBy",
+    "newPath": "shared.invoices.preferences.sortBy",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.preferences.sortOptions.amountAsc",
+    "newPath": "shared.invoices.preferences.sortOptions.amountAsc",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.preferences.sortOptions.amountDesc",
+    "newPath": "shared.invoices.preferences.sortOptions.amountDesc",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.preferences.sortOptions.dateAsc",
+    "newPath": "shared.invoices.preferences.sortOptions.dateAsc",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.preferences.sortOptions.dateDesc",
+    "newPath": "shared.invoices.preferences.sortOptions.dateDesc",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.preferences.sortOptions.nameAsc",
+    "newPath": "shared.invoices.preferences.sortOptions.nameAsc",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.preferences.title",
+    "newPath": "shared.invoices.preferences.title",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.preferences.views.grid",
+    "newPath": "shared.invoices.preferences.views.grid",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.preferences.views.table",
+    "newPath": "shared.invoices.preferences.views.table",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.shortcuts.close",
+    "newPath": "shared.invoices.shortcuts.close",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.shortcuts.closeDialog",
+    "newPath": "shared.invoices.shortcuts.closeDialog",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.shortcuts.description",
+    "newPath": "shared.invoices.shortcuts.description",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.shortcuts.newInvoice",
+    "newPath": "shared.invoices.shortcuts.newInvoice",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.shortcuts.openSearch",
+    "newPath": "shared.invoices.shortcuts.openSearch",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.shortcuts.showHelp",
+    "newPath": "shared.invoices.shortcuts.showHelp",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.shortcuts.title",
+    "newPath": "shared.invoices.shortcuts.title",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.shortcuts.uploadScan",
+    "newPath": "shared.invoices.shortcuts.uploadScan",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.statesLoading.description",
+    "newPath": "shared.invoices.statesLoading.description",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.statesLoading.title",
+    "newPath": "shared.invoices.statesLoading.title",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.statesNotFound.description",
+    "newPath": "shared.invoices.statesNotFound.description",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.statesNotFound.title",
+    "newPath": "shared.invoices.statesNotFound.title",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.unknownMerchant",
+    "newPath": "shared.invoices.unknownMerchant",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.workflowProgress.create",
+    "newPath": "shared.invoices.workflowProgress.create",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.workflowProgress.review",
+    "newPath": "shared.invoices.workflowProgress.review",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Common.workflowProgress.upload",
+    "newPath": "shared.invoices.workflowProgress.upload",
+    "reason": "shared invoice labels"
+  },
+  {
+    "oldPath": "IMS--Create.detailsForm.fields.category.label",
+    "newPath": "forms.invoices.createInvoice.detailsForm.fields.category.label",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.detailsForm.fields.category.options.carAuto",
+    "newPath": "forms.invoices.createInvoice.detailsForm.fields.category.options.carAuto",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.detailsForm.fields.category.options.fastFood",
+    "newPath": "forms.invoices.createInvoice.detailsForm.fields.category.options.fastFood",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.detailsForm.fields.category.options.grocery",
+    "newPath": "forms.invoices.createInvoice.detailsForm.fields.category.options.grocery",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.detailsForm.fields.category.options.homeCleaning",
+    "newPath": "forms.invoices.createInvoice.detailsForm.fields.category.options.homeCleaning",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.detailsForm.fields.category.options.notDefined",
+    "newPath": "forms.invoices.createInvoice.detailsForm.fields.category.options.notDefined",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.detailsForm.fields.category.options.other",
+    "newPath": "forms.invoices.createInvoice.detailsForm.fields.category.options.other",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.detailsForm.fields.category.placeholder",
+    "newPath": "forms.invoices.createInvoice.detailsForm.fields.category.placeholder",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.detailsForm.fields.description.hint",
+    "newPath": "forms.invoices.createInvoice.detailsForm.fields.description.hint",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.detailsForm.fields.description.label",
+    "newPath": "forms.invoices.createInvoice.detailsForm.fields.description.label",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.detailsForm.fields.description.placeholder",
+    "newPath": "forms.invoices.createInvoice.detailsForm.fields.description.placeholder",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.detailsForm.fields.name.hint",
+    "newPath": "forms.invoices.createInvoice.detailsForm.fields.name.hint",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.detailsForm.fields.name.label",
+    "newPath": "forms.invoices.createInvoice.detailsForm.fields.name.label",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.detailsForm.fields.name.placeholder",
+    "newPath": "forms.invoices.createInvoice.detailsForm.fields.name.placeholder",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.detailsForm.fields.paymentType.label",
+    "newPath": "forms.invoices.createInvoice.detailsForm.fields.paymentType.label",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.detailsForm.fields.paymentType.options.card",
+    "newPath": "forms.invoices.createInvoice.detailsForm.fields.paymentType.options.card",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.detailsForm.fields.paymentType.options.cash",
+    "newPath": "forms.invoices.createInvoice.detailsForm.fields.paymentType.options.cash",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.detailsForm.fields.paymentType.options.mobilePayment",
+    "newPath": "forms.invoices.createInvoice.detailsForm.fields.paymentType.options.mobilePayment",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.detailsForm.fields.paymentType.options.other",
+    "newPath": "forms.invoices.createInvoice.detailsForm.fields.paymentType.options.other",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.detailsForm.fields.paymentType.options.transfer",
+    "newPath": "forms.invoices.createInvoice.detailsForm.fields.paymentType.options.transfer",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.detailsForm.fields.paymentType.options.unknown",
+    "newPath": "forms.invoices.createInvoice.detailsForm.fields.paymentType.options.unknown",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.detailsForm.fields.paymentType.options.voucher",
+    "newPath": "forms.invoices.createInvoice.detailsForm.fields.paymentType.options.voucher",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.detailsForm.fields.paymentType.placeholder",
+    "newPath": "forms.invoices.createInvoice.detailsForm.fields.paymentType.placeholder",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.detailsForm.fields.transactionDate.label",
+    "newPath": "forms.invoices.createInvoice.detailsForm.fields.transactionDate.label",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.detailsForm.scanPreview.title",
+    "newPath": "forms.invoices.createInvoice.detailsForm.scanPreview.title",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.detailsForm.subtitle",
+    "newPath": "forms.invoices.createInvoice.detailsForm.subtitle",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.detailsForm.title",
+    "newPath": "forms.invoices.createInvoice.detailsForm.title",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.emptyState.description",
+    "newPath": "forms.invoices.createInvoice.emptyState.description",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.emptyState.title",
+    "newPath": "forms.invoices.createInvoice.emptyState.title",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.emptyState.uploadButton",
+    "newPath": "forms.invoices.createInvoice.emptyState.uploadButton",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.emptyState.viewScansButton",
+    "newPath": "forms.invoices.createInvoice.emptyState.viewScansButton",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.header.backToInvoices",
+    "newPath": "forms.invoices.createInvoice.header.backToInvoices",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.header.subtitle",
+    "newPath": "forms.invoices.createInvoice.header.subtitle",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.header.title",
+    "newPath": "forms.invoices.createInvoice.header.title",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.metadata.description",
+    "newPath": "forms.invoices.createInvoice.metadata.description",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.metadata.title",
+    "newPath": "forms.invoices.createInvoice.metadata.title",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.navigation.back",
+    "newPath": "forms.invoices.createInvoice.navigation.back",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.navigation.next",
+    "newPath": "forms.invoices.createInvoice.navigation.next",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.reviewStep.actions.create",
+    "newPath": "forms.invoices.createInvoice.reviewStep.actions.create",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.reviewStep.actions.creating",
+    "newPath": "forms.invoices.createInvoice.reviewStep.actions.creating",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.reviewStep.actions.hint",
+    "newPath": "forms.invoices.createInvoice.reviewStep.actions.hint",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.reviewStep.categories.carAuto",
+    "newPath": "forms.invoices.createInvoice.reviewStep.categories.carAuto",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.reviewStep.categories.fastFood",
+    "newPath": "forms.invoices.createInvoice.reviewStep.categories.fastFood",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.reviewStep.categories.grocery",
+    "newPath": "forms.invoices.createInvoice.reviewStep.categories.grocery",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.reviewStep.categories.homeCleaning",
+    "newPath": "forms.invoices.createInvoice.reviewStep.categories.homeCleaning",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.reviewStep.categories.notDefined",
+    "newPath": "forms.invoices.createInvoice.reviewStep.categories.notDefined",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.reviewStep.categories.other",
+    "newPath": "forms.invoices.createInvoice.reviewStep.categories.other",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.reviewStep.paymentTypes.card",
+    "newPath": "forms.invoices.createInvoice.reviewStep.paymentTypes.card",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.reviewStep.paymentTypes.cash",
+    "newPath": "forms.invoices.createInvoice.reviewStep.paymentTypes.cash",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.reviewStep.paymentTypes.mobilePayment",
+    "newPath": "forms.invoices.createInvoice.reviewStep.paymentTypes.mobilePayment",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.reviewStep.paymentTypes.other",
+    "newPath": "forms.invoices.createInvoice.reviewStep.paymentTypes.other",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.reviewStep.paymentTypes.transfer",
+    "newPath": "forms.invoices.createInvoice.reviewStep.paymentTypes.transfer",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.reviewStep.paymentTypes.unknown",
+    "newPath": "forms.invoices.createInvoice.reviewStep.paymentTypes.unknown",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.reviewStep.paymentTypes.voucher",
+    "newPath": "forms.invoices.createInvoice.reviewStep.paymentTypes.voucher",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.reviewStep.sections.details.category",
+    "newPath": "forms.invoices.createInvoice.reviewStep.sections.details.category",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.reviewStep.sections.details.description",
+    "newPath": "forms.invoices.createInvoice.reviewStep.sections.details.description",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.reviewStep.sections.details.name",
+    "newPath": "forms.invoices.createInvoice.reviewStep.sections.details.name",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.reviewStep.sections.details.paymentType",
+    "newPath": "forms.invoices.createInvoice.reviewStep.sections.details.paymentType",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.reviewStep.sections.details.title",
+    "newPath": "forms.invoices.createInvoice.reviewStep.sections.details.title",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.reviewStep.sections.details.transactionDate",
+    "newPath": "forms.invoices.createInvoice.reviewStep.sections.details.transactionDate",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.reviewStep.sections.scans.title",
+    "newPath": "forms.invoices.createInvoice.reviewStep.sections.scans.title",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.reviewStep.subtitle",
+    "newPath": "forms.invoices.createInvoice.reviewStep.subtitle",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.reviewStep.title",
+    "newPath": "forms.invoices.createInvoice.reviewStep.title",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.scanSelector.clearAll",
+    "newPath": "forms.invoices.createInvoice.scanSelector.clearAll",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.scanSelector.next",
+    "newPath": "forms.invoices.createInvoice.scanSelector.next",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.scanSelector.noScans",
+    "newPath": "forms.invoices.createInvoice.scanSelector.noScans",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.scanSelector.previous",
+    "newPath": "forms.invoices.createInvoice.scanSelector.previous",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.scanSelector.scansCount",
+    "newPath": "forms.invoices.createInvoice.scanSelector.scansCount",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.scanSelector.selectAll",
+    "newPath": "forms.invoices.createInvoice.scanSelector.selectAll",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.scanSelector.selectedCount",
+    "newPath": "forms.invoices.createInvoice.scanSelector.selectedCount",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.scanSelector.subtitle",
+    "newPath": "forms.invoices.createInvoice.scanSelector.subtitle",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.scanSelector.title",
+    "newPath": "forms.invoices.createInvoice.scanSelector.title",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.steps.details",
+    "newPath": "forms.invoices.createInvoice.steps.details",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.steps.detailsDesc",
+    "newPath": "forms.invoices.createInvoice.steps.detailsDesc",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.steps.review",
+    "newPath": "forms.invoices.createInvoice.steps.review",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.steps.reviewDesc",
+    "newPath": "forms.invoices.createInvoice.steps.reviewDesc",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.steps.selectScans",
+    "newPath": "forms.invoices.createInvoice.steps.selectScans",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Create.steps.selectScansDesc",
+    "newPath": "forms.invoices.createInvoice.steps.selectScansDesc",
+    "reason": "create-invoice flow"
+  },
+  {
+    "oldPath": "IMS--Dialogs.addScanDialog.buttons.cancel",
+    "newPath": "dialogs.invoices.addScanDialog.buttons.cancel",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.addScanDialog.buttons.upload",
+    "newPath": "dialogs.invoices.addScanDialog.buttons.upload",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.addScanDialog.buttons.uploading",
+    "newPath": "dialogs.invoices.addScanDialog.buttons.uploading",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.addScanDialog.description",
+    "newPath": "dialogs.invoices.addScanDialog.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.addScanDialog.dropzone.dragAndDrop",
+    "newPath": "dialogs.invoices.addScanDialog.dropzone.dragAndDrop",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.addScanDialog.dropzone.dropHere",
+    "newPath": "dialogs.invoices.addScanDialog.dropzone.dropHere",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.addScanDialog.dropzone.formats",
+    "newPath": "dialogs.invoices.addScanDialog.dropzone.formats",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.addScanDialog.dropzone.orClickBrowse",
+    "newPath": "dialogs.invoices.addScanDialog.dropzone.orClickBrowse",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.addScanDialog.scanType.jpeg",
+    "newPath": "dialogs.invoices.addScanDialog.scanType.jpeg",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.addScanDialog.scanType.label",
+    "newPath": "dialogs.invoices.addScanDialog.scanType.label",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.addScanDialog.scanType.other",
+    "newPath": "dialogs.invoices.addScanDialog.scanType.other",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.addScanDialog.scanType.pdf",
+    "newPath": "dialogs.invoices.addScanDialog.scanType.pdf",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.addScanDialog.scanType.placeholder",
+    "newPath": "dialogs.invoices.addScanDialog.scanType.placeholder",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.addScanDialog.scanType.png",
+    "newPath": "dialogs.invoices.addScanDialog.scanType.png",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.addScanDialog.title",
+    "newPath": "dialogs.invoices.addScanDialog.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.addScanDialog.toasts.fileTooLargeDescription",
+    "newPath": "dialogs.invoices.addScanDialog.toasts.fileTooLargeDescription",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.addScanDialog.toasts.fileTooLargeTitle",
+    "newPath": "dialogs.invoices.addScanDialog.toasts.fileTooLargeTitle",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.allergenDialog.aria.removeAllergen",
+    "newPath": "dialogs.invoices.allergenDialog.aria.removeAllergen",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.allergenDialog.buttons.add",
+    "newPath": "dialogs.invoices.allergenDialog.buttons.add",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.allergenDialog.buttons.cancel",
+    "newPath": "dialogs.invoices.allergenDialog.buttons.cancel",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.allergenDialog.buttons.save",
+    "newPath": "dialogs.invoices.allergenDialog.buttons.save",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.allergenDialog.buttons.saving",
+    "newPath": "dialogs.invoices.allergenDialog.buttons.saving",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.allergenDialog.defaultDescription",
+    "newPath": "dialogs.invoices.allergenDialog.defaultDescription",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.allergenDialog.description",
+    "newPath": "dialogs.invoices.allergenDialog.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.allergenDialog.empty.noAllergens",
+    "newPath": "dialogs.invoices.allergenDialog.empty.noAllergens",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.allergenDialog.errors.duplicate",
+    "newPath": "dialogs.invoices.allergenDialog.errors.duplicate",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.allergenDialog.errors.emptyName",
+    "newPath": "dialogs.invoices.allergenDialog.errors.emptyName",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.allergenDialog.errors.missingData",
+    "newPath": "dialogs.invoices.allergenDialog.errors.missingData",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.allergenDialog.errors.saveFailed",
+    "newPath": "dialogs.invoices.allergenDialog.errors.saveFailed",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.allergenDialog.labels.currentAllergens",
+    "newPath": "dialogs.invoices.allergenDialog.labels.currentAllergens",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.allergenDialog.labels.customAllergen",
+    "newPath": "dialogs.invoices.allergenDialog.labels.customAllergen",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.allergenDialog.labels.quickAdd",
+    "newPath": "dialogs.invoices.allergenDialog.labels.quickAdd",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.allergenDialog.placeholders.customAllergen",
+    "newPath": "dialogs.invoices.allergenDialog.placeholders.customAllergen",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.allergenDialog.success.added",
+    "newPath": "dialogs.invoices.allergenDialog.success.added",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.allergenDialog.success.removed",
+    "newPath": "dialogs.invoices.allergenDialog.success.removed",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.allergenDialog.success.saved",
+    "newPath": "dialogs.invoices.allergenDialog.success.saved",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.allergenDialog.title",
+    "newPath": "dialogs.invoices.allergenDialog.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.analysisSteps.analyzingWithAi",
+    "newPath": "dialogs.invoices.analyzeDialog.analysisSteps.analyzingWithAi",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.analysisSteps.categorizingItems",
+    "newPath": "dialogs.invoices.analyzeDialog.analysisSteps.categorizingItems",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.analysisSteps.finalizingResults",
+    "newPath": "dialogs.invoices.analyzeDialog.analysisSteps.finalizingResults",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.analysisSteps.preparingDocument",
+    "newPath": "dialogs.invoices.analyzeDialog.analysisSteps.preparingDocument",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.analysisSteps.processing",
+    "newPath": "dialogs.invoices.analyzeDialog.analysisSteps.processing",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.analysisSteps.runningOcrExtraction",
+    "newPath": "dialogs.invoices.analyzeDialog.analysisSteps.runningOcrExtraction",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.analyzing.progressComplete",
+    "newPath": "dialogs.invoices.analyzeDialog.analyzing.progressComplete",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.analyzing.title",
+    "newPath": "dialogs.invoices.analyzeDialog.analyzing.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.badges.recommended",
+    "newPath": "dialogs.invoices.analyzeDialog.badges.recommended",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.buttons.analyzing",
+    "newPath": "dialogs.invoices.analyzeDialog.buttons.analyzing",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.buttons.cancel",
+    "newPath": "dialogs.invoices.analyzeDialog.buttons.cancel",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.buttons.startAnalysis",
+    "newPath": "dialogs.invoices.analyzeDialog.buttons.startAnalysis",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.enhancements.priceComparison.description",
+    "newPath": "dialogs.invoices.analyzeDialog.enhancements.priceComparison.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.enhancements.priceComparison.label",
+    "newPath": "dialogs.invoices.analyzeDialog.enhancements.priceComparison.label",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.enhancements.quickExtract.description",
+    "newPath": "dialogs.invoices.analyzeDialog.enhancements.quickExtract.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.enhancements.quickExtract.label",
+    "newPath": "dialogs.invoices.analyzeDialog.enhancements.quickExtract.label",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.enhancements.savingsTips.description",
+    "newPath": "dialogs.invoices.analyzeDialog.enhancements.savingsTips.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.enhancements.savingsTips.label",
+    "newPath": "dialogs.invoices.analyzeDialog.enhancements.savingsTips.label",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.header.description",
+    "newPath": "dialogs.invoices.analyzeDialog.header.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.header.title",
+    "newPath": "dialogs.invoices.analyzeDialog.header.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.options.completeAnalysis.description",
+    "newPath": "dialogs.invoices.analyzeDialog.options.completeAnalysis.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.options.completeAnalysis.estimatedTime",
+    "newPath": "dialogs.invoices.analyzeDialog.options.completeAnalysis.estimatedTime",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.options.completeAnalysis.features.itemCategorization",
+    "newPath": "dialogs.invoices.analyzeDialog.options.completeAnalysis.features.itemCategorization",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.options.completeAnalysis.features.merchantIdentification",
+    "newPath": "dialogs.invoices.analyzeDialog.options.completeAnalysis.features.merchantIdentification",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.options.completeAnalysis.features.ocrExtraction",
+    "newPath": "dialogs.invoices.analyzeDialog.options.completeAnalysis.features.ocrExtraction",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.options.completeAnalysis.features.priceAnalysis",
+    "newPath": "dialogs.invoices.analyzeDialog.options.completeAnalysis.features.priceAnalysis",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.options.completeAnalysis.features.receiptValidation",
+    "newPath": "dialogs.invoices.analyzeDialog.options.completeAnalysis.features.receiptValidation",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.options.completeAnalysis.title",
+    "newPath": "dialogs.invoices.analyzeDialog.options.completeAnalysis.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.options.invoiceOnly.description",
+    "newPath": "dialogs.invoices.analyzeDialog.options.invoiceOnly.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.options.invoiceOnly.estimatedTime",
+    "newPath": "dialogs.invoices.analyzeDialog.options.invoiceOnly.estimatedTime",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.options.invoiceOnly.features.dateParsing",
+    "newPath": "dialogs.invoices.analyzeDialog.options.invoiceOnly.features.dateParsing",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.options.invoiceOnly.features.paymentMethodDetection",
+    "newPath": "dialogs.invoices.analyzeDialog.options.invoiceOnly.features.paymentMethodDetection",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.options.invoiceOnly.features.totalExtraction",
+    "newPath": "dialogs.invoices.analyzeDialog.options.invoiceOnly.features.totalExtraction",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.options.invoiceOnly.title",
+    "newPath": "dialogs.invoices.analyzeDialog.options.invoiceOnly.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.options.itemsOnly.description",
+    "newPath": "dialogs.invoices.analyzeDialog.options.itemsOnly.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.options.itemsOnly.estimatedTime",
+    "newPath": "dialogs.invoices.analyzeDialog.options.itemsOnly.estimatedTime",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.options.itemsOnly.features.categoryAssignment",
+    "newPath": "dialogs.invoices.analyzeDialog.options.itemsOnly.features.categoryAssignment",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.options.itemsOnly.features.itemExtraction",
+    "newPath": "dialogs.invoices.analyzeDialog.options.itemsOnly.features.itemExtraction",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.options.itemsOnly.features.pricePerItem",
+    "newPath": "dialogs.invoices.analyzeDialog.options.itemsOnly.features.pricePerItem",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.options.itemsOnly.features.quantityDetection",
+    "newPath": "dialogs.invoices.analyzeDialog.options.itemsOnly.features.quantityDetection",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.options.itemsOnly.title",
+    "newPath": "dialogs.invoices.analyzeDialog.options.itemsOnly.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.options.merchantOnly.description",
+    "newPath": "dialogs.invoices.analyzeDialog.options.merchantOnly.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.options.merchantOnly.estimatedTime",
+    "newPath": "dialogs.invoices.analyzeDialog.options.merchantOnly.estimatedTime",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.options.merchantOnly.features.businessCategory",
+    "newPath": "dialogs.invoices.analyzeDialog.options.merchantOnly.features.businessCategory",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.options.merchantOnly.features.contactInfo",
+    "newPath": "dialogs.invoices.analyzeDialog.options.merchantOnly.features.contactInfo",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.options.merchantOnly.features.locationExtraction",
+    "newPath": "dialogs.invoices.analyzeDialog.options.merchantOnly.features.locationExtraction",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.options.merchantOnly.features.merchantIdentification",
+    "newPath": "dialogs.invoices.analyzeDialog.options.merchantOnly.features.merchantIdentification",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.options.merchantOnly.title",
+    "newPath": "dialogs.invoices.analyzeDialog.options.merchantOnly.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.sections.analysisType",
+    "newPath": "dialogs.invoices.analyzeDialog.sections.analysisType",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.sections.enhancementsOptional",
+    "newPath": "dialogs.invoices.analyzeDialog.sections.enhancementsOptional",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.sections.includedFeatures",
+    "newPath": "dialogs.invoices.analyzeDialog.sections.includedFeatures",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.summary.enhancementsSelected",
+    "newPath": "dialogs.invoices.analyzeDialog.summary.enhancementsSelected",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.summary.estimatedTime",
+    "newPath": "dialogs.invoices.analyzeDialog.summary.estimatedTime",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.summary.noEnhancementsSelected",
+    "newPath": "dialogs.invoices.analyzeDialog.summary.noEnhancementsSelected",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.toasts.analysisComplete.description",
+    "newPath": "dialogs.invoices.analyzeDialog.toasts.analysisComplete.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.toasts.analysisComplete.title",
+    "newPath": "dialogs.invoices.analyzeDialog.toasts.analysisComplete.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.toasts.analysisFailed.description",
+    "newPath": "dialogs.invoices.analyzeDialog.toasts.analysisFailed.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.analyzeDialog.toasts.analysisFailed.title",
+    "newPath": "dialogs.invoices.analyzeDialog.toasts.analysisFailed.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.bulkCategoryDialog.buttons.cancel",
+    "newPath": "dialogs.invoices.bulkCategoryDialog.buttons.cancel",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.bulkCategoryDialog.buttons.save",
+    "newPath": "dialogs.invoices.bulkCategoryDialog.buttons.save",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.bulkCategoryDialog.buttons.saving",
+    "newPath": "dialogs.invoices.bulkCategoryDialog.buttons.saving",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.bulkCategoryDialog.description",
+    "newPath": "dialogs.invoices.bulkCategoryDialog.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.bulkCategoryDialog.errors.allFailed",
+    "newPath": "dialogs.invoices.bulkCategoryDialog.errors.allFailed",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.bulkCategoryDialog.errors.missingData",
+    "newPath": "dialogs.invoices.bulkCategoryDialog.errors.missingData",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.bulkCategoryDialog.errors.noProducts",
+    "newPath": "dialogs.invoices.bulkCategoryDialog.errors.noProducts",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.bulkCategoryDialog.errors.saveFailed",
+    "newPath": "dialogs.invoices.bulkCategoryDialog.errors.saveFailed",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.bulkCategoryDialog.labels.andMore",
+    "newPath": "dialogs.invoices.bulkCategoryDialog.labels.andMore",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.bulkCategoryDialog.labels.newCategory",
+    "newPath": "dialogs.invoices.bulkCategoryDialog.labels.newCategory",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.bulkCategoryDialog.labels.progress",
+    "newPath": "dialogs.invoices.bulkCategoryDialog.labels.progress",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.bulkCategoryDialog.labels.selectedProducts",
+    "newPath": "dialogs.invoices.bulkCategoryDialog.labels.selectedProducts",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.bulkCategoryDialog.placeholders.selectCategory",
+    "newPath": "dialogs.invoices.bulkCategoryDialog.placeholders.selectCategory",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.bulkCategoryDialog.progress.updating",
+    "newPath": "dialogs.invoices.bulkCategoryDialog.progress.updating",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.bulkCategoryDialog.success.partialSuccess",
+    "newPath": "dialogs.invoices.bulkCategoryDialog.success.partialSuccess",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.bulkCategoryDialog.success.saved",
+    "newPath": "dialogs.invoices.bulkCategoryDialog.success.saved",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.bulkCategoryDialog.title",
+    "newPath": "dialogs.invoices.bulkCategoryDialog.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.createInvoiceDialog.batchMode.description",
+    "newPath": "dialogs.invoices.createInvoiceDialog.batchMode.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.createInvoiceDialog.batchMode.title",
+    "newPath": "dialogs.invoices.createInvoiceDialog.batchMode.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.createInvoiceDialog.buttons.cancel",
+    "newPath": "dialogs.invoices.createInvoiceDialog.buttons.cancel",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.createInvoiceDialog.buttons.close",
+    "newPath": "dialogs.invoices.createInvoiceDialog.buttons.close",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.createInvoiceDialog.buttons.createMultiple",
+    "newPath": "dialogs.invoices.createInvoiceDialog.buttons.createMultiple",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.createInvoiceDialog.buttons.createSingle",
+    "newPath": "dialogs.invoices.createInvoiceDialog.buttons.createSingle",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.createInvoiceDialog.chooseMode",
+    "newPath": "dialogs.invoices.createInvoiceDialog.chooseMode",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.createInvoiceDialog.complete.description",
+    "newPath": "dialogs.invoices.createInvoiceDialog.complete.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.createInvoiceDialog.complete.descriptionPlural",
+    "newPath": "dialogs.invoices.createInvoiceDialog.complete.descriptionPlural",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.createInvoiceDialog.complete.errorsLabel",
+    "newPath": "dialogs.invoices.createInvoiceDialog.complete.errorsLabel",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.createInvoiceDialog.complete.failureDescription",
+    "newPath": "dialogs.invoices.createInvoiceDialog.complete.failureDescription",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.createInvoiceDialog.complete.failureTitle",
+    "newPath": "dialogs.invoices.createInvoiceDialog.complete.failureTitle",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.createInvoiceDialog.complete.nextSteps",
+    "newPath": "dialogs.invoices.createInvoiceDialog.complete.nextSteps",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.createInvoiceDialog.complete.nextStepsDescription",
+    "newPath": "dialogs.invoices.createInvoiceDialog.complete.nextStepsDescription",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.createInvoiceDialog.complete.nextStepsDescriptionPlural",
+    "newPath": "dialogs.invoices.createInvoiceDialog.complete.nextStepsDescriptionPlural",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.createInvoiceDialog.complete.partialDescription",
+    "newPath": "dialogs.invoices.createInvoiceDialog.complete.partialDescription",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.createInvoiceDialog.complete.partialTitle",
+    "newPath": "dialogs.invoices.createInvoiceDialog.complete.partialTitle",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.createInvoiceDialog.complete.retryButton",
+    "newPath": "dialogs.invoices.createInvoiceDialog.complete.retryButton",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.createInvoiceDialog.complete.title",
+    "newPath": "dialogs.invoices.createInvoiceDialog.complete.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.createInvoiceDialog.complete.titlePlural",
+    "newPath": "dialogs.invoices.createInvoiceDialog.complete.titlePlural",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.createInvoiceDialog.complete.viewButton",
+    "newPath": "dialogs.invoices.createInvoiceDialog.complete.viewButton",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.createInvoiceDialog.complete.viewButtonPlural",
+    "newPath": "dialogs.invoices.createInvoiceDialog.complete.viewButtonPlural",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.createInvoiceDialog.creating.processing",
+    "newPath": "dialogs.invoices.createInvoiceDialog.creating.processing",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.createInvoiceDialog.creating.processingPlural",
+    "newPath": "dialogs.invoices.createInvoiceDialog.creating.processingPlural",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.createInvoiceDialog.creating.step1Description",
+    "newPath": "dialogs.invoices.createInvoiceDialog.creating.step1Description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.createInvoiceDialog.creating.step1Title",
+    "newPath": "dialogs.invoices.createInvoiceDialog.creating.step1Title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.createInvoiceDialog.creating.step2Description",
+    "newPath": "dialogs.invoices.createInvoiceDialog.creating.step2Description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.createInvoiceDialog.creating.step2Title",
+    "newPath": "dialogs.invoices.createInvoiceDialog.creating.step2Title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.createInvoiceDialog.creating.step3Description",
+    "newPath": "dialogs.invoices.createInvoiceDialog.creating.step3Description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.createInvoiceDialog.creating.step3Title",
+    "newPath": "dialogs.invoices.createInvoiceDialog.creating.step3Title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.createInvoiceDialog.creating.title",
+    "newPath": "dialogs.invoices.createInvoiceDialog.creating.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.createInvoiceDialog.creating.titlePlural",
+    "newPath": "dialogs.invoices.createInvoiceDialog.creating.titlePlural",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.createInvoiceDialog.description",
+    "newPath": "dialogs.invoices.createInvoiceDialog.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.createInvoiceDialog.errors.createFailed",
+    "newPath": "dialogs.invoices.createInvoiceDialog.errors.createFailed",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.createInvoiceDialog.errors.partialFail",
+    "newPath": "dialogs.invoices.createInvoiceDialog.errors.partialFail",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.createInvoiceDialog.errors.unknown",
+    "newPath": "dialogs.invoices.createInvoiceDialog.errors.unknown",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.createInvoiceDialog.selectedScans",
+    "newPath": "dialogs.invoices.createInvoiceDialog.selectedScans",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.createInvoiceDialog.singleMode.description",
+    "newPath": "dialogs.invoices.createInvoiceDialog.singleMode.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.createInvoiceDialog.singleMode.title",
+    "newPath": "dialogs.invoices.createInvoiceDialog.singleMode.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.createInvoiceDialog.singleScanInfo.description",
+    "newPath": "dialogs.invoices.createInvoiceDialog.singleScanInfo.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.createInvoiceDialog.singleScanInfo.title",
+    "newPath": "dialogs.invoices.createInvoiceDialog.singleScanInfo.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.createInvoiceDialog.title",
+    "newPath": "dialogs.invoices.createInvoiceDialog.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.createInvoiceDialog.titlePlural",
+    "newPath": "dialogs.invoices.createInvoiceDialog.titlePlural",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.createInvoiceDialog.totalSize",
+    "newPath": "dialogs.invoices.createInvoiceDialog.totalSize",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.deleteInvoiceDialog.buttons.cancel",
+    "newPath": "dialogs.invoices.deleteInvoiceDialog.buttons.cancel",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.deleteInvoiceDialog.buttons.deletePermanently",
+    "newPath": "dialogs.invoices.deleteInvoiceDialog.buttons.deletePermanently",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.deleteInvoiceDialog.buttons.deleting",
+    "newPath": "dialogs.invoices.deleteInvoiceDialog.buttons.deleting",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.deleteInvoiceDialog.confirmation.typeToConfirm",
+    "newPath": "dialogs.invoices.deleteInvoiceDialog.confirmation.typeToConfirm",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.deleteInvoiceDialog.confirmation.understoodDescription",
+    "newPath": "dialogs.invoices.deleteInvoiceDialog.confirmation.understoodDescription",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.deleteInvoiceDialog.confirmation.understoodLabel",
+    "newPath": "dialogs.invoices.deleteInvoiceDialog.confirmation.understoodLabel",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.deleteInvoiceDialog.console.deleteError",
+    "newPath": "dialogs.invoices.deleteInvoiceDialog.console.deleteError",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.deleteInvoiceDialog.deleting.description",
+    "newPath": "dialogs.invoices.deleteInvoiceDialog.deleting.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.deleteInvoiceDialog.deleting.title",
+    "newPath": "dialogs.invoices.deleteInvoiceDialog.deleting.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.deleteInvoiceDialog.description",
+    "newPath": "dialogs.invoices.deleteInvoiceDialog.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.deleteInvoiceDialog.impact.intro",
+    "newPath": "dialogs.invoices.deleteInvoiceDialog.impact.intro",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.deleteInvoiceDialog.impact.invoiceRecord",
+    "newPath": "dialogs.invoices.deleteInvoiceDialog.impact.invoiceRecord",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.deleteInvoiceDialog.impact.lineItems",
+    "newPath": "dialogs.invoices.deleteInvoiceDialog.impact.lineItems",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.deleteInvoiceDialog.impact.sharedAccess",
+    "newPath": "dialogs.invoices.deleteInvoiceDialog.impact.sharedAccess",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.deleteInvoiceDialog.impact.title",
+    "newPath": "dialogs.invoices.deleteInvoiceDialog.impact.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.deleteInvoiceDialog.impact.uploadedScans",
+    "newPath": "dialogs.invoices.deleteInvoiceDialog.impact.uploadedScans",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.deleteInvoiceDialog.title",
+    "newPath": "dialogs.invoices.deleteInvoiceDialog.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.deleteInvoiceDialog.toasts.deletedDescription",
+    "newPath": "dialogs.invoices.deleteInvoiceDialog.toasts.deletedDescription",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.deleteInvoiceDialog.toasts.deletedTitle",
+    "newPath": "dialogs.invoices.deleteInvoiceDialog.toasts.deletedTitle",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.deleteInvoiceDialog.toasts.deleteFailedDescription",
+    "newPath": "dialogs.invoices.deleteInvoiceDialog.toasts.deleteFailedDescription",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.deleteInvoiceDialog.toasts.deleteFailedTitle",
+    "newPath": "dialogs.invoices.deleteInvoiceDialog.toasts.deleteFailedTitle",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.exportDialog.buttons.cancel",
+    "newPath": "dialogs.invoices.exportDialog.buttons.cancel",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.exportDialog.buttons.copied",
+    "newPath": "dialogs.invoices.exportDialog.buttons.copied",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.exportDialog.buttons.copy",
+    "newPath": "dialogs.invoices.exportDialog.buttons.copy",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.exportDialog.buttons.export",
+    "newPath": "dialogs.invoices.exportDialog.buttons.export",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.exportDialog.description",
+    "newPath": "dialogs.invoices.exportDialog.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.exportDialog.estimate.label",
+    "newPath": "dialogs.invoices.exportDialog.estimate.label",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.exportDialog.filename.hint",
+    "newPath": "dialogs.invoices.exportDialog.filename.hint",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.exportDialog.filename.label",
+    "newPath": "dialogs.invoices.exportDialog.filename.label",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.exportDialog.format.descriptions.csv",
+    "newPath": "dialogs.invoices.exportDialog.format.descriptions.csv",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.exportDialog.format.descriptions.json",
+    "newPath": "dialogs.invoices.exportDialog.format.descriptions.json",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.exportDialog.format.descriptions.pdf",
+    "newPath": "dialogs.invoices.exportDialog.format.descriptions.pdf",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.exportDialog.format.labels.csv",
+    "newPath": "dialogs.invoices.exportDialog.format.labels.csv",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.exportDialog.format.labels.json",
+    "newPath": "dialogs.invoices.exportDialog.format.labels.json",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.exportDialog.format.labels.pdf",
+    "newPath": "dialogs.invoices.exportDialog.format.labels.pdf",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.exportDialog.format.title",
+    "newPath": "dialogs.invoices.exportDialog.format.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.exportDialog.options.csv.delimiterLabel",
+    "newPath": "dialogs.invoices.exportDialog.options.csv.delimiterLabel",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.exportDialog.options.csv.delimiterPlaceholder",
+    "newPath": "dialogs.invoices.exportDialog.options.csv.delimiterPlaceholder",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.exportDialog.options.csv.includeHeaders",
+    "newPath": "dialogs.invoices.exportDialog.options.csv.includeHeaders",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.exportDialog.options.includeMerchant",
+    "newPath": "dialogs.invoices.exportDialog.options.includeMerchant",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.exportDialog.options.includeMetadata",
+    "newPath": "dialogs.invoices.exportDialog.options.includeMetadata",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.exportDialog.options.includeProducts",
+    "newPath": "dialogs.invoices.exportDialog.options.includeProducts",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.exportDialog.options.json.prettyPrint",
+    "newPath": "dialogs.invoices.exportDialog.options.json.prettyPrint",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.exportDialog.options.title",
+    "newPath": "dialogs.invoices.exportDialog.options.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.exportDialog.title",
+    "newPath": "dialogs.invoices.exportDialog.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.feedbackDialog.buttons.cancel",
+    "newPath": "dialogs.invoices.feedbackDialog.buttons.cancel",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.feedbackDialog.buttons.submit",
+    "newPath": "dialogs.invoices.feedbackDialog.buttons.submit",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.feedbackDialog.commentsPlaceholder",
+    "newPath": "dialogs.invoices.feedbackDialog.commentsPlaceholder",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.feedbackDialog.description",
+    "newPath": "dialogs.invoices.feedbackDialog.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.feedbackDialog.features.categoryBreakdown",
+    "newPath": "dialogs.invoices.feedbackDialog.features.categoryBreakdown",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.feedbackDialog.features.merchantAnalysis",
+    "newPath": "dialogs.invoices.feedbackDialog.features.merchantAnalysis",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.feedbackDialog.features.priceComparisons",
+    "newPath": "dialogs.invoices.feedbackDialog.features.priceComparisons",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.feedbackDialog.features.savingsTips",
+    "newPath": "dialogs.invoices.feedbackDialog.features.savingsTips",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.feedbackDialog.features.spendingTrends",
+    "newPath": "dialogs.invoices.feedbackDialog.features.spendingTrends",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.feedbackDialog.features.visualCharts",
+    "newPath": "dialogs.invoices.feedbackDialog.features.visualCharts",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.feedbackDialog.sections.comments",
+    "newPath": "dialogs.invoices.feedbackDialog.sections.comments",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.feedbackDialog.sections.features",
+    "newPath": "dialogs.invoices.feedbackDialog.sections.features",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.feedbackDialog.sections.rating",
+    "newPath": "dialogs.invoices.feedbackDialog.sections.rating",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.feedbackDialog.title",
+    "newPath": "dialogs.invoices.feedbackDialog.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.feedbackDialog.toasts.error.description",
+    "newPath": "dialogs.invoices.feedbackDialog.toasts.error.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.feedbackDialog.toasts.error.title",
+    "newPath": "dialogs.invoices.feedbackDialog.toasts.error.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.feedbackDialog.toasts.ratingRequired.description",
+    "newPath": "dialogs.invoices.feedbackDialog.toasts.ratingRequired.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.feedbackDialog.toasts.ratingRequired.title",
+    "newPath": "dialogs.invoices.feedbackDialog.toasts.ratingRequired.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.feedbackDialog.toasts.sending.description",
+    "newPath": "dialogs.invoices.feedbackDialog.toasts.sending.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.feedbackDialog.toasts.sending.title",
+    "newPath": "dialogs.invoices.feedbackDialog.toasts.sending.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.feedbackDialog.toasts.success.description",
+    "newPath": "dialogs.invoices.feedbackDialog.toasts.success.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.feedbackDialog.toasts.success.title",
+    "newPath": "dialogs.invoices.feedbackDialog.toasts.success.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.imageDialog.imageAlt",
+    "newPath": "dialogs.invoices.imageDialog.imageAlt",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.imageDialog.title",
+    "newPath": "dialogs.invoices.imageDialog.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.importDialog.buttons.cancel",
+    "newPath": "dialogs.invoices.importDialog.buttons.cancel",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.importDialog.buttons.import",
+    "newPath": "dialogs.invoices.importDialog.buttons.import",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.importDialog.buttons.importWithCount",
+    "newPath": "dialogs.invoices.importDialog.buttons.importWithCount",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.importDialog.description",
+    "newPath": "dialogs.invoices.importDialog.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.importDialog.dropzone.acceptsCsv",
+    "newPath": "dialogs.invoices.importDialog.dropzone.acceptsCsv",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.importDialog.dropzone.acceptsPdf",
+    "newPath": "dialogs.invoices.importDialog.dropzone.acceptsPdf",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.importDialog.dropzone.acceptsXlsx",
+    "newPath": "dialogs.invoices.importDialog.dropzone.acceptsXlsx",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.importDialog.dropzone.dragAndDrop",
+    "newPath": "dialogs.invoices.importDialog.dropzone.dragAndDrop",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.importDialog.dropzone.dropHere",
+    "newPath": "dialogs.invoices.importDialog.dropzone.dropHere",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.importDialog.dropzone.orClickBrowse",
+    "newPath": "dialogs.invoices.importDialog.dropzone.orClickBrowse",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.importDialog.remove",
+    "newPath": "dialogs.invoices.importDialog.remove",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.importDialog.selectedFiles",
+    "newPath": "dialogs.invoices.importDialog.selectedFiles",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.importDialog.status.error",
+    "newPath": "dialogs.invoices.importDialog.status.error",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.importDialog.status.success",
+    "newPath": "dialogs.invoices.importDialog.status.success",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.importDialog.tabs.csv",
+    "newPath": "dialogs.invoices.importDialog.tabs.csv",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.importDialog.tabs.pdf",
+    "newPath": "dialogs.invoices.importDialog.tabs.pdf",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.importDialog.tabs.xlsx",
+    "newPath": "dialogs.invoices.importDialog.tabs.xlsx",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.importDialog.title",
+    "newPath": "dialogs.invoices.importDialog.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.itemsDialog.aria.addItem",
+    "newPath": "dialogs.invoices.itemsDialog.aria.addItem",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.itemsDialog.aria.cancel",
+    "newPath": "dialogs.invoices.itemsDialog.aria.cancel",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.itemsDialog.aria.deleteItem",
+    "newPath": "dialogs.invoices.itemsDialog.aria.deleteItem",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.itemsDialog.aria.nextPage",
+    "newPath": "dialogs.invoices.itemsDialog.aria.nextPage",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.itemsDialog.aria.previousPage",
+    "newPath": "dialogs.invoices.itemsDialog.aria.previousPage",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.itemsDialog.aria.save",
+    "newPath": "dialogs.invoices.itemsDialog.aria.save",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.itemsDialog.aria.unnamedItem",
+    "newPath": "dialogs.invoices.itemsDialog.aria.unnamedItem",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.itemsDialog.buttons.addItem",
+    "newPath": "dialogs.invoices.itemsDialog.buttons.addItem",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.itemsDialog.buttons.cancel",
+    "newPath": "dialogs.invoices.itemsDialog.buttons.cancel",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.itemsDialog.buttons.next",
+    "newPath": "dialogs.invoices.itemsDialog.buttons.next",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.itemsDialog.buttons.previous",
+    "newPath": "dialogs.invoices.itemsDialog.buttons.previous",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.itemsDialog.buttons.saveChanges",
+    "newPath": "dialogs.invoices.itemsDialog.buttons.saveChanges",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.itemsDialog.description",
+    "newPath": "dialogs.invoices.itemsDialog.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.itemsDialog.footer.itemsFound",
+    "newPath": "dialogs.invoices.itemsDialog.footer.itemsFound",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.itemsDialog.footer.itemsTotal",
+    "newPath": "dialogs.invoices.itemsDialog.footer.itemsTotal",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.itemsDialog.footer.page",
+    "newPath": "dialogs.invoices.itemsDialog.footer.page",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.itemsDialog.table.actions",
+    "newPath": "dialogs.invoices.itemsDialog.table.actions",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.itemsDialog.table.item",
+    "newPath": "dialogs.invoices.itemsDialog.table.item",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.itemsDialog.table.price",
+    "newPath": "dialogs.invoices.itemsDialog.table.price",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.itemsDialog.table.quantity",
+    "newPath": "dialogs.invoices.itemsDialog.table.quantity",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.itemsDialog.table.total",
+    "newPath": "dialogs.invoices.itemsDialog.table.total",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.itemsDialog.table.unit",
+    "newPath": "dialogs.invoices.itemsDialog.table.unit",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.itemsDialog.title",
+    "newPath": "dialogs.invoices.itemsDialog.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.merchantDialog.buttons.openInMaps",
+    "newPath": "dialogs.invoices.merchantDialog.buttons.openInMaps",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.merchantDialog.description",
+    "newPath": "dialogs.invoices.merchantDialog.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.merchantDialog.fields.address",
+    "newPath": "dialogs.invoices.merchantDialog.fields.address",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.merchantDialog.fields.parentCompany",
+    "newPath": "dialogs.invoices.merchantDialog.fields.parentCompany",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.merchantDialog.fields.phone",
+    "newPath": "dialogs.invoices.merchantDialog.fields.phone",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.merchantDialog.noMerchantLinked",
+    "newPath": "dialogs.invoices.merchantDialog.noMerchantLinked",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.merchantDialog.title",
+    "newPath": "dialogs.invoices.merchantDialog.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.merchantReceiptsDialog.buttons.next",
+    "newPath": "dialogs.invoices.merchantReceiptsDialog.buttons.next",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.merchantReceiptsDialog.buttons.previous",
+    "newPath": "dialogs.invoices.merchantReceiptsDialog.buttons.previous",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.merchantReceiptsDialog.dateOptions.allTime",
+    "newPath": "dialogs.invoices.merchantReceiptsDialog.dateOptions.allTime",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.merchantReceiptsDialog.dateOptions.last30Days",
+    "newPath": "dialogs.invoices.merchantReceiptsDialog.dateOptions.last30Days",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.merchantReceiptsDialog.dateOptions.last90Days",
+    "newPath": "dialogs.invoices.merchantReceiptsDialog.dateOptions.last90Days",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.merchantReceiptsDialog.dateOptions.thisYear",
+    "newPath": "dialogs.invoices.merchantReceiptsDialog.dateOptions.thisYear",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.merchantReceiptsDialog.description",
+    "newPath": "dialogs.invoices.merchantReceiptsDialog.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.merchantReceiptsDialog.filters.date",
+    "newPath": "dialogs.invoices.merchantReceiptsDialog.filters.date",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.merchantReceiptsDialog.filters.sort",
+    "newPath": "dialogs.invoices.merchantReceiptsDialog.filters.sort",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.merchantReceiptsDialog.footer.page",
+    "newPath": "dialogs.invoices.merchantReceiptsDialog.footer.page",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.merchantReceiptsDialog.footer.receiptsFound",
+    "newPath": "dialogs.invoices.merchantReceiptsDialog.footer.receiptsFound",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.merchantReceiptsDialog.searchPlaceholder",
+    "newPath": "dialogs.invoices.merchantReceiptsDialog.searchPlaceholder",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.merchantReceiptsDialog.sortOptions.newest",
+    "newPath": "dialogs.invoices.merchantReceiptsDialog.sortOptions.newest",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.merchantReceiptsDialog.sortOptions.oldest",
+    "newPath": "dialogs.invoices.merchantReceiptsDialog.sortOptions.oldest",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.merchantReceiptsDialog.table.actions",
+    "newPath": "dialogs.invoices.merchantReceiptsDialog.table.actions",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.merchantReceiptsDialog.table.date",
+    "newPath": "dialogs.invoices.merchantReceiptsDialog.table.date",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.merchantReceiptsDialog.table.itemsCount",
+    "newPath": "dialogs.invoices.merchantReceiptsDialog.table.itemsCount",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.merchantReceiptsDialog.table.receipt",
+    "newPath": "dialogs.invoices.merchantReceiptsDialog.table.receipt",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.merchantReceiptsDialog.table.view",
+    "newPath": "dialogs.invoices.merchantReceiptsDialog.table.view",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.merchantReceiptsDialog.title",
+    "newPath": "dialogs.invoices.merchantReceiptsDialog.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.metadataDialog.add.description",
+    "newPath": "dialogs.invoices.metadataDialog.add.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.metadataDialog.add.title",
+    "newPath": "dialogs.invoices.metadataDialog.add.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.metadataDialog.buttons.cancel",
+    "newPath": "dialogs.invoices.metadataDialog.buttons.cancel",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.metadataDialog.buttons.delete",
+    "newPath": "dialogs.invoices.metadataDialog.buttons.delete",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.metadataDialog.buttons.save",
+    "newPath": "dialogs.invoices.metadataDialog.buttons.save",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.metadataDialog.delete.description",
+    "newPath": "dialogs.invoices.metadataDialog.delete.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.metadataDialog.delete.title",
+    "newPath": "dialogs.invoices.metadataDialog.delete.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.metadataDialog.edit.description",
+    "newPath": "dialogs.invoices.metadataDialog.edit.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.metadataDialog.edit.fieldLabel",
+    "newPath": "dialogs.invoices.metadataDialog.edit.fieldLabel",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.metadataDialog.edit.title",
+    "newPath": "dialogs.invoices.metadataDialog.edit.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.metadataDialog.fields.keyLabel",
+    "newPath": "dialogs.invoices.metadataDialog.fields.keyLabel",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.metadataDialog.fields.keyPlaceholder",
+    "newPath": "dialogs.invoices.metadataDialog.fields.keyPlaceholder",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.metadataDialog.fields.valueLabel",
+    "newPath": "dialogs.invoices.metadataDialog.fields.valueLabel",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.metadataDialog.fields.valuePlaceholder",
+    "newPath": "dialogs.invoices.metadataDialog.fields.valuePlaceholder",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.actions.enhanceInstructions",
+    "newPath": "dialogs.invoices.recipeDialog.actions.enhanceInstructions",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.actions.generateName",
+    "newPath": "dialogs.invoices.recipeDialog.actions.generateName",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.actions.unavailable",
+    "newPath": "dialogs.invoices.recipeDialog.actions.unavailable",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.buttons.add",
+    "newPath": "dialogs.invoices.recipeDialog.buttons.add",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.buttons.cancel",
+    "newPath": "dialogs.invoices.recipeDialog.buttons.cancel",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.buttons.close",
+    "newPath": "dialogs.invoices.recipeDialog.buttons.close",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.buttons.delete",
+    "newPath": "dialogs.invoices.recipeDialog.buttons.delete",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.buttons.deleting",
+    "newPath": "dialogs.invoices.recipeDialog.buttons.deleting",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.buttons.save",
+    "newPath": "dialogs.invoices.recipeDialog.buttons.save",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.buttons.saving",
+    "newPath": "dialogs.invoices.recipeDialog.buttons.saving",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.create.description",
+    "newPath": "dialogs.invoices.recipeDialog.create.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.create.error",
+    "newPath": "dialogs.invoices.recipeDialog.create.error",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.create.success",
+    "newPath": "dialogs.invoices.recipeDialog.create.success",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.create.title",
+    "newPath": "dialogs.invoices.recipeDialog.create.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.delete.description",
+    "newPath": "dialogs.invoices.recipeDialog.delete.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.delete.error",
+    "newPath": "dialogs.invoices.recipeDialog.delete.error",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.delete.missingRecipe",
+    "newPath": "dialogs.invoices.recipeDialog.delete.missingRecipe",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.delete.success",
+    "newPath": "dialogs.invoices.recipeDialog.delete.success",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.delete.title",
+    "newPath": "dialogs.invoices.recipeDialog.delete.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.difficulty.easy",
+    "newPath": "dialogs.invoices.recipeDialog.difficulty.easy",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.difficulty.hard",
+    "newPath": "dialogs.invoices.recipeDialog.difficulty.hard",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.difficulty.medium",
+    "newPath": "dialogs.invoices.recipeDialog.difficulty.medium",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.fields.complexity",
+    "newPath": "dialogs.invoices.recipeDialog.fields.complexity",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.fields.cookTime",
+    "newPath": "dialogs.invoices.recipeDialog.fields.cookTime",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.fields.description",
+    "newPath": "dialogs.invoices.recipeDialog.fields.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.fields.difficulty",
+    "newPath": "dialogs.invoices.recipeDialog.fields.difficulty",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.fields.ingredients",
+    "newPath": "dialogs.invoices.recipeDialog.fields.ingredients",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.fields.instructions",
+    "newPath": "dialogs.invoices.recipeDialog.fields.instructions",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.fields.prepTime",
+    "newPath": "dialogs.invoices.recipeDialog.fields.prepTime",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.fields.recipeName",
+    "newPath": "dialogs.invoices.recipeDialog.fields.recipeName",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.fields.totalDuration",
+    "newPath": "dialogs.invoices.recipeDialog.fields.totalDuration",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.minutes",
+    "newPath": "dialogs.invoices.recipeDialog.minutes",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.placeholders.cookTime",
+    "newPath": "dialogs.invoices.recipeDialog.placeholders.cookTime",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.placeholders.description",
+    "newPath": "dialogs.invoices.recipeDialog.placeholders.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.placeholders.instructions",
+    "newPath": "dialogs.invoices.recipeDialog.placeholders.instructions",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.placeholders.prepTime",
+    "newPath": "dialogs.invoices.recipeDialog.placeholders.prepTime",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.placeholders.recipeName",
+    "newPath": "dialogs.invoices.recipeDialog.placeholders.recipeName",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.placeholders.selectDifficulty",
+    "newPath": "dialogs.invoices.recipeDialog.placeholders.selectDifficulty",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.read.description",
+    "newPath": "dialogs.invoices.recipeDialog.read.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.read.missingRecipe",
+    "newPath": "dialogs.invoices.recipeDialog.read.missingRecipe",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.read.noDescription",
+    "newPath": "dialogs.invoices.recipeDialog.read.noDescription",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.read.notSpecified",
+    "newPath": "dialogs.invoices.recipeDialog.read.notSpecified",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.share.copied",
+    "newPath": "dialogs.invoices.recipeDialog.share.copied",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.share.copy",
+    "newPath": "dialogs.invoices.recipeDialog.share.copy",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.share.copyFailed",
+    "newPath": "dialogs.invoices.recipeDialog.share.copyFailed",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.share.description",
+    "newPath": "dialogs.invoices.recipeDialog.share.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.share.missingRecipe",
+    "newPath": "dialogs.invoices.recipeDialog.share.missingRecipe",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.share.title",
+    "newPath": "dialogs.invoices.recipeDialog.share.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.share.unavailable",
+    "newPath": "dialogs.invoices.recipeDialog.share.unavailable",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.tooltips.enhanceInstructions",
+    "newPath": "dialogs.invoices.recipeDialog.tooltips.enhanceInstructions",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.tooltips.generateName",
+    "newPath": "dialogs.invoices.recipeDialog.tooltips.generateName",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.update.description",
+    "newPath": "dialogs.invoices.recipeDialog.update.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.update.error",
+    "newPath": "dialogs.invoices.recipeDialog.update.error",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.update.missingRecipe",
+    "newPath": "dialogs.invoices.recipeDialog.update.missingRecipe",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.update.success",
+    "newPath": "dialogs.invoices.recipeDialog.update.success",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.recipeDialog.update.title",
+    "newPath": "dialogs.invoices.recipeDialog.update.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.removeScanDialog.buttons.cancel",
+    "newPath": "dialogs.invoices.removeScanDialog.buttons.cancel",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.removeScanDialog.buttons.remove",
+    "newPath": "dialogs.invoices.removeScanDialog.buttons.remove",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.removeScanDialog.buttons.removing",
+    "newPath": "dialogs.invoices.removeScanDialog.buttons.removing",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.removeScanDialog.console.deleteError",
+    "newPath": "dialogs.invoices.removeScanDialog.console.deleteError",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.removeScanDialog.description",
+    "newPath": "dialogs.invoices.removeScanDialog.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.removeScanDialog.descriptionLastScan",
+    "newPath": "dialogs.invoices.removeScanDialog.descriptionLastScan",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.removeScanDialog.errors.unknown",
+    "newPath": "dialogs.invoices.removeScanDialog.errors.unknown",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.removeScanDialog.scanAlt",
+    "newPath": "dialogs.invoices.removeScanDialog.scanAlt",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.removeScanDialog.scanCaption",
+    "newPath": "dialogs.invoices.removeScanDialog.scanCaption",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.removeScanDialog.title",
+    "newPath": "dialogs.invoices.removeScanDialog.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.removeScanDialog.toasts.cannotDeleteLastDescription",
+    "newPath": "dialogs.invoices.removeScanDialog.toasts.cannotDeleteLastDescription",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.removeScanDialog.toasts.cannotDeleteLastTitle",
+    "newPath": "dialogs.invoices.removeScanDialog.toasts.cannotDeleteLastTitle",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.removeScanDialog.toasts.removedDescription",
+    "newPath": "dialogs.invoices.removeScanDialog.toasts.removedDescription",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.removeScanDialog.toasts.removedTitle",
+    "newPath": "dialogs.invoices.removeScanDialog.toasts.removedTitle",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.removeScanDialog.toasts.removeFailedTitle",
+    "newPath": "dialogs.invoices.removeScanDialog.toasts.removeFailedTitle",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.removeScanDialog.warning.description",
+    "newPath": "dialogs.invoices.removeScanDialog.warning.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.removeScanDialog.warning.title",
+    "newPath": "dialogs.invoices.removeScanDialog.warning.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareAnalyticsDialog.description",
+    "newPath": "dialogs.invoices.shareAnalyticsDialog.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareAnalyticsDialog.email.description",
+    "newPath": "dialogs.invoices.shareAnalyticsDialog.email.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareAnalyticsDialog.email.label",
+    "newPath": "dialogs.invoices.shareAnalyticsDialog.email.label",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareAnalyticsDialog.email.placeholder",
+    "newPath": "dialogs.invoices.shareAnalyticsDialog.email.placeholder",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareAnalyticsDialog.email.send",
+    "newPath": "dialogs.invoices.shareAnalyticsDialog.email.send",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareAnalyticsDialog.image.copyToClipboard",
+    "newPath": "dialogs.invoices.shareAnalyticsDialog.image.copyToClipboard",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareAnalyticsDialog.image.description",
+    "newPath": "dialogs.invoices.shareAnalyticsDialog.image.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareAnalyticsDialog.image.download",
+    "newPath": "dialogs.invoices.shareAnalyticsDialog.image.download",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareAnalyticsDialog.image.previewPlaceholder",
+    "newPath": "dialogs.invoices.shareAnalyticsDialog.image.previewPlaceholder",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareAnalyticsDialog.tabs.email",
+    "newPath": "dialogs.invoices.shareAnalyticsDialog.tabs.email",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareAnalyticsDialog.tabs.image",
+    "newPath": "dialogs.invoices.shareAnalyticsDialog.tabs.image",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareAnalyticsDialog.title",
+    "newPath": "dialogs.invoices.shareAnalyticsDialog.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareAnalyticsDialog.toasts.emailSent.description",
+    "newPath": "dialogs.invoices.shareAnalyticsDialog.toasts.emailSent.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareAnalyticsDialog.toasts.emailSent.title",
+    "newPath": "dialogs.invoices.shareAnalyticsDialog.toasts.emailSent.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareAnalyticsDialog.toasts.imageCopied.description",
+    "newPath": "dialogs.invoices.shareAnalyticsDialog.toasts.imageCopied.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareAnalyticsDialog.toasts.imageCopied.title",
+    "newPath": "dialogs.invoices.shareAnalyticsDialog.toasts.imageCopied.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareAnalyticsDialog.toasts.imageSaved.description",
+    "newPath": "dialogs.invoices.shareAnalyticsDialog.toasts.imageSaved.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareAnalyticsDialog.toasts.imageSaved.title",
+    "newPath": "dialogs.invoices.shareAnalyticsDialog.toasts.imageSaved.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialog.dialogDescription.currentlyPublic",
+    "newPath": "dialogs.invoices.shareInvoiceDialog.dialogDescription.currentlyPublic",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialog.dialogDescription.private",
+    "newPath": "dialogs.invoices.shareInvoiceDialog.dialogDescription.private",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialog.dialogDescription.public",
+    "newPath": "dialogs.invoices.shareInvoiceDialog.dialogDescription.public",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialog.dialogDescription.selection",
+    "newPath": "dialogs.invoices.shareInvoiceDialog.dialogDescription.selection",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialog.errors.qrNotFound",
+    "newPath": "dialogs.invoices.shareInvoiceDialog.errors.qrNotFound",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialog.selection.description",
+    "newPath": "dialogs.invoices.shareInvoiceDialog.selection.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialog.selection.privacyNoticeDescription",
+    "newPath": "dialogs.invoices.shareInvoiceDialog.selection.privacyNoticeDescription",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialog.selection.privacyNoticeTitle",
+    "newPath": "dialogs.invoices.shareInvoiceDialog.selection.privacyNoticeTitle",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialog.selection.privateDescription",
+    "newPath": "dialogs.invoices.shareInvoiceDialog.selection.privateDescription",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialog.selection.privateTitle",
+    "newPath": "dialogs.invoices.shareInvoiceDialog.selection.privateTitle",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialog.selection.publicDescription",
+    "newPath": "dialogs.invoices.shareInvoiceDialog.selection.publicDescription",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialog.selection.publicTitle",
+    "newPath": "dialogs.invoices.shareInvoiceDialog.selection.publicTitle",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialog.title",
+    "newPath": "dialogs.invoices.shareInvoiceDialog.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialog.toasts.copyLink.error",
+    "newPath": "dialogs.invoices.shareInvoiceDialog.toasts.copyLink.error",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialog.toasts.copyLink.loadingMakePublic",
+    "newPath": "dialogs.invoices.shareInvoiceDialog.toasts.copyLink.loadingMakePublic",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialog.toasts.copyLink.loadingPublic",
+    "newPath": "dialogs.invoices.shareInvoiceDialog.toasts.copyLink.loadingPublic",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialog.toasts.copyLink.successMadePublic",
+    "newPath": "dialogs.invoices.shareInvoiceDialog.toasts.copyLink.successMadePublic",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialog.toasts.copyLink.successPublic",
+    "newPath": "dialogs.invoices.shareInvoiceDialog.toasts.copyLink.successPublic",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialog.toasts.copyQr.error",
+    "newPath": "dialogs.invoices.shareInvoiceDialog.toasts.copyQr.error",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialog.toasts.copyQr.loadingMakePublic",
+    "newPath": "dialogs.invoices.shareInvoiceDialog.toasts.copyQr.loadingMakePublic",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialog.toasts.copyQr.loadingPublic",
+    "newPath": "dialogs.invoices.shareInvoiceDialog.toasts.copyQr.loadingPublic",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialog.toasts.copyQr.successMadePublic",
+    "newPath": "dialogs.invoices.shareInvoiceDialog.toasts.copyQr.successMadePublic",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialog.toasts.copyQr.successPublic",
+    "newPath": "dialogs.invoices.shareInvoiceDialog.toasts.copyQr.successPublic",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialog.toasts.revoke.error",
+    "newPath": "dialogs.invoices.shareInvoiceDialog.toasts.revoke.error",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialog.toasts.revoke.loading",
+    "newPath": "dialogs.invoices.shareInvoiceDialog.toasts.revoke.loading",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialog.toasts.revoke.success",
+    "newPath": "dialogs.invoices.shareInvoiceDialog.toasts.revoke.success",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialog.toasts.sendEmail.comingSoon",
+    "newPath": "dialogs.invoices.shareInvoiceDialog.toasts.sendEmail.comingSoon",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialog.toasts.sendEmail.error",
+    "newPath": "dialogs.invoices.shareInvoiceDialog.toasts.sendEmail.error",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialog.toasts.sendEmail.loading",
+    "newPath": "dialogs.invoices.shareInvoiceDialog.toasts.sendEmail.loading",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialog.toasts.sendEmail.success",
+    "newPath": "dialogs.invoices.shareInvoiceDialog.toasts.sendEmail.success",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialogPrivate.backToOptions",
+    "newPath": "dialogs.invoices.shareInvoiceDialogPrivate.backToOptions",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialogPrivate.comingSoonTooltip",
+    "newPath": "dialogs.invoices.shareInvoiceDialogPrivate.comingSoonTooltip",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialogPrivate.description",
+    "newPath": "dialogs.invoices.shareInvoiceDialogPrivate.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialogPrivate.emailHint",
+    "newPath": "dialogs.invoices.shareInvoiceDialogPrivate.emailHint",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialogPrivate.emailLabel",
+    "newPath": "dialogs.invoices.shareInvoiceDialogPrivate.emailLabel",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialogPrivate.emailPlaceholder",
+    "newPath": "dialogs.invoices.shareInvoiceDialogPrivate.emailPlaceholder",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialogPrivate.sending",
+    "newPath": "dialogs.invoices.shareInvoiceDialogPrivate.sending",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialogPrivate.sendInvitation",
+    "newPath": "dialogs.invoices.shareInvoiceDialogPrivate.sendInvitation",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialogPrivate.title",
+    "newPath": "dialogs.invoices.shareInvoiceDialogPrivate.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialogPublic.alreadyPublic.description",
+    "newPath": "dialogs.invoices.shareInvoiceDialogPublic.alreadyPublic.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialogPublic.alreadyPublic.revoke",
+    "newPath": "dialogs.invoices.shareInvoiceDialogPublic.alreadyPublic.revoke",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialogPublic.alreadyPublic.revokeHint",
+    "newPath": "dialogs.invoices.shareInvoiceDialogPublic.alreadyPublic.revokeHint",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialogPublic.alreadyPublic.revoking",
+    "newPath": "dialogs.invoices.shareInvoiceDialogPublic.alreadyPublic.revoking",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialogPublic.alreadyPublic.title",
+    "newPath": "dialogs.invoices.shareInvoiceDialogPublic.alreadyPublic.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialogPublic.backToOptions",
+    "newPath": "dialogs.invoices.shareInvoiceDialogPublic.backToOptions",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialogPublic.copyQrImage",
+    "newPath": "dialogs.invoices.shareInvoiceDialogPublic.copyQrImage",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialogPublic.hints.link",
+    "newPath": "dialogs.invoices.shareInvoiceDialogPublic.hints.link",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialogPublic.hints.qr",
+    "newPath": "dialogs.invoices.shareInvoiceDialogPublic.hints.qr",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialogPublic.tabs.directLink",
+    "newPath": "dialogs.invoices.shareInvoiceDialogPublic.tabs.directLink",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialogPublic.tabs.qrCode",
+    "newPath": "dialogs.invoices.shareInvoiceDialogPublic.tabs.qrCode",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialogPublic.warning.description",
+    "newPath": "dialogs.invoices.shareInvoiceDialogPublic.warning.description",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Dialogs.shareInvoiceDialogPublic.warning.title",
+    "newPath": "dialogs.invoices.shareInvoiceDialogPublic.warning.title",
+    "reason": "invoice dialogs"
+  },
+  {
+    "oldPath": "IMS--Edit.changeHistory.changes.categoryUpdated",
+    "newPath": "pages.invoices.editInvoice.changeHistory.changes.categoryUpdated",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.changeHistory.changes.descriptionChanged",
+    "newPath": "pages.invoices.editInvoice.changeHistory.changes.descriptionChanged",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.changeHistory.changes.importanceChanged",
+    "newPath": "pages.invoices.editInvoice.changeHistory.changes.importanceChanged",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.changeHistory.changes.markedImportant",
+    "newPath": "pages.invoices.editInvoice.changeHistory.changes.markedImportant",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.changeHistory.changes.nameChanged",
+    "newPath": "pages.invoices.editInvoice.changeHistory.changes.nameChanged",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.changeHistory.changes.paymentTypeChanged",
+    "newPath": "pages.invoices.editInvoice.changeHistory.changes.paymentTypeChanged",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.changeHistory.changes.transactionDateChanged",
+    "newPath": "pages.invoices.editInvoice.changeHistory.changes.transactionDateChanged",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.changeHistory.changes.unmarkedImportant",
+    "newPath": "pages.invoices.editInvoice.changeHistory.changes.unmarkedImportant",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.changeHistory.created",
+    "newPath": "pages.invoices.editInvoice.changeHistory.created",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.changeHistory.modified",
+    "newPath": "pages.invoices.editInvoice.changeHistory.modified",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.changeHistory.pending",
+    "newPath": "pages.invoices.editInvoice.changeHistory.pending",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.changeHistory.time.daysAgo",
+    "newPath": "pages.invoices.editInvoice.changeHistory.time.daysAgo",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.changeHistory.time.hoursAgo",
+    "newPath": "pages.invoices.editInvoice.changeHistory.time.hoursAgo",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.changeHistory.time.justNow",
+    "newPath": "pages.invoices.editInvoice.changeHistory.time.justNow",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.changeHistory.time.minutesAgo",
+    "newPath": "pages.invoices.editInvoice.changeHistory.time.minutesAgo",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.changeHistory.time.secondsAgo",
+    "newPath": "pages.invoices.editInvoice.changeHistory.time.secondsAgo",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.changeHistory.title",
+    "newPath": "pages.invoices.editInvoice.changeHistory.title",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.changeHistory.unsavedChanges",
+    "newPath": "pages.invoices.editInvoice.changeHistory.unsavedChanges",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.editInvoiceContext.console.saveFailed",
+    "newPath": "pages.invoices.editInvoice.editInvoiceContext.console.saveFailed",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.editInvoiceContext.toasts.noChanges",
+    "newPath": "pages.invoices.editInvoice.editInvoiceContext.toasts.noChanges",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.editInvoiceContext.toasts.saveFailed",
+    "newPath": "pages.invoices.editInvoice.editInvoiceContext.toasts.saveFailed",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.editInvoiceContext.toasts.updated",
+    "newPath": "pages.invoices.editInvoice.editInvoiceContext.toasts.updated",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.guidedEditBanner.actions.dismiss",
+    "newPath": "pages.invoices.editInvoice.guidedEditBanner.actions.dismiss",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.guidedEditBanner.actions.reviewAll",
+    "newPath": "pages.invoices.editInvoice.guidedEditBanner.actions.reviewAll",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.guidedEditBanner.badges.lowConfidence",
+    "newPath": "pages.invoices.editInvoice.guidedEditBanner.badges.lowConfidence",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.guidedEditBanner.badges.missingName",
+    "newPath": "pages.invoices.editInvoice.guidedEditBanner.badges.missingName",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.guidedEditBanner.badges.uncategorized",
+    "newPath": "pages.invoices.editInvoice.guidedEditBanner.badges.uncategorized",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.guidedEditBanner.summary.lowConfidence",
+    "newPath": "pages.invoices.editInvoice.guidedEditBanner.summary.lowConfidence",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.guidedEditBanner.summary.missingName",
+    "newPath": "pages.invoices.editInvoice.guidedEditBanner.summary.missingName",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.guidedEditBanner.summary.uncategorized",
+    "newPath": "pages.invoices.editInvoice.guidedEditBanner.summary.uncategorized",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.guidedEditBanner.title",
+    "newPath": "pages.invoices.editInvoice.guidedEditBanner.title",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.actions.editAllergens",
+    "newPath": "pages.invoices.editInvoice.itemsTable.actions.editAllergens",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.actions.remove",
+    "newPath": "pages.invoices.editInvoice.itemsTable.actions.remove",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.actions.restore",
+    "newPath": "pages.invoices.editInvoice.itemsTable.actions.restore",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.bulkCategory.noSelection",
+    "newPath": "pages.invoices.editInvoice.itemsTable.bulkCategory.noSelection",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.bulkToolbar.changeCategory",
+    "newPath": "pages.invoices.editInvoice.itemsTable.bulkToolbar.changeCategory",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.bulkToolbar.deleteSelected",
+    "newPath": "pages.invoices.editInvoice.itemsTable.bulkToolbar.deleteSelected",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.bulkToolbar.noSelection",
+    "newPath": "pages.invoices.editInvoice.itemsTable.bulkToolbar.noSelection",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.bulkToolbar.selectedCount",
+    "newPath": "pages.invoices.editInvoice.itemsTable.bulkToolbar.selectedCount",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.buttons.addItem",
+    "newPath": "pages.invoices.editInvoice.itemsTable.buttons.addItem",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.buttons.editItems",
+    "newPath": "pages.invoices.editInvoice.itemsTable.buttons.editItems",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.columns.actions",
+    "newPath": "pages.invoices.editInvoice.itemsTable.columns.actions",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.columns.name",
+    "newPath": "pages.invoices.editInvoice.itemsTable.columns.name",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.columns.price",
+    "newPath": "pages.invoices.editInvoice.itemsTable.columns.price",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.columns.quantity",
+    "newPath": "pages.invoices.editInvoice.itemsTable.columns.quantity",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.columns.selectAll",
+    "newPath": "pages.invoices.editInvoice.itemsTable.columns.selectAll",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.columns.selectRow",
+    "newPath": "pages.invoices.editInvoice.itemsTable.columns.selectRow",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.columns.total",
+    "newPath": "pages.invoices.editInvoice.itemsTable.columns.total",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.columns.unit",
+    "newPath": "pages.invoices.editInvoice.itemsTable.columns.unit",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.deleteConfirm.cancel",
+    "newPath": "pages.invoices.editInvoice.itemsTable.deleteConfirm.cancel",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.deleteConfirm.confirm",
+    "newPath": "pages.invoices.editInvoice.itemsTable.deleteConfirm.confirm",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.deleteConfirm.description",
+    "newPath": "pages.invoices.editInvoice.itemsTable.deleteConfirm.description",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.deleteConfirm.success",
+    "newPath": "pages.invoices.editInvoice.itemsTable.deleteConfirm.success",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.deleteConfirm.title",
+    "newPath": "pages.invoices.editInvoice.itemsTable.deleteConfirm.title",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.editing.cancel",
+    "newPath": "pages.invoices.editInvoice.itemsTable.editing.cancel",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.editing.fieldLabel",
+    "newPath": "pages.invoices.editInvoice.itemsTable.editing.fieldLabel",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.editing.saved",
+    "newPath": "pages.invoices.editInvoice.itemsTable.editing.saved",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.footer.total",
+    "newPath": "pages.invoices.editInvoice.itemsTable.footer.total",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.indicators.allergens",
+    "newPath": "pages.invoices.editInvoice.itemsTable.indicators.allergens",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.indicators.edited",
+    "newPath": "pages.invoices.editInvoice.itemsTable.indicators.edited",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.indicators.editedTooltip",
+    "newPath": "pages.invoices.editInvoice.itemsTable.indicators.editedTooltip",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.indicators.lowConfidence",
+    "newPath": "pages.invoices.editInvoice.itemsTable.indicators.lowConfidence",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.indicators.lowConfidenceTooltip",
+    "newPath": "pages.invoices.editInvoice.itemsTable.indicators.lowConfidenceTooltip",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.indicators.missingName",
+    "newPath": "pages.invoices.editInvoice.itemsTable.indicators.missingName",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.indicators.missingNameTooltip",
+    "newPath": "pages.invoices.editInvoice.itemsTable.indicators.missingNameTooltip",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.indicators.uncategorized",
+    "newPath": "pages.invoices.editInvoice.itemsTable.indicators.uncategorized",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.indicators.uncategorizedTooltip",
+    "newPath": "pages.invoices.editInvoice.itemsTable.indicators.uncategorizedTooltip",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.newItem.added",
+    "newPath": "pages.invoices.editInvoice.itemsTable.newItem.added",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.newItem.defaultName",
+    "newPath": "pages.invoices.editInvoice.itemsTable.newItem.defaultName",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.pagination.next",
+    "newPath": "pages.invoices.editInvoice.itemsTable.pagination.next",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.pagination.pageOf",
+    "newPath": "pages.invoices.editInvoice.itemsTable.pagination.pageOf",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.pagination.previous",
+    "newPath": "pages.invoices.editInvoice.itemsTable.pagination.previous",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.pagination.totalItems",
+    "newPath": "pages.invoices.editInvoice.itemsTable.pagination.totalItems",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.restore.error",
+    "newPath": "pages.invoices.editInvoice.itemsTable.restore.error",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.restore.success",
+    "newPath": "pages.invoices.editInvoice.itemsTable.restore.success",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.search.placeholder",
+    "newPath": "pages.invoices.editInvoice.itemsTable.search.placeholder",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.softDelete.error",
+    "newPath": "pages.invoices.editInvoice.itemsTable.softDelete.error",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.softDelete.success",
+    "newPath": "pages.invoices.editInvoice.itemsTable.softDelete.success",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.tableHeaders.item",
+    "newPath": "pages.invoices.editInvoice.itemsTable.tableHeaders.item",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.tableHeaders.price",
+    "newPath": "pages.invoices.editInvoice.itemsTable.tableHeaders.price",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.tableHeaders.quantity",
+    "newPath": "pages.invoices.editInvoice.itemsTable.tableHeaders.quantity",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.tableHeaders.total",
+    "newPath": "pages.invoices.editInvoice.itemsTable.tableHeaders.total",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.title",
+    "newPath": "pages.invoices.editInvoice.itemsTable.title",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.itemsTable.tooltips.editInvoiceItemsAndQuantities",
+    "newPath": "pages.invoices.editInvoice.itemsTable.tooltips.editInvoiceItemsAndQuantities",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.metadata.description",
+    "newPath": "pages.invoices.editInvoice.metadata.description",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.metadata.title",
+    "newPath": "pages.invoices.editInvoice.metadata.title",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.metadataTab.badges.readonly",
+    "newPath": "pages.invoices.editInvoice.metadataTab.badges.readonly",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.metadataTab.buttons.addField",
+    "newPath": "pages.invoices.editInvoice.metadataTab.buttons.addField",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.metadataTab.buttons.addFirstMetadataField",
+    "newPath": "pages.invoices.editInvoice.metadataTab.buttons.addFirstMetadataField",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.metadataTab.dropdown.delete",
+    "newPath": "pages.invoices.editInvoice.metadataTab.dropdown.delete",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.metadataTab.dropdown.edit",
+    "newPath": "pages.invoices.editInvoice.metadataTab.dropdown.edit",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.metadataTab.emptyState.noMetadataFields",
+    "newPath": "pages.invoices.editInvoice.metadataTab.emptyState.noMetadataFields",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.metadataTab.header.description",
+    "newPath": "pages.invoices.editInvoice.metadataTab.header.description",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.metadataTab.header.title",
+    "newPath": "pages.invoices.editInvoice.metadataTab.header.title",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.metadataTab.tooltips.addCustomMetadata",
+    "newPath": "pages.invoices.editInvoice.metadataTab.tooltips.addCustomMetadata",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.recipesTab.buttons.addRecipe",
+    "newPath": "pages.invoices.editInvoice.recipesTab.buttons.addRecipe",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.recipesTab.buttons.createFirstRecipe",
+    "newPath": "pages.invoices.editInvoice.recipesTab.buttons.createFirstRecipe",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.recipesTab.buttons.generate",
+    "newPath": "pages.invoices.editInvoice.recipesTab.buttons.generate",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.recipesTab.emptyState.noRecipesAvailable",
+    "newPath": "pages.invoices.editInvoice.recipesTab.emptyState.noRecipesAvailable",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.recipesTab.header.description",
+    "newPath": "pages.invoices.editInvoice.recipesTab.header.description",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.recipesTab.header.title",
+    "newPath": "pages.invoices.editInvoice.recipesTab.header.title",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.recipesTab.pagination.next",
+    "newPath": "pages.invoices.editInvoice.recipesTab.pagination.next",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.recipesTab.pagination.pageOf",
+    "newPath": "pages.invoices.editInvoice.recipesTab.pagination.pageOf",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.recipesTab.pagination.previous",
+    "newPath": "pages.invoices.editInvoice.recipesTab.pagination.previous",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.recipesTab.toasts.aiGenerationComingSoon.description",
+    "newPath": "pages.invoices.editInvoice.recipesTab.toasts.aiGenerationComingSoon.description",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.recipesTab.toasts.aiGenerationComingSoon.title",
+    "newPath": "pages.invoices.editInvoice.recipesTab.toasts.aiGenerationComingSoon.title",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.recipesTab.tooltips.createRecipeWithIngredients",
+    "newPath": "pages.invoices.editInvoice.recipesTab.tooltips.createRecipeWithIngredients",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.recipesTab.tooltips.generateRecipeUsingAi",
+    "newPath": "pages.invoices.editInvoice.recipesTab.tooltips.generateRecipeUsingAi",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.triviaTips.banner.hint",
+    "newPath": "pages.invoices.editInvoice.triviaTips.banner.hint",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.triviaTips.banner.potentialSavingsLabel",
+    "newPath": "pages.invoices.editInvoice.triviaTips.banner.potentialSavingsLabel",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.triviaTips.buttons.viewMoreSavingsTips",
+    "newPath": "pages.invoices.editInvoice.triviaTips.buttons.viewMoreSavingsTips",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.triviaTips.completeLabel",
+    "newPath": "pages.invoices.editInvoice.triviaTips.completeLabel",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.triviaTips.completeness",
+    "newPath": "pages.invoices.editInvoice.triviaTips.completeness",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.triviaTips.contextActions.addDescription",
+    "newPath": "pages.invoices.editInvoice.triviaTips.contextActions.addDescription",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.triviaTips.contextActions.analyze",
+    "newPath": "pages.invoices.editInvoice.triviaTips.contextActions.analyze",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.triviaTips.contextActions.setCategory",
+    "newPath": "pages.invoices.editInvoice.triviaTips.contextActions.setCategory",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.triviaTips.contextTips.defaultCategory",
+    "newPath": "pages.invoices.editInvoice.triviaTips.contextTips.defaultCategory",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.triviaTips.contextTips.noCategory",
+    "newPath": "pages.invoices.editInvoice.triviaTips.contextTips.noCategory",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.triviaTips.contextTips.noDescription",
+    "newPath": "pages.invoices.editInvoice.triviaTips.contextTips.noDescription",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.triviaTips.contextTips.noItems",
+    "newPath": "pages.invoices.editInvoice.triviaTips.contextTips.noItems",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.triviaTips.contextTips.noRecipes",
+    "newPath": "pages.invoices.editInvoice.triviaTips.contextTips.noRecipes",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.triviaTips.difficulty.easy",
+    "newPath": "pages.invoices.editInvoice.triviaTips.difficulty.easy",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.triviaTips.difficulty.medium",
+    "newPath": "pages.invoices.editInvoice.triviaTips.difficulty.medium",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.triviaTips.disclaimer",
+    "newPath": "pages.invoices.editInvoice.triviaTips.disclaimer",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.triviaTips.tips.bulkPurchase.description",
+    "newPath": "pages.invoices.editInvoice.triviaTips.tips.bulkPurchase.description",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.triviaTips.tips.bulkPurchase.title",
+    "newPath": "pages.invoices.editInvoice.triviaTips.tips.bulkPurchase.title",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.triviaTips.tips.digitalCoupons.description",
+    "newPath": "pages.invoices.editInvoice.triviaTips.tips.digitalCoupons.description",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.triviaTips.tips.digitalCoupons.title",
+    "newPath": "pages.invoices.editInvoice.triviaTips.tips.digitalCoupons.title",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.triviaTips.tips.loyaltyProgram.description",
+    "newPath": "pages.invoices.editInvoice.triviaTips.tips.loyaltyProgram.description",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.triviaTips.tips.loyaltyProgram.title",
+    "newPath": "pages.invoices.editInvoice.triviaTips.tips.loyaltyProgram.title",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.triviaTips.title",
+    "newPath": "pages.invoices.editInvoice.triviaTips.title",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Edit.triviaTips.tooltips.estimatedSavings",
+    "newPath": "pages.invoices.editInvoice.triviaTips.tooltips.estimatedSavings",
+    "reason": "edit-invoice experience"
+  },
+  {
+    "oldPath": "IMS--Hooks.useInvoiceDelete.bulkDeleteError",
+    "newPath": "toasts.invoices.useInvoiceDelete.bulkDeleteError",
+    "reason": "user-visible hook feedback"
+  },
+  {
+    "oldPath": "IMS--Hooks.useInvoiceDelete.bulkDeletePartial",
+    "newPath": "toasts.invoices.useInvoiceDelete.bulkDeletePartial",
+    "reason": "user-visible hook feedback"
+  },
+  {
+    "oldPath": "IMS--Hooks.useInvoiceDelete.bulkDeleteSuccess",
+    "newPath": "toasts.invoices.useInvoiceDelete.bulkDeleteSuccess",
+    "reason": "user-visible hook feedback"
+  },
+  {
+    "oldPath": "IMS--Hooks.useInvoiceDelete.deleteError",
+    "newPath": "toasts.invoices.useInvoiceDelete.deleteError",
+    "reason": "user-visible hook feedback"
+  },
+  {
+    "oldPath": "IMS--Hooks.useInvoiceDelete.deleteSuccess",
+    "newPath": "toasts.invoices.useInvoiceDelete.deleteSuccess",
+    "reason": "user-visible hook feedback"
+  },
+  {
+    "oldPath": "IMS--Hooks.useInvoiceShare.emailError",
+    "newPath": "toasts.invoices.useInvoiceShare.emailError",
+    "reason": "user-visible hook feedback"
+  },
+  {
+    "oldPath": "IMS--Hooks.useInvoiceShare.emailSending",
+    "newPath": "toasts.invoices.useInvoiceShare.emailSending",
+    "reason": "user-visible hook feedback"
+  },
+  {
+    "oldPath": "IMS--Hooks.useInvoiceShare.emailSuccess",
+    "newPath": "toasts.invoices.useInvoiceShare.emailSuccess",
+    "reason": "user-visible hook feedback"
+  },
+  {
+    "oldPath": "IMS--Hooks.useInvoiceShare.revokeError",
+    "newPath": "toasts.invoices.useInvoiceShare.revokeError",
+    "reason": "user-visible hook feedback"
+  },
+  {
+    "oldPath": "IMS--Hooks.useInvoiceShare.toggleError",
+    "newPath": "toasts.invoices.useInvoiceShare.toggleError",
+    "reason": "user-visible hook feedback"
+  },
+  {
+    "oldPath": "IMS--Hooks.useRecipeAdd.error",
+    "newPath": "toasts.invoices.useRecipeAdd.error",
+    "reason": "user-visible hook feedback"
+  },
+  {
+    "oldPath": "IMS--Hooks.useRecipeDelete.error",
+    "newPath": "toasts.invoices.useRecipeDelete.error",
+    "reason": "user-visible hook feedback"
+  },
+  {
+    "oldPath": "IMS--Hooks.useRecipeUpdate.error",
+    "newPath": "toasts.invoices.useRecipeUpdate.error",
+    "reason": "user-visible hook feedback"
+  },
+  {
+    "oldPath": "IMS--Hooks.useScanAdd.addError",
+    "newPath": "toasts.invoices.useScanAdd.addError",
+    "reason": "user-visible hook feedback"
+  },
+  {
+    "oldPath": "IMS--Hooks.useScanAdd.addSuccess",
+    "newPath": "toasts.invoices.useScanAdd.addSuccess",
+    "reason": "user-visible hook feedback"
+  },
+  {
+    "oldPath": "IMS--Hooks.useScanAdd.uploadFailed",
+    "newPath": "toasts.invoices.useScanAdd.uploadFailed",
+    "reason": "user-visible hook feedback"
+  },
+  {
+    "oldPath": "IMS--Landing.bento.ai.description",
+    "newPath": "pages.invoices.landing.bento.ai.description",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.bento.ai.title",
+    "newPath": "pages.invoices.landing.bento.ai.title",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.bento.analyticsCard.description",
+    "newPath": "pages.invoices.landing.bento.analyticsCard.description",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.bento.analyticsCard.title",
+    "newPath": "pages.invoices.landing.bento.analyticsCard.title",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.bento.cloud.description",
+    "newPath": "pages.invoices.landing.bento.cloud.description",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.bento.cloud.title",
+    "newPath": "pages.invoices.landing.bento.cloud.title",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.bento.description",
+    "newPath": "pages.invoices.landing.bento.description",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.bento.mobile",
+    "newPath": "pages.invoices.landing.bento.mobile",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.bento.ocr.description",
+    "newPath": "pages.invoices.landing.bento.ocr.description",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.bento.ocr.title",
+    "newPath": "pages.invoices.landing.bento.ocr.title",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.bento.secure.description",
+    "newPath": "pages.invoices.landing.bento.secure.description",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.bento.secure.title",
+    "newPath": "pages.invoices.landing.bento.secure.title",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.bento.share.description",
+    "newPath": "pages.invoices.landing.bento.share.description",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.bento.share.title",
+    "newPath": "pages.invoices.landing.bento.share.title",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.bento.title",
+    "newPath": "pages.invoices.landing.bento.title",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.cta.badges.ai",
+    "newPath": "pages.invoices.landing.cta.badges.ai",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.cta.badges.cloud",
+    "newPath": "pages.invoices.landing.cta.badges.cloud",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.cta.badges.secure",
+    "newPath": "pages.invoices.landing.cta.badges.secure",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.cta.description",
+    "newPath": "pages.invoices.landing.cta.description",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.cta.learnMore",
+    "newPath": "pages.invoices.landing.cta.learnMore",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.cta.title",
+    "newPath": "pages.invoices.landing.cta.title",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.cta.uploadButton",
+    "newPath": "pages.invoices.landing.cta.uploadButton",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.features.analytics.description",
+    "newPath": "pages.invoices.landing.features.analytics.description",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.features.analytics.title",
+    "newPath": "pages.invoices.landing.features.analytics.title",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.features.batch.description",
+    "newPath": "pages.invoices.landing.features.batch.description",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.features.batch.title",
+    "newPath": "pages.invoices.landing.features.batch.title",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.features.description",
+    "newPath": "pages.invoices.landing.features.description",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.features.imageAlt",
+    "newPath": "pages.invoices.landing.features.imageAlt",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.features.ocr.description",
+    "newPath": "pages.invoices.landing.features.ocr.description",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.features.ocr.title",
+    "newPath": "pages.invoices.landing.features.ocr.title",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.features.signIn",
+    "newPath": "pages.invoices.landing.features.signIn",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.features.signInPrompt",
+    "newPath": "pages.invoices.landing.features.signInPrompt",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.features.title",
+    "newPath": "pages.invoices.landing.features.title",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.hero.description",
+    "newPath": "pages.invoices.landing.hero.description",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.hero.getStarted",
+    "newPath": "pages.invoices.landing.hero.getStarted",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.hero.imageAlt",
+    "newPath": "pages.invoices.landing.hero.imageAlt",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.hero.title",
+    "newPath": "pages.invoices.landing.hero.title",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.hero.titleHighlight",
+    "newPath": "pages.invoices.landing.hero.titleHighlight",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.hero.titleSuffix",
+    "newPath": "pages.invoices.landing.hero.titleSuffix",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.hero.viewMyInvoices",
+    "newPath": "pages.invoices.landing.hero.viewMyInvoices",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.metadata.description",
+    "newPath": "pages.invoices.landing.metadata.description",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.metadata.title",
+    "newPath": "pages.invoices.landing.metadata.title",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.workflow.description",
+    "newPath": "pages.invoices.landing.workflow.description",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.workflow.step1.button",
+    "newPath": "pages.invoices.landing.workflow.step1.button",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.workflow.step1.description",
+    "newPath": "pages.invoices.landing.workflow.step1.description",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.workflow.step1.title",
+    "newPath": "pages.invoices.landing.workflow.step1.title",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.workflow.step2.button",
+    "newPath": "pages.invoices.landing.workflow.step2.button",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.workflow.step2.description",
+    "newPath": "pages.invoices.landing.workflow.step2.description",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.workflow.step2.title",
+    "newPath": "pages.invoices.landing.workflow.step2.title",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.workflow.step3.button",
+    "newPath": "pages.invoices.landing.workflow.step3.button",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.workflow.step3.description",
+    "newPath": "pages.invoices.landing.workflow.step3.description",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.workflow.step3.title",
+    "newPath": "pages.invoices.landing.workflow.step3.title",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--Landing.workflow.title",
+    "newPath": "pages.invoices.landing.workflow.title",
+    "reason": "invoice landing page"
+  },
+  {
+    "oldPath": "IMS--List.bulkActions.categories.carAuto",
+    "newPath": "pages.invoices.viewInvoices.bulkActions.categories.carAuto",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.bulkActions.categories.fastFood",
+    "newPath": "pages.invoices.viewInvoices.bulkActions.categories.fastFood",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.bulkActions.categories.grocery",
+    "newPath": "pages.invoices.viewInvoices.bulkActions.categories.grocery",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.bulkActions.categories.homeCleaning",
+    "newPath": "pages.invoices.viewInvoices.bulkActions.categories.homeCleaning",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.bulkActions.categories.notDefined",
+    "newPath": "pages.invoices.viewInvoices.bulkActions.categories.notDefined",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.bulkActions.categories.other",
+    "newPath": "pages.invoices.viewInvoices.bulkActions.categories.other",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.bulkActions.categoryChanged",
+    "newPath": "pages.invoices.viewInvoices.bulkActions.categoryChanged",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.bulkActions.categoryChangeError",
+    "newPath": "pages.invoices.viewInvoices.bulkActions.categoryChangeError",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.bulkActions.categoryPartialSuccess",
+    "newPath": "pages.invoices.viewInvoices.bulkActions.categoryPartialSuccess",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.bulkActions.changeCategory",
+    "newPath": "pages.invoices.viewInvoices.bulkActions.changeCategory",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.bulkActions.clearSelection",
+    "newPath": "pages.invoices.viewInvoices.bulkActions.clearSelection",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.bulkActions.delete",
+    "newPath": "pages.invoices.viewInvoices.bulkActions.delete",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.bulkActions.deleteConfirm.cancel",
+    "newPath": "pages.invoices.viewInvoices.bulkActions.deleteConfirm.cancel",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.bulkActions.deleteConfirm.confirm",
+    "newPath": "pages.invoices.viewInvoices.bulkActions.deleteConfirm.confirm",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.bulkActions.deleteConfirm.description",
+    "newPath": "pages.invoices.viewInvoices.bulkActions.deleteConfirm.description",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.bulkActions.deleteConfirm.title",
+    "newPath": "pages.invoices.viewInvoices.bulkActions.deleteConfirm.title",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.bulkActions.deleteError",
+    "newPath": "pages.invoices.viewInvoices.bulkActions.deleteError",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.bulkActions.deletePartialSuccess",
+    "newPath": "pages.invoices.viewInvoices.bulkActions.deletePartialSuccess",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.bulkActions.deleteSuccess",
+    "newPath": "pages.invoices.viewInvoices.bulkActions.deleteSuccess",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.bulkActions.export",
+    "newPath": "pages.invoices.viewInvoices.bulkActions.export",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.bulkActions.selected",
+    "newPath": "pages.invoices.viewInvoices.bulkActions.selected",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.generativeView.chatDescription",
+    "newPath": "pages.invoices.viewInvoices.generativeView.chatDescription",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.generativeView.help",
+    "newPath": "pages.invoices.viewInvoices.generativeView.help",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.generativeView.settings.allowInvoiceData",
+    "newPath": "pages.invoices.viewInvoices.generativeView.settings.allowInvoiceData",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.generativeView.settings.allowMerchantData",
+    "newPath": "pages.invoices.viewInvoices.generativeView.settings.allowMerchantData",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.generativeView.settings.dataAccessTitle",
+    "newPath": "pages.invoices.viewInvoices.generativeView.settings.dataAccessTitle",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.generativeView.settings.description",
+    "newPath": "pages.invoices.viewInvoices.generativeView.settings.description",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.generativeView.settings.historyLabel",
+    "newPath": "pages.invoices.viewInvoices.generativeView.settings.historyLabel",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.generativeView.settings.notificationPreferences",
+    "newPath": "pages.invoices.viewInvoices.generativeView.settings.notificationPreferences",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.generativeView.settings.notifyInsights",
+    "newPath": "pages.invoices.viewInvoices.generativeView.settings.notifyInsights",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.generativeView.settings.retention.30",
+    "newPath": "pages.invoices.viewInvoices.generativeView.settings.retention.30",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.generativeView.settings.retention.60",
+    "newPath": "pages.invoices.viewInvoices.generativeView.settings.retention.60",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.generativeView.settings.retention.90",
+    "newPath": "pages.invoices.viewInvoices.generativeView.settings.retention.90",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.generativeView.settings.retention.none",
+    "newPath": "pages.invoices.viewInvoices.generativeView.settings.retention.none",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.generativeView.settings.retentionPlaceholder",
+    "newPath": "pages.invoices.viewInvoices.generativeView.settings.retentionPlaceholder",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.generativeView.settings.save",
+    "newPath": "pages.invoices.viewInvoices.generativeView.settings.save",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.generativeView.settings.title",
+    "newPath": "pages.invoices.viewInvoices.generativeView.settings.title",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.generativeView.subtitle",
+    "newPath": "pages.invoices.viewInvoices.generativeView.subtitle",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.generativeView.tabs.chat",
+    "newPath": "pages.invoices.viewInvoices.generativeView.tabs.chat",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.generativeView.tabs.settings",
+    "newPath": "pages.invoices.viewInvoices.generativeView.tabs.settings",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.generativeView.title",
+    "newPath": "pages.invoices.viewInvoices.generativeView.title",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.generativeView.welcomeMessage",
+    "newPath": "pages.invoices.viewInvoices.generativeView.welcomeMessage",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.gridView.itemCount",
+    "newPath": "pages.invoices.viewInvoices.gridView.itemCount",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.gridView.tooltips.viewDetails",
+    "newPath": "pages.invoices.viewInvoices.gridView.tooltips.viewDetails",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.invoicesHeader.actions.export",
+    "newPath": "pages.invoices.viewInvoices.invoicesHeader.actions.export",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.invoicesHeader.actions.import",
+    "newPath": "pages.invoices.viewInvoices.invoicesHeader.actions.import",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.invoicesHeader.actions.newInvoice",
+    "newPath": "pages.invoices.viewInvoices.invoicesHeader.actions.newInvoice",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.invoicesHeader.actions.print",
+    "newPath": "pages.invoices.viewInvoices.invoicesHeader.actions.print",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.invoicesHeader.description",
+    "newPath": "pages.invoices.viewInvoices.invoicesHeader.description",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.invoicesHeader.title",
+    "newPath": "pages.invoices.viewInvoices.invoicesHeader.title",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.invoicesHeader.tooltips.export",
+    "newPath": "pages.invoices.viewInvoices.invoicesHeader.tooltips.export",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.invoicesHeader.tooltips.import",
+    "newPath": "pages.invoices.viewInvoices.invoicesHeader.tooltips.import",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.invoicesHeader.tooltips.newInvoice",
+    "newPath": "pages.invoices.viewInvoices.invoicesHeader.tooltips.newInvoice",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.invoicesHeader.tooltips.print",
+    "newPath": "pages.invoices.viewInvoices.invoicesHeader.tooltips.print",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.categories.all",
+    "newPath": "pages.invoices.viewInvoices.invoicesView.categories.all",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.categories.dining",
+    "newPath": "pages.invoices.viewInvoices.invoicesView.categories.dining",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.categories.entertainment",
+    "newPath": "pages.invoices.viewInvoices.invoicesView.categories.entertainment",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.categories.groceries",
+    "newPath": "pages.invoices.viewInvoices.invoicesView.categories.groceries",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.categories.other",
+    "newPath": "pages.invoices.viewInvoices.invoicesView.categories.other",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.categories.travel",
+    "newPath": "pages.invoices.viewInvoices.invoicesView.categories.travel",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.categories.utilities",
+    "newPath": "pages.invoices.viewInvoices.invoicesView.categories.utilities",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.filters.activeCount",
+    "newPath": "forms.invoices.filters.activeCount",
+    "reason": "invoice list filters"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.filters.amountMax",
+    "newPath": "forms.invoices.filters.amountMax",
+    "reason": "invoice list filters"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.filters.amountMin",
+    "newPath": "forms.invoices.filters.amountMin",
+    "reason": "invoice list filters"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.filters.amountPresets.0to50",
+    "newPath": "forms.invoices.filters.amountPresets.0to50",
+    "reason": "invoice list filters"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.filters.amountPresets.100to500",
+    "newPath": "forms.invoices.filters.amountPresets.100to500",
+    "reason": "invoice list filters"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.filters.amountPresets.500plus",
+    "newPath": "forms.invoices.filters.amountPresets.500plus",
+    "reason": "invoice list filters"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.filters.amountPresets.50to100",
+    "newPath": "forms.invoices.filters.amountPresets.50to100",
+    "reason": "invoice list filters"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.filters.amountRange",
+    "newPath": "forms.invoices.filters.amountRange",
+    "reason": "invoice list filters"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.filters.anyValue",
+    "newPath": "forms.invoices.filters.anyValue",
+    "reason": "invoice list filters"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.filters.button",
+    "newPath": "forms.invoices.filters.button",
+    "reason": "invoice list filters"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.filters.categories",
+    "newPath": "forms.invoices.filters.categories",
+    "reason": "invoice list filters"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.filters.category",
+    "newPath": "forms.invoices.filters.category",
+    "reason": "invoice list filters"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.filters.clear",
+    "newPath": "forms.invoices.filters.clear",
+    "reason": "invoice list filters"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.filters.currency",
+    "newPath": "forms.invoices.filters.currency",
+    "reason": "invoice list filters"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.filters.currencyAny",
+    "newPath": "forms.invoices.filters.currencyAny",
+    "reason": "invoice list filters"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.filters.dateFrom",
+    "newPath": "forms.invoices.filters.dateFrom",
+    "reason": "invoice list filters"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.filters.datePresets.30d",
+    "newPath": "forms.invoices.filters.datePresets.30d",
+    "reason": "invoice list filters"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.filters.datePresets.90d",
+    "newPath": "forms.invoices.filters.datePresets.90d",
+    "reason": "invoice list filters"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.filters.datePresets.all",
+    "newPath": "forms.invoices.filters.datePresets.all",
+    "reason": "invoice list filters"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.filters.datePresets.custom",
+    "newPath": "forms.invoices.filters.datePresets.custom",
+    "reason": "invoice list filters"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.filters.datePresets.ytd",
+    "newPath": "forms.invoices.filters.datePresets.ytd",
+    "reason": "invoice list filters"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.filters.dateRange",
+    "newPath": "forms.invoices.filters.dateRange",
+    "reason": "invoice list filters"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.filters.dateTo",
+    "newPath": "forms.invoices.filters.dateTo",
+    "reason": "invoice list filters"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.filters.defaultValue",
+    "newPath": "forms.invoices.filters.defaultValue",
+    "reason": "invoice list filters"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.filters.dynamicHint",
+    "newPath": "forms.invoices.filters.dynamicHint",
+    "reason": "invoice list filters"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.filters.paymentTypeLabels.card",
+    "newPath": "forms.invoices.filters.paymentTypeLabels.card",
+    "reason": "invoice list filters"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.filters.paymentTypeLabels.cash",
+    "newPath": "forms.invoices.filters.paymentTypeLabels.cash",
+    "reason": "invoice list filters"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.filters.paymentTypeLabels.mobile",
+    "newPath": "forms.invoices.filters.paymentTypeLabels.mobile",
+    "reason": "invoice list filters"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.filters.paymentTypeLabels.other",
+    "newPath": "forms.invoices.filters.paymentTypeLabels.other",
+    "reason": "invoice list filters"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.filters.paymentTypeLabels.transfer",
+    "newPath": "forms.invoices.filters.paymentTypeLabels.transfer",
+    "reason": "invoice list filters"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.filters.paymentTypeLabels.voucher",
+    "newPath": "forms.invoices.filters.paymentTypeLabels.voucher",
+    "reason": "invoice list filters"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.filters.paymentTypes",
+    "newPath": "forms.invoices.filters.paymentTypes",
+    "reason": "invoice list filters"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.filters.showResults",
+    "newPath": "forms.invoices.filters.showResults",
+    "reason": "invoice list filters"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.filters.sortBy",
+    "newPath": "forms.invoices.filters.sortBy",
+    "reason": "invoice list filters"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.filters.sortOptions.amountHighToLow",
+    "newPath": "forms.invoices.filters.sortOptions.amountHighToLow",
+    "reason": "invoice list filters"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.filters.sortOptions.amountLowToHigh",
+    "newPath": "forms.invoices.filters.sortOptions.amountLowToHigh",
+    "reason": "invoice list filters"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.filters.sortOptions.dateNewest",
+    "newPath": "forms.invoices.filters.sortOptions.dateNewest",
+    "reason": "invoice list filters"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.filters.sortOptions.dateOldest",
+    "newPath": "forms.invoices.filters.sortOptions.dateOldest",
+    "reason": "invoice list filters"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.filters.sortOptions.nameAZ",
+    "newPath": "forms.invoices.filters.sortOptions.nameAZ",
+    "reason": "invoice list filters"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.filters.sortOptions.nameZA",
+    "newPath": "forms.invoices.filters.sortOptions.nameZA",
+    "reason": "invoice list filters"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.filters.timeOfDay",
+    "newPath": "forms.invoices.filters.timeOfDay",
+    "reason": "invoice list filters"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.filters.title",
+    "newPath": "forms.invoices.filters.title",
+    "reason": "invoice list filters"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.placeholderPanel",
+    "newPath": "pages.invoices.viewInvoices.invoicesView.placeholderPanel",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.searchPlaceholder",
+    "newPath": "pages.invoices.viewInvoices.invoicesView.searchPlaceholder",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.times.all",
+    "newPath": "pages.invoices.viewInvoices.invoicesView.times.all",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.times.day",
+    "newPath": "pages.invoices.viewInvoices.invoicesView.times.day",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.times.night",
+    "newPath": "pages.invoices.viewInvoices.invoicesView.times.night",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.viewModes.grid",
+    "newPath": "pages.invoices.viewInvoices.invoicesView.viewModes.grid",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.invoicesView.viewModes.table",
+    "newPath": "pages.invoices.viewInvoices.invoicesView.viewModes.table",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.messageList.aiAssistant",
+    "newPath": "pages.invoices.viewInvoices.messageList.aiAssistant",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.messageList.you",
+    "newPath": "pages.invoices.viewInvoices.messageList.you",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.metadata.description",
+    "newPath": "pages.invoices.viewInvoices.metadata.description",
+    "reason": "view-invoices metadata"
+  },
+  {
+    "oldPath": "IMS--List.metadata.title",
+    "newPath": "pages.invoices.viewInvoices.metadata.title",
+    "reason": "view-invoices metadata"
+  },
+  {
+    "oldPath": "IMS--List.subtitle",
+    "newPath": "pages.invoices.viewInvoices.subtitle",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.tableView.aria.rowsPerPage",
+    "newPath": "pages.invoices.viewInvoices.tableView.aria.rowsPerPage",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.tableView.aria.selectAllInvoices",
+    "newPath": "pages.invoices.viewInvoices.tableView.aria.selectAllInvoices",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.tableView.aria.selectInvoice",
+    "newPath": "pages.invoices.viewInvoices.tableView.aria.selectInvoice",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.tableView.aria.sortByAmount",
+    "newPath": "pages.invoices.viewInvoices.tableView.aria.sortByAmount",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.tableView.aria.sortByDate",
+    "newPath": "pages.invoices.viewInvoices.tableView.aria.sortByDate",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.tableView.columns.actions",
+    "newPath": "pages.invoices.viewInvoices.tableView.columns.actions",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.tableView.columns.amount",
+    "newPath": "pages.invoices.viewInvoices.tableView.columns.amount",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.tableView.columns.category",
+    "newPath": "pages.invoices.viewInvoices.tableView.columns.category",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.tableView.columns.date",
+    "newPath": "pages.invoices.viewInvoices.tableView.columns.date",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.tableView.columns.invoice",
+    "newPath": "pages.invoices.viewInvoices.tableView.columns.invoice",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.tableView.empty.description",
+    "newPath": "pages.invoices.viewInvoices.tableView.empty.description",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.tableView.empty.title",
+    "newPath": "pages.invoices.viewInvoices.tableView.empty.title",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.tableView.empty.uploadCta",
+    "newPath": "pages.invoices.viewInvoices.tableView.empty.uploadCta",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.tableView.nextPage",
+    "newPath": "pages.invoices.viewInvoices.tableView.nextPage",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.tableView.pageOf",
+    "newPath": "pages.invoices.viewInvoices.tableView.pageOf",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.tableView.previousPage",
+    "newPath": "pages.invoices.viewInvoices.tableView.previousPage",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.tableView.rowsPerPage",
+    "newPath": "pages.invoices.viewInvoices.tableView.rowsPerPage",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.tableView.tooltips.notAnalyzed",
+    "newPath": "pages.invoices.viewInvoices.tableView.tooltips.notAnalyzed",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.tableView.viewInvoice",
+    "newPath": "pages.invoices.viewInvoices.tableView.viewInvoice",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.tableViewActions.actions.delete",
+    "newPath": "pages.invoices.viewInvoices.tableViewActions.actions.delete",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.tableViewActions.actions.edit",
+    "newPath": "pages.invoices.viewInvoices.tableViewActions.actions.edit",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.tableViewActions.actions.share",
+    "newPath": "pages.invoices.viewInvoices.tableViewActions.actions.share",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.tableViewActions.tooltips.delete",
+    "newPath": "pages.invoices.viewInvoices.tableViewActions.tooltips.delete",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.tableViewActions.tooltips.edit",
+    "newPath": "pages.invoices.viewInvoices.tableViewActions.tooltips.edit",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.tableViewActions.tooltips.moreActions",
+    "newPath": "pages.invoices.viewInvoices.tableViewActions.tooltips.moreActions",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.tableViewActions.tooltips.share",
+    "newPath": "pages.invoices.viewInvoices.tableViewActions.tooltips.share",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.title",
+    "newPath": "pages.invoices.viewInvoices.title",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.viewInvoicesIsland.tabs.invoices",
+    "newPath": "pages.invoices.viewInvoices.viewInvoicesIsland.tabs.invoices",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.viewInvoicesIsland.tabs.liveAnalysis",
+    "newPath": "pages.invoices.viewInvoices.viewInvoicesIsland.tabs.liveAnalysis",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.viewInvoicesIsland.tabs.statistics",
+    "newPath": "pages.invoices.viewInvoices.viewInvoicesIsland.tabs.statistics",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--List.viewInvoicesPage.guestName",
+    "newPath": "pages.invoices.viewInvoices.viewInvoicesPage.guestName",
+    "reason": "view-invoices page"
+  },
+  {
+    "oldPath": "IMS--Stats.allergenSummary.ariaLabel",
+    "newPath": "cards.invoices.statistics.allergenSummary.ariaLabel",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.allergenSummary.description",
+    "newPath": "cards.invoices.statistics.allergenSummary.description",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.allergenSummary.empty",
+    "newPath": "cards.invoices.statistics.allergenSummary.empty",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.allergenSummary.stats.ofTotal",
+    "newPath": "cards.invoices.statistics.allergenSummary.stats.ofTotal",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.allergenSummary.stats.products",
+    "newPath": "cards.invoices.statistics.allergenSummary.stats.products",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.allergenSummary.title",
+    "newPath": "cards.invoices.statistics.allergenSummary.title",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.calendarHeatmap.aria.calendarGrid",
+    "newPath": "cards.invoices.statistics.calendarHeatmap.aria.calendarGrid",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.calendarHeatmap.days.fri",
+    "newPath": "cards.invoices.statistics.calendarHeatmap.days.fri",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.calendarHeatmap.days.mon",
+    "newPath": "cards.invoices.statistics.calendarHeatmap.days.mon",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.calendarHeatmap.days.sat",
+    "newPath": "cards.invoices.statistics.calendarHeatmap.days.sat",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.calendarHeatmap.days.sun",
+    "newPath": "cards.invoices.statistics.calendarHeatmap.days.sun",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.calendarHeatmap.days.thu",
+    "newPath": "cards.invoices.statistics.calendarHeatmap.days.thu",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.calendarHeatmap.days.tue",
+    "newPath": "cards.invoices.statistics.calendarHeatmap.days.tue",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.calendarHeatmap.days.wed",
+    "newPath": "cards.invoices.statistics.calendarHeatmap.days.wed",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.calendarHeatmap.description",
+    "newPath": "cards.invoices.statistics.calendarHeatmap.description",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.calendarHeatmap.legend.less",
+    "newPath": "cards.invoices.statistics.calendarHeatmap.legend.less",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.calendarHeatmap.legend.more",
+    "newPath": "cards.invoices.statistics.calendarHeatmap.legend.more",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.calendarHeatmap.navigation.next",
+    "newPath": "cards.invoices.statistics.calendarHeatmap.navigation.next",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.calendarHeatmap.navigation.previous",
+    "newPath": "cards.invoices.statistics.calendarHeatmap.navigation.previous",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.calendarHeatmap.title",
+    "newPath": "cards.invoices.statistics.calendarHeatmap.title",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.calendarHeatmap.tooltip.amount",
+    "newPath": "cards.invoices.statistics.calendarHeatmap.tooltip.amount",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.calendarHeatmap.tooltip.invoices",
+    "newPath": "cards.invoices.statistics.calendarHeatmap.tooltip.invoices",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.calendarHeatmap.tooltip.noSpending",
+    "newPath": "cards.invoices.statistics.calendarHeatmap.tooltip.noSpending",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.categoryBreakdown.description",
+    "newPath": "cards.invoices.statistics.categoryBreakdown.description",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.categoryBreakdown.title",
+    "newPath": "cards.invoices.statistics.categoryBreakdown.title",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.categoryBreakdown.tooltip.invoiceCount",
+    "newPath": "cards.invoices.statistics.categoryBreakdown.tooltip.invoiceCount",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.categoryBreakdown.totalLabel",
+    "newPath": "cards.invoices.statistics.categoryBreakdown.totalLabel",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.comparison.decrease",
+    "newPath": "cards.invoices.statistics.comparison.decrease",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.comparison.description",
+    "newPath": "cards.invoices.statistics.comparison.description",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.comparison.discovered",
+    "newPath": "cards.invoices.statistics.comparison.discovered",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.comparison.increase",
+    "newPath": "cards.invoices.statistics.comparison.increase",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.comparison.invoiceCount",
+    "newPath": "cards.invoices.statistics.comparison.invoiceCount",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.comparison.newMerchants",
+    "newPath": "cards.invoices.statistics.comparison.newMerchants",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.comparison.none",
+    "newPath": "cards.invoices.statistics.comparison.none",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.comparison.spendingDelta",
+    "newPath": "cards.invoices.statistics.comparison.spendingDelta",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.comparison.title",
+    "newPath": "cards.invoices.statistics.comparison.title",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.currencyDistribution.description",
+    "newPath": "cards.invoices.statistics.currencyDistribution.description",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.currencyDistribution.invoiceCount",
+    "newPath": "cards.invoices.statistics.currencyDistribution.invoiceCount",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.currencyDistribution.originalAmount",
+    "newPath": "cards.invoices.statistics.currencyDistribution.originalAmount",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.currencyDistribution.ronEquivalent",
+    "newPath": "cards.invoices.statistics.currencyDistribution.ronEquivalent",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.currencyDistribution.showOriginal",
+    "newPath": "cards.invoices.statistics.currencyDistribution.showOriginal",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.currencyDistribution.showRON",
+    "newPath": "cards.invoices.statistics.currencyDistribution.showRON",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.currencyDistribution.singleCurrency",
+    "newPath": "cards.invoices.statistics.currencyDistribution.singleCurrency",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.currencyDistribution.title",
+    "newPath": "cards.invoices.statistics.currencyDistribution.title",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.currencyDistribution.toggleLabel",
+    "newPath": "cards.invoices.statistics.currencyDistribution.toggleLabel",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.currencyDistribution.totalAmount",
+    "newPath": "cards.invoices.statistics.currencyDistribution.totalAmount",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.currencyDistribution.totalCurrencies",
+    "newPath": "cards.invoices.statistics.currencyDistribution.totalCurrencies",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.currencyDistribution.totalSpending",
+    "newPath": "cards.invoices.statistics.currencyDistribution.totalSpending",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.empty.cta",
+    "newPath": "cards.invoices.statistics.empty.cta",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.empty.subtitle",
+    "newPath": "cards.invoices.statistics.empty.subtitle",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.empty.title",
+    "newPath": "cards.invoices.statistics.empty.title",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.kpi.acrossInvoices",
+    "newPath": "cards.invoices.statistics.kpi.acrossInvoices",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.kpi.averageItems",
+    "newPath": "cards.invoices.statistics.kpi.averageItems",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.kpi.avgPerInvoice",
+    "newPath": "cards.invoices.statistics.kpi.avgPerInvoice",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.kpi.invoiceCount",
+    "newPath": "cards.invoices.statistics.kpi.invoiceCount",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.kpi.noneYet",
+    "newPath": "cards.invoices.statistics.kpi.noneYet",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.kpi.topMerchant",
+    "newPath": "cards.invoices.statistics.kpi.topMerchant",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.kpi.totalSpending",
+    "newPath": "cards.invoices.statistics.kpi.totalSpending",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.kpi.visits",
+    "newPath": "cards.invoices.statistics.kpi.visits",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.kpi.vsLastMonth",
+    "newPath": "cards.invoices.statistics.kpi.vsLastMonth",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.merchantLeaderboard.description",
+    "newPath": "cards.invoices.statistics.merchantLeaderboard.description",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.merchantLeaderboard.empty",
+    "newPath": "cards.invoices.statistics.merchantLeaderboard.empty",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.merchantLeaderboard.labels.totalSpent",
+    "newPath": "cards.invoices.statistics.merchantLeaderboard.labels.totalSpent",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.merchantLeaderboard.title",
+    "newPath": "cards.invoices.statistics.merchantLeaderboard.title",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.merchantLeaderboard.tooltip.invoiceCount",
+    "newPath": "cards.invoices.statistics.merchantLeaderboard.tooltip.invoiceCount",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.merchantLeaderboard.unknownMerchant",
+    "newPath": "cards.invoices.statistics.merchantLeaderboard.unknownMerchant",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.merchantTrends.aria.sparkline",
+    "newPath": "cards.invoices.statistics.merchantTrends.aria.sparkline",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.merchantTrends.description",
+    "newPath": "cards.invoices.statistics.merchantTrends.description",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.merchantTrends.empty",
+    "newPath": "cards.invoices.statistics.merchantTrends.empty",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.merchantTrends.labels.merchant",
+    "newPath": "cards.invoices.statistics.merchantTrends.labels.merchant",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.merchantTrends.labels.totalSpend",
+    "newPath": "cards.invoices.statistics.merchantTrends.labels.totalSpend",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.merchantTrends.labels.trend",
+    "newPath": "cards.invoices.statistics.merchantTrends.labels.trend",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.merchantTrends.title",
+    "newPath": "cards.invoices.statistics.merchantTrends.title",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.merchantVisit.description",
+    "newPath": "cards.invoices.statistics.merchantVisit.description",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.merchantVisit.empty",
+    "newPath": "cards.invoices.statistics.merchantVisit.empty",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.merchantVisit.metrics.avgSpend",
+    "newPath": "cards.invoices.statistics.merchantVisit.metrics.avgSpend",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.merchantVisit.metrics.basketSize",
+    "newPath": "cards.invoices.statistics.merchantVisit.metrics.basketSize",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.merchantVisit.metrics.preferredDay",
+    "newPath": "cards.invoices.statistics.merchantVisit.metrics.preferredDay",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.merchantVisit.metrics.totalVisits",
+    "newPath": "cards.invoices.statistics.merchantVisit.metrics.totalVisits",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.merchantVisit.metrics.visitsPerMonth",
+    "newPath": "cards.invoices.statistics.merchantVisit.metrics.visitsPerMonth",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.merchantVisit.title",
+    "newPath": "cards.invoices.statistics.merchantVisit.title",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.priceDistribution.description",
+    "newPath": "cards.invoices.statistics.priceDistribution.description",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.priceDistribution.labels.itemCount",
+    "newPath": "cards.invoices.statistics.priceDistribution.labels.itemCount",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.priceDistribution.title",
+    "newPath": "cards.invoices.statistics.priceDistribution.title",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.priceDistribution.tooltip.itemCount",
+    "newPath": "cards.invoices.statistics.priceDistribution.tooltip.itemCount",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.productAnalytics.subtitle",
+    "newPath": "cards.invoices.statistics.productAnalytics.subtitle",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.productAnalytics.title",
+    "newPath": "cards.invoices.statistics.productAnalytics.title",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.productCategory.description",
+    "newPath": "cards.invoices.statistics.productCategory.description",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.productCategory.empty",
+    "newPath": "cards.invoices.statistics.productCategory.empty",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.productCategory.title",
+    "newPath": "cards.invoices.statistics.productCategory.title",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.productCategory.tooltip.productCount",
+    "newPath": "cards.invoices.statistics.productCategory.tooltip.productCount",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.spendingOverTime.description",
+    "newPath": "cards.invoices.statistics.spendingOverTime.description",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.spendingOverTime.labels.amount",
+    "newPath": "cards.invoices.statistics.spendingOverTime.labels.amount",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.spendingOverTime.title",
+    "newPath": "cards.invoices.statistics.spendingOverTime.title",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.spendingOverTime.tooltip.andMore",
+    "newPath": "cards.invoices.statistics.spendingOverTime.tooltip.andMore",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.spendingOverTime.tooltip.invoiceCount",
+    "newPath": "cards.invoices.statistics.spendingOverTime.tooltip.invoiceCount",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.subtitle",
+    "newPath": "cards.invoices.statistics.subtitle",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.timeOfDay.description",
+    "newPath": "cards.invoices.statistics.timeOfDay.description",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.timeOfDay.labels.invoiceCount",
+    "newPath": "cards.invoices.statistics.timeOfDay.labels.invoiceCount",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.timeOfDay.title",
+    "newPath": "cards.invoices.statistics.timeOfDay.title",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.timeOfDay.tooltip.invoiceCount",
+    "newPath": "cards.invoices.statistics.timeOfDay.tooltip.invoiceCount",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.title",
+    "newPath": "cards.invoices.statistics.title",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.topProducts.ariaLabel",
+    "newPath": "cards.invoices.statistics.topProducts.ariaLabel",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.topProducts.description",
+    "newPath": "cards.invoices.statistics.topProducts.description",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.topProducts.empty",
+    "newPath": "cards.invoices.statistics.topProducts.empty",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.topProducts.headers.avgPrice",
+    "newPath": "cards.invoices.statistics.topProducts.headers.avgPrice",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.topProducts.headers.product",
+    "newPath": "cards.invoices.statistics.topProducts.headers.product",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.topProducts.headers.purchases",
+    "newPath": "cards.invoices.statistics.topProducts.headers.purchases",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.topProducts.headers.quantity",
+    "newPath": "cards.invoices.statistics.topProducts.headers.quantity",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.topProducts.headers.rank",
+    "newPath": "cards.invoices.statistics.topProducts.headers.rank",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.topProducts.headers.totalSpent",
+    "newPath": "cards.invoices.statistics.topProducts.headers.totalSpent",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--Stats.topProducts.title",
+    "newPath": "cards.invoices.statistics.topProducts.title",
+    "reason": "invoice statistics widgets"
+  },
+  {
+    "oldPath": "IMS--UploadScans.breadcrumb",
+    "newPath": "pages.invoices.uploadScans.breadcrumb",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.buttons.myInvoices",
+    "newPath": "pages.invoices.uploadScans.buttons.myInvoices",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.buttons.uploadFirst",
+    "newPath": "pages.invoices.uploadScans.buttons.uploadFirst",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.buttons.viewScans",
+    "newPath": "pages.invoices.uploadScans.buttons.viewScans",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.errors.tooLarge",
+    "newPath": "pages.invoices.uploadScans.errors.tooLarge",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.errors.unsupportedType",
+    "newPath": "pages.invoices.uploadScans.errors.unsupportedType",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.header.description",
+    "newPath": "pages.invoices.uploadScans.header.description",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.header.title",
+    "newPath": "pages.invoices.uploadScans.header.title",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.header.tooltip",
+    "newPath": "pages.invoices.uploadScans.header.tooltip",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.metadata.description",
+    "newPath": "pages.invoices.uploadScans.metadata.description",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.metadata.title",
+    "newPath": "pages.invoices.uploadScans.metadata.title",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.postUpload.createInvoice",
+    "newPath": "pages.invoices.uploadScans.postUpload.createInvoice",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.postUpload.dismiss",
+    "newPath": "pages.invoices.uploadScans.postUpload.dismiss",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.postUpload.subtitle",
+    "newPath": "pages.invoices.uploadScans.postUpload.subtitle",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.postUpload.title",
+    "newPath": "pages.invoices.uploadScans.postUpload.title",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.postUpload.viewScans",
+    "newPath": "pages.invoices.uploadScans.postUpload.viewScans",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.preview.pagination.next",
+    "newPath": "pages.invoices.uploadScans.preview.pagination.next",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.preview.pagination.pageInfo",
+    "newPath": "pages.invoices.uploadScans.preview.pagination.pageInfo",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.preview.pagination.previous",
+    "newPath": "pages.invoices.uploadScans.preview.pagination.previous",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.preview.pendingTooltip",
+    "newPath": "pages.invoices.uploadScans.preview.pendingTooltip",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.preview.removeTooltip",
+    "newPath": "pages.invoices.uploadScans.preview.removeTooltip",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.preview.retryAttempt",
+    "newPath": "pages.invoices.uploadScans.preview.retryAttempt",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.preview.status.completed",
+    "newPath": "pages.invoices.uploadScans.preview.status.completed",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.preview.status.failed",
+    "newPath": "pages.invoices.uploadScans.preview.status.failed",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.preview.status.pending",
+    "newPath": "pages.invoices.uploadScans.preview.status.pending",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.preview.status.retrying",
+    "newPath": "pages.invoices.uploadScans.preview.status.retrying",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.preview.status.uploading",
+    "newPath": "pages.invoices.uploadScans.preview.status.uploading",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.preview.title",
+    "newPath": "pages.invoices.uploadScans.preview.title",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.sidebar.formats.documentExtensions",
+    "newPath": "pages.invoices.uploadScans.sidebar.formats.documentExtensions",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.sidebar.formats.documents",
+    "newPath": "pages.invoices.uploadScans.sidebar.formats.documents",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.sidebar.formats.imageExtensions",
+    "newPath": "pages.invoices.uploadScans.sidebar.formats.imageExtensions",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.sidebar.formats.images",
+    "newPath": "pages.invoices.uploadScans.sidebar.formats.images",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.sidebar.formats.maxSize",
+    "newPath": "pages.invoices.uploadScans.sidebar.formats.maxSize",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.sidebar.formats.title",
+    "newPath": "pages.invoices.uploadScans.sidebar.formats.title",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.sidebar.nextSteps.button",
+    "newPath": "pages.invoices.uploadScans.sidebar.nextSteps.button",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.sidebar.nextSteps.description",
+    "newPath": "pages.invoices.uploadScans.sidebar.nextSteps.description",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.sidebar.nextSteps.title",
+    "newPath": "pages.invoices.uploadScans.sidebar.nextSteps.title",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.sidebar.security.description",
+    "newPath": "pages.invoices.uploadScans.sidebar.security.description",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.sidebar.security.title",
+    "newPath": "pages.invoices.uploadScans.sidebar.security.title",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.sidebar.tips.tip1",
+    "newPath": "pages.invoices.uploadScans.sidebar.tips.tip1",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.sidebar.tips.tip2",
+    "newPath": "pages.invoices.uploadScans.sidebar.tips.tip2",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.sidebar.tips.tip3",
+    "newPath": "pages.invoices.uploadScans.sidebar.tips.tip3",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.sidebar.tips.tip4",
+    "newPath": "pages.invoices.uploadScans.sidebar.tips.tip4",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.sidebar.tips.tip5",
+    "newPath": "pages.invoices.uploadScans.sidebar.tips.tip5",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.sidebar.tips.title",
+    "newPath": "pages.invoices.uploadScans.sidebar.tips.title",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.stats.added",
+    "newPath": "pages.invoices.uploadScans.stats.added",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.stats.completed",
+    "newPath": "pages.invoices.uploadScans.stats.completed",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.stats.failed",
+    "newPath": "pages.invoices.uploadScans.stats.failed",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.stats.pending",
+    "newPath": "pages.invoices.uploadScans.stats.pending",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.stats.uploading",
+    "newPath": "pages.invoices.uploadScans.stats.uploading",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.subtitle",
+    "newPath": "pages.invoices.uploadScans.subtitle",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.title",
+    "newPath": "pages.invoices.uploadScans.title",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.upload.browse",
+    "newPath": "pages.invoices.uploadScans.upload.browse",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.upload.dropzone",
+    "newPath": "pages.invoices.uploadScans.upload.dropzone",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.upload.or",
+    "newPath": "pages.invoices.uploadScans.upload.or",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.uploadArea.actions.clearAll",
+    "newPath": "pages.invoices.uploadScans.uploadArea.actions.clearAll",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.uploadArea.actions.uploading",
+    "newPath": "pages.invoices.uploadScans.uploadArea.actions.uploading",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.uploadArea.actions.uploadScans",
+    "newPath": "pages.invoices.uploadScans.uploadArea.actions.uploadScans",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.uploadArea.aria.uploadFiles",
+    "newPath": "pages.invoices.uploadScans.uploadArea.aria.uploadFiles",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.uploadArea.compact.dropActive",
+    "newPath": "pages.invoices.uploadScans.uploadArea.compact.dropActive",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.uploadArea.compact.dropInactive",
+    "newPath": "pages.invoices.uploadScans.uploadArea.compact.dropInactive",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.uploadArea.compact.subtitle",
+    "newPath": "pages.invoices.uploadScans.uploadArea.compact.subtitle",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.uploadArea.empty.chooseFiles",
+    "newPath": "pages.invoices.uploadScans.uploadArea.empty.chooseFiles",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.uploadArea.empty.dropActive",
+    "newPath": "pages.invoices.uploadScans.uploadArea.empty.dropActive",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.uploadArea.empty.dropInactive",
+    "newPath": "pages.invoices.uploadScans.uploadArea.empty.dropInactive",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.uploadArea.empty.formats",
+    "newPath": "pages.invoices.uploadScans.uploadArea.empty.formats",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.uploadArea.empty.note",
+    "newPath": "pages.invoices.uploadScans.uploadArea.empty.note",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.uploadArea.empty.pasteHint",
+    "newPath": "pages.invoices.uploadScans.uploadArea.empty.pasteHint",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.uploadArea.empty.title",
+    "newPath": "pages.invoices.uploadScans.uploadArea.empty.title",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.uploadArea.tooltips.clearAll",
+    "newPath": "pages.invoices.uploadScans.uploadArea.tooltips.clearAll",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--UploadScans.uploadArea.tooltips.uploadScans",
+    "newPath": "pages.invoices.uploadScans.uploadArea.tooltips.uploadScans",
+    "reason": "upload-scans page"
+  },
+  {
+    "oldPath": "IMS--View.analysisPanel.analyzing.progress",
+    "newPath": "pages.invoices.viewInvoice.analysisPanel.analyzing.progress",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.analysisPanel.analyzing.title",
+    "newPath": "pages.invoices.viewInvoice.analysisPanel.analyzing.title",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.analysisPanel.buttons.reanalyze",
+    "newPath": "pages.invoices.viewInvoice.analysisPanel.buttons.reanalyze",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.analysisPanel.description",
+    "newPath": "pages.invoices.viewInvoice.analysisPanel.description",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.analysisPanel.labels.analysisComplete",
+    "newPath": "pages.invoices.viewInvoice.analysisPanel.labels.analysisComplete",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.analysisPanel.labels.granularOptions",
+    "newPath": "pages.invoices.viewInvoice.analysisPanel.labels.granularOptions",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.analysisPanel.labels.lastAnalyzed",
+    "newPath": "pages.invoices.viewInvoice.analysisPanel.labels.lastAnalyzed",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.analysisPanel.labels.updates",
+    "newPath": "pages.invoices.viewInvoice.analysisPanel.labels.updates",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.analysisPanel.options.completeAnalysis",
+    "newPath": "pages.invoices.viewInvoice.analysisPanel.options.completeAnalysis",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.analysisPanel.options.invoiceOnly",
+    "newPath": "pages.invoices.viewInvoice.analysisPanel.options.invoiceOnly",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.analysisPanel.options.itemsOnly",
+    "newPath": "pages.invoices.viewInvoice.analysisPanel.options.itemsOnly",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.analysisPanel.options.merchantOnly",
+    "newPath": "pages.invoices.viewInvoice.analysisPanel.options.merchantOnly",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.analysisPanel.steps.analyzing",
+    "newPath": "pages.invoices.viewInvoice.analysisPanel.steps.analyzing",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.analysisPanel.steps.complete",
+    "newPath": "pages.invoices.viewInvoice.analysisPanel.steps.complete",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.analysisPanel.steps.extracting",
+    "newPath": "pages.invoices.viewInvoice.analysisPanel.steps.extracting",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.analysisPanel.steps.finalizing",
+    "newPath": "pages.invoices.viewInvoice.analysisPanel.steps.finalizing",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.analysisPanel.steps.preparing",
+    "newPath": "pages.invoices.viewInvoice.analysisPanel.steps.preparing",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.analysisPanel.steps.processing",
+    "newPath": "pages.invoices.viewInvoice.analysisPanel.steps.processing",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.analysisPanel.tip",
+    "newPath": "pages.invoices.viewInvoice.analysisPanel.tip",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.analysisPanel.title",
+    "newPath": "pages.invoices.viewInvoice.analysisPanel.title",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.analysisPanel.toasts.error.description",
+    "newPath": "pages.invoices.viewInvoice.analysisPanel.toasts.error.description",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.analysisPanel.toasts.error.title",
+    "newPath": "pages.invoices.viewInvoice.analysisPanel.toasts.error.title",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.analysisPanel.toasts.success.description",
+    "newPath": "pages.invoices.viewInvoice.analysisPanel.toasts.success.description",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.analysisPanel.toasts.success.title",
+    "newPath": "pages.invoices.viewInvoice.analysisPanel.toasts.success.title",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.analysisPanel.tooltips.completeAnalysis",
+    "newPath": "pages.invoices.viewInvoice.analysisPanel.tooltips.completeAnalysis",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.analysisPanel.tooltips.invoiceOnly",
+    "newPath": "pages.invoices.viewInvoice.analysisPanel.tooltips.invoiceOnly",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.analysisPanel.tooltips.itemsOnly",
+    "newPath": "pages.invoices.viewInvoice.analysisPanel.tooltips.itemsOnly",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.analysisPanel.tooltips.merchantOnly",
+    "newPath": "pages.invoices.viewInvoice.analysisPanel.tooltips.merchantOnly",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.analysisPanel.tooltips.reanalyze",
+    "newPath": "pages.invoices.viewInvoice.analysisPanel.tooltips.reanalyze",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.categoryComparisonChart.description",
+    "newPath": "pages.invoices.viewInvoice.categoryComparisonChart.description",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.categoryComparisonChart.labels.average",
+    "newPath": "pages.invoices.viewInvoice.categoryComparisonChart.labels.average",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.categoryComparisonChart.labels.current",
+    "newPath": "pages.invoices.viewInvoice.categoryComparisonChart.labels.current",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.categoryComparisonChart.title",
+    "newPath": "pages.invoices.viewInvoice.categoryComparisonChart.title",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.export.copyError",
+    "newPath": "pages.invoices.viewInvoice.export.copyError",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.export.copySuccess",
+    "newPath": "pages.invoices.viewInvoice.export.copySuccess",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.export.copySummary.description",
+    "newPath": "pages.invoices.viewInvoice.export.copySummary.description",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.export.copySummary.title",
+    "newPath": "pages.invoices.viewInvoice.export.copySummary.title",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.export.csv.description",
+    "newPath": "pages.invoices.viewInvoice.export.csv.description",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.export.csv.title",
+    "newPath": "pages.invoices.viewInvoice.export.csv.title",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.export.csvError",
+    "newPath": "pages.invoices.viewInvoice.export.csvError",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.export.csvSuccess",
+    "newPath": "pages.invoices.viewInvoice.export.csvSuccess",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.export.description",
+    "newPath": "pages.invoices.viewInvoice.export.description",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.export.json.description",
+    "newPath": "pages.invoices.viewInvoice.export.json.description",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.export.json.title",
+    "newPath": "pages.invoices.viewInvoice.export.json.title",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.export.jsonError",
+    "newPath": "pages.invoices.viewInvoice.export.jsonError",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.export.jsonSuccess",
+    "newPath": "pages.invoices.viewInvoice.export.jsonSuccess",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.export.pdf.description",
+    "newPath": "pages.invoices.viewInvoice.export.pdf.description",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.export.pdf.title",
+    "newPath": "pages.invoices.viewInvoice.export.pdf.title",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.export.pdfError",
+    "newPath": "pages.invoices.viewInvoice.export.pdfError",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.export.pdfGenerating",
+    "newPath": "pages.invoices.viewInvoice.export.pdfGenerating",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.export.pdfSuccess",
+    "newPath": "pages.invoices.viewInvoice.export.pdfSuccess",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.export.print.description",
+    "newPath": "pages.invoices.viewInvoice.export.print.description",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.export.print.title",
+    "newPath": "pages.invoices.viewInvoice.export.print.title",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.export.printError",
+    "newPath": "pages.invoices.viewInvoice.export.printError",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.export.printSuccess",
+    "newPath": "pages.invoices.viewInvoice.export.printSuccess",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.export.title",
+    "newPath": "pages.invoices.viewInvoice.export.title",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.healthScore.cta.analyze",
+    "newPath": "pages.invoices.viewInvoice.healthScore.cta.analyze",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.healthScore.cta.edit",
+    "newPath": "pages.invoices.viewInvoice.healthScore.cta.edit",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.healthScore.dialogTitle",
+    "newPath": "pages.invoices.viewInvoice.healthScore.dialogTitle",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.healthScore.factors.categoriesAssigned",
+    "newPath": "pages.invoices.viewInvoice.healthScore.factors.categoriesAssigned",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.healthScore.factors.merchantLinked",
+    "newPath": "pages.invoices.viewInvoice.healthScore.factors.merchantLinked",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.healthScore.factors.ocrConfidence",
+    "newPath": "pages.invoices.viewInvoice.healthScore.factors.ocrConfidence",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.healthScore.factors.paymentInfo",
+    "newPath": "pages.invoices.viewInvoice.healthScore.factors.paymentInfo",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.healthScore.factors.productCompleteness",
+    "newPath": "pages.invoices.viewInvoice.healthScore.factors.productCompleteness",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.healthScore.factors.productsPresent",
+    "newPath": "pages.invoices.viewInvoice.healthScore.factors.productsPresent",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.healthScore.factors.recipesGenerated",
+    "newPath": "pages.invoices.viewInvoice.healthScore.factors.recipesGenerated",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.healthScore.hideDetails",
+    "newPath": "pages.invoices.viewInvoice.healthScore.hideDetails",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.healthScore.points",
+    "newPath": "pages.invoices.viewInvoice.healthScore.points",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.healthScore.seeReport",
+    "newPath": "pages.invoices.viewInvoice.healthScore.seeReport",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.healthScore.showDetails",
+    "newPath": "pages.invoices.viewInvoice.healthScore.showDetails",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.healthScore.status.excellent",
+    "newPath": "pages.invoices.viewInvoice.healthScore.status.excellent",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.healthScore.status.good",
+    "newPath": "pages.invoices.viewInvoice.healthScore.status.good",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.healthScore.status.incomplete",
+    "newPath": "pages.invoices.viewInvoice.healthScore.status.incomplete",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.healthScore.status.needsAttention",
+    "newPath": "pages.invoices.viewInvoice.healthScore.status.needsAttention",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.healthScore.subtitle",
+    "newPath": "pages.invoices.viewInvoice.healthScore.subtitle",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.healthScore.suggestions.fix",
+    "newPath": "pages.invoices.viewInvoice.healthScore.suggestions.fix",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.healthScore.suggestions.incompletePayment",
+    "newPath": "pages.invoices.viewInvoice.healthScore.suggestions.incompletePayment",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.healthScore.suggestions.incompleteProducts",
+    "newPath": "pages.invoices.viewInvoice.healthScore.suggestions.incompleteProducts",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.healthScore.suggestions.lowOcrConfidence",
+    "newPath": "pages.invoices.viewInvoice.healthScore.suggestions.lowOcrConfidence",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.healthScore.suggestions.noMerchant",
+    "newPath": "pages.invoices.viewInvoice.healthScore.suggestions.noMerchant",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.healthScore.suggestions.noProducts",
+    "newPath": "pages.invoices.viewInvoice.healthScore.suggestions.noProducts",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.healthScore.suggestions.noRecipes",
+    "newPath": "pages.invoices.viewInvoice.healthScore.suggestions.noRecipes",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.healthScore.suggestions.title",
+    "newPath": "pages.invoices.viewInvoice.healthScore.suggestions.title",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.healthScore.suggestions.uncategorizedProducts",
+    "newPath": "pages.invoices.viewInvoice.healthScore.suggestions.uncategorizedProducts",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.healthScore.title",
+    "newPath": "pages.invoices.viewInvoice.healthScore.title",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.invoiceAnalytics.emptyState.description",
+    "newPath": "pages.invoices.viewInvoice.invoiceAnalytics.emptyState.description",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.invoiceAnalytics.emptyState.title",
+    "newPath": "pages.invoices.viewInvoice.invoiceAnalytics.emptyState.title",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.invoiceAnalytics.tabs.compare",
+    "newPath": "pages.invoices.viewInvoice.invoiceAnalytics.tabs.compare",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.invoiceAnalytics.tabs.current",
+    "newPath": "pages.invoices.viewInvoice.invoiceAnalytics.tabs.current",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.invoiceAnalytics.title",
+    "newPath": "pages.invoices.viewInvoice.invoiceAnalytics.title",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.invoiceGuestBanner.description",
+    "newPath": "pages.invoices.viewInvoice.invoiceGuestBanner.description",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.invoiceGuestBanner.title",
+    "newPath": "pages.invoices.viewInvoice.invoiceGuestBanner.title",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.invoiceTabs.actions.generate",
+    "newPath": "pages.invoices.viewInvoice.invoiceTabs.actions.generate",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.invoiceTabs.actions.regenerate",
+    "newPath": "pages.invoices.viewInvoice.invoiceTabs.actions.regenerate",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.invoiceTabs.actions.regenerateTooltip",
+    "newPath": "pages.invoices.viewInvoice.invoiceTabs.actions.regenerateTooltip",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.invoiceTabs.empty.additionalInfo",
+    "newPath": "pages.invoices.viewInvoice.invoiceTabs.empty.additionalInfo",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.invoiceTabs.empty.recipes",
+    "newPath": "pages.invoices.viewInvoice.invoiceTabs.empty.recipes",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.invoiceTabs.recipe.duration",
+    "newPath": "pages.invoices.viewInvoice.invoiceTabs.recipe.duration",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.invoiceTabs.recipe.ingredients",
+    "newPath": "pages.invoices.viewInvoice.invoiceTabs.recipe.ingredients",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.invoiceTabs.recipe.instructions",
+    "newPath": "pages.invoices.viewInvoice.invoiceTabs.recipe.instructions",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.invoiceTabs.recipe.prepCook",
+    "newPath": "pages.invoices.viewInvoice.invoiceTabs.recipe.prepCook",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.invoiceTabs.recipe.viewRecipe",
+    "newPath": "pages.invoices.viewInvoice.invoiceTabs.recipe.viewRecipe",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.invoiceTabs.tabs.additionalInfo",
+    "newPath": "pages.invoices.viewInvoice.invoiceTabs.tabs.additionalInfo",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.invoiceTabs.tabs.possibleRecipes",
+    "newPath": "pages.invoices.viewInvoice.invoiceTabs.tabs.possibleRecipes",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.invoiceTimeline.eventCount",
+    "newPath": "pages.invoices.viewInvoice.invoiceTimeline.eventCount",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.invoiceTimeline.subtitle",
+    "newPath": "pages.invoices.viewInvoice.invoiceTimeline.subtitle",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.invoiceTimeline.title",
+    "newPath": "pages.invoices.viewInvoice.invoiceTimeline.title",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.itemAnalytics.columns.category",
+    "newPath": "pages.invoices.viewInvoice.itemAnalytics.columns.category",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.itemAnalytics.columns.name",
+    "newPath": "pages.invoices.viewInvoice.itemAnalytics.columns.name",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.itemAnalytics.columns.price",
+    "newPath": "pages.invoices.viewInvoice.itemAnalytics.columns.price",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.itemAnalytics.columns.quantity",
+    "newPath": "pages.invoices.viewInvoice.itemAnalytics.columns.quantity",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.itemAnalytics.columns.total",
+    "newPath": "pages.invoices.viewInvoice.itemAnalytics.columns.total",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.itemAnalytics.confidence.ariaLabel",
+    "newPath": "pages.invoices.viewInvoice.itemAnalytics.confidence.ariaLabel",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.itemAnalytics.confidence.high",
+    "newPath": "pages.invoices.viewInvoice.itemAnalytics.confidence.high",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.itemAnalytics.confidence.label",
+    "newPath": "pages.invoices.viewInvoice.itemAnalytics.confidence.label",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.itemAnalytics.confidence.low",
+    "newPath": "pages.invoices.viewInvoice.itemAnalytics.confidence.low",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.itemAnalytics.confidence.lowWarning",
+    "newPath": "pages.invoices.viewInvoice.itemAnalytics.confidence.lowWarning",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.itemAnalytics.confidence.medium",
+    "newPath": "pages.invoices.viewInvoice.itemAnalytics.confidence.medium",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.itemAnalytics.empty.subtitle",
+    "newPath": "pages.invoices.viewInvoice.itemAnalytics.empty.subtitle",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.itemAnalytics.empty.title",
+    "newPath": "pages.invoices.viewInvoice.itemAnalytics.empty.title",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.itemAnalytics.searchPlaceholder",
+    "newPath": "pages.invoices.viewInvoice.itemAnalytics.searchPlaceholder",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.itemAnalytics.summary.allergens",
+    "newPath": "pages.invoices.viewInvoice.itemAnalytics.summary.allergens",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.itemAnalytics.summary.categories",
+    "newPath": "pages.invoices.viewInvoice.itemAnalytics.summary.categories",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.itemAnalytics.summary.cheapest",
+    "newPath": "pages.invoices.viewInvoice.itemAnalytics.summary.cheapest",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.itemAnalytics.summary.mostExpensive",
+    "newPath": "pages.invoices.viewInvoice.itemAnalytics.summary.mostExpensive",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.itemAnalytics.summary.title",
+    "newPath": "pages.invoices.viewInvoice.itemAnalytics.summary.title",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.itemAnalytics.title",
+    "newPath": "pages.invoices.viewInvoice.itemAnalytics.title",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.itemAnalytics.totalLabel",
+    "newPath": "pages.invoices.viewInvoice.itemAnalytics.totalLabel",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.itemsBreakdownChart.description",
+    "newPath": "pages.invoices.viewInvoice.itemsBreakdownChart.description",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.itemsBreakdownChart.labels.price",
+    "newPath": "pages.invoices.viewInvoice.itemsBreakdownChart.labels.price",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.itemsBreakdownChart.labels.quantity",
+    "newPath": "pages.invoices.viewInvoice.itemsBreakdownChart.labels.quantity",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.itemsBreakdownChart.title",
+    "newPath": "pages.invoices.viewInvoice.itemsBreakdownChart.title",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.merchantBreakdownChart.description",
+    "newPath": "pages.invoices.viewInvoice.merchantBreakdownChart.description",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.merchantBreakdownChart.labels.averagePerVisit",
+    "newPath": "pages.invoices.viewInvoice.merchantBreakdownChart.labels.averagePerVisit",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.merchantBreakdownChart.labels.total",
+    "newPath": "pages.invoices.viewInvoice.merchantBreakdownChart.labels.total",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.merchantBreakdownChart.labels.totalSpent",
+    "newPath": "pages.invoices.viewInvoice.merchantBreakdownChart.labels.totalSpent",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.merchantBreakdownChart.labels.visits",
+    "newPath": "pages.invoices.viewInvoice.merchantBreakdownChart.labels.visits",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.merchantBreakdownChart.title",
+    "newPath": "pages.invoices.viewInvoice.merchantBreakdownChart.title",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.merchantBreakdownChart.unknownMerchant",
+    "newPath": "pages.invoices.viewInvoice.merchantBreakdownChart.unknownMerchant",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.metadata.description",
+    "newPath": "pages.invoices.viewInvoice.metadata.description",
+    "reason": "view-invoice metadata"
+  },
+  {
+    "oldPath": "IMS--View.metadata.title",
+    "newPath": "pages.invoices.viewInvoice.metadata.title",
+    "reason": "view-invoice metadata"
+  },
+  {
+    "oldPath": "IMS--View.priceDistributionChart.description",
+    "newPath": "pages.invoices.viewInvoice.priceDistributionChart.description",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.priceDistributionChart.labels.items",
+    "newPath": "pages.invoices.viewInvoice.priceDistributionChart.labels.items",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.priceDistributionChart.title",
+    "newPath": "pages.invoices.viewInvoice.priceDistributionChart.title",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.priceDistributionChart.tooltip.itemCount",
+    "newPath": "pages.invoices.viewInvoice.priceDistributionChart.tooltip.itemCount",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.print.generatedOn",
+    "newPath": "pages.invoices.viewInvoice.print.generatedOn",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.print.labels.date",
+    "newPath": "pages.invoices.viewInvoice.print.labels.date",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.print.labels.items",
+    "newPath": "pages.invoices.viewInvoice.print.labels.items",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.print.labels.merchant",
+    "newPath": "pages.invoices.viewInvoice.print.labels.merchant",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.print.labels.total",
+    "newPath": "pages.invoices.viewInvoice.print.labels.total",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.print.page",
+    "newPath": "pages.invoices.viewInvoice.print.page",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.relatedInvoices.noRelated",
+    "newPath": "pages.invoices.viewInvoice.relatedInvoices.noRelated",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.relatedInvoices.sameCategory",
+    "newPath": "pages.invoices.viewInvoice.relatedInvoices.sameCategory",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.relatedInvoices.sameMerchant",
+    "newPath": "pages.invoices.viewInvoice.relatedInvoices.sameMerchant",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.relatedInvoices.similarAmount",
+    "newPath": "pages.invoices.viewInvoice.relatedInvoices.similarAmount",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.relatedInvoices.subtitle",
+    "newPath": "pages.invoices.viewInvoice.relatedInvoices.subtitle",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.relatedInvoices.title",
+    "newPath": "pages.invoices.viewInvoice.relatedInvoices.title",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.relatedInvoices.viewInvoice",
+    "newPath": "pages.invoices.viewInvoice.relatedInvoices.viewInvoice",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.shareCollaborate.activity.created",
+    "newPath": "pages.invoices.viewInvoice.shareCollaborate.activity.created",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.shareCollaborate.activity.daysAgo",
+    "newPath": "pages.invoices.viewInvoice.shareCollaborate.activity.daysAgo",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.shareCollaborate.activity.modified",
+    "newPath": "pages.invoices.viewInvoice.shareCollaborate.activity.modified",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.shareCollaborate.activity.title",
+    "newPath": "pages.invoices.viewInvoice.shareCollaborate.activity.title",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.shareCollaborate.activity.today",
+    "newPath": "pages.invoices.viewInvoice.shareCollaborate.activity.today",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.shareCollaborate.copied",
+    "newPath": "pages.invoices.viewInvoice.shareCollaborate.copied",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.shareCollaborate.copyError",
+    "newPath": "pages.invoices.viewInvoice.shareCollaborate.copyError",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.shareCollaborate.copyLink",
+    "newPath": "pages.invoices.viewInvoice.shareCollaborate.copyLink",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.shareCollaborate.madePrivate",
+    "newPath": "pages.invoices.viewInvoice.shareCollaborate.madePrivate",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.shareCollaborate.madePublic",
+    "newPath": "pages.invoices.viewInvoice.shareCollaborate.madePublic",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.shareCollaborate.manageSharing",
+    "newPath": "pages.invoices.viewInvoice.shareCollaborate.manageSharing",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.shareCollaborate.private",
+    "newPath": "pages.invoices.viewInvoice.shareCollaborate.private",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.shareCollaborate.public",
+    "newPath": "pages.invoices.viewInvoice.shareCollaborate.public",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.shareCollaborate.publicAccess",
+    "newPath": "pages.invoices.viewInvoice.shareCollaborate.publicAccess",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.shareCollaborate.publicAccessDescription",
+    "newPath": "pages.invoices.viewInvoice.shareCollaborate.publicAccessDescription",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.shareCollaborate.qrCode",
+    "newPath": "pages.invoices.viewInvoice.shareCollaborate.qrCode",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.shareCollaborate.qrCopied",
+    "newPath": "pages.invoices.viewInvoice.shareCollaborate.qrCopied",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.shareCollaborate.shared",
+    "newPath": "pages.invoices.viewInvoice.shareCollaborate.shared",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.shareCollaborate.sharedWith",
+    "newPath": "pages.invoices.viewInvoice.shareCollaborate.sharedWith",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.shareCollaborate.shareEmail",
+    "newPath": "pages.invoices.viewInvoice.shareCollaborate.shareEmail",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.shareCollaborate.title",
+    "newPath": "pages.invoices.viewInvoice.shareCollaborate.title",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.shareCollaborate.toggleError",
+    "newPath": "pages.invoices.viewInvoice.shareCollaborate.toggleError",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.spendingByCategoryChart.description",
+    "newPath": "pages.invoices.viewInvoice.spendingByCategoryChart.description",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.spendingByCategoryChart.title",
+    "newPath": "pages.invoices.viewInvoice.spendingByCategoryChart.title",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.spendingByCategoryChart.tooltip.itemCount",
+    "newPath": "pages.invoices.viewInvoice.spendingByCategoryChart.tooltip.itemCount",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.spendingByCategoryChart.totalLabel",
+    "newPath": "pages.invoices.viewInvoice.spendingByCategoryChart.totalLabel",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.spendingTrendChart.description",
+    "newPath": "pages.invoices.viewInvoice.spendingTrendChart.description",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.spendingTrendChart.labels.amount",
+    "newPath": "pages.invoices.viewInvoice.spendingTrendChart.labels.amount",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.spendingTrendChart.title",
+    "newPath": "pages.invoices.viewInvoice.spendingTrendChart.title",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.spendingTrendChart.tooltip.andMore",
+    "newPath": "pages.invoices.viewInvoice.spendingTrendChart.tooltip.andMore",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.spendingTrendChart.tooltip.currentInvoice",
+    "newPath": "pages.invoices.viewInvoice.spendingTrendChart.tooltip.currentInvoice",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.timelineItem.aria.moreInfo",
+    "newPath": "sections.invoices.timeline.item.aria.moreInfo",
+    "reason": "invoice timeline item"
+  },
+  {
+    "oldPath": "IMS--View.timelineItem.confidence",
+    "newPath": "sections.invoices.timeline.item.confidence",
+    "reason": "invoice timeline item"
+  },
+  {
+    "oldPath": "IMS--View.timelineItem.events.aiAnalysis.description",
+    "newPath": "sections.invoices.timeline.item.events.aiAnalysis.description",
+    "reason": "invoice timeline item"
+  },
+  {
+    "oldPath": "IMS--View.timelineItem.events.aiAnalysis.title",
+    "newPath": "sections.invoices.timeline.item.events.aiAnalysis.title",
+    "reason": "invoice timeline item"
+  },
+  {
+    "oldPath": "IMS--View.timelineItem.events.categorized.description",
+    "newPath": "sections.invoices.timeline.item.events.categorized.description",
+    "reason": "invoice timeline item"
+  },
+  {
+    "oldPath": "IMS--View.timelineItem.events.categorized.title",
+    "newPath": "sections.invoices.timeline.item.events.categorized.title",
+    "reason": "invoice timeline item"
+  },
+  {
+    "oldPath": "IMS--View.timelineItem.events.created.description",
+    "newPath": "sections.invoices.timeline.item.events.created.description",
+    "reason": "invoice timeline item"
+  },
+  {
+    "oldPath": "IMS--View.timelineItem.events.created.title",
+    "newPath": "sections.invoices.timeline.item.events.created.title",
+    "reason": "invoice timeline item"
+  },
+  {
+    "oldPath": "IMS--View.timelineItem.events.edited.title",
+    "newPath": "sections.invoices.timeline.item.events.edited.title",
+    "reason": "invoice timeline item"
+  },
+  {
+    "oldPath": "IMS--View.timelineItem.events.exported.title",
+    "newPath": "sections.invoices.timeline.item.events.exported.title",
+    "reason": "invoice timeline item"
+  },
+  {
+    "oldPath": "IMS--View.timelineItem.events.markedImportant.description",
+    "newPath": "sections.invoices.timeline.item.events.markedImportant.description",
+    "reason": "invoice timeline item"
+  },
+  {
+    "oldPath": "IMS--View.timelineItem.events.markedImportant.title",
+    "newPath": "sections.invoices.timeline.item.events.markedImportant.title",
+    "reason": "invoice timeline item"
+  },
+  {
+    "oldPath": "IMS--View.timelineItem.events.recipesGenerated.description",
+    "newPath": "sections.invoices.timeline.item.events.recipesGenerated.description",
+    "reason": "invoice timeline item"
+  },
+  {
+    "oldPath": "IMS--View.timelineItem.events.recipesGenerated.title",
+    "newPath": "sections.invoices.timeline.item.events.recipesGenerated.title",
+    "reason": "invoice timeline item"
+  },
+  {
+    "oldPath": "IMS--View.timelineItem.events.shared.description",
+    "newPath": "sections.invoices.timeline.item.events.shared.description",
+    "reason": "invoice timeline item"
+  },
+  {
+    "oldPath": "IMS--View.timelineItem.events.shared.title",
+    "newPath": "sections.invoices.timeline.item.events.shared.title",
+    "reason": "invoice timeline item"
+  },
+  {
+    "oldPath": "IMS--View.timelineItem.fallbacks.ocr",
+    "newPath": "sections.invoices.timeline.item.fallbacks.ocr",
+    "reason": "invoice timeline item"
+  },
+  {
+    "oldPath": "IMS--View.timelineItem.fallbacks.pdf",
+    "newPath": "sections.invoices.timeline.item.fallbacks.pdf",
+    "reason": "invoice timeline item"
+  },
+  {
+    "oldPath": "IMS--View.timelineItem.relativeTime.now",
+    "newPath": "sections.invoices.timeline.item.relativeTime.now",
+    "reason": "invoice timeline item"
+  },
+  {
+    "oldPath": "IMS--View.timelineItem.tooltips.aiAnalysis",
+    "newPath": "sections.invoices.timeline.item.tooltips.aiAnalysis",
+    "reason": "invoice timeline item"
+  },
+  {
+    "oldPath": "IMS--View.timelineItem.tooltips.categorized",
+    "newPath": "sections.invoices.timeline.item.tooltips.categorized",
+    "reason": "invoice timeline item"
+  },
+  {
+    "oldPath": "IMS--View.timelineItem.tooltips.created",
+    "newPath": "sections.invoices.timeline.item.tooltips.created",
+    "reason": "invoice timeline item"
+  },
+  {
+    "oldPath": "IMS--View.timelineItem.tooltips.edited",
+    "newPath": "sections.invoices.timeline.item.tooltips.edited",
+    "reason": "invoice timeline item"
+  },
+  {
+    "oldPath": "IMS--View.timelineItem.tooltips.exported",
+    "newPath": "sections.invoices.timeline.item.tooltips.exported",
+    "reason": "invoice timeline item"
+  },
+  {
+    "oldPath": "IMS--View.timelineItem.tooltips.markedImportant",
+    "newPath": "sections.invoices.timeline.item.tooltips.markedImportant",
+    "reason": "invoice timeline item"
+  },
+  {
+    "oldPath": "IMS--View.timelineItem.tooltips.recipesGenerated",
+    "newPath": "sections.invoices.timeline.item.tooltips.recipesGenerated",
+    "reason": "invoice timeline item"
+  },
+  {
+    "oldPath": "IMS--View.timelineItem.tooltips.shared",
+    "newPath": "sections.invoices.timeline.item.tooltips.shared",
+    "reason": "invoice timeline item"
+  },
+  {
+    "oldPath": "IMS--View.timelineItem.tooltips.unavailable",
+    "newPath": "sections.invoices.timeline.item.tooltips.unavailable",
+    "reason": "invoice timeline item"
+  },
+  {
+    "oldPath": "IMS--View.timelineSharedWithList.actions.manageSharing",
+    "newPath": "pages.invoices.viewInvoice.timelineSharedWithList.actions.manageSharing",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.timelineSharedWithList.actions.sendEmail",
+    "newPath": "pages.invoices.viewInvoice.timelineSharedWithList.actions.sendEmail",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.timelineSharedWithList.aria.sendEmail",
+    "newPath": "pages.invoices.viewInvoice.timelineSharedWithList.aria.sendEmail",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.timelineSharedWithList.header.publicBadge",
+    "newPath": "pages.invoices.viewInvoice.timelineSharedWithList.header.publicBadge",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.timelineSharedWithList.header.title",
+    "newPath": "pages.invoices.viewInvoice.timelineSharedWithList.header.title",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.timelineSharedWithList.publicAccess.description",
+    "newPath": "pages.invoices.viewInvoice.timelineSharedWithList.publicAccess.description",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--View.timelineSharedWithList.publicAccess.title",
+    "newPath": "pages.invoices.viewInvoice.timelineSharedWithList.publicAccess.title",
+    "reason": "view-invoice page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.breadcrumb",
+    "newPath": "pages.invoices.viewScans.breadcrumb",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.createFromAll.button",
+    "newPath": "pages.invoices.viewScans.createFromAll.button",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.createFromAll.description",
+    "newPath": "pages.invoices.viewScans.createFromAll.description",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.createFromAll.title",
+    "newPath": "pages.invoices.viewScans.createFromAll.title",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.emptyState.description",
+    "newPath": "pages.invoices.viewScans.emptyState.description",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.emptyState.learnMoreButton",
+    "newPath": "pages.invoices.viewScans.emptyState.learnMoreButton",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.emptyState.step1Description",
+    "newPath": "pages.invoices.viewScans.emptyState.step1Description",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.emptyState.step1Title",
+    "newPath": "pages.invoices.viewScans.emptyState.step1Title",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.emptyState.step2Description",
+    "newPath": "pages.invoices.viewScans.emptyState.step2Description",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.emptyState.step2Title",
+    "newPath": "pages.invoices.viewScans.emptyState.step2Title",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.emptyState.step3Description",
+    "newPath": "pages.invoices.viewScans.emptyState.step3Description",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.emptyState.step3Title",
+    "newPath": "pages.invoices.viewScans.emptyState.step3Title",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.emptyState.title",
+    "newPath": "pages.invoices.viewScans.emptyState.title",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.emptyState.uploadButton",
+    "newPath": "pages.invoices.viewScans.emptyState.uploadButton",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.groupBanner.createInvoice",
+    "newPath": "pages.invoices.viewScans.groupBanner.createInvoice",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.groupBanner.dismiss",
+    "newPath": "pages.invoices.viewScans.groupBanner.dismiss",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.groupBanner.subtitle",
+    "newPath": "pages.invoices.viewScans.groupBanner.subtitle",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.groupBanner.title",
+    "newPath": "pages.invoices.viewScans.groupBanner.title",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.header.invoices",
+    "newPath": "pages.invoices.viewScans.header.invoices",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.header.lastSynced",
+    "newPath": "pages.invoices.viewScans.header.lastSynced",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.header.myInvoices",
+    "newPath": "pages.invoices.viewScans.header.myInvoices",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.header.myInvoicesTooltip",
+    "newPath": "pages.invoices.viewScans.header.myInvoicesTooltip",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.header.subtitle",
+    "newPath": "pages.invoices.viewScans.header.subtitle",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.header.sync",
+    "newPath": "pages.invoices.viewScans.header.sync",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.header.syncing",
+    "newPath": "pages.invoices.viewScans.header.syncing",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.header.syncTooltip",
+    "newPath": "pages.invoices.viewScans.header.syncTooltip",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.header.title",
+    "newPath": "pages.invoices.viewScans.header.title",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.header.titleWithCount",
+    "newPath": "pages.invoices.viewScans.header.titleWithCount",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.header.tooltip",
+    "newPath": "pages.invoices.viewScans.header.tooltip",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.header.upload",
+    "newPath": "pages.invoices.viewScans.header.upload",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.header.uploadMore",
+    "newPath": "pages.invoices.viewScans.header.uploadMore",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.header.uploadTooltip",
+    "newPath": "pages.invoices.viewScans.header.uploadTooltip",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.metadata.description",
+    "newPath": "pages.invoices.viewScans.metadata.description",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.metadata.title",
+    "newPath": "pages.invoices.viewScans.metadata.title",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.pagination.next",
+    "newPath": "pages.invoices.viewScans.pagination.next",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.pagination.pageInfo",
+    "newPath": "pages.invoices.viewScans.pagination.pageInfo",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.pagination.previous",
+    "newPath": "pages.invoices.viewScans.pagination.previous",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.scanCard.actions.delete",
+    "newPath": "pages.invoices.viewScans.scanCard.actions.delete",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.scanCard.actions.rename",
+    "newPath": "pages.invoices.viewScans.scanCard.actions.rename",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.scanCard.actions.rotateCCW",
+    "newPath": "pages.invoices.viewScans.scanCard.actions.rotateCCW",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.scanCard.actions.rotateCW",
+    "newPath": "pages.invoices.viewScans.scanCard.actions.rotateCW",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.scanCard.actions.rotateError",
+    "newPath": "pages.invoices.viewScans.scanCard.actions.rotateError",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.scanCard.actions.rotateSuccess",
+    "newPath": "pages.invoices.viewScans.scanCard.actions.rotateSuccess",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.scanCard.actions.rotateUnsupported",
+    "newPath": "pages.invoices.viewScans.scanCard.actions.rotateUnsupported",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.scanCard.actions.rotating",
+    "newPath": "pages.invoices.viewScans.scanCard.actions.rotating",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.scanCard.delete",
+    "newPath": "pages.invoices.viewScans.scanCard.delete",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.scanCard.deleteDialog.cancel",
+    "newPath": "pages.invoices.viewScans.scanCard.deleteDialog.cancel",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.scanCard.deleteDialog.delete",
+    "newPath": "pages.invoices.viewScans.scanCard.deleteDialog.delete",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.scanCard.deleteDialog.deleting",
+    "newPath": "pages.invoices.viewScans.scanCard.deleteDialog.deleting",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.scanCard.deleteDialog.description",
+    "newPath": "pages.invoices.viewScans.scanCard.deleteDialog.description",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.scanCard.deleteDialog.error",
+    "newPath": "pages.invoices.viewScans.scanCard.deleteDialog.error",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.scanCard.deleteDialog.linkedDescription",
+    "newPath": "pages.invoices.viewScans.scanCard.deleteDialog.linkedDescription",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.scanCard.deleteDialog.linkedWarning",
+    "newPath": "pages.invoices.viewScans.scanCard.deleteDialog.linkedWarning",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.scanCard.deleteDialog.success",
+    "newPath": "pages.invoices.viewScans.scanCard.deleteDialog.success",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.scanCard.deleteDialog.title",
+    "newPath": "pages.invoices.viewScans.scanCard.deleteDialog.title",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.scanCard.linked",
+    "newPath": "pages.invoices.viewScans.scanCard.linked",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.scanCard.loading",
+    "newPath": "pages.invoices.viewScans.scanCard.loading",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.scanCard.preview",
+    "newPath": "pages.invoices.viewScans.scanCard.preview",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.scanCard.previewTitle",
+    "newPath": "pages.invoices.viewScans.scanCard.previewTitle",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.scanCard.rename",
+    "newPath": "pages.invoices.viewScans.scanCard.rename",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.scanCard.renamePlaceholder",
+    "newPath": "pages.invoices.viewScans.scanCard.renamePlaceholder",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.sidebar.howTo.step1Description",
+    "newPath": "pages.invoices.viewScans.sidebar.howTo.step1Description",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.sidebar.howTo.step1Title",
+    "newPath": "pages.invoices.viewScans.sidebar.howTo.step1Title",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.sidebar.howTo.step2Description",
+    "newPath": "pages.invoices.viewScans.sidebar.howTo.step2Description",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.sidebar.howTo.step2Title",
+    "newPath": "pages.invoices.viewScans.sidebar.howTo.step2Title",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.sidebar.howTo.step3Description",
+    "newPath": "pages.invoices.viewScans.sidebar.howTo.step3Description",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.sidebar.howTo.step3Title",
+    "newPath": "pages.invoices.viewScans.sidebar.howTo.step3Title",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.sidebar.howTo.title",
+    "newPath": "pages.invoices.viewScans.sidebar.howTo.title",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.sidebar.quickUpload.button",
+    "newPath": "pages.invoices.viewScans.sidebar.quickUpload.button",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.sidebar.quickUpload.description",
+    "newPath": "pages.invoices.viewScans.sidebar.quickUpload.description",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.sidebar.quickUpload.title",
+    "newPath": "pages.invoices.viewScans.sidebar.quickUpload.title",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.sidebar.selectionStatus.plural",
+    "newPath": "pages.invoices.viewScans.sidebar.selectionStatus.plural",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.sidebar.selectionStatus.readyPlural",
+    "newPath": "pages.invoices.viewScans.sidebar.selectionStatus.readyPlural",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.sidebar.selectionStatus.readySingular",
+    "newPath": "pages.invoices.viewScans.sidebar.selectionStatus.readySingular",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.sidebar.selectionStatus.singular",
+    "newPath": "pages.invoices.viewScans.sidebar.selectionStatus.singular",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.stats.ready",
+    "newPath": "pages.invoices.viewScans.stats.ready",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.stats.selected",
+    "newPath": "pages.invoices.viewScans.stats.selected",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.stats.selectHint",
+    "newPath": "pages.invoices.viewScans.stats.selectHint",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.stats.tapHint",
+    "newPath": "pages.invoices.viewScans.stats.tapHint",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.stats.totalScans",
+    "newPath": "pages.invoices.viewScans.stats.totalScans",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.subtitle",
+    "newPath": "pages.invoices.viewScans.subtitle",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.title",
+    "newPath": "pages.invoices.viewScans.title",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.toolbar.clearSelection",
+    "newPath": "pages.invoices.viewScans.toolbar.clearSelection",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.toolbar.createInvoice",
+    "newPath": "pages.invoices.viewScans.toolbar.createInvoice",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.toolbar.createInvoices",
+    "newPath": "pages.invoices.viewScans.toolbar.createInvoices",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.toolbar.delete.button",
+    "newPath": "pages.invoices.viewScans.toolbar.delete.button",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.toolbar.delete.cancel",
+    "newPath": "pages.invoices.viewScans.toolbar.delete.cancel",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.toolbar.delete.confirm",
+    "newPath": "pages.invoices.viewScans.toolbar.delete.confirm",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.toolbar.delete.confirmDescription",
+    "newPath": "pages.invoices.viewScans.toolbar.delete.confirmDescription",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.toolbar.delete.confirmTitle",
+    "newPath": "pages.invoices.viewScans.toolbar.delete.confirmTitle",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.toolbar.delete.error",
+    "newPath": "pages.invoices.viewScans.toolbar.delete.error",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.toolbar.delete.failed",
+    "newPath": "pages.invoices.viewScans.toolbar.delete.failed",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.toolbar.delete.partial",
+    "newPath": "pages.invoices.viewScans.toolbar.delete.partial",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.toolbar.delete.success",
+    "newPath": "pages.invoices.viewScans.toolbar.delete.success",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "IMS--ViewScans.toolbar.selected",
+    "newPath": "pages.invoices.viewScans.toolbar.selected",
+    "reason": "view-scans page"
+  },
+  {
+    "oldPath": "Legal.PrivacyPolicy.contactInformation.content",
+    "newPath": "sections.legal.privacyPolicy.contactInformation.content",
+    "reason": "privacy policy content"
+  },
+  {
+    "oldPath": "Legal.PrivacyPolicy.contactInformation.title",
+    "newPath": "sections.legal.privacyPolicy.contactInformation.title",
+    "reason": "privacy policy content"
+  },
+  {
+    "oldPath": "Legal.PrivacyPolicy.last_updated",
+    "newPath": "sections.legal.privacyPolicy.lastUpdated",
+    "reason": "privacy policy content"
+  },
+  {
+    "oldPath": "Legal.PrivacyPolicy.metadata.description",
+    "newPath": "pages.legal.privacyPolicy.metadata.description",
+    "reason": "privacy metadata"
+  },
+  {
+    "oldPath": "Legal.PrivacyPolicy.metadata.title",
+    "newPath": "pages.legal.privacyPolicy.metadata.title",
+    "reason": "privacy metadata"
+  },
+  {
+    "oldPath": "Legal.PrivacyPolicy.terms.childrenPrivacy.content",
+    "newPath": "sections.legal.privacyPolicy.terms.childrenPrivacy.content",
+    "reason": "privacy policy content"
+  },
+  {
+    "oldPath": "Legal.PrivacyPolicy.terms.childrenPrivacy.title",
+    "newPath": "sections.legal.privacyPolicy.terms.childrenPrivacy.title",
+    "reason": "privacy policy content"
+  },
+  {
+    "oldPath": "Legal.PrivacyPolicy.terms.cookiesDefinition.content",
+    "newPath": "sections.legal.privacyPolicy.terms.cookiesDefinition.content",
+    "reason": "privacy policy content"
+  },
+  {
+    "oldPath": "Legal.PrivacyPolicy.terms.cookiesDefinition.title",
+    "newPath": "sections.legal.privacyPolicy.terms.cookiesDefinition.title",
+    "reason": "privacy policy content"
+  },
+  {
+    "oldPath": "Legal.PrivacyPolicy.terms.dataCollectionTerms.content",
+    "newPath": "sections.legal.privacyPolicy.terms.dataCollectionTerms.content",
+    "reason": "privacy policy content"
+  },
+  {
+    "oldPath": "Legal.PrivacyPolicy.terms.dataCollectionTerms.title",
+    "newPath": "sections.legal.privacyPolicy.terms.dataCollectionTerms.title",
+    "reason": "privacy policy content"
+  },
+  {
+    "oldPath": "Legal.PrivacyPolicy.terms.dataTransferTerms.content",
+    "newPath": "sections.legal.privacyPolicy.terms.dataTransferTerms.content",
+    "reason": "privacy policy content"
+  },
+  {
+    "oldPath": "Legal.PrivacyPolicy.terms.dataTransferTerms.title",
+    "newPath": "sections.legal.privacyPolicy.terms.dataTransferTerms.title",
+    "reason": "privacy policy content"
+  },
+  {
+    "oldPath": "Legal.PrivacyPolicy.terms.deviceUsageTerms.content",
+    "newPath": "sections.legal.privacyPolicy.terms.deviceUsageTerms.content",
+    "reason": "privacy policy content"
+  },
+  {
+    "oldPath": "Legal.PrivacyPolicy.terms.deviceUsageTerms.title",
+    "newPath": "sections.legal.privacyPolicy.terms.deviceUsageTerms.title",
+    "reason": "privacy policy content"
+  },
+  {
+    "oldPath": "Legal.PrivacyPolicy.terms.exerciseRights.content",
+    "newPath": "sections.legal.privacyPolicy.terms.exerciseRights.content",
+    "reason": "privacy policy content"
+  },
+  {
+    "oldPath": "Legal.PrivacyPolicy.terms.exerciseRights.title",
+    "newPath": "sections.legal.privacyPolicy.terms.exerciseRights.title",
+    "reason": "privacy policy content"
+  },
+  {
+    "oldPath": "Legal.PrivacyPolicy.terms.howWeCollectDataTerms.content",
+    "newPath": "sections.legal.privacyPolicy.terms.howWeCollectDataTerms.content",
+    "reason": "privacy policy content"
+  },
+  {
+    "oldPath": "Legal.PrivacyPolicy.terms.howWeCollectDataTerms.title",
+    "newPath": "sections.legal.privacyPolicy.terms.howWeCollectDataTerms.title",
+    "reason": "privacy policy content"
+  },
+  {
+    "oldPath": "Legal.PrivacyPolicy.terms.legalTerms.content",
+    "newPath": "sections.legal.privacyPolicy.terms.legalTerms.content",
+    "reason": "privacy policy content"
+  },
+  {
+    "oldPath": "Legal.PrivacyPolicy.terms.legalTerms.title",
+    "newPath": "sections.legal.privacyPolicy.terms.legalTerms.title",
+    "reason": "privacy policy content"
+  },
+  {
+    "oldPath": "Legal.PrivacyPolicy.terms.personalDataRights.content",
+    "newPath": "sections.legal.privacyPolicy.terms.personalDataRights.content",
+    "reason": "privacy policy content"
+  },
+  {
+    "oldPath": "Legal.PrivacyPolicy.terms.personalDataRights.title",
+    "newPath": "sections.legal.privacyPolicy.terms.personalDataRights.title",
+    "reason": "privacy policy content"
+  },
+  {
+    "oldPath": "Legal.PrivacyPolicy.terms.policyChanges.content",
+    "newPath": "sections.legal.privacyPolicy.terms.policyChanges.content",
+    "reason": "privacy policy content"
+  },
+  {
+    "oldPath": "Legal.PrivacyPolicy.terms.policyChanges.title",
+    "newPath": "sections.legal.privacyPolicy.terms.policyChanges.title",
+    "reason": "privacy policy content"
+  },
+  {
+    "oldPath": "Legal.PrivacyPolicy.terms.processingDataTerms.content",
+    "newPath": "sections.legal.privacyPolicy.terms.processingDataTerms.content",
+    "reason": "privacy policy content"
+  },
+  {
+    "oldPath": "Legal.PrivacyPolicy.terms.processingDataTerms.title",
+    "newPath": "sections.legal.privacyPolicy.terms.processingDataTerms.title",
+    "reason": "privacy policy content"
+  },
+  {
+    "oldPath": "Legal.PrivacyPolicy.terms.processingTerms.content",
+    "newPath": "sections.legal.privacyPolicy.terms.processingTerms.content",
+    "reason": "privacy policy content"
+  },
+  {
+    "oldPath": "Legal.PrivacyPolicy.terms.processingTerms.title",
+    "newPath": "sections.legal.privacyPolicy.terms.processingTerms.title",
+    "reason": "privacy policy content"
+  },
+  {
+    "oldPath": "Legal.PrivacyPolicy.terms.safeDataTerms.content",
+    "newPath": "sections.legal.privacyPolicy.terms.safeDataTerms.content",
+    "reason": "privacy policy content"
+  },
+  {
+    "oldPath": "Legal.PrivacyPolicy.terms.safeDataTerms.title",
+    "newPath": "sections.legal.privacyPolicy.terms.safeDataTerms.title",
+    "reason": "privacy policy content"
+  },
+  {
+    "oldPath": "Legal.PrivacyPolicy.terms.scopeTerms.content",
+    "newPath": "sections.legal.privacyPolicy.terms.scopeTerms.content",
+    "reason": "privacy policy content"
+  },
+  {
+    "oldPath": "Legal.PrivacyPolicy.terms.scopeTerms.title",
+    "newPath": "sections.legal.privacyPolicy.terms.scopeTerms.title",
+    "reason": "privacy policy content"
+  },
+  {
+    "oldPath": "Legal.PrivacyPolicy.terms.serviceProviderTerms.content",
+    "newPath": "sections.legal.privacyPolicy.terms.serviceProviderTerms.content",
+    "reason": "privacy policy content"
+  },
+  {
+    "oldPath": "Legal.PrivacyPolicy.terms.serviceProviderTerms.title",
+    "newPath": "sections.legal.privacyPolicy.terms.serviceProviderTerms.title",
+    "reason": "privacy policy content"
+  },
+  {
+    "oldPath": "Legal.PrivacyPolicy.terms.sharingAndDisclosureTerms.content",
+    "newPath": "sections.legal.privacyPolicy.terms.sharingAndDisclosureTerms.content",
+    "reason": "privacy policy content"
+  },
+  {
+    "oldPath": "Legal.PrivacyPolicy.terms.sharingAndDisclosureTerms.title",
+    "newPath": "sections.legal.privacyPolicy.terms.sharingAndDisclosureTerms.title",
+    "reason": "privacy policy content"
+  },
+  {
+    "oldPath": "Legal.PrivacyPolicy.terms.thirdPartyData.content",
+    "newPath": "sections.legal.privacyPolicy.terms.thirdPartyData.content",
+    "reason": "privacy policy content"
+  },
+  {
+    "oldPath": "Legal.PrivacyPolicy.terms.thirdPartyData.title",
+    "newPath": "sections.legal.privacyPolicy.terms.thirdPartyData.title",
+    "reason": "privacy policy content"
+  },
+  {
+    "oldPath": "Legal.PrivacyPolicy.terms.whatIsTerms.content",
+    "newPath": "sections.legal.privacyPolicy.terms.whatIsTerms.content",
+    "reason": "privacy policy content"
+  },
+  {
+    "oldPath": "Legal.PrivacyPolicy.terms.whatIsTerms.title",
+    "newPath": "sections.legal.privacyPolicy.terms.whatIsTerms.title",
+    "reason": "privacy policy content"
+  },
+  {
+    "oldPath": "Legal.PrivacyPolicy.terms.withdrawingConsent.content",
+    "newPath": "sections.legal.privacyPolicy.terms.withdrawingConsent.content",
+    "reason": "privacy policy content"
+  },
+  {
+    "oldPath": "Legal.PrivacyPolicy.terms.withdrawingConsent.title",
+    "newPath": "sections.legal.privacyPolicy.terms.withdrawingConsent.title",
+    "reason": "privacy policy content"
+  },
+  {
+    "oldPath": "Legal.PrivacyPolicy.title",
+    "newPath": "sections.legal.privacyPolicy.title",
+    "reason": "privacy policy content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.contactInformation.content",
+    "newPath": "sections.legal.termsOfService.contactInformation.content",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.contactInformation.title",
+    "newPath": "sections.legal.termsOfService.contactInformation.title",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.last_updated",
+    "newPath": "sections.legal.termsOfService.lastUpdated",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.metadata.description",
+    "newPath": "pages.legal.termsOfService.metadata.description",
+    "reason": "terms metadata"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.metadata.title",
+    "newPath": "pages.legal.termsOfService.metadata.title",
+    "reason": "terms metadata"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.amendmentsTerms.content",
+    "newPath": "sections.legal.termsOfService.terms.amendmentsTerms.content",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.amendmentsTerms.title",
+    "newPath": "sections.legal.termsOfService.terms.amendmentsTerms.title",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.arbitrateTerms.content",
+    "newPath": "sections.legal.termsOfService.terms.arbitrateTerms.content",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.arbitrateTerms.title",
+    "newPath": "sections.legal.termsOfService.terms.arbitrateTerms.title",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.changesToTos.content",
+    "newPath": "sections.legal.termsOfService.terms.changesToTos.content",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.changesToTos.title",
+    "newPath": "sections.legal.termsOfService.terms.changesToTos.title",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.consentTerms.content",
+    "newPath": "sections.legal.termsOfService.terms.consentTerms.content",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.consentTerms.title",
+    "newPath": "sections.legal.termsOfService.terms.consentTerms.title",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.cookiesTerms.content",
+    "newPath": "sections.legal.termsOfService.terms.cookiesTerms.content",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.cookiesTerms.title",
+    "newPath": "sections.legal.termsOfService.terms.cookiesTerms.title",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.copyrightTerms.content",
+    "newPath": "sections.legal.termsOfService.terms.copyrightTerms.content",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.copyrightTerms.title",
+    "newPath": "sections.legal.termsOfService.terms.copyrightTerms.title",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.definitionTerms.content",
+    "newPath": "sections.legal.termsOfService.terms.definitionTerms.content",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.definitionTerms.title",
+    "newPath": "sections.legal.termsOfService.terms.definitionTerms.title",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.disclaimerTerms.content",
+    "newPath": "sections.legal.termsOfService.terms.disclaimerTerms.content",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.disclaimerTerms.title",
+    "newPath": "sections.legal.termsOfService.terms.disclaimerTerms.title",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.disputeNoticeTerms.content",
+    "newPath": "sections.legal.termsOfService.terms.disputeNoticeTerms.content",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.disputeNoticeTerms.title",
+    "newPath": "sections.legal.termsOfService.terms.disputeNoticeTerms.title",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.entireAgreementTerms.content",
+    "newPath": "sections.legal.termsOfService.terms.entireAgreementTerms.content",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.entireAgreementTerms.title",
+    "newPath": "sections.legal.termsOfService.terms.entireAgreementTerms.title",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.generalTerms.content",
+    "newPath": "sections.legal.termsOfService.terms.generalTerms.content",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.generalTerms.title",
+    "newPath": "sections.legal.termsOfService.terms.generalTerms.title",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.liabilityTerms.content",
+    "newPath": "sections.legal.termsOfService.terms.liabilityTerms.content",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.liabilityTerms.title",
+    "newPath": "sections.legal.termsOfService.terms.liabilityTerms.title",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.licenseTerms.content",
+    "newPath": "sections.legal.termsOfService.terms.licenseTerms.content",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.licenseTerms.title",
+    "newPath": "sections.legal.termsOfService.terms.licenseTerms.title",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.linksToOtherSitesTerms.content",
+    "newPath": "sections.legal.termsOfService.terms.linksToOtherSitesTerms.content",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.linksToOtherSitesTerms.title",
+    "newPath": "sections.legal.termsOfService.terms.linksToOtherSitesTerms.title",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.miscellaneousTerms.content",
+    "newPath": "sections.legal.termsOfService.terms.miscellaneousTerms.content",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.miscellaneousTerms.title",
+    "newPath": "sections.legal.termsOfService.terms.miscellaneousTerms.title",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.noWarrantiesTerms.content",
+    "newPath": "sections.legal.termsOfService.terms.noWarrantiesTerms.content",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.noWarrantiesTerms.title",
+    "newPath": "sections.legal.termsOfService.terms.noWarrantiesTerms.title",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.promotionTerms.content",
+    "newPath": "sections.legal.termsOfService.terms.promotionTerms.content",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.promotionTerms.title",
+    "newPath": "sections.legal.termsOfService.terms.promotionTerms.title",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.restrictionTerms.content",
+    "newPath": "sections.legal.termsOfService.terms.restrictionTerms.content",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.restrictionTerms.title",
+    "newPath": "sections.legal.termsOfService.terms.restrictionTerms.title",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.severabilityTerms.content",
+    "newPath": "sections.legal.termsOfService.terms.severabilityTerms.content",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.severabilityTerms.title",
+    "newPath": "sections.legal.termsOfService.terms.severabilityTerms.title",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.submissionsAndPrivacyTerms.content",
+    "newPath": "sections.legal.termsOfService.terms.submissionsAndPrivacyTerms.content",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.submissionsAndPrivacyTerms.title",
+    "newPath": "sections.legal.termsOfService.terms.submissionsAndPrivacyTerms.title",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.terminationTerms.content",
+    "newPath": "sections.legal.termsOfService.terms.terminationTerms.content",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.terminationTerms.title",
+    "newPath": "sections.legal.termsOfService.terms.terminationTerms.title",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.thirdPartyTerms.content",
+    "newPath": "sections.legal.termsOfService.terms.thirdPartyTerms.content",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.thirdPartyTerms.title",
+    "newPath": "sections.legal.termsOfService.terms.thirdPartyTerms.title",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.typographyErrorsTerms.content",
+    "newPath": "sections.legal.termsOfService.terms.typographyErrorsTerms.content",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.typographyErrorsTerms.title",
+    "newPath": "sections.legal.termsOfService.terms.typographyErrorsTerms.title",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.updateOfServicesTerms.content",
+    "newPath": "sections.legal.termsOfService.terms.updateOfServicesTerms.content",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.updateOfServicesTerms.title",
+    "newPath": "sections.legal.termsOfService.terms.updateOfServicesTerms.title",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.waiverTerms.content",
+    "newPath": "sections.legal.termsOfService.terms.waiverTerms.content",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.terms.waiverTerms.title",
+    "newPath": "sections.legal.termsOfService.terms.waiverTerms.title",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Legal.TermsOfService.title",
+    "newPath": "sections.legal.termsOfService.title",
+    "reason": "terms content"
+  },
+  {
+    "oldPath": "Navigation.about",
+    "newPath": "app.navigation.about",
+    "reason": "app shell navigation"
+  },
+  {
+    "oldPath": "Navigation.domains",
+    "newPath": "app.navigation.domains",
+    "reason": "app shell navigation"
+  },
+  {
+    "oldPath": "Navigation.invoices",
+    "newPath": "app.navigation.invoices",
+    "reason": "app shell navigation"
+  },
+  {
+    "oldPath": "Navigation.mobile.closeNavigation",
+    "newPath": "app.navigation.mobile.closeNavigation",
+    "reason": "app shell navigation"
+  },
+  {
+    "oldPath": "Navigation.mobile.openNavigation",
+    "newPath": "app.navigation.mobile.openNavigation",
+    "reason": "app shell navigation"
+  },
+  {
+    "oldPath": "Navigation.mobile.title",
+    "newPath": "app.navigation.mobile.title",
+    "reason": "app shell navigation"
+  },
+  {
+    "oldPath": "Navigation.myInvoices",
+    "newPath": "app.navigation.myInvoices",
+    "reason": "app shell navigation"
+  },
+  {
+    "oldPath": "Navigation.myProfile",
+    "newPath": "app.navigation.myProfile",
+    "reason": "app shell navigation"
+  },
+  {
+    "oldPath": "Navigation.theAuthor",
+    "newPath": "app.navigation.theAuthor",
+    "reason": "app shell navigation"
+  },
+  {
+    "oldPath": "Navigation.thePlatform",
+    "newPath": "app.navigation.thePlatform",
+    "reason": "app shell navigation"
+  },
+  {
+    "oldPath": "Navigation.uploadScans",
+    "newPath": "app.navigation.uploadScans",
+    "reason": "app shell navigation"
+  },
+  {
+    "oldPath": "Navigation.viewScans",
+    "newPath": "app.navigation.viewScans",
+    "reason": "app shell navigation"
+  },
+  {
+    "oldPath": "Profile.header.completionHint",
+    "newPath": "pages.profile.header.completionHint",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.header.daysActive",
+    "newPath": "pages.profile.header.daysActive",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.header.editProfile",
+    "newPath": "pages.profile.header.editProfile",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.header.editProfileClerkNote",
+    "newPath": "pages.profile.header.editProfileClerkNote",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.header.editProfileDescription",
+    "newPath": "pages.profile.header.editProfileDescription",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.header.editProfileTitle",
+    "newPath": "pages.profile.header.editProfileTitle",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.header.manageOnClerk",
+    "newPath": "pages.profile.header.manageOnClerk",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.header.memberSince",
+    "newPath": "pages.profile.header.memberSince",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.header.premium",
+    "newPath": "pages.profile.header.premium",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.header.profileCompletion",
+    "newPath": "pages.profile.header.profileCompletion",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.header.userId",
+    "newPath": "pages.profile.header.userId",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.island.merchants",
+    "newPath": "pages.profile.island.merchants",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.island.scans",
+    "newPath": "pages.profile.island.scans",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.island.settingsNavigationAriaLabel",
+    "newPath": "pages.profile.island.settingsNavigationAriaLabel",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.island.totalInvoices",
+    "newPath": "pages.profile.island.totalInvoices",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.metadata.description",
+    "newPath": "pages.profile.metadata.description",
+    "reason": "profile page metadata"
+  },
+  {
+    "oldPath": "Profile.metadata.title",
+    "newPath": "pages.profile.metadata.title",
+    "reason": "profile page metadata"
+  },
+  {
+    "oldPath": "Profile.settings.ai.behavior.description",
+    "newPath": "pages.profile.settings.ai.behavior.description",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.ai.behavior.title",
+    "newPath": "pages.profile.settings.ai.behavior.title",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.ai.description",
+    "newPath": "pages.profile.settings.ai.description",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.ai.features.autoSuggest",
+    "newPath": "pages.profile.settings.ai.features.autoSuggest",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.ai.features.autoSuggestHint",
+    "newPath": "pages.profile.settings.ai.features.autoSuggestHint",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.ai.features.contextAwareness",
+    "newPath": "pages.profile.settings.ai.features.contextAwareness",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.ai.features.contextAwarenessHint",
+    "newPath": "pages.profile.settings.ai.features.contextAwarenessHint",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.ai.features.description",
+    "newPath": "pages.profile.settings.ai.features.description",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.ai.features.memory",
+    "newPath": "pages.profile.settings.ai.features.memory",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.ai.features.memoryHint",
+    "newPath": "pages.profile.settings.ai.features.memoryHint",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.ai.features.title",
+    "newPath": "pages.profile.settings.ai.features.title",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.ai.maxTokens.description",
+    "newPath": "pages.profile.settings.ai.maxTokens.description",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.ai.maxTokens.title",
+    "newPath": "pages.profile.settings.ai.maxTokens.title",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.ai.model.description",
+    "newPath": "pages.profile.settings.ai.model.description",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.ai.model.title",
+    "newPath": "pages.profile.settings.ai.model.title",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.ai.temperature.creative",
+    "newPath": "pages.profile.settings.ai.temperature.creative",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.ai.temperature.description",
+    "newPath": "pages.profile.settings.ai.temperature.description",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.ai.temperature.precise",
+    "newPath": "pages.profile.settings.ai.temperature.precise",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.ai.temperature.title",
+    "newPath": "pages.profile.settings.ai.temperature.title",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.ai.title",
+    "newPath": "pages.profile.settings.ai.title",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.ai.voice.description",
+    "newPath": "pages.profile.settings.ai.voice.description",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.ai.voice.enabled",
+    "newPath": "pages.profile.settings.ai.voice.enabled",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.ai.voice.enabledHint",
+    "newPath": "pages.profile.settings.ai.voice.enabledHint",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.ai.voice.title",
+    "newPath": "pages.profile.settings.ai.voice.title",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.analytics.advanced.benchmarking",
+    "newPath": "pages.profile.settings.analytics.advanced.benchmarking",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.analytics.advanced.benchmarkingHint",
+    "newPath": "pages.profile.settings.analytics.advanced.benchmarkingHint",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.analytics.advanced.description",
+    "newPath": "pages.profile.settings.analytics.advanced.description",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.analytics.advanced.predictive",
+    "newPath": "pages.profile.settings.analytics.advanced.predictive",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.analytics.advanced.predictiveHint",
+    "newPath": "pages.profile.settings.analytics.advanced.predictiveHint",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.analytics.advanced.title",
+    "newPath": "pages.profile.settings.analytics.advanced.title",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.analytics.dataUsage.info",
+    "newPath": "pages.profile.settings.analytics.dataUsage.info",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.analytics.dataUsage.title",
+    "newPath": "pages.profile.settings.analytics.dataUsage.title",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.analytics.description",
+    "newPath": "pages.profile.settings.analytics.description",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.analytics.enabled.description",
+    "newPath": "pages.profile.settings.analytics.enabled.description",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.analytics.enabled.hint",
+    "newPath": "pages.profile.settings.analytics.enabled.hint",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.analytics.enabled.label",
+    "newPath": "pages.profile.settings.analytics.enabled.label",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.analytics.enabled.title",
+    "newPath": "pages.profile.settings.analytics.enabled.title",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.analytics.export.description",
+    "newPath": "pages.profile.settings.analytics.export.description",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.analytics.export.title",
+    "newPath": "pages.profile.settings.analytics.export.title",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.analytics.granularity.description",
+    "newPath": "pages.profile.settings.analytics.granularity.description",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.analytics.granularity.title",
+    "newPath": "pages.profile.settings.analytics.granularity.title",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.analytics.title",
+    "newPath": "pages.profile.settings.analytics.title",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.analytics.tracking.categories",
+    "newPath": "pages.profile.settings.analytics.tracking.categories",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.analytics.tracking.categoriesHint",
+    "newPath": "pages.profile.settings.analytics.tracking.categoriesHint",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.analytics.tracking.description",
+    "newPath": "pages.profile.settings.analytics.tracking.description",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.analytics.tracking.merchants",
+    "newPath": "pages.profile.settings.analytics.tracking.merchants",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.analytics.tracking.merchantsHint",
+    "newPath": "pages.profile.settings.analytics.tracking.merchantsHint",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.analytics.tracking.spending",
+    "newPath": "pages.profile.settings.analytics.tracking.spending",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.analytics.tracking.spendingHint",
+    "newPath": "pages.profile.settings.analytics.tracking.spendingHint",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.analytics.tracking.title",
+    "newPath": "pages.profile.settings.analytics.tracking.title",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.appearance.advanced.animations",
+    "newPath": "pages.profile.settings.appearance.advanced.animations",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.appearance.advanced.animationsHint",
+    "newPath": "pages.profile.settings.appearance.advanced.animationsHint",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.appearance.advanced.compactMode",
+    "newPath": "pages.profile.settings.appearance.advanced.compactMode",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.appearance.advanced.compactModeHint",
+    "newPath": "pages.profile.settings.appearance.advanced.compactModeHint",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.appearance.advanced.description",
+    "newPath": "pages.profile.settings.appearance.advanced.description",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.appearance.advanced.title",
+    "newPath": "pages.profile.settings.appearance.advanced.title",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.appearance.colors.description",
+    "newPath": "pages.profile.settings.appearance.colors.description",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.appearance.colors.intermediary",
+    "newPath": "pages.profile.settings.appearance.colors.intermediary",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.appearance.colors.preview",
+    "newPath": "pages.profile.settings.appearance.colors.preview",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.appearance.colors.previewText",
+    "newPath": "pages.profile.settings.appearance.colors.previewText",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.appearance.colors.primary",
+    "newPath": "pages.profile.settings.appearance.colors.primary",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.appearance.colors.secondary",
+    "newPath": "pages.profile.settings.appearance.colors.secondary",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.appearance.colors.title",
+    "newPath": "pages.profile.settings.appearance.colors.title",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.appearance.description",
+    "newPath": "pages.profile.settings.appearance.description",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.appearance.font.description",
+    "newPath": "pages.profile.settings.appearance.font.description",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.appearance.font.dyslexic",
+    "newPath": "pages.profile.settings.appearance.font.dyslexic",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.appearance.font.dyslexicHint",
+    "newPath": "pages.profile.settings.appearance.font.dyslexicHint",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.appearance.font.normal",
+    "newPath": "pages.profile.settings.appearance.font.normal",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.appearance.font.title",
+    "newPath": "pages.profile.settings.appearance.font.title",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.appearance.locale.description",
+    "newPath": "pages.profile.settings.appearance.locale.description",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.appearance.locale.title",
+    "newPath": "pages.profile.settings.appearance.locale.title",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.appearance.presets.custom",
+    "newPath": "pages.profile.settings.appearance.presets.custom",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.appearance.presets.customDescription",
+    "newPath": "pages.profile.settings.appearance.presets.customDescription",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.appearance.presets.description",
+    "newPath": "pages.profile.settings.appearance.presets.description",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.appearance.presets.title",
+    "newPath": "pages.profile.settings.appearance.presets.title",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.appearance.theme.dark",
+    "newPath": "pages.profile.settings.appearance.theme.dark",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.appearance.theme.description",
+    "newPath": "pages.profile.settings.appearance.theme.description",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.appearance.theme.hint",
+    "newPath": "pages.profile.settings.appearance.theme.hint",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.appearance.theme.light",
+    "newPath": "pages.profile.settings.appearance.theme.light",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.appearance.theme.system",
+    "newPath": "pages.profile.settings.appearance.theme.system",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.appearance.theme.title",
+    "newPath": "pages.profile.settings.appearance.theme.title",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.appearance.title",
+    "newPath": "pages.profile.settings.appearance.title",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.data.backup.autoBackup",
+    "newPath": "pages.profile.settings.data.backup.autoBackup",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.data.backup.autoBackupHint",
+    "newPath": "pages.profile.settings.data.backup.autoBackupHint",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.data.backup.description",
+    "newPath": "pages.profile.settings.data.backup.description",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.data.backup.frequency",
+    "newPath": "pages.profile.settings.data.backup.frequency",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.data.backup.title",
+    "newPath": "pages.profile.settings.data.backup.title",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.data.danger.deleteAccount",
+    "newPath": "pages.profile.settings.data.danger.deleteAccount",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.data.danger.deleteAccountHint",
+    "newPath": "pages.profile.settings.data.danger.deleteAccountHint",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.data.danger.deleteButton",
+    "newPath": "pages.profile.settings.data.danger.deleteButton",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.data.danger.deleteData",
+    "newPath": "pages.profile.settings.data.danger.deleteData",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.data.danger.deleteDataHint",
+    "newPath": "pages.profile.settings.data.danger.deleteDataHint",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.data.danger.description",
+    "newPath": "pages.profile.settings.data.danger.description",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.data.danger.manageAccount",
+    "newPath": "pages.profile.settings.data.danger.manageAccount",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.data.danger.title",
+    "newPath": "pages.profile.settings.data.danger.title",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.data.description",
+    "newPath": "pages.profile.settings.data.description",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.data.export.description",
+    "newPath": "pages.profile.settings.data.export.description",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.data.export.downloadAll",
+    "newPath": "pages.profile.settings.data.export.downloadAll",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.data.export.hint",
+    "newPath": "pages.profile.settings.data.export.hint",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.data.export.title",
+    "newPath": "pages.profile.settings.data.export.title",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.data.privacy.description",
+    "newPath": "pages.profile.settings.data.privacy.description",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.data.privacy.shareAnonymous",
+    "newPath": "pages.profile.settings.data.privacy.shareAnonymous",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.data.privacy.shareAnonymousHint",
+    "newPath": "pages.profile.settings.data.privacy.shareAnonymousHint",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.data.privacy.title",
+    "newPath": "pages.profile.settings.data.privacy.title",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.data.retention.description",
+    "newPath": "pages.profile.settings.data.retention.description",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.data.retention.hint",
+    "newPath": "pages.profile.settings.data.retention.hint",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.data.retention.title",
+    "newPath": "pages.profile.settings.data.retention.title",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.data.title",
+    "newPath": "pages.profile.settings.data.title",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.notifications.description",
+    "newPath": "pages.profile.settings.notifications.description",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.notifications.email.description",
+    "newPath": "pages.profile.settings.notifications.email.description",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.notifications.email.enabled",
+    "newPath": "pages.profile.settings.notifications.email.enabled",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.notifications.email.enabledHint",
+    "newPath": "pages.profile.settings.notifications.email.enabledHint",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.notifications.email.title",
+    "newPath": "pages.profile.settings.notifications.email.title",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.notifications.financial.budgetAlerts",
+    "newPath": "pages.profile.settings.notifications.financial.budgetAlerts",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.notifications.financial.budgetAlertsHint",
+    "newPath": "pages.profile.settings.notifications.financial.budgetAlertsHint",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.notifications.financial.description",
+    "newPath": "pages.profile.settings.notifications.financial.description",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.notifications.financial.spendingAlerts",
+    "newPath": "pages.profile.settings.notifications.financial.spendingAlerts",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.notifications.financial.spendingAlertsHint",
+    "newPath": "pages.profile.settings.notifications.financial.spendingAlertsHint",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.notifications.financial.title",
+    "newPath": "pages.profile.settings.notifications.financial.title",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.notifications.reports.description",
+    "newPath": "pages.profile.settings.notifications.reports.description",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.notifications.reports.monthlyReport",
+    "newPath": "pages.profile.settings.notifications.reports.monthlyReport",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.notifications.reports.monthlyReportHint",
+    "newPath": "pages.profile.settings.notifications.reports.monthlyReportHint",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.notifications.reports.title",
+    "newPath": "pages.profile.settings.notifications.reports.title",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.notifications.reports.weeklyDigest",
+    "newPath": "pages.profile.settings.notifications.reports.weeklyDigest",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.notifications.reports.weeklyDigestHint",
+    "newPath": "pages.profile.settings.notifications.reports.weeklyDigestHint",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.notifications.security.alwaysOnNote",
+    "newPath": "pages.profile.settings.notifications.security.alwaysOnNote",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.notifications.security.description",
+    "newPath": "pages.profile.settings.notifications.security.description",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.notifications.security.securityAlerts",
+    "newPath": "pages.profile.settings.notifications.security.securityAlerts",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.notifications.security.securityAlertsHint",
+    "newPath": "pages.profile.settings.notifications.security.securityAlertsHint",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.notifications.security.title",
+    "newPath": "pages.profile.settings.notifications.security.title",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.notifications.title",
+    "newPath": "pages.profile.settings.notifications.title",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.notifications.updates.description",
+    "newPath": "pages.profile.settings.notifications.updates.description",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.notifications.updates.marketing",
+    "newPath": "pages.profile.settings.notifications.updates.marketing",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.notifications.updates.marketingHint",
+    "newPath": "pages.profile.settings.notifications.updates.marketingHint",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.notifications.updates.newFeatures",
+    "newPath": "pages.profile.settings.notifications.updates.newFeatures",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.notifications.updates.newFeaturesHint",
+    "newPath": "pages.profile.settings.notifications.updates.newFeaturesHint",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.notifications.updates.title",
+    "newPath": "pages.profile.settings.notifications.updates.title",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.security.description",
+    "newPath": "pages.profile.settings.security.description",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.security.devices.current",
+    "newPath": "pages.profile.settings.security.devices.current",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.security.devices.description",
+    "newPath": "pages.profile.settings.security.devices.description",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.security.devices.empty",
+    "newPath": "pages.profile.settings.security.devices.empty",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.security.devices.lastUsed",
+    "newPath": "pages.profile.settings.security.devices.lastUsed",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.security.devices.title",
+    "newPath": "pages.profile.settings.security.devices.title",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.security.password.changePassword",
+    "newPath": "pages.profile.settings.security.password.changePassword",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.security.password.clerkNote",
+    "newPath": "pages.profile.settings.security.password.clerkNote",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.security.password.description",
+    "newPath": "pages.profile.settings.security.password.description",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.security.password.title",
+    "newPath": "pages.profile.settings.security.password.title",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.security.session.description",
+    "newPath": "pages.profile.settings.security.session.description",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.security.session.hour",
+    "newPath": "pages.profile.settings.security.session.hour",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.security.session.hours",
+    "newPath": "pages.profile.settings.security.session.hours",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.security.session.loginNotifications",
+    "newPath": "pages.profile.settings.security.session.loginNotifications",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.security.session.loginNotificationsHint",
+    "newPath": "pages.profile.settings.security.session.loginNotificationsHint",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.security.session.minutes",
+    "newPath": "pages.profile.settings.security.session.minutes",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.security.session.timeout",
+    "newPath": "pages.profile.settings.security.session.timeout",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.security.session.title",
+    "newPath": "pages.profile.settings.security.session.title",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.security.title",
+    "newPath": "pages.profile.settings.security.title",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.security.twoFactor.activeMessage",
+    "newPath": "pages.profile.settings.security.twoFactor.activeMessage",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.security.twoFactor.description",
+    "newPath": "pages.profile.settings.security.twoFactor.description",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.security.twoFactor.enabled",
+    "newPath": "pages.profile.settings.security.twoFactor.enabled",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.security.twoFactor.enabledHint",
+    "newPath": "pages.profile.settings.security.twoFactor.enabledHint",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.settings.security.twoFactor.title",
+    "newPath": "pages.profile.settings.security.twoFactor.title",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.sidebar.account",
+    "newPath": "pages.profile.sidebar.account",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.sidebar.daysActive",
+    "newPath": "pages.profile.sidebar.daysActive",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.sidebar.manageClerk",
+    "newPath": "pages.profile.sidebar.manageClerk",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.sidebar.nav.ai",
+    "newPath": "pages.profile.sidebar.nav.ai",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.sidebar.nav.analytics",
+    "newPath": "pages.profile.sidebar.nav.analytics",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.sidebar.nav.appearance",
+    "newPath": "pages.profile.sidebar.nav.appearance",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.sidebar.nav.data",
+    "newPath": "pages.profile.sidebar.nav.data",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.sidebar.nav.notifications",
+    "newPath": "pages.profile.sidebar.nav.notifications",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.sidebar.nav.profile",
+    "newPath": "pages.profile.sidebar.nav.profile",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.sidebar.nav.security",
+    "newPath": "pages.profile.sidebar.nav.security",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.sidebar.preferences",
+    "newPath": "pages.profile.sidebar.preferences",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.sidebar.premium",
+    "newPath": "pages.profile.sidebar.premium",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.sidebar.profileCompletion",
+    "newPath": "pages.profile.sidebar.profileCompletion",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.stats.aiQueries.description",
+    "newPath": "pages.profile.stats.aiQueries.description",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.stats.aiQueries.title",
+    "newPath": "pages.profile.stats.aiQueries.title",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.stats.description",
+    "newPath": "pages.profile.stats.description",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.stats.invoices.description",
+    "newPath": "pages.profile.stats.invoices.description",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.stats.invoices.title",
+    "newPath": "pages.profile.stats.invoices.title",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.stats.merchants.description",
+    "newPath": "pages.profile.stats.merchants.description",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.stats.merchants.title",
+    "newPath": "pages.profile.stats.merchants.title",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.stats.monthly.description",
+    "newPath": "pages.profile.stats.monthly.description",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.stats.monthly.title",
+    "newPath": "pages.profile.stats.monthly.title",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.stats.saved.description",
+    "newPath": "pages.profile.stats.saved.description",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.stats.saved.title",
+    "newPath": "pages.profile.stats.saved.title",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.stats.scans.description",
+    "newPath": "pages.profile.stats.scans.description",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.stats.scans.title",
+    "newPath": "pages.profile.stats.scans.title",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.stats.storage.description",
+    "newPath": "pages.profile.stats.storage.description",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.stats.storage.title",
+    "newPath": "pages.profile.stats.storage.title",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.stats.storage.used",
+    "newPath": "pages.profile.stats.storage.used",
+    "reason": "profile page content and settings"
+  },
+  {
+    "oldPath": "Profile.stats.title",
+    "newPath": "pages.profile.stats.title",
+    "reason": "profile page content and settings"
+  }
+]

--- a/scripts/migrations/message-tree/key-map.json
+++ b/scripts/migrations/message-tree/key-map.json
@@ -1306,17 +1306,17 @@
   },
   {
     "oldPath": "About.Hub.navigation.author.features.0",
-    "newPath": "pages.about.hub.navigation.author.features.0",
+    "newPath": "pages.about.hub.navigation.author.features.item0",
     "reason": "about hub page"
   },
   {
     "oldPath": "About.Hub.navigation.author.features.1",
-    "newPath": "pages.about.hub.navigation.author.features.1",
+    "newPath": "pages.about.hub.navigation.author.features.item1",
     "reason": "about hub page"
   },
   {
     "oldPath": "About.Hub.navigation.author.features.2",
-    "newPath": "pages.about.hub.navigation.author.features.2",
+    "newPath": "pages.about.hub.navigation.author.features.item2",
     "reason": "about hub page"
   },
   {
@@ -1336,17 +1336,17 @@
   },
   {
     "oldPath": "About.Hub.navigation.platform.features.0",
-    "newPath": "pages.about.hub.navigation.platform.features.0",
+    "newPath": "pages.about.hub.navigation.platform.features.item0",
     "reason": "about hub page"
   },
   {
     "oldPath": "About.Hub.navigation.platform.features.1",
-    "newPath": "pages.about.hub.navigation.platform.features.1",
+    "newPath": "pages.about.hub.navigation.platform.features.item1",
     "reason": "about hub page"
   },
   {
     "oldPath": "About.Hub.navigation.platform.features.2",
-    "newPath": "pages.about.hub.navigation.platform.features.2",
+    "newPath": "pages.about.hub.navigation.platform.features.item2",
     "reason": "about hub page"
   },
   {
@@ -3841,22 +3841,22 @@
   },
   {
     "oldPath": "email.firstInvoiceUploaded.featuresToExplore.0",
-    "newPath": "emails.firstInvoiceUploaded.featuresToExplore.0",
+    "newPath": "emails.firstInvoiceUploaded.featuresToExplore.item0",
     "reason": "email templates"
   },
   {
     "oldPath": "email.firstInvoiceUploaded.featuresToExplore.1",
-    "newPath": "emails.firstInvoiceUploaded.featuresToExplore.1",
+    "newPath": "emails.firstInvoiceUploaded.featuresToExplore.item1",
     "reason": "email templates"
   },
   {
     "oldPath": "email.firstInvoiceUploaded.featuresToExplore.2",
-    "newPath": "emails.firstInvoiceUploaded.featuresToExplore.2",
+    "newPath": "emails.firstInvoiceUploaded.featuresToExplore.item2",
     "reason": "email templates"
   },
   {
     "oldPath": "email.firstInvoiceUploaded.featuresToExplore.3",
-    "newPath": "emails.firstInvoiceUploaded.featuresToExplore.3",
+    "newPath": "emails.firstInvoiceUploaded.featuresToExplore.item3",
     "reason": "email templates"
   },
   {
@@ -3936,17 +3936,17 @@
   },
   {
     "oldPath": "email.firstInvoiceUploaded.whatHappensNext.0",
-    "newPath": "emails.firstInvoiceUploaded.whatHappensNext.0",
+    "newPath": "emails.firstInvoiceUploaded.whatHappensNext.item0",
     "reason": "email templates"
   },
   {
     "oldPath": "email.firstInvoiceUploaded.whatHappensNext.1",
-    "newPath": "emails.firstInvoiceUploaded.whatHappensNext.1",
+    "newPath": "emails.firstInvoiceUploaded.whatHappensNext.item1",
     "reason": "email templates"
   },
   {
     "oldPath": "email.firstInvoiceUploaded.whatHappensNext.2",
-    "newPath": "emails.firstInvoiceUploaded.whatHappensNext.2",
+    "newPath": "emails.firstInvoiceUploaded.whatHappensNext.item2",
     "reason": "email templates"
   },
   {
@@ -4086,22 +4086,22 @@
   },
   {
     "oldPath": "email.incompleteInvoice.tips.0",
-    "newPath": "emails.incompleteInvoice.tips.0",
+    "newPath": "emails.incompleteInvoice.tips.item0",
     "reason": "email templates"
   },
   {
     "oldPath": "email.incompleteInvoice.tips.1",
-    "newPath": "emails.incompleteInvoice.tips.1",
+    "newPath": "emails.incompleteInvoice.tips.item1",
     "reason": "email templates"
   },
   {
     "oldPath": "email.incompleteInvoice.tips.2",
-    "newPath": "emails.incompleteInvoice.tips.2",
+    "newPath": "emails.incompleteInvoice.tips.item2",
     "reason": "email templates"
   },
   {
     "oldPath": "email.incompleteInvoice.tips.3",
-    "newPath": "emails.incompleteInvoice.tips.3",
+    "newPath": "emails.incompleteInvoice.tips.item3",
     "reason": "email templates"
   },
   {
@@ -4201,27 +4201,27 @@
   },
   {
     "oldPath": "email.invoiceAnalyzed.whatWasAnalyzed.0",
-    "newPath": "emails.invoiceAnalyzed.whatWasAnalyzed.0",
+    "newPath": "emails.invoiceAnalyzed.whatWasAnalyzed.item0",
     "reason": "email templates"
   },
   {
     "oldPath": "email.invoiceAnalyzed.whatWasAnalyzed.1",
-    "newPath": "emails.invoiceAnalyzed.whatWasAnalyzed.1",
+    "newPath": "emails.invoiceAnalyzed.whatWasAnalyzed.item1",
     "reason": "email templates"
   },
   {
     "oldPath": "email.invoiceAnalyzed.whatWasAnalyzed.2",
-    "newPath": "emails.invoiceAnalyzed.whatWasAnalyzed.2",
+    "newPath": "emails.invoiceAnalyzed.whatWasAnalyzed.item2",
     "reason": "email templates"
   },
   {
     "oldPath": "email.invoiceAnalyzed.whatWasAnalyzed.3",
-    "newPath": "emails.invoiceAnalyzed.whatWasAnalyzed.3",
+    "newPath": "emails.invoiceAnalyzed.whatWasAnalyzed.item3",
     "reason": "email templates"
   },
   {
     "oldPath": "email.invoiceAnalyzed.whatWasAnalyzed.4",
-    "newPath": "emails.invoiceAnalyzed.whatWasAnalyzed.4",
+    "newPath": "emails.invoiceAnalyzed.whatWasAnalyzed.item4",
     "reason": "email templates"
   },
   {
@@ -4311,22 +4311,22 @@
   },
   {
     "oldPath": "email.invoiceDeleted.whatYouShouldKnow.0",
-    "newPath": "emails.invoiceDeleted.whatYouShouldKnow.0",
+    "newPath": "emails.invoiceDeleted.whatYouShouldKnow.item0",
     "reason": "email templates"
   },
   {
     "oldPath": "email.invoiceDeleted.whatYouShouldKnow.1",
-    "newPath": "emails.invoiceDeleted.whatYouShouldKnow.1",
+    "newPath": "emails.invoiceDeleted.whatYouShouldKnow.item1",
     "reason": "email templates"
   },
   {
     "oldPath": "email.invoiceDeleted.whatYouShouldKnow.2",
-    "newPath": "emails.invoiceDeleted.whatYouShouldKnow.2",
+    "newPath": "emails.invoiceDeleted.whatYouShouldKnow.item2",
     "reason": "email templates"
   },
   {
     "oldPath": "email.invoiceDeleted.whatYouShouldKnow.3",
-    "newPath": "emails.invoiceDeleted.whatYouShouldKnow.3",
+    "newPath": "emails.invoiceDeleted.whatYouShouldKnow.item3",
     "reason": "email templates"
   },
   {
@@ -4336,22 +4336,22 @@
   },
   {
     "oldPath": "email.invoiceInactivity.badge.14",
-    "newPath": "emails.invoiceInactivity.badge.14",
+    "newPath": "emails.invoiceInactivity.badge.item14",
     "reason": "email templates"
   },
   {
     "oldPath": "email.invoiceInactivity.badge.3",
-    "newPath": "emails.invoiceInactivity.badge.3",
+    "newPath": "emails.invoiceInactivity.badge.item3",
     "reason": "email templates"
   },
   {
     "oldPath": "email.invoiceInactivity.badge.30",
-    "newPath": "emails.invoiceInactivity.badge.30",
+    "newPath": "emails.invoiceInactivity.badge.item30",
     "reason": "email templates"
   },
   {
     "oldPath": "email.invoiceInactivity.badge.7",
-    "newPath": "emails.invoiceInactivity.badge.7",
+    "newPath": "emails.invoiceInactivity.badge.item7",
     "reason": "email templates"
   },
   {
@@ -4371,22 +4371,22 @@
   },
   {
     "oldPath": "email.invoiceInactivity.heading.14",
-    "newPath": "emails.invoiceInactivity.heading.14",
+    "newPath": "emails.invoiceInactivity.heading.item14",
     "reason": "email templates"
   },
   {
     "oldPath": "email.invoiceInactivity.heading.3",
-    "newPath": "emails.invoiceInactivity.heading.3",
+    "newPath": "emails.invoiceInactivity.heading.item3",
     "reason": "email templates"
   },
   {
     "oldPath": "email.invoiceInactivity.heading.30",
-    "newPath": "emails.invoiceInactivity.heading.30",
+    "newPath": "emails.invoiceInactivity.heading.item30",
     "reason": "email templates"
   },
   {
     "oldPath": "email.invoiceInactivity.heading.7",
-    "newPath": "emails.invoiceInactivity.heading.7",
+    "newPath": "emails.invoiceInactivity.heading.item7",
     "reason": "email templates"
   },
   {
@@ -4406,22 +4406,22 @@
   },
   {
     "oldPath": "email.invoiceInactivity.intro.14",
-    "newPath": "emails.invoiceInactivity.intro.14",
+    "newPath": "emails.invoiceInactivity.intro.item14",
     "reason": "email templates"
   },
   {
     "oldPath": "email.invoiceInactivity.intro.3",
-    "newPath": "emails.invoiceInactivity.intro.3",
+    "newPath": "emails.invoiceInactivity.intro.item3",
     "reason": "email templates"
   },
   {
     "oldPath": "email.invoiceInactivity.intro.30",
-    "newPath": "emails.invoiceInactivity.intro.30",
+    "newPath": "emails.invoiceInactivity.intro.item30",
     "reason": "email templates"
   },
   {
     "oldPath": "email.invoiceInactivity.intro.7",
-    "newPath": "emails.invoiceInactivity.intro.7",
+    "newPath": "emails.invoiceInactivity.intro.item7",
     "reason": "email templates"
   },
   {
@@ -4561,17 +4561,17 @@
   },
   {
     "oldPath": "email.invoiceMadePublic.howToShare.0",
-    "newPath": "emails.invoiceMadePublic.howToShare.0",
+    "newPath": "emails.invoiceMadePublic.howToShare.item0",
     "reason": "email templates"
   },
   {
     "oldPath": "email.invoiceMadePublic.howToShare.1",
-    "newPath": "emails.invoiceMadePublic.howToShare.1",
+    "newPath": "emails.invoiceMadePublic.howToShare.item1",
     "reason": "email templates"
   },
   {
     "oldPath": "email.invoiceMadePublic.howToShare.2",
-    "newPath": "emails.invoiceMadePublic.howToShare.2",
+    "newPath": "emails.invoiceMadePublic.howToShare.item2",
     "reason": "email templates"
   },
   {
@@ -4701,17 +4701,17 @@
   },
   {
     "oldPath": "email.invoiceShared.whatYouCanDo.0",
-    "newPath": "emails.invoiceShared.whatYouCanDo.0",
+    "newPath": "emails.invoiceShared.whatYouCanDo.item0",
     "reason": "email templates"
   },
   {
     "oldPath": "email.invoiceShared.whatYouCanDo.1",
-    "newPath": "emails.invoiceShared.whatYouCanDo.1",
+    "newPath": "emails.invoiceShared.whatYouCanDo.item1",
     "reason": "email templates"
   },
   {
     "oldPath": "email.invoiceShared.whatYouCanDo.2",
-    "newPath": "emails.invoiceShared.whatYouCanDo.2",
+    "newPath": "emails.invoiceShared.whatYouCanDo.item2",
     "reason": "email templates"
   },
   {
@@ -4961,17 +4961,17 @@
   },
   {
     "oldPath": "email.invoiceUnshared.whatThisMeans.0",
-    "newPath": "emails.invoiceUnshared.whatThisMeans.0",
+    "newPath": "emails.invoiceUnshared.whatThisMeans.item0",
     "reason": "email templates"
   },
   {
     "oldPath": "email.invoiceUnshared.whatThisMeans.1",
-    "newPath": "emails.invoiceUnshared.whatThisMeans.1",
+    "newPath": "emails.invoiceUnshared.whatThisMeans.item1",
     "reason": "email templates"
   },
   {
     "oldPath": "email.invoiceUnshared.whatThisMeans.2",
-    "newPath": "emails.invoiceUnshared.whatThisMeans.2",
+    "newPath": "emails.invoiceUnshared.whatThisMeans.item2",
     "reason": "email templates"
   },
   {
@@ -5066,17 +5066,17 @@
   },
   {
     "oldPath": "email.newsletterSubscribed.whatToExpect.0",
-    "newPath": "emails.newsletterSubscribed.whatToExpect.0",
+    "newPath": "emails.newsletterSubscribed.whatToExpect.item0",
     "reason": "email templates"
   },
   {
     "oldPath": "email.newsletterSubscribed.whatToExpect.1",
-    "newPath": "emails.newsletterSubscribed.whatToExpect.1",
+    "newPath": "emails.newsletterSubscribed.whatToExpect.item1",
     "reason": "email templates"
   },
   {
     "oldPath": "email.newsletterSubscribed.whatToExpect.2",
-    "newPath": "emails.newsletterSubscribed.whatToExpect.2",
+    "newPath": "emails.newsletterSubscribed.whatToExpect.item2",
     "reason": "email templates"
   },
   {
@@ -5146,17 +5146,17 @@
   },
   {
     "oldPath": "email.newsletterUnsubscribed.whatHappensNext.0",
-    "newPath": "emails.newsletterUnsubscribed.whatHappensNext.0",
+    "newPath": "emails.newsletterUnsubscribed.whatHappensNext.item0",
     "reason": "email templates"
   },
   {
     "oldPath": "email.newsletterUnsubscribed.whatHappensNext.1",
-    "newPath": "emails.newsletterUnsubscribed.whatHappensNext.1",
+    "newPath": "emails.newsletterUnsubscribed.whatHappensNext.item1",
     "reason": "email templates"
   },
   {
     "oldPath": "email.newsletterUnsubscribed.whatHappensNext.2",
-    "newPath": "emails.newsletterUnsubscribed.whatHappensNext.2",
+    "newPath": "emails.newsletterUnsubscribed.whatHappensNext.item2",
     "reason": "email templates"
   },
   {
@@ -5291,32 +5291,32 @@
   },
   {
     "oldPath": "email.spendingAlert.tipsOnTrack.0",
-    "newPath": "emails.spendingAlert.tipsOnTrack.0",
+    "newPath": "emails.spendingAlert.tipsOnTrack.item0",
     "reason": "email templates"
   },
   {
     "oldPath": "email.spendingAlert.tipsOnTrack.1",
-    "newPath": "emails.spendingAlert.tipsOnTrack.1",
+    "newPath": "emails.spendingAlert.tipsOnTrack.item1",
     "reason": "email templates"
   },
   {
     "oldPath": "email.spendingAlert.tipsOnTrack.2",
-    "newPath": "emails.spendingAlert.tipsOnTrack.2",
+    "newPath": "emails.spendingAlert.tipsOnTrack.item2",
     "reason": "email templates"
   },
   {
     "oldPath": "email.spendingAlert.tipsOverBudget.0",
-    "newPath": "emails.spendingAlert.tipsOverBudget.0",
+    "newPath": "emails.spendingAlert.tipsOverBudget.item0",
     "reason": "email templates"
   },
   {
     "oldPath": "email.spendingAlert.tipsOverBudget.1",
-    "newPath": "emails.spendingAlert.tipsOverBudget.1",
+    "newPath": "emails.spendingAlert.tipsOverBudget.item1",
     "reason": "email templates"
   },
   {
     "oldPath": "email.spendingAlert.tipsOverBudget.2",
-    "newPath": "emails.spendingAlert.tipsOverBudget.2",
+    "newPath": "emails.spendingAlert.tipsOverBudget.item2",
     "reason": "email templates"
   },
   {
@@ -5331,27 +5331,27 @@
   },
   {
     "oldPath": "email.unanalyzedInvoices.analysisProvides.0",
-    "newPath": "emails.unanalyzedInvoices.analysisProvides.0",
+    "newPath": "emails.unanalyzedInvoices.analysisProvides.item0",
     "reason": "email templates"
   },
   {
     "oldPath": "email.unanalyzedInvoices.analysisProvides.1",
-    "newPath": "emails.unanalyzedInvoices.analysisProvides.1",
+    "newPath": "emails.unanalyzedInvoices.analysisProvides.item1",
     "reason": "email templates"
   },
   {
     "oldPath": "email.unanalyzedInvoices.analysisProvides.2",
-    "newPath": "emails.unanalyzedInvoices.analysisProvides.2",
+    "newPath": "emails.unanalyzedInvoices.analysisProvides.item2",
     "reason": "email templates"
   },
   {
     "oldPath": "email.unanalyzedInvoices.analysisProvides.3",
-    "newPath": "emails.unanalyzedInvoices.analysisProvides.3",
+    "newPath": "emails.unanalyzedInvoices.analysisProvides.item3",
     "reason": "email templates"
   },
   {
     "oldPath": "email.unanalyzedInvoices.analysisProvides.4",
-    "newPath": "emails.unanalyzedInvoices.analysisProvides.4",
+    "newPath": "emails.unanalyzedInvoices.analysisProvides.item4",
     "reason": "email templates"
   },
   {
@@ -5486,17 +5486,17 @@
   },
   {
     "oldPath": "email.weeklyUploadReminder.quickTips.0",
-    "newPath": "emails.weeklyUploadReminder.quickTips.0",
+    "newPath": "emails.weeklyUploadReminder.quickTips.item0",
     "reason": "email templates"
   },
   {
     "oldPath": "email.weeklyUploadReminder.quickTips.1",
-    "newPath": "emails.weeklyUploadReminder.quickTips.1",
+    "newPath": "emails.weeklyUploadReminder.quickTips.item1",
     "reason": "email templates"
   },
   {
     "oldPath": "email.weeklyUploadReminder.quickTips.2",
-    "newPath": "emails.weeklyUploadReminder.quickTips.2",
+    "newPath": "emails.weeklyUploadReminder.quickTips.item2",
     "reason": "email templates"
   },
   {
@@ -5561,17 +5561,17 @@
   },
   {
     "oldPath": "email.welcome.howItWorks.0",
-    "newPath": "emails.welcome.howItWorks.0",
+    "newPath": "emails.welcome.howItWorks.item0",
     "reason": "email templates"
   },
   {
     "oldPath": "email.welcome.howItWorks.1",
-    "newPath": "emails.welcome.howItWorks.1",
+    "newPath": "emails.welcome.howItWorks.item1",
     "reason": "email templates"
   },
   {
     "oldPath": "email.welcome.howItWorks.2",
-    "newPath": "emails.welcome.howItWorks.2",
+    "newPath": "emails.welcome.howItWorks.item2",
     "reason": "email templates"
   },
   {
@@ -5606,22 +5606,22 @@
   },
   {
     "oldPath": "email.welcome.whatYouCanDo.0",
-    "newPath": "emails.welcome.whatYouCanDo.0",
+    "newPath": "emails.welcome.whatYouCanDo.item0",
     "reason": "email templates"
   },
   {
     "oldPath": "email.welcome.whatYouCanDo.1",
-    "newPath": "emails.welcome.whatYouCanDo.1",
+    "newPath": "emails.welcome.whatYouCanDo.item1",
     "reason": "email templates"
   },
   {
     "oldPath": "email.welcome.whatYouCanDo.2",
-    "newPath": "emails.welcome.whatYouCanDo.2",
+    "newPath": "emails.welcome.whatYouCanDo.item2",
     "reason": "email templates"
   },
   {
     "oldPath": "email.welcome.whatYouCanDo.3",
-    "newPath": "emails.welcome.whatYouCanDo.3",
+    "newPath": "emails.welcome.whatYouCanDo.item3",
     "reason": "email templates"
   },
   {
@@ -11941,17 +11941,17 @@
   },
   {
     "oldPath": "IMS--List.generativeView.settings.retention.30",
-    "newPath": "pages.invoices.viewInvoices.generativeView.settings.retention.30",
+    "newPath": "pages.invoices.viewInvoices.generativeView.settings.retention.item30",
     "reason": "view-invoices page"
   },
   {
     "oldPath": "IMS--List.generativeView.settings.retention.60",
-    "newPath": "pages.invoices.viewInvoices.generativeView.settings.retention.60",
+    "newPath": "pages.invoices.viewInvoices.generativeView.settings.retention.item60",
     "reason": "view-invoices page"
   },
   {
     "oldPath": "IMS--List.generativeView.settings.retention.90",
-    "newPath": "pages.invoices.viewInvoices.generativeView.settings.retention.90",
+    "newPath": "pages.invoices.viewInvoices.generativeView.settings.retention.item90",
     "reason": "view-invoices page"
   },
   {
@@ -12111,22 +12111,22 @@
   },
   {
     "oldPath": "IMS--List.invoicesView.filters.amountPresets.0to50",
-    "newPath": "forms.invoices.filters.amountPresets.0to50",
+    "newPath": "forms.invoices.filters.amountPresets.value0to50",
     "reason": "invoice list filters"
   },
   {
     "oldPath": "IMS--List.invoicesView.filters.amountPresets.100to500",
-    "newPath": "forms.invoices.filters.amountPresets.100to500",
+    "newPath": "forms.invoices.filters.amountPresets.value100to500",
     "reason": "invoice list filters"
   },
   {
     "oldPath": "IMS--List.invoicesView.filters.amountPresets.500plus",
-    "newPath": "forms.invoices.filters.amountPresets.500plus",
+    "newPath": "forms.invoices.filters.amountPresets.value500plus",
     "reason": "invoice list filters"
   },
   {
     "oldPath": "IMS--List.invoicesView.filters.amountPresets.50to100",
-    "newPath": "forms.invoices.filters.amountPresets.50to100",
+    "newPath": "forms.invoices.filters.amountPresets.value50to100",
     "reason": "invoice list filters"
   },
   {
@@ -12176,12 +12176,12 @@
   },
   {
     "oldPath": "IMS--List.invoicesView.filters.datePresets.30d",
-    "newPath": "forms.invoices.filters.datePresets.30d",
+    "newPath": "forms.invoices.filters.datePresets.value30d",
     "reason": "invoice list filters"
   },
   {
     "oldPath": "IMS--List.invoicesView.filters.datePresets.90d",
-    "newPath": "forms.invoices.filters.datePresets.90d",
+    "newPath": "forms.invoices.filters.datePresets.value90d",
     "reason": "invoice list filters"
   },
   {

--- a/scripts/migrations/message-tree/report.ts
+++ b/scripts/migrations/message-tree/report.ts
@@ -1,0 +1,60 @@
+import fs from "node:fs";
+import path from "node:path";
+import {flattenMessages, getMessagesDirectory, getPathDepth, getRepositoryRoot, localeNames, readMessageTree} from "./treeUtils.ts";
+import {allowedTopLevelBuckets} from "./taxonomy.ts";
+
+type BucketReport = Readonly<{
+  bucket: string;
+  leaves: number;
+  maxDepth: number;
+  childCount: number;
+}>;
+
+type LocaleReport = Readonly<{
+  locale: string;
+  topLevelCount: number;
+  leafCount: number;
+  maxDepth: number;
+  allowedBucketLeaves: number;
+  retiredPrefixLeaves: number;
+  buckets: readonly BucketReport[];
+}>;
+
+function buildLocaleReport(locale: (typeof localeNames)[number]): LocaleReport {
+  const tree = readMessageTree(locale);
+  const flat = flattenMessages(tree);
+  const buckets = Object.entries(tree).map(([bucket, value]) => {
+    const branchFlat = typeof value === "string" ? new Map([[bucket, value]]) : flattenMessages(value, bucket);
+    const paths = [...branchFlat.keys()];
+    return {
+      bucket,
+      leaves: paths.length,
+      maxDepth: Math.max(...paths.map(getPathDepth)),
+      childCount: typeof value === "string" ? 0 : Object.keys(value).length,
+    };
+  });
+
+  return {
+    locale,
+    topLevelCount: Object.keys(tree).length,
+    leafCount: flat.size,
+    maxDepth: Math.max(...[...flat.keys()].map(getPathDepth)),
+    allowedBucketLeaves: [...flat.keys()].filter((key) => allowedTopLevelBuckets.some((bucket) => key === bucket || key.startsWith(`${bucket}.`))).length,
+    retiredPrefixLeaves: [...flat.keys()].filter((key) => key.includes("IMS--")).length,
+    buckets: buckets.sort((left, right) => right.leaves - left.leaves),
+  };
+}
+
+const report = {
+  generatedAt: new Date().toISOString(),
+  messagesDirectory: path.relative(getRepositoryRoot(), getMessagesDirectory()),
+  locales: localeNames.map(buildLocaleReport),
+};
+
+const outputPath = process.argv[2];
+if (outputPath) {
+  fs.mkdirSync(path.dirname(outputPath), {recursive: true});
+  fs.writeFileSync(outputPath, `${JSON.stringify(report, null, 2)}\n`);
+}
+
+console.log(JSON.stringify(report, null, 2));

--- a/scripts/migrations/message-tree/reports/after.json
+++ b/scripts/migrations/message-tree/reports/after.json
@@ -1,0 +1,198 @@
+{
+  "generatedAt": "2026-05-26T20:35:30.697Z",
+  "messagesDirectory": "sites\\arolariu.ro\\messages",
+  "locales": [
+    {
+      "locale": "en",
+      "topLevelCount": 9,
+      "leafCount": 3326,
+      "maxDepth": 8,
+      "allowedBucketLeaves": 3326,
+      "retiredPrefixLeaves": 0,
+      "buckets": [
+        {
+          "bucket": "pages",
+          "leaves": 1052,
+          "maxDepth": 7,
+          "childCount": 7
+        },
+        {
+          "bucket": "sections",
+          "leaves": 688,
+          "maxDepth": 7,
+          "childCount": 3
+        },
+        {
+          "bucket": "dialogs",
+          "leaves": 450,
+          "maxDepth": 7,
+          "childCount": 1
+        },
+        {
+          "bucket": "cards",
+          "leaves": 431,
+          "maxDepth": 6,
+          "childCount": 1
+        },
+        {
+          "bucket": "emails",
+          "leaves": 382,
+          "maxDepth": 5,
+          "childCount": 17
+        },
+        {
+          "bucket": "forms",
+          "leaves": 120,
+          "maxDepth": 8,
+          "childCount": 1
+        },
+        {
+          "bucket": "shared",
+          "leaves": 107,
+          "maxDepth": 6,
+          "childCount": 3
+        },
+        {
+          "bucket": "app",
+          "leaves": 80,
+          "maxDepth": 5,
+          "childCount": 4
+        },
+        {
+          "bucket": "toasts",
+          "leaves": 16,
+          "maxDepth": 4,
+          "childCount": 1
+        }
+      ]
+    },
+    {
+      "locale": "ro",
+      "topLevelCount": 9,
+      "leafCount": 3326,
+      "maxDepth": 8,
+      "allowedBucketLeaves": 3326,
+      "retiredPrefixLeaves": 0,
+      "buckets": [
+        {
+          "bucket": "pages",
+          "leaves": 1052,
+          "maxDepth": 7,
+          "childCount": 7
+        },
+        {
+          "bucket": "sections",
+          "leaves": 688,
+          "maxDepth": 7,
+          "childCount": 3
+        },
+        {
+          "bucket": "dialogs",
+          "leaves": 450,
+          "maxDepth": 7,
+          "childCount": 1
+        },
+        {
+          "bucket": "cards",
+          "leaves": 431,
+          "maxDepth": 6,
+          "childCount": 1
+        },
+        {
+          "bucket": "emails",
+          "leaves": 382,
+          "maxDepth": 5,
+          "childCount": 17
+        },
+        {
+          "bucket": "forms",
+          "leaves": 120,
+          "maxDepth": 8,
+          "childCount": 1
+        },
+        {
+          "bucket": "shared",
+          "leaves": 107,
+          "maxDepth": 6,
+          "childCount": 3
+        },
+        {
+          "bucket": "app",
+          "leaves": 80,
+          "maxDepth": 5,
+          "childCount": 4
+        },
+        {
+          "bucket": "toasts",
+          "leaves": 16,
+          "maxDepth": 4,
+          "childCount": 1
+        }
+      ]
+    },
+    {
+      "locale": "fr",
+      "topLevelCount": 9,
+      "leafCount": 3326,
+      "maxDepth": 8,
+      "allowedBucketLeaves": 3326,
+      "retiredPrefixLeaves": 0,
+      "buckets": [
+        {
+          "bucket": "pages",
+          "leaves": 1052,
+          "maxDepth": 7,
+          "childCount": 7
+        },
+        {
+          "bucket": "sections",
+          "leaves": 688,
+          "maxDepth": 7,
+          "childCount": 3
+        },
+        {
+          "bucket": "dialogs",
+          "leaves": 450,
+          "maxDepth": 7,
+          "childCount": 1
+        },
+        {
+          "bucket": "cards",
+          "leaves": 431,
+          "maxDepth": 6,
+          "childCount": 1
+        },
+        {
+          "bucket": "emails",
+          "leaves": 382,
+          "maxDepth": 5,
+          "childCount": 17
+        },
+        {
+          "bucket": "forms",
+          "leaves": 120,
+          "maxDepth": 8,
+          "childCount": 1
+        },
+        {
+          "bucket": "shared",
+          "leaves": 107,
+          "maxDepth": 6,
+          "childCount": 3
+        },
+        {
+          "bucket": "app",
+          "leaves": 80,
+          "maxDepth": 5,
+          "childCount": 4
+        },
+        {
+          "bucket": "toasts",
+          "leaves": 16,
+          "maxDepth": 4,
+          "childCount": 1
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/migrations/message-tree/reports/before.json
+++ b/scripts/migrations/message-tree/reports/before.json
@@ -1,0 +1,504 @@
+{
+  "generatedAt": "2026-05-26T20:22:29.393Z",
+  "messagesDirectory": "sites\\arolariu.ro\\messages",
+  "locales": [
+    {
+      "locale": "en",
+      "topLevelCount": 26,
+      "leafCount": 3326,
+      "maxDepth": 6,
+      "allowedBucketLeaves": 0,
+      "retiredPrefixLeaves": 1787,
+      "buckets": [
+        {
+          "bucket": "About",
+          "leaves": 570,
+          "maxDepth": 6,
+          "childCount": 8
+        },
+        {
+          "bucket": "IMS--Dialogs",
+          "leaves": 450,
+          "maxDepth": 6,
+          "childCount": 20
+        },
+        {
+          "bucket": "email",
+          "leaves": 382,
+          "maxDepth": 5,
+          "childCount": 17
+        },
+        {
+          "bucket": "IMS--Cards",
+          "leaves": 319,
+          "maxDepth": 5,
+          "childCount": 19
+        },
+        {
+          "bucket": "IMS--View",
+          "leaves": 224,
+          "maxDepth": 5,
+          "childCount": 20
+        },
+        {
+          "bucket": "Profile",
+          "leaves": 208,
+          "maxDepth": 5,
+          "childCount": 6
+        },
+        {
+          "bucket": "IMS--List",
+          "leaves": 146,
+          "maxDepth": 5,
+          "childCount": 13
+        },
+        {
+          "bucket": "IMS--Edit",
+          "leaves": 132,
+          "maxDepth": 5,
+          "childCount": 8
+        },
+        {
+          "bucket": "IMS--Stats",
+          "leaves": 112,
+          "maxDepth": 4,
+          "childCount": 18
+        },
+        {
+          "bucket": "Legal",
+          "leaves": 100,
+          "maxDepth": 5,
+          "childCount": 2
+        },
+        {
+          "bucket": "IMS--ViewScans",
+          "leaves": 95,
+          "maxDepth": 4,
+          "childCount": 13
+        },
+        {
+          "bucket": "IMS--Common",
+          "leaves": 91,
+          "maxDepth": 5,
+          "childCount": 13
+        },
+        {
+          "bucket": "Acknowledgements",
+          "leaves": 82,
+          "maxDepth": 5,
+          "childCount": 9
+        },
+        {
+          "bucket": "IMS--Create",
+          "leaves": 78,
+          "maxDepth": 6,
+          "childCount": 8
+        },
+        {
+          "bucket": "IMS--UploadScans",
+          "leaves": 71,
+          "maxDepth": 4,
+          "childCount": 13
+        },
+        {
+          "bucket": "Auth",
+          "leaves": 58,
+          "maxDepth": 5,
+          "childCount": 5
+        },
+        {
+          "bucket": "IMS--Landing",
+          "leaves": 53,
+          "maxDepth": 4,
+          "childCount": 6
+        },
+        {
+          "bucket": "Errors",
+          "leaves": 30,
+          "maxDepth": 4,
+          "childCount": 2
+        },
+        {
+          "bucket": "Home",
+          "leaves": 26,
+          "maxDepth": 4,
+          "childCount": 6
+        },
+        {
+          "bucket": "Commander",
+          "leaves": 21,
+          "maxDepth": 3,
+          "childCount": 4
+        },
+        {
+          "bucket": "EULA",
+          "leaves": 20,
+          "maxDepth": 5,
+          "childCount": 8
+        },
+        {
+          "bucket": "Footer",
+          "leaves": 17,
+          "maxDepth": 3,
+          "childCount": 9
+        },
+        {
+          "bucket": "IMS--Hooks",
+          "leaves": 16,
+          "maxDepth": 3,
+          "childCount": 6
+        },
+        {
+          "bucket": "Navigation",
+          "leaves": 12,
+          "maxDepth": 3,
+          "childCount": 10
+        },
+        {
+          "bucket": "Domains",
+          "leaves": 8,
+          "maxDepth": 5,
+          "childCount": 4
+        },
+        {
+          "bucket": "Common",
+          "leaves": 5,
+          "maxDepth": 4,
+          "childCount": 2
+        }
+      ]
+    },
+    {
+      "locale": "ro",
+      "topLevelCount": 26,
+      "leafCount": 3326,
+      "maxDepth": 6,
+      "allowedBucketLeaves": 0,
+      "retiredPrefixLeaves": 1787,
+      "buckets": [
+        {
+          "bucket": "About",
+          "leaves": 570,
+          "maxDepth": 6,
+          "childCount": 8
+        },
+        {
+          "bucket": "IMS--Dialogs",
+          "leaves": 450,
+          "maxDepth": 6,
+          "childCount": 20
+        },
+        {
+          "bucket": "email",
+          "leaves": 382,
+          "maxDepth": 5,
+          "childCount": 17
+        },
+        {
+          "bucket": "IMS--Cards",
+          "leaves": 319,
+          "maxDepth": 5,
+          "childCount": 19
+        },
+        {
+          "bucket": "IMS--View",
+          "leaves": 224,
+          "maxDepth": 5,
+          "childCount": 20
+        },
+        {
+          "bucket": "Profile",
+          "leaves": 208,
+          "maxDepth": 5,
+          "childCount": 6
+        },
+        {
+          "bucket": "IMS--List",
+          "leaves": 146,
+          "maxDepth": 5,
+          "childCount": 13
+        },
+        {
+          "bucket": "IMS--Edit",
+          "leaves": 132,
+          "maxDepth": 5,
+          "childCount": 8
+        },
+        {
+          "bucket": "IMS--Stats",
+          "leaves": 112,
+          "maxDepth": 4,
+          "childCount": 18
+        },
+        {
+          "bucket": "Legal",
+          "leaves": 100,
+          "maxDepth": 5,
+          "childCount": 2
+        },
+        {
+          "bucket": "IMS--ViewScans",
+          "leaves": 95,
+          "maxDepth": 4,
+          "childCount": 13
+        },
+        {
+          "bucket": "IMS--Common",
+          "leaves": 91,
+          "maxDepth": 5,
+          "childCount": 13
+        },
+        {
+          "bucket": "Acknowledgements",
+          "leaves": 82,
+          "maxDepth": 5,
+          "childCount": 9
+        },
+        {
+          "bucket": "IMS--Create",
+          "leaves": 78,
+          "maxDepth": 6,
+          "childCount": 8
+        },
+        {
+          "bucket": "IMS--UploadScans",
+          "leaves": 71,
+          "maxDepth": 4,
+          "childCount": 13
+        },
+        {
+          "bucket": "Auth",
+          "leaves": 58,
+          "maxDepth": 5,
+          "childCount": 5
+        },
+        {
+          "bucket": "IMS--Landing",
+          "leaves": 53,
+          "maxDepth": 4,
+          "childCount": 6
+        },
+        {
+          "bucket": "Errors",
+          "leaves": 30,
+          "maxDepth": 4,
+          "childCount": 2
+        },
+        {
+          "bucket": "Home",
+          "leaves": 26,
+          "maxDepth": 4,
+          "childCount": 6
+        },
+        {
+          "bucket": "Commander",
+          "leaves": 21,
+          "maxDepth": 3,
+          "childCount": 4
+        },
+        {
+          "bucket": "EULA",
+          "leaves": 20,
+          "maxDepth": 5,
+          "childCount": 8
+        },
+        {
+          "bucket": "Footer",
+          "leaves": 17,
+          "maxDepth": 3,
+          "childCount": 9
+        },
+        {
+          "bucket": "IMS--Hooks",
+          "leaves": 16,
+          "maxDepth": 3,
+          "childCount": 6
+        },
+        {
+          "bucket": "Navigation",
+          "leaves": 12,
+          "maxDepth": 3,
+          "childCount": 10
+        },
+        {
+          "bucket": "Domains",
+          "leaves": 8,
+          "maxDepth": 5,
+          "childCount": 4
+        },
+        {
+          "bucket": "Common",
+          "leaves": 5,
+          "maxDepth": 4,
+          "childCount": 2
+        }
+      ]
+    },
+    {
+      "locale": "fr",
+      "topLevelCount": 26,
+      "leafCount": 3326,
+      "maxDepth": 6,
+      "allowedBucketLeaves": 0,
+      "retiredPrefixLeaves": 1787,
+      "buckets": [
+        {
+          "bucket": "About",
+          "leaves": 570,
+          "maxDepth": 6,
+          "childCount": 8
+        },
+        {
+          "bucket": "IMS--Dialogs",
+          "leaves": 450,
+          "maxDepth": 6,
+          "childCount": 20
+        },
+        {
+          "bucket": "email",
+          "leaves": 382,
+          "maxDepth": 5,
+          "childCount": 17
+        },
+        {
+          "bucket": "IMS--Cards",
+          "leaves": 319,
+          "maxDepth": 5,
+          "childCount": 19
+        },
+        {
+          "bucket": "IMS--View",
+          "leaves": 224,
+          "maxDepth": 5,
+          "childCount": 20
+        },
+        {
+          "bucket": "Profile",
+          "leaves": 208,
+          "maxDepth": 5,
+          "childCount": 6
+        },
+        {
+          "bucket": "IMS--List",
+          "leaves": 146,
+          "maxDepth": 5,
+          "childCount": 13
+        },
+        {
+          "bucket": "IMS--Edit",
+          "leaves": 132,
+          "maxDepth": 5,
+          "childCount": 8
+        },
+        {
+          "bucket": "IMS--Stats",
+          "leaves": 112,
+          "maxDepth": 4,
+          "childCount": 18
+        },
+        {
+          "bucket": "Legal",
+          "leaves": 100,
+          "maxDepth": 5,
+          "childCount": 2
+        },
+        {
+          "bucket": "IMS--ViewScans",
+          "leaves": 95,
+          "maxDepth": 4,
+          "childCount": 13
+        },
+        {
+          "bucket": "IMS--Common",
+          "leaves": 91,
+          "maxDepth": 5,
+          "childCount": 13
+        },
+        {
+          "bucket": "Acknowledgements",
+          "leaves": 82,
+          "maxDepth": 5,
+          "childCount": 9
+        },
+        {
+          "bucket": "IMS--Create",
+          "leaves": 78,
+          "maxDepth": 6,
+          "childCount": 8
+        },
+        {
+          "bucket": "IMS--UploadScans",
+          "leaves": 71,
+          "maxDepth": 4,
+          "childCount": 13
+        },
+        {
+          "bucket": "Auth",
+          "leaves": 58,
+          "maxDepth": 5,
+          "childCount": 5
+        },
+        {
+          "bucket": "IMS--Landing",
+          "leaves": 53,
+          "maxDepth": 4,
+          "childCount": 6
+        },
+        {
+          "bucket": "Errors",
+          "leaves": 30,
+          "maxDepth": 4,
+          "childCount": 2
+        },
+        {
+          "bucket": "Home",
+          "leaves": 26,
+          "maxDepth": 4,
+          "childCount": 6
+        },
+        {
+          "bucket": "Commander",
+          "leaves": 21,
+          "maxDepth": 3,
+          "childCount": 4
+        },
+        {
+          "bucket": "EULA",
+          "leaves": 20,
+          "maxDepth": 5,
+          "childCount": 8
+        },
+        {
+          "bucket": "Footer",
+          "leaves": 17,
+          "maxDepth": 3,
+          "childCount": 9
+        },
+        {
+          "bucket": "IMS--Hooks",
+          "leaves": 16,
+          "maxDepth": 3,
+          "childCount": 6
+        },
+        {
+          "bucket": "Navigation",
+          "leaves": 12,
+          "maxDepth": 3,
+          "childCount": 10
+        },
+        {
+          "bucket": "Domains",
+          "leaves": 8,
+          "maxDepth": 5,
+          "childCount": 4
+        },
+        {
+          "bucket": "Common",
+          "leaves": 5,
+          "maxDepth": 4,
+          "childCount": 2
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/migrations/message-tree/rewriteCallSites.ts
+++ b/scripts/migrations/message-tree/rewriteCallSites.ts
@@ -1,0 +1,83 @@
+import fs from "node:fs";
+import path from "node:path";
+import {getRepositoryRoot} from "./treeUtils.ts";
+
+type KeyMapEntry = Readonly<{
+  oldPath: string;
+  newPath: string;
+  reason: string;
+}>;
+
+const repositoryRoot = getRepositoryRoot();
+const roots = [
+  path.join(repositoryRoot, "sites", "arolariu.ro", "src"),
+  path.join(repositoryRoot, "sites", "arolariu.ro", "emails"),
+  path.join(repositoryRoot, "sites", "arolariu.ro", "vitest.setup.ts"),
+];
+const keyMap = JSON.parse(
+  fs.readFileSync(path.join(repositoryRoot, "scripts", "migrations", "message-tree", "key-map.json"), "utf8"),
+) as readonly KeyMapEntry[];
+const sortedMap = [...keyMap].sort((left, right) => right.oldPath.length - left.oldPath.length);
+const selectorRootRules = deriveSelectorRootRules(sortedMap);
+
+function collectFiles(targetPath: string): string[] {
+  if (fs.statSync(targetPath).isFile()) return [targetPath];
+  return fs.readdirSync(targetPath, {withFileTypes: true}).flatMap((entry) => {
+    const fullPath = path.join(targetPath, entry.name);
+    if (entry.isDirectory()) return collectFiles(fullPath);
+    return /\.(ts|tsx)$/u.test(fullPath) ? [fullPath] : [];
+  });
+}
+
+function rewriteText(input: string): string {
+  let output = input;
+  for (const entry of sortedMap) {
+    output = output.split(entry.oldPath).join(entry.newPath);
+
+    output = output.split(`m${toSelectorAccess(entry.oldPath)}`).join(`m${toSelectorAccess(entry.newPath)}`);
+  }
+
+  for (const [oldRoot, newRoot] of selectorRootRules) {
+    output = output.split(`m${toSelectorAccess(oldRoot)}`).join(`m${toSelectorAccess(newRoot)}`);
+  }
+  return output;
+}
+
+function toSelectorAccess(messagePath: string): string {
+  return messagePath
+    .split(".")
+    .map((segment) => (/^[A-Za-z_$][\w$]*$/u.test(segment) ? `.${segment}` : `[${JSON.stringify(segment)}]`))
+    .join("");
+}
+
+function deriveSelectorRootRules(entries: readonly KeyMapEntry[]): ReadonlyArray<readonly [oldRoot: string, newRoot: string]> {
+  const roots = new Map<string, Map<string, number>>();
+  for (const entry of entries) {
+    const oldRoot = entry.oldPath.split(".")[0] ?? "";
+    const newSegments = entry.newPath.split(".");
+    const newRoot = oldRoot.startsWith("IMS--") ? newSegments.slice(0, 2).join(".") : newSegments[0] ?? "";
+    const counts = roots.get(oldRoot) ?? new Map<string, number>();
+    counts.set(newRoot, (counts.get(newRoot) ?? 0) + 1);
+    roots.set(oldRoot, counts);
+  }
+
+  return [...roots.entries()]
+    .map(([oldRoot, counts]) => {
+      const [newRoot] = [...counts.entries()].sort((left, right) => right[1] - left[1])[0] ?? [""];
+      return [oldRoot, newRoot] as const;
+    })
+    .filter(([oldRoot, newRoot]) => oldRoot.length > 0 && newRoot.length > 0 && oldRoot !== newRoot)
+    .sort((left, right) => right[0].length - left[0].length);
+}
+
+let changedCount = 0;
+for (const filePath of roots.flatMap(collectFiles)) {
+  const oldText = fs.readFileSync(filePath, "utf8");
+  const newText = rewriteText(oldText);
+  if (newText !== oldText) {
+    fs.writeFileSync(filePath, newText);
+    changedCount += 1;
+  }
+}
+
+console.info(`[message-tree] Rewrote ${changedCount} call-site file(s).`);

--- a/scripts/migrations/message-tree/taxonomy.ts
+++ b/scripts/migrations/message-tree/taxonomy.ts
@@ -1,0 +1,81 @@
+import {flattenMessages, isLowerCamelCase, localeNames, readMessageTree, type LocaleName, type MessageTree} from "./treeUtils.ts";
+
+export const allowedTopLevelBuckets = [
+  "app",
+  "pages",
+  "sections",
+  "components",
+  "dialogs",
+  "cards",
+  "forms",
+  "tables",
+  "toasts",
+  "emails",
+  "shared",
+] as const;
+
+export type TopLevelBucket = (typeof allowedTopLevelBuckets)[number];
+
+export type ValidationIssue = Readonly<{
+  locale: LocaleName;
+  path: string;
+  message: string;
+}>;
+
+export function validateMessageTaxonomy(locale: LocaleName, tree: MessageTree): ValidationIssue[] {
+  const issues: ValidationIssue[] = [];
+  const flat = flattenMessages(tree);
+
+  for (const messagePath of flat.keys()) {
+    const segments = messagePath.split(".");
+    const topLevel = segments[0] ?? "";
+    if (!allowedTopLevelBuckets.includes(topLevel as TopLevelBucket)) {
+      issues.push({locale, path: messagePath, message: `Top-level bucket "${topLevel}" is not allowed.`});
+    }
+
+    for (const segment of segments) {
+      if (segment.includes("IMS--")) {
+        issues.push({locale, path: messagePath, message: `Segment "${segment}" contains the retired IMS-- prefix.`});
+      }
+      if (!isLowerCamelCase(segment)) {
+        issues.push({locale, path: messagePath, message: `Segment "${segment}" must be lower camelCase.`});
+      }
+    }
+
+    const value = flat.get(messagePath);
+    if (locale === "en" && value?.trim().length === 0) {
+      issues.push({locale, path: messagePath, message: "English source messages must not be empty."});
+    }
+  }
+
+  return issues;
+}
+
+export function validateLocaleParity(): ValidationIssue[] {
+  const [baseLocale, ...targetLocales] = localeNames;
+  const baseFlat = flattenMessages(readMessageTree(baseLocale));
+  const issues: ValidationIssue[] = [];
+
+  for (const locale of targetLocales) {
+    const currentFlat = flattenMessages(readMessageTree(locale));
+    for (const key of baseFlat.keys()) {
+      if (!currentFlat.has(key)) {
+        issues.push({locale, path: key, message: "Missing key from target locale."});
+      }
+    }
+    for (const key of currentFlat.keys()) {
+      if (!baseFlat.has(key)) {
+        issues.push({locale, path: key, message: "Extra key not present in English source locale."});
+      }
+    }
+  }
+
+  return issues;
+}
+
+export function validateAllMessages(): ValidationIssue[] {
+  return [
+    ...localeNames.flatMap((locale) => validateMessageTaxonomy(locale, readMessageTree(locale))),
+    ...validateLocaleParity(),
+  ];
+}

--- a/scripts/migrations/message-tree/treeUtils.ts
+++ b/scripts/migrations/message-tree/treeUtils.ts
@@ -1,0 +1,99 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export type MessageLeaf = string;
+export type MessageTree = {
+  readonly [key: string]: MessageLeaf | MessageTree;
+};
+
+export type FlatMessages = ReadonlyMap<string, MessageLeaf>;
+
+export const localeNames = ["en", "ro", "fr"] as const;
+export type LocaleName = (typeof localeNames)[number];
+
+export function getRepositoryRoot(startDirectory: string = process.cwd()): string {
+  let currentDirectory = startDirectory;
+  while (!fs.existsSync(path.join(currentDirectory, "package.json")) || !fs.existsSync(path.join(currentDirectory, "sites", "arolariu.ro"))) {
+    const parentDirectory = path.dirname(currentDirectory);
+    if (parentDirectory === currentDirectory) {
+      throw new Error("Could not locate repository root.");
+    }
+
+    currentDirectory = parentDirectory;
+  }
+
+  return currentDirectory;
+}
+
+export function getMessagesDirectory(repositoryRoot: string = getRepositoryRoot()): string {
+  return path.join(repositoryRoot, "sites", "arolariu.ro", "messages");
+}
+
+export function readMessageTree(locale: LocaleName, messagesDirectory: string = getMessagesDirectory()): MessageTree {
+  return JSON.parse(fs.readFileSync(path.join(messagesDirectory, `${locale}.json`), "utf8")) as MessageTree;
+}
+
+export function writeMessageTree(locale: LocaleName, tree: MessageTree, messagesDirectory: string = getMessagesDirectory()): void {
+  fs.writeFileSync(path.join(messagesDirectory, `${locale}.json`), `${JSON.stringify(sortTree(tree), null, 2)}\n`);
+}
+
+export function flattenMessages(tree: MessageTree, prefix: string = ""): Map<string, MessageLeaf> {
+  const result = new Map<string, MessageLeaf>();
+  for (const [key, value] of Object.entries(tree)) {
+    const nextPath = prefix ? `${prefix}.${key}` : key;
+    if (typeof value === "string") {
+      result.set(nextPath, value);
+    } else {
+      for (const [childPath, childValue] of flattenMessages(value, nextPath)) {
+        result.set(childPath, childValue);
+      }
+    }
+  }
+
+  return result;
+}
+
+export function unflattenMessages(flatMessages: ReadonlyMap<string, MessageLeaf>): MessageTree {
+  const root: Record<string, MessageLeaf | Record<string, unknown>> = {};
+  for (const [messagePath, value] of flatMessages) {
+    const segments = messagePath.split(".");
+    let pointer: Record<string, MessageLeaf | Record<string, unknown>> = root;
+    for (const [index, segment] of segments.entries()) {
+      if (index === segments.length - 1) {
+        pointer[segment] = value;
+      } else {
+        const existing = pointer[segment];
+        if (typeof existing === "string") {
+          throw new Error(`Cannot create nested path "${messagePath}" because "${segments.slice(0, index + 1).join(".")}" is already a leaf.`);
+        }
+
+        pointer[segment] = existing ?? {};
+        pointer = pointer[segment] as Record<string, MessageLeaf | Record<string, unknown>>;
+      }
+    }
+  }
+
+  return root as MessageTree;
+}
+
+export function sortTree(tree: MessageTree): MessageTree {
+  return Object.fromEntries(
+    Object.entries(tree)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, value]) => [key, typeof value === "string" ? value : sortTree(value)]),
+  ) as MessageTree;
+}
+
+export function getPathDepth(messagePath: string): number {
+  return messagePath.split(".").length;
+}
+
+export function isLowerCamelCase(segment: string): boolean {
+  return /^[a-z][A-Za-z0-9]*$/u.test(segment);
+}
+
+export function replacePrefix(messagePath: string, oldPrefix: string, newPrefix: string): string {
+  if (messagePath === oldPrefix) return newPrefix;
+  if (messagePath.startsWith(`${oldPrefix}.`)) return `${newPrefix}${messagePath.slice(oldPrefix.length)}`;
+  return messagePath;
+}

--- a/scripts/migrations/message-tree/validateMessages.ts
+++ b/scripts/migrations/message-tree/validateMessages.ts
@@ -1,0 +1,15 @@
+import {validateAllMessages} from "./taxonomy.ts";
+
+const issues = validateAllMessages();
+if (issues.length > 0) {
+  console.error(`[message-tree] Found ${issues.length} message taxonomy issue(s).`);
+  for (const issue of issues.slice(0, 200)) {
+    console.error(`- ${issue.locale}:${issue.path} — ${issue.message}`);
+  }
+  if (issues.length > 200) {
+    console.error(`[message-tree] ${issues.length - 200} additional issue(s) omitted.`);
+  }
+  process.exit(1);
+}
+
+console.info("[message-tree] Message taxonomy validation passed.");

--- a/sites/arolariu.ro/emails/_components/EmailLayout.tsx
+++ b/sites/arolariu.ro/emails/_components/EmailLayout.tsx
@@ -138,7 +138,7 @@ export default async function EmailLayout({
               alt={BRAND.name}
               style={styles.logo}
             />
-            <Text style={styles.headerTagline}>{tLayout(selectorFromPath("email.layout.tagline"))}</Text>
+            <Text style={styles.headerTagline}>{tLayout(selectorFromPath("emails.layout.tagline"))}</Text>
           </Section>
 
           <Section style={styles.content}>
@@ -154,7 +154,7 @@ export default async function EmailLayout({
                   {primaryCta.label}
                 </Link>
                 <Text style={styles.fallbackLinkText}>
-                  {tLayout(selectorFromPath("email.layout.buttonFallback"))}{" "}
+                  {tLayout(selectorFromPath("emails.layout.buttonFallback"))}{" "}
                   <Link
                     href={primaryCta.href}
                     style={styles.link}>
@@ -166,7 +166,7 @@ export default async function EmailLayout({
 
             {secondaryCta ? (
               <Text style={styles.fallbackLinkText}>
-                {tLayout(selectorFromPath("email.layout.secondaryFallback"))}{" "}
+                {tLayout(selectorFromPath("emails.layout.secondaryFallback"))}{" "}
                 <Link
                   href={secondaryCta.href}
                   style={styles.link}>
@@ -200,7 +200,7 @@ export default async function EmailLayout({
                 <Link
                   href={managePreferencesUrl}
                   style={styles.link}>
-                  {tLayout(selectorFromPath("email.layout.managePreferences"))}
+                  {tLayout(selectorFromPath("emails.layout.managePreferences"))}
                 </Link>
               </Text>
             ) : null}
@@ -210,12 +210,12 @@ export default async function EmailLayout({
                 <Link
                   href={unsubscribeUrl}
                   style={styles.link}>
-                  {tLayout(selectorFromPath("email.layout.unsubscribe"))}
+                  {tLayout(selectorFromPath("emails.layout.unsubscribe"))}
                 </Link>
               </Text>
             ) : null}
 
-            <Text style={styles.footerFinePrint}>{tLayout(selectorFromPath("email.layout.allRightsReserved"), {year: new Date().getFullYear(), brand: BRAND.name})}</Text>
+            <Text style={styles.footerFinePrint}>{tLayout(selectorFromPath("emails.layout.allRightsReserved"), {year: new Date().getFullYear(), brand: BRAND.name})}</Text>
           </Section>
         </Container>
       </Body>

--- a/sites/arolariu.ro/emails/_components/EmailLayout.tsx
+++ b/sites/arolariu.ro/emails/_components/EmailLayout.tsx
@@ -81,7 +81,7 @@ const styles = {
  * The shared chrome wrapping every email body.
  *
  * @remarks
- * **Self-contained i18n.** Resolves its own `email.layout`-scoped strings
+ * **Self-contained i18n.** Resolves its own `emails.layout`-scoped strings
  * via {@link getLayoutTranslator} (memoised per locale in
  * `./layoutTranslator.ts`). Templates pass only data — they do **not**
  * thread a translator function down. This keeps the layout's prop

--- a/sites/arolariu.ro/emails/_components/layoutTranslator.test.ts
+++ b/sites/arolariu.ro/emails/_components/layoutTranslator.test.ts
@@ -4,7 +4,7 @@ import {beforeEach, describe, expect, it, vi} from "vitest";
 import * as i18n from "../_lib/i18n";
 import {__resetLayoutTranslatorCache, getLayoutTranslator} from "./layoutTranslator";
 
-const FIXTURE = {email: {layout: {tagline: "Tag", buttonFallback: "BF"}}};
+const FIXTURE = {emails: {layout: {tagline: "Tag", buttonFallback: "BF"}}};
 
 describe("getLayoutTranslator", () => {
   beforeEach(() => {

--- a/sites/arolariu.ro/emails/_components/layoutTranslator.test.ts
+++ b/sites/arolariu.ro/emails/_components/layoutTranslator.test.ts
@@ -44,7 +44,7 @@ describe("getLayoutTranslator", () => {
     expect(createSpy).toHaveBeenCalledTimes(3); // one per locale
   });
 
-  it("returns translators that resolve namespace 'email.layout' keys", async () => {
+  it("returns translators that resolve namespace 'emails.layout' keys", async () => {
     vi.spyOn(i18n, "loadMessages").mockResolvedValue(FIXTURE);
     const t = await getLayoutTranslator("en");
     expect(t(selectorFromPath("emails.layout.tagline"))).toBe("Tag");

--- a/sites/arolariu.ro/emails/_components/layoutTranslator.test.ts
+++ b/sites/arolariu.ro/emails/_components/layoutTranslator.test.ts
@@ -47,8 +47,8 @@ describe("getLayoutTranslator", () => {
   it("returns translators that resolve namespace 'email.layout' keys", async () => {
     vi.spyOn(i18n, "loadMessages").mockResolvedValue(FIXTURE);
     const t = await getLayoutTranslator("en");
-    expect(t(selectorFromPath("email.layout.tagline"))).toBe("Tag");
-    expect(t(selectorFromPath("email.layout.buttonFallback"))).toBe("BF");
+    expect(t(selectorFromPath("emails.layout.tagline"))).toBe("Tag");
+    expect(t(selectorFromPath("emails.layout.buttonFallback"))).toBe("BF");
   });
 
   it("__resetLayoutTranslatorCache clears the cache", async () => {

--- a/sites/arolariu.ro/emails/_components/layoutTranslator.ts
+++ b/sites/arolariu.ro/emails/_components/layoutTranslator.ts
@@ -1,12 +1,12 @@
 import {createEmailTranslator, type EmailLocale, type EmailTranslator, loadMessages} from "../_lib/i18n";
 
 /**
- * @fileoverview Memoised `email.layout`-scoped translator per locale.
+ * @fileoverview Memoised `emails.layout`-scoped translator per locale.
  * @module emails/_components/layoutTranslator
  *
  * @remarks
  * The layout's strings (tagline, footer, fallbacks) live in the
- * `email.layout` next-intl namespace. Resolving them on every render
+ * `emails.layout` next-intl namespace. Resolving them on every render
  * would mean a redundant `loadMessages` + `createEmailTranslator` pair
  * per email — the template has already done that work for its own
  * namespace.
@@ -29,7 +29,7 @@ import {createEmailTranslator, type EmailLocale, type EmailTranslator, loadMessa
 const _layoutTranslatorByLocale = new Map<EmailLocale, EmailTranslator>();
 
 /**
- * Get the memoised `email.layout`-scoped translator for a locale.
+ * Get the memoised `emails.layout`-scoped translator for a locale.
  *
  * @param locale - Resolved locale to translate for.
  * @returns The cached or newly-constructed translator.
@@ -45,7 +45,7 @@ export async function getLayoutTranslator(locale: EmailLocale): Promise<EmailTra
   const cached = _layoutTranslatorByLocale.get(locale);
   if (cached) return cached;
   const messages = await loadMessages(locale);
-  const t = createEmailTranslator({locale, messages, namespace: "email.layout"});
+  const t = createEmailTranslator({locale, messages, namespace: "emails.layout"});
   _layoutTranslatorByLocale.set(locale, t);
   return t;
 }

--- a/sites/arolariu.ro/emails/_lib/defineEmailTemplate.test.ts
+++ b/sites/arolariu.ro/emails/_lib/defineEmailTemplate.test.ts
@@ -5,7 +5,7 @@ import {defineEmailTemplate} from "./defineEmailTemplate";
 import * as i18n from "./i18n";
 
 const FIXTURE_MESSAGES = {
-  email: {
+  emails: {
     welcome: {
       subject: "Welcome, {name}!",
       greeting: "Hi {name}",

--- a/sites/arolariu.ro/emails/_lib/defineEmailTemplate.test.ts
+++ b/sites/arolariu.ro/emails/_lib/defineEmailTemplate.test.ts
@@ -74,7 +74,7 @@ describe("defineEmailTemplate", () => {
     const T = defineEmailTemplate<{readonly name: string}>({
       namespace: "email.welcome",
       render: ({t, props}) => {
-        seen.greeting = t(selectorFromPath("email.welcome.greeting"), {name: props.name});
+        seen.greeting = t(selectorFromPath("emails.welcome.greeting"), {name: props.name});
         return {type: "div", props: {}} as never;
       },
     });

--- a/sites/arolariu.ro/emails/_lib/defineEmailTemplate.test.ts
+++ b/sites/arolariu.ro/emails/_lib/defineEmailTemplate.test.ts
@@ -19,17 +19,17 @@ const FIXTURE_MESSAGES = {
 describe("defineEmailTemplate", () => {
   it("attaches .namespace to the returned template", () => {
     const T = defineEmailTemplate<{}>({
-      namespace: "email.welcome",
+      namespace: "emails.welcome",
       render: () => ({type: "div", props: {}}) as never,
     });
-    expect(T.namespace).toBe("email.welcome");
+    expect(T.namespace).toBe("emails.welcome");
   });
 
   it("defaults locale to 'en' when omitted", async () => {
     vi.spyOn(i18n, "loadMessages").mockResolvedValueOnce(FIXTURE_MESSAGES);
     const seen: {locale?: string} = {};
     const T = defineEmailTemplate<{}>({
-      namespace: "email.welcome",
+      namespace: "emails.welcome",
       render: (ctx) => {
         seen.locale = ctx.locale;
         return {type: "div", props: {}} as never;
@@ -43,7 +43,7 @@ describe("defineEmailTemplate", () => {
     vi.spyOn(i18n, "loadMessages").mockResolvedValueOnce(FIXTURE_MESSAGES);
     const seen: {locale?: string} = {};
     const T = defineEmailTemplate<{}>({
-      namespace: "email.welcome",
+      namespace: "emails.welcome",
       render: (ctx) => {
         seen.locale = ctx.locale;
         return {type: "div", props: {}} as never;
@@ -58,7 +58,7 @@ describe("defineEmailTemplate", () => {
     const seen: {props?: unknown} = {};
     type P = {readonly username: string};
     const T = defineEmailTemplate<P>({
-      namespace: "email.welcome",
+      namespace: "emails.welcome",
       render: (ctx) => {
         seen.props = ctx.props;
         return {type: "div", props: {}} as never;
@@ -72,7 +72,7 @@ describe("defineEmailTemplate", () => {
     vi.spyOn(i18n, "loadMessages").mockResolvedValueOnce(FIXTURE_MESSAGES);
     const seen: {greeting?: string} = {};
     const T = defineEmailTemplate<{readonly name: string}>({
-      namespace: "email.welcome",
+      namespace: "emails.welcome",
       render: ({t, props}) => {
         seen.greeting = t(selectorFromPath("emails.welcome.greeting"), {name: props.name});
         return {type: "div", props: {}} as never;
@@ -86,7 +86,7 @@ describe("defineEmailTemplate", () => {
     vi.spyOn(i18n, "loadMessages").mockResolvedValueOnce(FIXTURE_MESSAGES);
     const expected = {type: "div", props: {"data-marker": "ok"}};
     const T = defineEmailTemplate<{}>({
-      namespace: "email.welcome",
+      namespace: "emails.welcome",
       render: () => expected as never,
     });
     const out = await T({});
@@ -96,7 +96,7 @@ describe("defineEmailTemplate", () => {
   it(".getSubject() defaults locale to 'en'", async () => {
     vi.spyOn(i18n, "loadMessages").mockResolvedValueOnce(FIXTURE_MESSAGES);
     const T = defineEmailTemplate<{}>({
-      namespace: "email.plain",
+      namespace: "emails.plain",
       render: () => ({type: "div", props: {}}) as never,
     });
     const subject = await T.getSubject();
@@ -106,7 +106,7 @@ describe("defineEmailTemplate", () => {
   it(".getSubject() interpolates ICU vars", async () => {
     vi.spyOn(i18n, "loadMessages").mockResolvedValueOnce(FIXTURE_MESSAGES);
     const T = defineEmailTemplate<{}>({
-      namespace: "email.welcome",
+      namespace: "emails.welcome",
       render: () => ({type: "div", props: {}}) as never,
     });
     const subject = await T.getSubject("en", {name: "Alex"});

--- a/sites/arolariu.ro/emails/_lib/defineEmailTemplate.ts
+++ b/sites/arolariu.ro/emails/_lib/defineEmailTemplate.ts
@@ -16,14 +16,14 @@ import {createEmailTranslator, DEFAULT_LOCALE, type EmailLocale, type EmailTrans
  * do not call `loadMessages` themselves; doing so re-parses the bundle and
  * defeats the optimisation.
  *
- * `EmailLayout` resolves its own `email.layout`-scoped translator via the
+ * `EmailLayout` resolves its own `emails.layout`-scoped translator via the
  * memoised `getLayoutTranslator` helper, so no `tLayout` is threaded
  * through this context.
  */
 export type EmailRenderContext<P> = {
   /** Resolved locale (defaulted to `"en"` if the caller omitted it). */
   readonly locale: EmailLocale;
-  /** Translator scoped to the template's namespace, e.g. `"email.welcome"`. */
+  /** Translator scoped to the template's namespace, e.g. `"emails.welcome"`. */
   readonly t: EmailTranslator;
   /** The caller-supplied props, minus `locale`. */
   readonly props: P;
@@ -37,7 +37,7 @@ export type EmailRenderContext<P> = {
 export type EmailTemplateConfig<P> = {
   /**
    * Full next-intl namespace path — must point at a JSON object that
-   * contains a `subject` key. Example: `"email.welcome"`.
+   * contains a `subject` key. Example: `"emails.welcome"`.
    *
    * @remarks
    * The HOF reads this string when constructing the namespace-scoped
@@ -130,7 +130,7 @@ export type EmailTemplate<P> = ((props: P & {readonly locale?: EmailLocale}) => 
  * };
  *
  * const WelcomeEmail = defineEmailTemplate<Props>({
- *   namespace: "email.welcome",
+ *   namespace: "emails.welcome",
  *   render: ({locale, t, props}) => {
  *     const name = props.username?.trim() || "there";
  *     return (
@@ -152,7 +152,7 @@ export type EmailTemplate<P> = ((props: P & {readonly locale?: EmailLocale}) => 
  * @example Reading the namespace from outside
  * ```ts
  * import WelcomeEmail from "./WelcomeEmail";
- * console.log(WelcomeEmail.namespace);            // "email.welcome"
+ * console.log(WelcomeEmail.namespace);            // "emails.welcome"
  * const subject = await WelcomeEmail.getSubject("ro", {name: "Alex"});
  * ```
  */

--- a/sites/arolariu.ro/emails/_lib/defineEmailTemplate.ts
+++ b/sites/arolariu.ro/emails/_lib/defineEmailTemplate.ts
@@ -58,9 +58,9 @@ export type EmailTemplateConfig<P> = {
    * render: ({locale, t, props}) => (
    *   <EmailLayout
    *     locale={locale}
-   *     preview={t(selectorFromPath("email.welcome.preview"), {name: props.username})}
-   *     heading={t(selectorFromPath("email.welcome.heading"))}>
-   *     <Text>{t(selectorFromPath("email.welcome.greeting"), {name: props.username})}</Text>
+   *     preview={t(selectorFromPath("emails.welcome.preview"), {name: props.username})}
+   *     heading={t(selectorFromPath("emails.welcome.heading"))}>
+   *     <Text>{t(selectorFromPath("emails.welcome.greeting"), {name: props.username})}</Text>
    *   </EmailLayout>
    * )
    * ```
@@ -136,9 +136,9 @@ export type EmailTemplate<P> = ((props: P & {readonly locale?: EmailLocale}) => 
  *     return (
  *       <EmailLayout
  *         locale={locale}
- *         preview={t(selectorFromPath("email.welcome.preview"), {brand: BRAND.name, name})}
- *         heading={t(selectorFromPath("email.welcome.heading"), {brand: BRAND.name})}>
- *         <Text>{t(selectorFromPath("email.welcome.greeting"), {name})}</Text>
+ *         preview={t(selectorFromPath("emails.welcome.preview"), {brand: BRAND.name, name})}
+ *         heading={t(selectorFromPath("emails.welcome.heading"), {brand: BRAND.name})}>
+ *         <Text>{t(selectorFromPath("emails.welcome.greeting"), {name})}</Text>
  *       </EmailLayout>
  *     );
  *   },

--- a/sites/arolariu.ro/emails/_lib/i18n.tsx
+++ b/sites/arolariu.ro/emails/_lib/i18n.tsx
@@ -100,7 +100,7 @@ export async function loadMessages(locale: EmailLocale = DEFAULT_LOCALE): Promis
  * @example
  * ```ts
  * const messages = await loadMessages("ro");
- * const t = createEmailTranslator({locale: "ro", messages, namespace: "email.welcome"});
+ * const t = createEmailTranslator({locale: "ro", messages, namespace: "emails.welcome"});
  * t(selectorFromPath("emails.welcome.greeting"), {name: "Alex"}); // → "Salut, Alex"
  * ```
  */

--- a/sites/arolariu.ro/emails/_lib/i18n.tsx
+++ b/sites/arolariu.ro/emails/_lib/i18n.tsx
@@ -101,7 +101,7 @@ export async function loadMessages(locale: EmailLocale = DEFAULT_LOCALE): Promis
  * ```ts
  * const messages = await loadMessages("ro");
  * const t = createEmailTranslator({locale: "ro", messages, namespace: "email.welcome"});
- * t(selectorFromPath("email.welcome.greeting"), {name: "Alex"}); // → "Salut, Alex"
+ * t(selectorFromPath("emails.welcome.greeting"), {name: "Alex"}); // → "Salut, Alex"
  * ```
  */
 export function createEmailTranslator(opts: {

--- a/sites/arolariu.ro/emails/accounts/AccountInactivityWarningEmail.tsx
+++ b/sites/arolariu.ro/emails/accounts/AccountInactivityWarningEmail.tsx
@@ -141,7 +141,7 @@ const AccountInactivityWarningEmail = async (props: Readonly<Props>) => {
 
   const locale: EmailLocale = props.locale ?? DEFAULT_LOCALE;
   const messages = await loadMessages(locale);
-  const t = createEmailTranslator({locale, messages, namespace: "email.accountInactivity"});
+  const t = createEmailTranslator({locale, messages, namespace: "emails.accountInactivity"});
 
   const name = username?.trim() ? username : "there";
   const effectiveSignInUrl = signInUrl ?? `${BRAND.url}/auth/sign-in`;

--- a/sites/arolariu.ro/emails/accounts/AccountInactivityWarningEmail.tsx
+++ b/sites/arolariu.ro/emails/accounts/AccountInactivityWarningEmail.tsx
@@ -149,41 +149,41 @@ const AccountInactivityWarningEmail = async (props: Readonly<Props>) => {
   return (
     <EmailLayout
       locale={locale}
-      title={`${BRAND.name} | ${t(selectorFromPath("email.accountInactivity.heading"))}`}
-      preview={t(selectorFromPath("email.accountInactivity.preview"), {name, inactiveDays})}
-      badge={t(selectorFromPath("email.accountInactivity.badge"))}
-      heading={t(selectorFromPath("email.accountInactivity.heading"))}
-      primaryCta={{href: effectiveSignInUrl, label: t(selectorFromPath("email.accountInactivity.cta.primary"))}}
-      secondaryCta={{href: `mailto:${BRAND.supportEmail}`, label: t(selectorFromPath("email.accountInactivity.cta.secondary"))}}
+      title={`${BRAND.name} | ${t(selectorFromPath("emails.accountInactivity.heading"))}`}
+      preview={t(selectorFromPath("emails.accountInactivity.preview"), {name, inactiveDays})}
+      badge={t(selectorFromPath("emails.accountInactivity.badge"))}
+      heading={t(selectorFromPath("emails.accountInactivity.heading"))}
+      primaryCta={{href: effectiveSignInUrl, label: t(selectorFromPath("emails.accountInactivity.cta.primary"))}}
+      secondaryCta={{href: `mailto:${BRAND.supportEmail}`, label: t(selectorFromPath("emails.accountInactivity.cta.secondary"))}}
       showUnsubscribe={false}
       unsubscribeUrl=''
       managePreferencesUrl=''>
-      <Text style={EmailParagraphStyles}>{t(selectorFromPath("email.accountInactivity.greeting"), {name})}</Text>
+      <Text style={EmailParagraphStyles}>{t(selectorFromPath("emails.accountInactivity.greeting"), {name})}</Text>
 
       <Text style={EmailParagraphStyles}>
-        {t.rich(selectorFromPath("email.accountInactivity.intro"), {
+        {t.rich(selectorFromPath("emails.accountInactivity.intro"), {
           inactiveDays,
           // eslint-disable-next-line react/no-unstable-nested-components -- emails render server-side via React Email; never mounted, no reconciliation
           count: (chunks) => <strong>{chunks}</strong>,
         })}
       </Text>
 
-      <EmailCard title={t(selectorFromPath("email.accountInactivity.whatThisMeans.title"))}>
-        <BulletList items={[t(selectorFromPath("email.accountInactivity.whatThisMeans.bullet1")), t(selectorFromPath("email.accountInactivity.whatThisMeans.bullet2"), {daysUntilClosure}), t(selectorFromPath("email.accountInactivity.whatThisMeans.bullet3"))]} />
+      <EmailCard title={t(selectorFromPath("emails.accountInactivity.whatThisMeans.title"))}>
+        <BulletList items={[t(selectorFromPath("emails.accountInactivity.whatThisMeans.bullet1")), t(selectorFromPath("emails.accountInactivity.whatThisMeans.bullet2"), {daysUntilClosure}), t(selectorFromPath("emails.accountInactivity.whatThisMeans.bullet3"))]} />
       </EmailCard>
 
-      <EmailCard title={t(selectorFromPath("email.accountInactivity.timeline.title"))}>
+      <EmailCard title={t(selectorFromPath("emails.accountInactivity.timeline.title"))}>
         <KeyValueTable
           title=''
           items={[
-            {label: t(selectorFromPath("email.accountInactivity.timeline.inactiveFor")), value: t(selectorFromPath("email.accountInactivity.timeline.daysValue"), {days: inactiveDays})},
-            {label: t(selectorFromPath("email.accountInactivity.timeline.timeRemaining")), value: t(selectorFromPath("email.accountInactivity.timeline.daysValue"), {days: daysUntilClosure})},
+            {label: t(selectorFromPath("emails.accountInactivity.timeline.inactiveFor")), value: t(selectorFromPath("emails.accountInactivity.timeline.daysValue"), {days: inactiveDays})},
+            {label: t(selectorFromPath("emails.accountInactivity.timeline.timeRemaining")), value: t(selectorFromPath("emails.accountInactivity.timeline.daysValue"), {days: daysUntilClosure})},
           ]}
         />
       </EmailCard>
 
       <Text style={EmailParagraphStyles}>
-        {t.rich(selectorFromPath("email.accountInactivity.supportPrompt"), {
+        {t.rich(selectorFromPath("emails.accountInactivity.supportPrompt"), {
           supportEmail: BRAND.supportEmail,
           // eslint-disable-next-line react/no-unstable-nested-components -- emails render server-side via React Email; never mounted, no reconciliation
           link: (chunks) => (
@@ -197,9 +197,9 @@ const AccountInactivityWarningEmail = async (props: Readonly<Props>) => {
       </Text>
 
       <Text style={{...EmailParagraphStyles, margin: "0"}}>
-        {t(selectorFromPath("email.accountInactivity.signOff.line1"))}
+        {t(selectorFromPath("emails.accountInactivity.signOff.line1"))}
         <br />
-        {t(selectorFromPath("email.accountInactivity.signOff.line2"), {brand: BRAND.name})}
+        {t(selectorFromPath("emails.accountInactivity.signOff.line2"), {brand: BRAND.name})}
       </Text>
 
       <Text
@@ -210,7 +210,7 @@ const AccountInactivityWarningEmail = async (props: Readonly<Props>) => {
           lineHeight: "18px",
           color: EMAIL_COLORS.muted,
         }}>
-        {t(selectorFromPath("email.accountInactivity.footnote"))}
+        {t(selectorFromPath("emails.accountInactivity.footnote"))}
       </Text>
     </EmailLayout>
   );

--- a/sites/arolariu.ro/emails/accounts/WelcomeEmail.tsx
+++ b/sites/arolariu.ro/emails/accounts/WelcomeEmail.tsx
@@ -25,26 +25,26 @@ const WelcomeEmail = defineEmailTemplate<Props>({
     return (
       <EmailLayout
         locale={locale}
-        title={`${BRAND.name} | ${t(selectorFromPath("email.welcome.badge"))}`}
-        preview={t(selectorFromPath("email.welcome.preview"), {brand: BRAND.name, name})}
-        badge={t(selectorFromPath("email.welcome.badge"))}
-        heading={t(selectorFromPath("email.welcome.heading"), {brand: BRAND.name})}
-        primaryCta={{href: uploadUrl, label: t(selectorFromPath("email.welcome.ctaPrimary"))}}
-        secondaryCta={{href: dashboardUrl, label: t(selectorFromPath("email.welcome.ctaSecondary"))}}
+        title={`${BRAND.name} | ${t(selectorFromPath("emails.welcome.badge"))}`}
+        preview={t(selectorFromPath("emails.welcome.preview"), {brand: BRAND.name, name})}
+        badge={t(selectorFromPath("emails.welcome.badge"))}
+        heading={t(selectorFromPath("emails.welcome.heading"), {brand: BRAND.name})}
+        primaryCta={{href: uploadUrl, label: t(selectorFromPath("emails.welcome.ctaPrimary"))}}
+        secondaryCta={{href: dashboardUrl, label: t(selectorFromPath("emails.welcome.ctaSecondary"))}}
         showUnsubscribe={false}
         unsubscribeUrl=''
         managePreferencesUrl=''>
-        <Text style={EmailParagraphStyles}>{t(selectorFromPath("email.welcome.greeting"), {name})}</Text>
-        <Text style={EmailParagraphStyles}>{t(selectorFromPath("email.welcome.intro"), {brand: BRAND.name})}</Text>
-        <EmailCard title={t(selectorFromPath("email.welcome.howItWorksTitle"))}>
-          <BulletList items={[t(selectorFromPath("email.welcome.howItWorks.0")), t(selectorFromPath("email.welcome.howItWorks.1")), t(selectorFromPath("email.welcome.howItWorks.2"))]} />
+        <Text style={EmailParagraphStyles}>{t(selectorFromPath("emails.welcome.greeting"), {name})}</Text>
+        <Text style={EmailParagraphStyles}>{t(selectorFromPath("emails.welcome.intro"), {brand: BRAND.name})}</Text>
+        <EmailCard title={t(selectorFromPath("emails.welcome.howItWorksTitle"))}>
+          <BulletList items={[t(selectorFromPath("emails.welcome.howItWorks.item0")), t(selectorFromPath("emails.welcome.howItWorks.item1")), t(selectorFromPath("emails.welcome.howItWorks.item2"))]} />
         </EmailCard>
-        <EmailCard title={t(selectorFromPath("email.welcome.whatYouCanDoTitle"))}>
-          <BulletList items={[t(selectorFromPath("email.welcome.whatYouCanDo.0")), t(selectorFromPath("email.welcome.whatYouCanDo.1")), t(selectorFromPath("email.welcome.whatYouCanDo.2")), t(selectorFromPath("email.welcome.whatYouCanDo.3"))]} />
+        <EmailCard title={t(selectorFromPath("emails.welcome.whatYouCanDoTitle"))}>
+          <BulletList items={[t(selectorFromPath("emails.welcome.whatYouCanDo.item0")), t(selectorFromPath("emails.welcome.whatYouCanDo.item1")), t(selectorFromPath("emails.welcome.whatYouCanDo.item2")), t(selectorFromPath("emails.welcome.whatYouCanDo.item3"))]} />
         </EmailCard>
-        <Text style={EmailParagraphStyles}>{t(selectorFromPath("email.welcome.body"))}</Text>
+        <Text style={EmailParagraphStyles}>{t(selectorFromPath("emails.welcome.body"))}</Text>
         <Text style={EmailParagraphStyles}>
-          {t.rich(selectorFromPath("email.welcome.feedbackPrompt"), {
+          {t.rich(selectorFromPath("emails.welcome.feedbackPrompt"), {
             email: () => (
               <Link
                 href={`mailto:${BRAND.supportEmail}`}
@@ -55,9 +55,9 @@ const WelcomeEmail = defineEmailTemplate<Props>({
           })}
         </Text>
         <Text style={{...EmailParagraphStyles, margin: "0"}}>
-          {t(selectorFromPath("email.welcome.signOff.line1"))}
+          {t(selectorFromPath("emails.welcome.signOff.line1"))}
           <br />
-          {t(selectorFromPath("email.welcome.signOff.line2"), {brand: BRAND.name})}
+          {t(selectorFromPath("emails.welcome.signOff.line2"), {brand: BRAND.name})}
         </Text>
       </EmailLayout>
     );

--- a/sites/arolariu.ro/emails/accounts/WelcomeEmail.tsx
+++ b/sites/arolariu.ro/emails/accounts/WelcomeEmail.tsx
@@ -16,7 +16,7 @@ type Props = {
 };
 
 const WelcomeEmail = defineEmailTemplate<Props>({
-  namespace: "email.welcome",
+  namespace: "emails.welcome",
   render: ({locale, t, props}) => {
     const name = props.username?.trim() || "there";
     const uploadUrl = props.uploadUrl ?? `${BRAND.url}/domains/invoices/upload-scans`;

--- a/sites/arolariu.ro/emails/invoices/FirstInvoiceUploadedEmail.tsx
+++ b/sites/arolariu.ro/emails/invoices/FirstInvoiceUploadedEmail.tsx
@@ -81,34 +81,34 @@ const FirstInvoiceUploadedEmail = defineEmailTemplate<Props>({
     return (
       <EmailLayout
         locale={locale}
-        title={`${BRAND.name} | ${t(selectorFromPath("email.firstInvoiceUploaded.badge"))}`}
-        preview={t(selectorFromPath("email.firstInvoiceUploaded.preview"), {name})}
-        badge={t(selectorFromPath("email.firstInvoiceUploaded.badge"))}
-        heading={t(selectorFromPath("email.firstInvoiceUploaded.heading"))}
-        primaryCta={{href: effectiveInvoiceUrl, label: t(selectorFromPath("email.firstInvoiceUploaded.ctaPrimary"))}}
-        secondaryCta={{href: effectiveUploadUrl, label: t(selectorFromPath("email.firstInvoiceUploaded.ctaSecondary"))}}
+        title={`${BRAND.name} | ${t(selectorFromPath("emails.firstInvoiceUploaded.badge"))}`}
+        preview={t(selectorFromPath("emails.firstInvoiceUploaded.preview"), {name})}
+        badge={t(selectorFromPath("emails.firstInvoiceUploaded.badge"))}
+        heading={t(selectorFromPath("emails.firstInvoiceUploaded.heading"))}
+        primaryCta={{href: effectiveInvoiceUrl, label: t(selectorFromPath("emails.firstInvoiceUploaded.ctaPrimary"))}}
+        secondaryCta={{href: effectiveUploadUrl, label: t(selectorFromPath("emails.firstInvoiceUploaded.ctaSecondary"))}}
         showUnsubscribe={false}
         unsubscribeUrl=''
         managePreferencesUrl=''>
-        <Text style={EmailParagraphStyles}>{t(selectorFromPath("email.firstInvoiceUploaded.greeting"), {name})}</Text>
-        <Text style={EmailParagraphStyles}>{t(selectorFromPath("email.firstInvoiceUploaded.intro"))}</Text>
+        <Text style={EmailParagraphStyles}>{t(selectorFromPath("emails.firstInvoiceUploaded.greeting"), {name})}</Text>
+        <Text style={EmailParagraphStyles}>{t(selectorFromPath("emails.firstInvoiceUploaded.intro"))}</Text>
         <KeyValueTable
-          title={t(selectorFromPath("email.firstInvoiceUploaded.invoiceSummaryTitle"))}
+          title={t(selectorFromPath("emails.firstInvoiceUploaded.invoiceSummaryTitle"))}
           items={[
-            {label: t(selectorFromPath("email.firstInvoiceUploaded.invoiceSummary.invoiceName")), value: invoiceName || t(selectorFromPath("email.firstInvoiceUploaded.untitledFallback"))},
-            {label: t(selectorFromPath("email.firstInvoiceUploaded.invoiceSummary.uploaded")), value: uploadDate},
-            {label: t(selectorFromPath("email.firstInvoiceUploaded.invoiceSummary.status")), value: t(selectorFromPath("email.firstInvoiceUploaded.statusValue"))},
+            {label: t(selectorFromPath("emails.firstInvoiceUploaded.invoiceSummary.invoiceName")), value: invoiceName || t(selectorFromPath("emails.firstInvoiceUploaded.untitledFallback"))},
+            {label: t(selectorFromPath("emails.firstInvoiceUploaded.invoiceSummary.uploaded")), value: uploadDate},
+            {label: t(selectorFromPath("emails.firstInvoiceUploaded.invoiceSummary.status")), value: t(selectorFromPath("emails.firstInvoiceUploaded.statusValue"))},
           ]}
         />
-        <EmailCard title={t(selectorFromPath("email.firstInvoiceUploaded.whatHappensNextTitle"))}>
-          <BulletList items={[t(selectorFromPath("email.firstInvoiceUploaded.whatHappensNext.0")), t(selectorFromPath("email.firstInvoiceUploaded.whatHappensNext.1")), t(selectorFromPath("email.firstInvoiceUploaded.whatHappensNext.2"))]} />
+        <EmailCard title={t(selectorFromPath("emails.firstInvoiceUploaded.whatHappensNextTitle"))}>
+          <BulletList items={[t(selectorFromPath("emails.firstInvoiceUploaded.whatHappensNext.item0")), t(selectorFromPath("emails.firstInvoiceUploaded.whatHappensNext.item1")), t(selectorFromPath("emails.firstInvoiceUploaded.whatHappensNext.item2"))]} />
         </EmailCard>
-        <EmailCard title={t(selectorFromPath("email.firstInvoiceUploaded.featuresToExploreTitle"))}>
-          <BulletList items={[t(selectorFromPath("email.firstInvoiceUploaded.featuresToExplore.0")), t(selectorFromPath("email.firstInvoiceUploaded.featuresToExplore.1")), t(selectorFromPath("email.firstInvoiceUploaded.featuresToExplore.2")), t(selectorFromPath("email.firstInvoiceUploaded.featuresToExplore.3"))]} />
+        <EmailCard title={t(selectorFromPath("emails.firstInvoiceUploaded.featuresToExploreTitle"))}>
+          <BulletList items={[t(selectorFromPath("emails.firstInvoiceUploaded.featuresToExplore.item0")), t(selectorFromPath("emails.firstInvoiceUploaded.featuresToExplore.item1")), t(selectorFromPath("emails.firstInvoiceUploaded.featuresToExplore.item2")), t(selectorFromPath("emails.firstInvoiceUploaded.featuresToExplore.item3"))]} />
         </EmailCard>
-        <Text style={EmailParagraphStyles}>{t(selectorFromPath("email.firstInvoiceUploaded.body"))}</Text>
+        <Text style={EmailParagraphStyles}>{t(selectorFromPath("emails.firstInvoiceUploaded.body"))}</Text>
         <Text style={EmailParagraphStyles}>
-          {t.rich(selectorFromPath("email.firstInvoiceUploaded.feedbackPrompt"), {
+          {t.rich(selectorFromPath("emails.firstInvoiceUploaded.feedbackPrompt"), {
             email: () => (
               <Link
                 href={`mailto:${BRAND.supportEmail}`}
@@ -119,9 +119,9 @@ const FirstInvoiceUploadedEmail = defineEmailTemplate<Props>({
           })}
         </Text>
         <Text style={{...EmailParagraphStyles, margin: "0"}}>
-          {t(selectorFromPath("email.firstInvoiceUploaded.signOff.line1"))}
+          {t(selectorFromPath("emails.firstInvoiceUploaded.signOff.line1"))}
           <br />
-          {t(selectorFromPath("email.firstInvoiceUploaded.signOff.line2"), {brand: BRAND.name})}
+          {t(selectorFromPath("emails.firstInvoiceUploaded.signOff.line2"), {brand: BRAND.name})}
         </Text>
       </EmailLayout>
     );

--- a/sites/arolariu.ro/emails/invoices/FirstInvoiceUploadedEmail.tsx
+++ b/sites/arolariu.ro/emails/invoices/FirstInvoiceUploadedEmail.tsx
@@ -45,7 +45,7 @@ type Props = {
 };
 
 /**
- * React component that renders the "First Invoice Uploaded" celebration email.
+ * React component that renders the "First Invoice Uploaded" celebration emails.
  *
  * @remarks
  * **Rendering Context**: React Email.
@@ -70,7 +70,7 @@ type Props = {
  * ```
  */
 const FirstInvoiceUploadedEmail = defineEmailTemplate<Props>({
-  namespace: "email.firstInvoiceUploaded",
+  namespace: "emails.firstInvoiceUploaded",
   render: ({locale, t, props}) => {
     const {username, invoiceName, uploadDate, invoiceUrl, uploadUrl} = props;
 

--- a/sites/arolariu.ro/emails/invoices/InvoiceHasBeenAnalyzedEmail.tsx
+++ b/sites/arolariu.ro/emails/invoices/InvoiceHasBeenAnalyzedEmail.tsx
@@ -48,34 +48,34 @@ const InvoiceHasBeenAnalyzedEmail = defineEmailTemplate<Props>({
     return (
       <EmailLayout
         locale={locale}
-        title={`${BRAND.name} | ${t(selectorFromPath("email.invoiceAnalyzed.badge"))}`}
-        preview={t(selectorFromPath("email.invoiceAnalyzed.preview"), {name: safeName})}
-        badge={t(selectorFromPath("email.invoiceAnalyzed.badge"))}
-        heading={t(selectorFromPath("email.invoiceAnalyzed.heading"))}
-        primaryCta={{href: invoiceUrl, label: t(selectorFromPath("email.invoiceAnalyzed.ctaPrimary"))}}
+        title={`${BRAND.name} | ${t(selectorFromPath("emails.invoiceAnalyzed.badge"))}`}
+        preview={t(selectorFromPath("emails.invoiceAnalyzed.preview"), {name: safeName})}
+        badge={t(selectorFromPath("emails.invoiceAnalyzed.badge"))}
+        heading={t(selectorFromPath("emails.invoiceAnalyzed.heading"))}
+        primaryCta={{href: invoiceUrl, label: t(selectorFromPath("emails.invoiceAnalyzed.ctaPrimary"))}}
         secondaryCta={null}
         showUnsubscribe={false}
         unsubscribeUrl=''
         managePreferencesUrl=''>
-        <Text style={EmailParagraphStyles}>{t(selectorFromPath("email.invoiceAnalyzed.greeting"), {name: safeName})}</Text>
-        <Text style={EmailParagraphStyles}>{t(selectorFromPath("email.invoiceAnalyzed.intro"))}</Text>
+        <Text style={EmailParagraphStyles}>{t(selectorFromPath("emails.invoiceAnalyzed.greeting"), {name: safeName})}</Text>
+        <Text style={EmailParagraphStyles}>{t(selectorFromPath("emails.invoiceAnalyzed.intro"))}</Text>
         <KeyValueTable
-          title={t(selectorFromPath("email.invoiceAnalyzed.summaryTitle"))}
+          title={t(selectorFromPath("emails.invoiceAnalyzed.summaryTitle"))}
           items={[
-            {label: t(selectorFromPath("email.invoiceAnalyzed.summary.invoiceName")), value: invoice?.name ?? `#${invoice?.id ?? "—"}`},
-            {label: t(selectorFromPath("email.invoiceAnalyzed.summary.merchantId")), value: invoice?.merchantReference ?? t(selectorFromPath("email.invoiceAnalyzed.summary.notIdentified"))},
-            {label: t(selectorFromPath("email.invoiceAnalyzed.summary.itemsDetected")), value: String(itemCount)},
-            {label: t(selectorFromPath("email.invoiceAnalyzed.summary.totalAmount")), value: totalText},
+            {label: t(selectorFromPath("emails.invoiceAnalyzed.summary.invoiceName")), value: invoice?.name ?? `#${invoice?.id ?? "—"}`},
+            {label: t(selectorFromPath("emails.invoiceAnalyzed.summary.merchantId")), value: invoice?.merchantReference ?? t(selectorFromPath("emails.invoiceAnalyzed.summary.notIdentified"))},
+            {label: t(selectorFromPath("emails.invoiceAnalyzed.summary.itemsDetected")), value: String(itemCount)},
+            {label: t(selectorFromPath("emails.invoiceAnalyzed.summary.totalAmount")), value: totalText},
           ]}
         />
-        <EmailCard title={t(selectorFromPath("email.invoiceAnalyzed.whatWasAnalyzedTitle"))}>
+        <EmailCard title={t(selectorFromPath("emails.invoiceAnalyzed.whatWasAnalyzedTitle"))}>
           <BulletList
-            items={[t(selectorFromPath("email.invoiceAnalyzed.whatWasAnalyzed.0")), t(selectorFromPath("email.invoiceAnalyzed.whatWasAnalyzed.1")), t(selectorFromPath("email.invoiceAnalyzed.whatWasAnalyzed.2")), t(selectorFromPath("email.invoiceAnalyzed.whatWasAnalyzed.3")), t(selectorFromPath("email.invoiceAnalyzed.whatWasAnalyzed.4"))]}
+            items={[t(selectorFromPath("emails.invoiceAnalyzed.whatWasAnalyzed.item0")), t(selectorFromPath("emails.invoiceAnalyzed.whatWasAnalyzed.item1")), t(selectorFromPath("emails.invoiceAnalyzed.whatWasAnalyzed.item2")), t(selectorFromPath("emails.invoiceAnalyzed.whatWasAnalyzed.item3")), t(selectorFromPath("emails.invoiceAnalyzed.whatWasAnalyzed.item4"))]}
           />
         </EmailCard>
-        <Text style={EmailParagraphStyles}>{t(selectorFromPath("email.invoiceAnalyzed.body"))}</Text>
+        <Text style={EmailParagraphStyles}>{t(selectorFromPath("emails.invoiceAnalyzed.body"))}</Text>
         <Text style={EmailParagraphStyles}>
-          {t.rich(selectorFromPath("email.invoiceAnalyzed.feedbackPrompt"), {
+          {t.rich(selectorFromPath("emails.invoiceAnalyzed.feedbackPrompt"), {
             email: () => (
               <Link
                 href={`mailto:${BRAND.supportEmail}`}
@@ -86,9 +86,9 @@ const InvoiceHasBeenAnalyzedEmail = defineEmailTemplate<Props>({
           })}
         </Text>
         <Text style={{...EmailParagraphStyles, margin: "0"}}>
-          {t(selectorFromPath("email.invoiceAnalyzed.signOff.line1"))}
+          {t(selectorFromPath("emails.invoiceAnalyzed.signOff.line1"))}
           <br />
-          {t(selectorFromPath("email.invoiceAnalyzed.signOff.line2"), {brand: BRAND.name})}
+          {t(selectorFromPath("emails.invoiceAnalyzed.signOff.line2"), {brand: BRAND.name})}
         </Text>
       </EmailLayout>
     );

--- a/sites/arolariu.ro/emails/invoices/InvoiceHasBeenAnalyzedEmail.tsx
+++ b/sites/arolariu.ro/emails/invoices/InvoiceHasBeenAnalyzedEmail.tsx
@@ -34,7 +34,7 @@ type Props = {
  * @returns A rendered React Email template.
  */
 const InvoiceHasBeenAnalyzedEmail = defineEmailTemplate<Props>({
-  namespace: "email.invoiceAnalyzed",
+  namespace: "emails.invoiceAnalyzed",
   render: ({locale, t, props}) => {
     const {username, invoice} = props;
 

--- a/sites/arolariu.ro/emails/invoices/InvoiceHasBeenDeletedEmail.tsx
+++ b/sites/arolariu.ro/emails/invoices/InvoiceHasBeenDeletedEmail.tsx
@@ -35,7 +35,7 @@ type Props = {
  * @returns A rendered React Email template.
  */
 const InvoiceHasBeenDeletedEmail = defineEmailTemplate<Props>({
-  namespace: "email.invoiceDeleted",
+  namespace: "emails.invoiceDeleted",
   render: ({locale, t, props}) => {
     const {username, invoiceId, invoiceName} = props;
 

--- a/sites/arolariu.ro/emails/invoices/InvoiceHasBeenDeletedEmail.tsx
+++ b/sites/arolariu.ro/emails/invoices/InvoiceHasBeenDeletedEmail.tsx
@@ -46,30 +46,30 @@ const InvoiceHasBeenDeletedEmail = defineEmailTemplate<Props>({
     return (
       <EmailLayout
         locale={locale}
-        title={`${BRAND.name} | ${t(selectorFromPath("email.invoiceDeleted.badge"))}`}
-        preview={t(selectorFromPath("email.invoiceDeleted.preview"), {invoiceLabel})}
-        badge={t(selectorFromPath("email.invoiceDeleted.badge"))}
-        heading={t(selectorFromPath("email.invoiceDeleted.heading"))}
-        primaryCta={{href: invoicesUrl, label: t(selectorFromPath("email.invoiceDeleted.ctaPrimary"))}}
+        title={`${BRAND.name} | ${t(selectorFromPath("emails.invoiceDeleted.badge"))}`}
+        preview={t(selectorFromPath("emails.invoiceDeleted.preview"), {invoiceLabel})}
+        badge={t(selectorFromPath("emails.invoiceDeleted.badge"))}
+        heading={t(selectorFromPath("emails.invoiceDeleted.heading"))}
+        primaryCta={{href: invoicesUrl, label: t(selectorFromPath("emails.invoiceDeleted.ctaPrimary"))}}
         secondaryCta={null}
         showUnsubscribe={false}
         unsubscribeUrl=''
         managePreferencesUrl=''>
-        <Text style={EmailParagraphStyles}>{t(selectorFromPath("email.invoiceDeleted.greeting"), {name: safeName})}</Text>
-        <Text style={EmailParagraphStyles}>{t(selectorFromPath("email.invoiceDeleted.intro"), {brand: BRAND.name})}</Text>
+        <Text style={EmailParagraphStyles}>{t(selectorFromPath("emails.invoiceDeleted.greeting"), {name: safeName})}</Text>
+        <Text style={EmailParagraphStyles}>{t(selectorFromPath("emails.invoiceDeleted.intro"), {brand: BRAND.name})}</Text>
         <KeyValueTable
-          title={t(selectorFromPath("email.invoiceDeleted.detailsTitle"))}
+          title={t(selectorFromPath("emails.invoiceDeleted.detailsTitle"))}
           items={[
-            {label: t(selectorFromPath("email.invoiceDeleted.details.invoice")), value: invoiceName ?? `#${invoiceId}`},
-            {label: t(selectorFromPath("email.invoiceDeleted.details.invoiceId")), value: invoiceId ?? t(selectorFromPath("email.invoiceDeleted.placeholder"))},
-            {label: t(selectorFromPath("email.invoiceDeleted.details.status")), value: t(selectorFromPath("email.invoiceDeleted.statusValue"))},
+            {label: t(selectorFromPath("emails.invoiceDeleted.details.invoice")), value: invoiceName ?? `#${invoiceId}`},
+            {label: t(selectorFromPath("emails.invoiceDeleted.details.invoiceId")), value: invoiceId ?? t(selectorFromPath("emails.invoiceDeleted.placeholder"))},
+            {label: t(selectorFromPath("emails.invoiceDeleted.details.status")), value: t(selectorFromPath("emails.invoiceDeleted.statusValue"))},
           ]}
         />
-        <EmailCard title={t(selectorFromPath("email.invoiceDeleted.whatYouShouldKnowTitle"))}>
-          <BulletList items={[t(selectorFromPath("email.invoiceDeleted.whatYouShouldKnow.0")), t(selectorFromPath("email.invoiceDeleted.whatYouShouldKnow.1")), t(selectorFromPath("email.invoiceDeleted.whatYouShouldKnow.2")), t(selectorFromPath("email.invoiceDeleted.whatYouShouldKnow.3"))]} />
+        <EmailCard title={t(selectorFromPath("emails.invoiceDeleted.whatYouShouldKnowTitle"))}>
+          <BulletList items={[t(selectorFromPath("emails.invoiceDeleted.whatYouShouldKnow.item0")), t(selectorFromPath("emails.invoiceDeleted.whatYouShouldKnow.item1")), t(selectorFromPath("emails.invoiceDeleted.whatYouShouldKnow.item2")), t(selectorFromPath("emails.invoiceDeleted.whatYouShouldKnow.item3"))]} />
         </EmailCard>
         <Text style={EmailParagraphStyles}>
-          {t.rich(selectorFromPath("email.invoiceDeleted.body"), {
+          {t.rich(selectorFromPath("emails.invoiceDeleted.body"), {
             email: () => (
               <Link
                 href={`mailto:${BRAND.supportEmail}`}
@@ -80,9 +80,9 @@ const InvoiceHasBeenDeletedEmail = defineEmailTemplate<Props>({
           })}
         </Text>
         <Text style={{...EmailParagraphStyles, margin: "0"}}>
-          {t(selectorFromPath("email.invoiceDeleted.signOff.line1"))}
+          {t(selectorFromPath("emails.invoiceDeleted.signOff.line1"))}
           <br />
-          {t(selectorFromPath("email.invoiceDeleted.signOff.line2"), {brand: BRAND.name})}
+          {t(selectorFromPath("emails.invoiceDeleted.signOff.line2"), {brand: BRAND.name})}
         </Text>
       </EmailLayout>
     );

--- a/sites/arolariu.ro/emails/invoices/InvoiceHasBeenMadePublicEmail.tsx
+++ b/sites/arolariu.ro/emails/invoices/InvoiceHasBeenMadePublicEmail.tsx
@@ -70,26 +70,26 @@ const InvoiceHasBeenMadePublicEmail = defineEmailTemplate<Props>({
     return (
       <EmailLayout
         locale={locale}
-        title={`${BRAND.name} | ${t(selectorFromPath("email.invoiceMadePublic.badge"))}`}
-        preview={t(selectorFromPath("email.invoiceMadePublic.preview"), {invoiceName})}
-        badge={t(selectorFromPath("email.invoiceMadePublic.badge"))}
-        heading={t(selectorFromPath("email.invoiceMadePublic.heading"))}
-        primaryCta={{href: invoiceUrl, label: t(selectorFromPath("email.invoiceMadePublic.ctaPrimary"))}}
+        title={`${BRAND.name} | ${t(selectorFromPath("emails.invoiceMadePublic.badge"))}`}
+        preview={t(selectorFromPath("emails.invoiceMadePublic.preview"), {invoiceName})}
+        badge={t(selectorFromPath("emails.invoiceMadePublic.badge"))}
+        heading={t(selectorFromPath("emails.invoiceMadePublic.heading"))}
+        primaryCta={{href: invoiceUrl, label: t(selectorFromPath("emails.invoiceMadePublic.ctaPrimary"))}}
         secondaryCta={null}
         showUnsubscribe={false}
         unsubscribeUrl=''
         managePreferencesUrl=''>
-        <Text style={EmailParagraphStyles}>{t(selectorFromPath("email.invoiceMadePublic.greeting"), {name: safeName})}</Text>
-        <Text style={EmailParagraphStyles}>{t(selectorFromPath("email.invoiceMadePublic.intro"))}</Text>
+        <Text style={EmailParagraphStyles}>{t(selectorFromPath("emails.invoiceMadePublic.greeting"), {name: safeName})}</Text>
+        <Text style={EmailParagraphStyles}>{t(selectorFromPath("emails.invoiceMadePublic.intro"))}</Text>
         <KeyValueTable
-          title={t(selectorFromPath("email.invoiceMadePublic.detailsTitle"))}
+          title={t(selectorFromPath("emails.invoiceMadePublic.detailsTitle"))}
           items={[
-            {label: t(selectorFromPath("email.invoiceMadePublic.details.invoiceName")), value: invoiceName},
-            {label: t(selectorFromPath("email.invoiceMadePublic.details.invoiceId")), value: invoiceId},
-            {label: t(selectorFromPath("email.invoiceMadePublic.details.merchant")), value: merchantName},
-            {label: t(selectorFromPath("email.invoiceMadePublic.details.total")), value: `${totalAmount} ${currency}`.trim()},
-            {label: t(selectorFromPath("email.invoiceMadePublic.details.created")), value: dateCreated},
-            {label: t(selectorFromPath("email.invoiceMadePublic.details.access")), value: t(selectorFromPath("email.invoiceMadePublic.accessValue"))},
+            {label: t(selectorFromPath("emails.invoiceMadePublic.details.invoiceName")), value: invoiceName},
+            {label: t(selectorFromPath("emails.invoiceMadePublic.details.invoiceId")), value: invoiceId},
+            {label: t(selectorFromPath("emails.invoiceMadePublic.details.merchant")), value: merchantName},
+            {label: t(selectorFromPath("emails.invoiceMadePublic.details.total")), value: `${totalAmount} ${currency}`.trim()},
+            {label: t(selectorFromPath("emails.invoiceMadePublic.details.created")), value: dateCreated},
+            {label: t(selectorFromPath("emails.invoiceMadePublic.details.access")), value: t(selectorFromPath("emails.invoiceMadePublic.accessValue"))},
           ]}
         />
         <Section
@@ -101,10 +101,10 @@ const InvoiceHasBeenMadePublicEmail = defineEmailTemplate<Props>({
             margin: "18px 0",
             textAlign: "center",
           }}>
-          <Text style={{...EmailParagraphStyles, margin: "0 0 10px", fontSize: "14px", fontWeight: "700"}}>{t(selectorFromPath("email.invoiceMadePublic.qrTitle"))}</Text>
+          <Text style={{...EmailParagraphStyles, margin: "0 0 10px", fontSize: "14px", fontWeight: "700"}}>{t(selectorFromPath("emails.invoiceMadePublic.qrTitle"))}</Text>
           <Img
             src={qrUrl}
-            alt={t(selectorFromPath("email.invoiceMadePublic.qrAlt"))}
+            alt={t(selectorFromPath("emails.invoiceMadePublic.qrAlt"))}
             style={{
               display: "block",
               margin: "0 auto",
@@ -114,10 +114,10 @@ const InvoiceHasBeenMadePublicEmail = defineEmailTemplate<Props>({
               border: `1px solid ${EMAIL_COLORS.border}`,
             }}
           />
-          <Text style={{...EmailParagraphStyles, margin: "10px 0 0", fontSize: "12px", color: EMAIL_COLORS.muted}}>{t(selectorFromPath("email.invoiceMadePublic.qrSubText"))}</Text>
+          <Text style={{...EmailParagraphStyles, margin: "10px 0 0", fontSize: "12px", color: EMAIL_COLORS.muted}}>{t(selectorFromPath("emails.invoiceMadePublic.qrSubText"))}</Text>
         </Section>
-        <EmailCard title={t(selectorFromPath("email.invoiceMadePublic.howToShareTitle"))}>
-          <BulletList items={[t(selectorFromPath("email.invoiceMadePublic.howToShare.0")), t(selectorFromPath("email.invoiceMadePublic.howToShare.1")), t(selectorFromPath("email.invoiceMadePublic.howToShare.2"))]} />
+        <EmailCard title={t(selectorFromPath("emails.invoiceMadePublic.howToShareTitle"))}>
+          <BulletList items={[t(selectorFromPath("emails.invoiceMadePublic.howToShare.item0")), t(selectorFromPath("emails.invoiceMadePublic.howToShare.item1")), t(selectorFromPath("emails.invoiceMadePublic.howToShare.item2"))]} />
         </EmailCard>
         <Section
           style={{
@@ -128,14 +128,14 @@ const InvoiceHasBeenMadePublicEmail = defineEmailTemplate<Props>({
             margin: "18px 0",
           }}>
           <Text style={{...EmailParagraphStyles, margin: "0 0 6px", fontSize: "14px", fontWeight: "700", color: EMAIL_COLORS.warningInk}}>
-            {t(selectorFromPath("email.invoiceMadePublic.privacyNoticeTitle"))}
+            {t(selectorFromPath("emails.invoiceMadePublic.privacyNoticeTitle"))}
           </Text>
           <Text style={{...EmailParagraphStyles, margin: "0", fontSize: "14px", color: EMAIL_COLORS.warningInk}}>
-            {t(selectorFromPath("email.invoiceMadePublic.privacyNoticeBody"))}
+            {t(selectorFromPath("emails.invoiceMadePublic.privacyNoticeBody"))}
           </Text>
         </Section>
         <Text style={EmailParagraphStyles}>
-          {t(selectorFromPath("email.invoiceMadePublic.directLinkLabel"))}{" "}
+          {t(selectorFromPath("emails.invoiceMadePublic.directLinkLabel"))}{" "}
           <Link
             href={invoiceUrl}
             style={EmailLinkStyles}>
@@ -143,7 +143,7 @@ const InvoiceHasBeenMadePublicEmail = defineEmailTemplate<Props>({
           </Link>
         </Text>
         <Text style={EmailParagraphStyles}>
-          {t.rich(selectorFromPath("email.invoiceMadePublic.feedbackPrompt"), {
+          {t.rich(selectorFromPath("emails.invoiceMadePublic.feedbackPrompt"), {
             email: () => (
               <Link
                 href={`mailto:${BRAND.supportEmail}`}
@@ -154,9 +154,9 @@ const InvoiceHasBeenMadePublicEmail = defineEmailTemplate<Props>({
           })}
         </Text>
         <Text style={{...EmailParagraphStyles, margin: "0"}}>
-          {t(selectorFromPath("email.invoiceMadePublic.signOff.line1"))}
+          {t(selectorFromPath("emails.invoiceMadePublic.signOff.line1"))}
           <br />
-          {t(selectorFromPath("email.invoiceMadePublic.signOff.line2"), {brand: BRAND.name})}
+          {t(selectorFromPath("emails.invoiceMadePublic.signOff.line2"), {brand: BRAND.name})}
         </Text>
       </EmailLayout>
     );

--- a/sites/arolariu.ro/emails/invoices/InvoiceHasBeenMadePublicEmail.tsx
+++ b/sites/arolariu.ro/emails/invoices/InvoiceHasBeenMadePublicEmail.tsx
@@ -28,7 +28,7 @@ import {defineEmailTemplate} from "../_lib/defineEmailTemplate";
  * Properties for the InvoiceHasBeenMadePublicEmail component.
  *
  * @remarks
- * All fields are required to provide a complete summary of the invoice in the email.
+ * All fields are required to provide a complete summary of the invoice in the emails.
  */
 type Props = {
   /** The username of the recipient */
@@ -55,11 +55,11 @@ type Props = {
  *
  * **Design**: Uses shared email primitives and includes a QR code for quick access.
  *
- * @param props - The invoice details to be displayed in the email.
+ * @param props - The invoice details to be displayed in the emails.
  * @returns A rendered React Email template.
  */
 const InvoiceHasBeenMadePublicEmail = defineEmailTemplate<Props>({
-  namespace: "email.invoiceMadePublic",
+  namespace: "emails.invoiceMadePublic",
   render: ({locale, t, props}) => {
     const {username, invoiceId, invoiceName, merchantName, totalAmount, currency, dateCreated} = props;
 

--- a/sites/arolariu.ro/emails/invoices/InvoiceHasBeenSharedWithEmail.tsx
+++ b/sites/arolariu.ro/emails/invoices/InvoiceHasBeenSharedWithEmail.tsx
@@ -35,7 +35,7 @@ type Props = {
  * @returns A rendered React Email template.
  */
 const InvoiceHasBeenSharedWithEmail = defineEmailTemplate<Props>({
-  namespace: "email.invoiceShared",
+  namespace: "emails.invoiceShared",
   render: ({locale, t, props}) => {
     const {fromUsername, toUsername, identifier} = props;
 

--- a/sites/arolariu.ro/emails/invoices/InvoiceHasBeenSharedWithEmail.tsx
+++ b/sites/arolariu.ro/emails/invoices/InvoiceHasBeenSharedWithEmail.tsx
@@ -46,35 +46,35 @@ const InvoiceHasBeenSharedWithEmail = defineEmailTemplate<Props>({
     return (
       <EmailLayout
         locale={locale}
-        title={`${BRAND.name} | ${t(selectorFromPath("email.invoiceShared.badge"))}`}
-        preview={t(selectorFromPath("email.invoiceShared.preview"), {fromName: safeFrom})}
-        badge={t(selectorFromPath("email.invoiceShared.badge"))}
-        heading={t(selectorFromPath("email.invoiceShared.heading"))}
-        primaryCta={{href: invoiceUrl, label: t(selectorFromPath("email.invoiceShared.ctaPrimary"))}}
+        title={`${BRAND.name} | ${t(selectorFromPath("emails.invoiceShared.badge"))}`}
+        preview={t(selectorFromPath("emails.invoiceShared.preview"), {fromName: safeFrom})}
+        badge={t(selectorFromPath("emails.invoiceShared.badge"))}
+        heading={t(selectorFromPath("emails.invoiceShared.heading"))}
+        primaryCta={{href: invoiceUrl, label: t(selectorFromPath("emails.invoiceShared.ctaPrimary"))}}
         secondaryCta={null}
         showUnsubscribe={false}
         unsubscribeUrl=''
         managePreferencesUrl=''>
-        <Text style={EmailParagraphStyles}>{t(selectorFromPath("email.invoiceShared.greeting"), {toName: safeTo})}</Text>
+        <Text style={EmailParagraphStyles}>{t(selectorFromPath("emails.invoiceShared.greeting"), {toName: safeTo})}</Text>
         <Text style={EmailParagraphStyles}>
-          {t.rich(selectorFromPath("email.invoiceShared.intro"), {
+          {t.rich(selectorFromPath("emails.invoiceShared.intro"), {
             brand: BRAND.name,
             from: () => <strong>{safeFrom}</strong>,
           })}
         </Text>
         <KeyValueTable
-          title={t(selectorFromPath("email.invoiceShared.detailsTitle"))}
+          title={t(selectorFromPath("emails.invoiceShared.detailsTitle"))}
           items={[
-            {label: t(selectorFromPath("email.invoiceShared.details.sharedBy")), value: safeFrom},
-            {label: t(selectorFromPath("email.invoiceShared.details.invoiceId")), value: identifier},
+            {label: t(selectorFromPath("emails.invoiceShared.details.sharedBy")), value: safeFrom},
+            {label: t(selectorFromPath("emails.invoiceShared.details.invoiceId")), value: identifier},
           ]}
         />
-        <EmailCard title={t(selectorFromPath("email.invoiceShared.whatYouCanDoTitle"))}>
-          <BulletList items={[t(selectorFromPath("email.invoiceShared.whatYouCanDo.0")), t(selectorFromPath("email.invoiceShared.whatYouCanDo.1")), t(selectorFromPath("email.invoiceShared.whatYouCanDo.2"))]} />
+        <EmailCard title={t(selectorFromPath("emails.invoiceShared.whatYouCanDoTitle"))}>
+          <BulletList items={[t(selectorFromPath("emails.invoiceShared.whatYouCanDo.item0")), t(selectorFromPath("emails.invoiceShared.whatYouCanDo.item1")), t(selectorFromPath("emails.invoiceShared.whatYouCanDo.item2"))]} />
         </EmailCard>
-        <Text style={EmailParagraphStyles}>{t(selectorFromPath("email.invoiceShared.body"))}</Text>
+        <Text style={EmailParagraphStyles}>{t(selectorFromPath("emails.invoiceShared.body"))}</Text>
         <Text style={EmailParagraphStyles}>
-          {t.rich(selectorFromPath("email.invoiceShared.feedbackPrompt"), {
+          {t.rich(selectorFromPath("emails.invoiceShared.feedbackPrompt"), {
             email: () => (
               <Link
                 href={`mailto:${BRAND.supportEmail}`}
@@ -85,9 +85,9 @@ const InvoiceHasBeenSharedWithEmail = defineEmailTemplate<Props>({
           })}
         </Text>
         <Text style={{...EmailParagraphStyles, margin: "0"}}>
-          {t(selectorFromPath("email.invoiceShared.signOff.line1"))}
+          {t(selectorFromPath("emails.invoiceShared.signOff.line1"))}
           <br />
-          {t(selectorFromPath("email.invoiceShared.signOff.line2"), {brand: BRAND.name})}
+          {t(selectorFromPath("emails.invoiceShared.signOff.line2"), {brand: BRAND.name})}
         </Text>
       </EmailLayout>
     );

--- a/sites/arolariu.ro/emails/invoices/InvoiceHasBeenUnsharedWithEmail.tsx
+++ b/sites/arolariu.ro/emails/invoices/InvoiceHasBeenUnsharedWithEmail.tsx
@@ -24,7 +24,7 @@ type Props = {
 };
 
 const InvoiceHasBeenUnsharedWithEmail = defineEmailTemplate<Props>({
-  namespace: "email.invoiceUnshared",
+  namespace: "emails.invoiceUnshared",
   render: ({locale, t, props}) => {
     const {fromUsername, toUsername, identifier, revokedAt} = props;
 

--- a/sites/arolariu.ro/emails/invoices/InvoiceHasBeenUnsharedWithEmail.tsx
+++ b/sites/arolariu.ro/emails/invoices/InvoiceHasBeenUnsharedWithEmail.tsx
@@ -36,40 +36,40 @@ const InvoiceHasBeenUnsharedWithEmail = defineEmailTemplate<Props>({
     return (
       <EmailLayout
         locale={locale}
-        title={`${BRAND.name} | ${t(selectorFromPath("email.invoiceUnshared.badge"))}`}
-        preview={t(selectorFromPath("email.invoiceUnshared.preview"), {fromName: safeFrom})}
-        badge={t(selectorFromPath("email.invoiceUnshared.badge"))}
-        heading={t(selectorFromPath("email.invoiceUnshared.heading"))}
-        primaryCta={{href: invoicesUrl, label: t(selectorFromPath("email.invoiceUnshared.ctaPrimary"))}}
-        secondaryCta={{href: `mailto:${BRAND.supportEmail}`, label: t(selectorFromPath("email.invoiceUnshared.ctaSecondary"))}}
+        title={`${BRAND.name} | ${t(selectorFromPath("emails.invoiceUnshared.badge"))}`}
+        preview={t(selectorFromPath("emails.invoiceUnshared.preview"), {fromName: safeFrom})}
+        badge={t(selectorFromPath("emails.invoiceUnshared.badge"))}
+        heading={t(selectorFromPath("emails.invoiceUnshared.heading"))}
+        primaryCta={{href: invoicesUrl, label: t(selectorFromPath("emails.invoiceUnshared.ctaPrimary"))}}
+        secondaryCta={{href: `mailto:${BRAND.supportEmail}`, label: t(selectorFromPath("emails.invoiceUnshared.ctaSecondary"))}}
         showUnsubscribe={false}
         unsubscribeUrl=''
         managePreferencesUrl=''>
-        <Text style={EmailParagraphStyles}>{t(selectorFromPath("email.invoiceUnshared.greeting"), {toName: safeTo})}</Text>
+        <Text style={EmailParagraphStyles}>{t(selectorFromPath("emails.invoiceUnshared.greeting"), {toName: safeTo})}</Text>
         <Text style={EmailParagraphStyles}>
-          {t.rich(selectorFromPath("email.invoiceUnshared.intro"), {
+          {t.rich(selectorFromPath("emails.invoiceUnshared.intro"), {
             from: () => <strong>{safeFrom}</strong>,
           })}
         </Text>
         <KeyValueTable
-          title={t(selectorFromPath("email.invoiceUnshared.detailsTitle"))}
+          title={t(selectorFromPath("emails.invoiceUnshared.detailsTitle"))}
           items={[
-            {label: t(selectorFromPath("email.invoiceUnshared.details.revokedBy")), value: safeFrom},
-            {label: t(selectorFromPath("email.invoiceUnshared.details.invoiceId")), value: identifier},
-            {label: t(selectorFromPath("email.invoiceUnshared.details.revokedAt")), value: revokedAt ?? t(selectorFromPath("email.invoiceUnshared.details.notProvided"))},
-            {label: t(selectorFromPath("email.invoiceUnshared.details.yourAccess")), value: t(selectorFromPath("email.invoiceUnshared.details.accessRevoked"))},
+            {label: t(selectorFromPath("emails.invoiceUnshared.details.revokedBy")), value: safeFrom},
+            {label: t(selectorFromPath("emails.invoiceUnshared.details.invoiceId")), value: identifier},
+            {label: t(selectorFromPath("emails.invoiceUnshared.details.revokedAt")), value: revokedAt ?? t(selectorFromPath("emails.invoiceUnshared.details.notProvided"))},
+            {label: t(selectorFromPath("emails.invoiceUnshared.details.yourAccess")), value: t(selectorFromPath("emails.invoiceUnshared.details.accessRevoked"))},
           ]}
         />
-        <EmailCard title={t(selectorFromPath("email.invoiceUnshared.whatThisMeansTitle"))}>
-          <BulletList items={[t(selectorFromPath("email.invoiceUnshared.whatThisMeans.0")), t(selectorFromPath("email.invoiceUnshared.whatThisMeans.1")), t(selectorFromPath("email.invoiceUnshared.whatThisMeans.2"))]} />
+        <EmailCard title={t(selectorFromPath("emails.invoiceUnshared.whatThisMeansTitle"))}>
+          <BulletList items={[t(selectorFromPath("emails.invoiceUnshared.whatThisMeans.item0")), t(selectorFromPath("emails.invoiceUnshared.whatThisMeans.item1")), t(selectorFromPath("emails.invoiceUnshared.whatThisMeans.item2"))]} />
         </EmailCard>
         <Text style={EmailParagraphStyles}>
-          {t.rich(selectorFromPath("email.invoiceUnshared.body"), {
+          {t.rich(selectorFromPath("emails.invoiceUnshared.body"), {
             from: () => <strong>{safeFrom}</strong>,
           })}
         </Text>
         <Text style={EmailParagraphStyles}>
-          {t.rich(selectorFromPath("email.invoiceUnshared.feedbackPrompt"), {
+          {t.rich(selectorFromPath("emails.invoiceUnshared.feedbackPrompt"), {
             email: () => (
               <Link
                 href={`mailto:${BRAND.supportEmail}`}
@@ -80,9 +80,9 @@ const InvoiceHasBeenUnsharedWithEmail = defineEmailTemplate<Props>({
           })}
         </Text>
         <Text style={{...EmailParagraphStyles, margin: "0"}}>
-          {t(selectorFromPath("email.invoiceUnshared.signOff.line1"))}
+          {t(selectorFromPath("emails.invoiceUnshared.signOff.line1"))}
           <br />
-          {t(selectorFromPath("email.invoiceUnshared.signOff.line2"), {brand: BRAND.name})}
+          {t(selectorFromPath("emails.invoiceUnshared.signOff.line2"), {brand: BRAND.name})}
         </Text>
       </EmailLayout>
     );

--- a/sites/arolariu.ro/emails/invoices/alerts/SpendingThresholdAlertEmail.tsx
+++ b/sites/arolariu.ro/emails/invoices/alerts/SpendingThresholdAlertEmail.tsx
@@ -82,7 +82,7 @@ type Props = {
 };
 
 /**
- * React component that renders the "Spending Threshold Alert" email.
+ * React component that renders the "Spending Threshold Alert" emails.
  *
  * @remarks
  * **Rendering Context**: React Email.
@@ -116,7 +116,7 @@ type Props = {
  * ```
  */
 const SpendingThresholdAlertEmail = defineEmailTemplate<Props>({
-  namespace: "email.spendingAlert",
+  namespace: "emails.spendingAlert",
   render: ({locale, t, props}) => {
     const {
       username,

--- a/sites/arolariu.ro/emails/invoices/alerts/SpendingThresholdAlertEmail.tsx
+++ b/sites/arolariu.ro/emails/invoices/alerts/SpendingThresholdAlertEmail.tsx
@@ -140,16 +140,16 @@ const SpendingThresholdAlertEmail = defineEmailTemplate<Props>({
       <EmailLayout
         locale={locale}
         title={`${BRAND.name} | Spending alert`}
-        preview={t(selectorFromPath("email.spendingAlert.preview"), {name, percent: thresholdPercent, category, period})}
-        badge={t(selectorFromPath("email.spendingAlert.badge"), {percent: thresholdPercent})}
-        heading={t(selectorFromPath("email.spendingAlert.heading"), {percent: thresholdPercent})}
-        primaryCta={{href: effectiveDashboardUrl, label: t(selectorFromPath("email.spendingAlert.ctaPrimary"))}}
+        preview={t(selectorFromPath("emails.spendingAlert.preview"), {name, percent: thresholdPercent, category, period})}
+        badge={t(selectorFromPath("emails.spendingAlert.badge"), {percent: thresholdPercent})}
+        heading={t(selectorFromPath("emails.spendingAlert.heading"), {percent: thresholdPercent})}
+        primaryCta={{href: effectiveDashboardUrl, label: t(selectorFromPath("emails.spendingAlert.ctaPrimary"))}}
         secondaryCta={null}
         showUnsubscribe={true}
         unsubscribeUrl={`${BRAND.url}/unsubscribe`}
         managePreferencesUrl={`${BRAND.url}/settings/notifications`}>
-        <Text style={EmailParagraphStyles}>{t(selectorFromPath("email.spendingAlert.greeting"), {name})}</Text>
-        <Text style={EmailParagraphStyles}>{t(selectorFromPath("email.spendingAlert.intro"), {state: budgetState, category, period, percent: thresholdPercent})}</Text>
+        <Text style={EmailParagraphStyles}>{t(selectorFromPath("emails.spendingAlert.greeting"), {name})}</Text>
+        <Text style={EmailParagraphStyles}>{t(selectorFromPath("emails.spendingAlert.intro"), {state: budgetState, category, period, percent: thresholdPercent})}</Text>
         {isOverBudget ? (
           <Text
             style={{
@@ -160,56 +160,56 @@ const SpendingThresholdAlertEmail = defineEmailTemplate<Props>({
               borderRadius: "10px",
               padding: "12px",
             }}>
-            {t(selectorFromPath("email.spendingAlert.overBudgetWarning"))}
+            {t(selectorFromPath("emails.spendingAlert.overBudgetWarning"))}
           </Text>
         ) : null}
         <MetricsGrid
           metrics={[
-            {label: t(selectorFromPath("email.spendingAlert.metricsLabels.budgetLimit")), value: budgetLimit},
-            {label: t(selectorFromPath("email.spendingAlert.metricsLabels.currentSpending")), value: currentSpending},
-            {label: t(selectorFromPath("email.spendingAlert.metricsLabels.remaining")), value: isOverBudget ? t(selectorFromPath("email.spendingAlert.overBudgetValue")) : remainingBudget},
-            {label: t(selectorFromPath("email.spendingAlert.metricsLabels.threshold")), value: `${thresholdPercent}%`},
+            {label: t(selectorFromPath("emails.spendingAlert.metricsLabels.budgetLimit")), value: budgetLimit},
+            {label: t(selectorFromPath("emails.spendingAlert.metricsLabels.currentSpending")), value: currentSpending},
+            {label: t(selectorFromPath("emails.spendingAlert.metricsLabels.remaining")), value: isOverBudget ? t(selectorFromPath("emails.spendingAlert.overBudgetValue")) : remainingBudget},
+            {label: t(selectorFromPath("emails.spendingAlert.metricsLabels.threshold")), value: `${thresholdPercent}%`},
           ]}
         />
         <KeyValueTable
-          title={t(selectorFromPath("email.spendingAlert.detailsTitle"))}
+          title={t(selectorFromPath("emails.spendingAlert.detailsTitle"))}
           items={[
-            {label: t(selectorFromPath("email.spendingAlert.detailsLabels.category")), value: category},
-            {label: t(selectorFromPath("email.spendingAlert.detailsLabels.period")), value: period},
-            {label: t(selectorFromPath("email.spendingAlert.detailsLabels.budget")), value: budgetLimit},
-            {label: t(selectorFromPath("email.spendingAlert.detailsLabels.spent")), value: currentSpending},
+            {label: t(selectorFromPath("emails.spendingAlert.detailsLabels.category")), value: category},
+            {label: t(selectorFromPath("emails.spendingAlert.detailsLabels.period")), value: period},
+            {label: t(selectorFromPath("emails.spendingAlert.detailsLabels.budget")), value: budgetLimit},
+            {label: t(selectorFromPath("emails.spendingAlert.detailsLabels.spent")), value: currentSpending},
           ]}
         />
         {categoryBreakdown.length > 0 ? (
           <DonutChart
-            title={t(selectorFromPath("email.spendingAlert.chartTitle"))}
+            title={t(selectorFromPath("emails.spendingAlert.chartTitle"))}
             data={categoryBreakdown}
             chartImageUrl={chartImageUrl}
-            alt={t(selectorFromPath("email.spendingAlert.chartAlt"), {period})}
+            alt={t(selectorFromPath("emails.spendingAlert.chartAlt"), {period})}
           />
         ) : null}
-        <EmailCard title={t(selectorFromPath("email.spendingAlert.tipsTitle"), {state: budgetState})}>
+        <EmailCard title={t(selectorFromPath("emails.spendingAlert.tipsTitle"), {state: budgetState})}>
           <BulletList
             items={
               isOverBudget
-                ? [t(selectorFromPath("email.spendingAlert.tipsOverBudget.0")), t(selectorFromPath("email.spendingAlert.tipsOverBudget.1")), t(selectorFromPath("email.spendingAlert.tipsOverBudget.2"))]
-                : [t(selectorFromPath("email.spendingAlert.tipsOnTrack.0")), t(selectorFromPath("email.spendingAlert.tipsOnTrack.1")), t(selectorFromPath("email.spendingAlert.tipsOnTrack.2"))]
+                ? [t(selectorFromPath("emails.spendingAlert.tipsOverBudget.item0")), t(selectorFromPath("emails.spendingAlert.tipsOverBudget.item1")), t(selectorFromPath("emails.spendingAlert.tipsOverBudget.item2"))]
+                : [t(selectorFromPath("emails.spendingAlert.tipsOnTrack.item0")), t(selectorFromPath("emails.spendingAlert.tipsOnTrack.item1")), t(selectorFromPath("emails.spendingAlert.tipsOnTrack.item2"))]
             }
           />
         </EmailCard>
         <Text style={EmailParagraphStyles}>
-          {t.rich(selectorFromPath("email.spendingAlert.notificationsParagraph"), {
+          {t.rich(selectorFromPath("emails.spendingAlert.notificationsParagraph"), {
             settings: () => (
               <Link
                 href={`${BRAND.url}/settings/notifications`}
                 style={EmailLinkStyles}>
-                {t(selectorFromPath("email.spendingAlert.notificationsLink"))}
+                {t(selectorFromPath("emails.spendingAlert.notificationsLink"))}
               </Link>
             ),
           })}
         </Text>
         <Text style={EmailParagraphStyles}>
-          {t.rich(selectorFromPath("email.spendingAlert.feedbackPrompt"), {
+          {t.rich(selectorFromPath("emails.spendingAlert.feedbackPrompt"), {
             email: () => (
               <Link
                 href={`mailto:${BRAND.supportEmail}`}
@@ -220,9 +220,9 @@ const SpendingThresholdAlertEmail = defineEmailTemplate<Props>({
           })}
         </Text>
         <Text style={{...EmailParagraphStyles, margin: "0"}}>
-          {t(selectorFromPath("email.spendingAlert.signOff.line1"))}
+          {t(selectorFromPath("emails.spendingAlert.signOff.line1"))}
           <br />
-          {t(selectorFromPath("email.spendingAlert.signOff.line2"), {brand: BRAND.name})}
+          {t(selectorFromPath("emails.spendingAlert.signOff.line2"), {brand: BRAND.name})}
         </Text>
       </EmailLayout>
     );

--- a/sites/arolariu.ro/emails/invoices/inactivity/InvoiceUploadInactivityReminderEmail.tsx
+++ b/sites/arolariu.ro/emails/invoices/inactivity/InvoiceUploadInactivityReminderEmail.tsx
@@ -48,7 +48,7 @@ import {
 import {defineEmailTemplate} from "../../_lib/defineEmailTemplate";
 
 /**
- * Properties for the invoice upload inactivity reminder email.
+ * Properties for the invoice upload inactivity reminder emails.
  *
  * @remarks
  * **Type Safety**: `daysWithoutUpload` uses literal union type (3 | 7 | 14 | 30)
@@ -101,7 +101,7 @@ export type Props = {
 };
 
 const InvoiceUploadInactivityReminderEmail = defineEmailTemplate<Props>({
-  namespace: "email.invoiceInactivity",
+  namespace: "emails.invoiceInactivity",
   render: ({locale, t, props}) => {
     const {username, daysWithoutUpload, lastUploadDate, createInvoiceUrl, invoicesUrl} = props;
 
@@ -113,17 +113,17 @@ const InvoiceUploadInactivityReminderEmail = defineEmailTemplate<Props>({
     return (
       <EmailLayout
         locale={locale}
-        title={`${BRAND.name} | ${t(selectorFromPath(`email.invoiceInactivity.heading.${dayKey}`))}`}
+        title={`${BRAND.name} | ${t(selectorFromPath(`emails.invoiceInactivity.heading.${dayKey}`))}`}
         preview={t(selectorFromPath("emails.invoiceInactivity.preview"), {name, days: daysWithoutUpload})}
-        badge={t(selectorFromPath(`email.invoiceInactivity.badge.${dayKey}`))}
-        heading={t(selectorFromPath(`email.invoiceInactivity.heading.${dayKey}`))}
+        badge={t(selectorFromPath(`emails.invoiceInactivity.badge.${dayKey}`))}
+        heading={t(selectorFromPath(`emails.invoiceInactivity.heading.${dayKey}`))}
         primaryCta={{href: effectiveCreateInvoiceUrl, label: t(selectorFromPath("emails.invoiceInactivity.cta.primary"))}}
         secondaryCta={{href: effectiveInvoicesUrl, label: t(selectorFromPath("emails.invoiceInactivity.cta.secondary"))}}
         showUnsubscribe={false}
         unsubscribeUrl=''
         managePreferencesUrl=''>
         <Text style={EmailParagraphStyles}>{t(selectorFromPath("emails.invoiceInactivity.greeting"), {name})}</Text>
-        <Text style={EmailParagraphStyles}>{t(selectorFromPath(`email.invoiceInactivity.intro.${dayKey}`))}</Text>
+        <Text style={EmailParagraphStyles}>{t(selectorFromPath(`emails.invoiceInactivity.intro.${dayKey}`))}</Text>
         <EmailCard title={t(selectorFromPath("emails.invoiceInactivity.whyWorthIt.title"))}>
           <BulletList items={[t(selectorFromPath("emails.invoiceInactivity.whyWorthIt.bullet1")), t(selectorFromPath("emails.invoiceInactivity.whyWorthIt.bullet2")), t(selectorFromPath("emails.invoiceInactivity.whyWorthIt.bullet3"))]} />
         </EmailCard>

--- a/sites/arolariu.ro/emails/invoices/inactivity/InvoiceUploadInactivityReminderEmail.tsx
+++ b/sites/arolariu.ro/emails/invoices/inactivity/InvoiceUploadInactivityReminderEmail.tsx
@@ -114,35 +114,35 @@ const InvoiceUploadInactivityReminderEmail = defineEmailTemplate<Props>({
       <EmailLayout
         locale={locale}
         title={`${BRAND.name} | ${t(selectorFromPath(`email.invoiceInactivity.heading.${dayKey}`))}`}
-        preview={t(selectorFromPath("email.invoiceInactivity.preview"), {name, days: daysWithoutUpload})}
+        preview={t(selectorFromPath("emails.invoiceInactivity.preview"), {name, days: daysWithoutUpload})}
         badge={t(selectorFromPath(`email.invoiceInactivity.badge.${dayKey}`))}
         heading={t(selectorFromPath(`email.invoiceInactivity.heading.${dayKey}`))}
-        primaryCta={{href: effectiveCreateInvoiceUrl, label: t(selectorFromPath("email.invoiceInactivity.cta.primary"))}}
-        secondaryCta={{href: effectiveInvoicesUrl, label: t(selectorFromPath("email.invoiceInactivity.cta.secondary"))}}
+        primaryCta={{href: effectiveCreateInvoiceUrl, label: t(selectorFromPath("emails.invoiceInactivity.cta.primary"))}}
+        secondaryCta={{href: effectiveInvoicesUrl, label: t(selectorFromPath("emails.invoiceInactivity.cta.secondary"))}}
         showUnsubscribe={false}
         unsubscribeUrl=''
         managePreferencesUrl=''>
-        <Text style={EmailParagraphStyles}>{t(selectorFromPath("email.invoiceInactivity.greeting"), {name})}</Text>
+        <Text style={EmailParagraphStyles}>{t(selectorFromPath("emails.invoiceInactivity.greeting"), {name})}</Text>
         <Text style={EmailParagraphStyles}>{t(selectorFromPath(`email.invoiceInactivity.intro.${dayKey}`))}</Text>
-        <EmailCard title={t(selectorFromPath("email.invoiceInactivity.whyWorthIt.title"))}>
-          <BulletList items={[t(selectorFromPath("email.invoiceInactivity.whyWorthIt.bullet1")), t(selectorFromPath("email.invoiceInactivity.whyWorthIt.bullet2")), t(selectorFromPath("email.invoiceInactivity.whyWorthIt.bullet3"))]} />
+        <EmailCard title={t(selectorFromPath("emails.invoiceInactivity.whyWorthIt.title"))}>
+          <BulletList items={[t(selectorFromPath("emails.invoiceInactivity.whyWorthIt.bullet1")), t(selectorFromPath("emails.invoiceInactivity.whyWorthIt.bullet2")), t(selectorFromPath("emails.invoiceInactivity.whyWorthIt.bullet3"))]} />
         </EmailCard>
-        <EmailCard title={t(selectorFromPath("email.invoiceInactivity.status.title"))}>
+        <EmailCard title={t(selectorFromPath("emails.invoiceInactivity.status.title"))}>
           <KeyValueTable
             title=''
             items={[
-              {label: t(selectorFromPath("email.invoiceInactivity.status.daysWithoutUpload")), value: String(daysWithoutUpload)},
-              {label: t(selectorFromPath("email.invoiceInactivity.status.lastUpload")), value: lastUploadDate ?? "—"},
+              {label: t(selectorFromPath("emails.invoiceInactivity.status.daysWithoutUpload")), value: String(daysWithoutUpload)},
+              {label: t(selectorFromPath("emails.invoiceInactivity.status.lastUpload")), value: lastUploadDate ?? "—"},
             ]}
           />
         </EmailCard>
         {daysWithoutUpload >= 14 ? (
-          <EmailCard title={t(selectorFromPath("email.invoiceInactivity.tip.title"))}>
-            <Text style={{...EmailParagraphStyles, fontSize: "14px", margin: "0"}}>{t(selectorFromPath("email.invoiceInactivity.tip.message"))}</Text>
+          <EmailCard title={t(selectorFromPath("emails.invoiceInactivity.tip.title"))}>
+            <Text style={{...EmailParagraphStyles, fontSize: "14px", margin: "0"}}>{t(selectorFromPath("emails.invoiceInactivity.tip.message"))}</Text>
           </EmailCard>
         ) : null}
         {daysWithoutUpload >= 30 ? (
-          <EmailCard title={t(selectorFromPath("email.invoiceInactivity.important.title"))}>
+          <EmailCard title={t(selectorFromPath("emails.invoiceInactivity.important.title"))}>
             <Text
               style={{
                 ...EmailParagraphStyles,
@@ -153,12 +153,12 @@ const InvoiceUploadInactivityReminderEmail = defineEmailTemplate<Props>({
                 borderRadius: "10px",
                 padding: "12px",
               }}>
-              {t(selectorFromPath("email.invoiceInactivity.important.message"))}
+              {t(selectorFromPath("emails.invoiceInactivity.important.message"))}
             </Text>
           </EmailCard>
         ) : null}
         <Text style={EmailParagraphStyles}>
-          {t.rich(selectorFromPath("email.invoiceInactivity.helpPrompt"), {
+          {t.rich(selectorFromPath("emails.invoiceInactivity.helpPrompt"), {
             supportEmail: BRAND.supportEmail,
             link: (chunks) => (
               <Link
@@ -170,9 +170,9 @@ const InvoiceUploadInactivityReminderEmail = defineEmailTemplate<Props>({
           })}
         </Text>
         <Text style={{...EmailParagraphStyles, margin: "0"}}>
-          {t(selectorFromPath("email.invoiceInactivity.signOff.line1"))}
+          {t(selectorFromPath("emails.invoiceInactivity.signOff.line1"))}
           <br />
-          {t(selectorFromPath("email.invoiceInactivity.signOff.line2"), {brand: BRAND.name})}
+          {t(selectorFromPath("emails.invoiceInactivity.signOff.line2"), {brand: BRAND.name})}
         </Text>
       </EmailLayout>
     );

--- a/sites/arolariu.ro/emails/invoices/reminders/IncompleteInvoiceReminderEmail.tsx
+++ b/sites/arolariu.ro/emails/invoices/reminders/IncompleteInvoiceReminderEmail.tsx
@@ -68,7 +68,7 @@ type Props = {
 };
 
 /**
- * React component that renders the "Incomplete Invoice Reminder" email.
+ * React component that renders the "Incomplete Invoice Reminder" emails.
  *
  * @remarks
  * **Rendering Context**: React Email.
@@ -100,7 +100,7 @@ const IncompleteInvoiceReminderEmail = async (props: Readonly<Props>): Promise<R
 
   const locale: EmailLocale = props.locale ?? DEFAULT_LOCALE;
   const messages = await loadMessages(locale);
-  const t = createEmailTranslator({locale, messages, namespace: "email.incompleteInvoice"});
+  const t = createEmailTranslator({locale, messages, namespace: "emails.incompleteInvoice"});
 
   const name = username?.trim() ? username : "there";
 
@@ -128,8 +128,8 @@ const IncompleteInvoiceReminderEmail = async (props: Readonly<Props>): Promise<R
       />
       <EmailCard title={t(selectorFromPath("emails.incompleteInvoice.whatsMissingTitle"))}>
         {missingFields.map((field) => {
-          const label = t(selectorFromPath(`email.incompleteInvoice.missingFields.${field}.label`));
-          const suggestion = t(selectorFromPath(`email.incompleteInvoice.missingFields.${field}.suggestion`));
+          const label = t(selectorFromPath(`emails.incompleteInvoice.missingFields.${field}.label`));
+          const suggestion = t(selectorFromPath(`emails.incompleteInvoice.missingFields.${field}.suggestion`));
           return (
             <Text
               key={field}

--- a/sites/arolariu.ro/emails/invoices/reminders/IncompleteInvoiceReminderEmail.tsx
+++ b/sites/arolariu.ro/emails/invoices/reminders/IncompleteInvoiceReminderEmail.tsx
@@ -108,25 +108,25 @@ const IncompleteInvoiceReminderEmail = async (props: Readonly<Props>): Promise<R
     <EmailLayout
       locale={locale}
       title={`${BRAND.name} | Incomplete invoice`}
-      preview={t(selectorFromPath("email.incompleteInvoice.preview"), {name, invoiceName})}
-      badge={t(selectorFromPath("email.incompleteInvoice.badge"))}
-      heading={t(selectorFromPath("email.incompleteInvoice.heading"))}
-      primaryCta={{href: editInvoiceUrl, label: t(selectorFromPath("email.incompleteInvoice.primaryCta"))}}
-      secondaryCta={reanalyzeUrl ? {href: reanalyzeUrl, label: t(selectorFromPath("email.incompleteInvoice.secondaryCta"))} : null}
+      preview={t(selectorFromPath("emails.incompleteInvoice.preview"), {name, invoiceName})}
+      badge={t(selectorFromPath("emails.incompleteInvoice.badge"))}
+      heading={t(selectorFromPath("emails.incompleteInvoice.heading"))}
+      primaryCta={{href: editInvoiceUrl, label: t(selectorFromPath("emails.incompleteInvoice.primaryCta"))}}
+      secondaryCta={reanalyzeUrl ? {href: reanalyzeUrl, label: t(selectorFromPath("emails.incompleteInvoice.secondaryCta"))} : null}
       showUnsubscribe={true}
       unsubscribeUrl={`${BRAND.url}/unsubscribe`}
       managePreferencesUrl={`${BRAND.url}/settings/notifications`}>
-      <Text style={EmailParagraphStyles}>{t(selectorFromPath("email.incompleteInvoice.greeting"), {name})}</Text>
-      <Text style={EmailParagraphStyles}>{t(selectorFromPath("email.incompleteInvoice.intro"), {invoiceName: `"${invoiceName}"`})}</Text>
+      <Text style={EmailParagraphStyles}>{t(selectorFromPath("emails.incompleteInvoice.greeting"), {name})}</Text>
+      <Text style={EmailParagraphStyles}>{t(selectorFromPath("emails.incompleteInvoice.intro"), {invoiceName: `"${invoiceName}"`})}</Text>
       <KeyValueTable
-        title={t(selectorFromPath("email.incompleteInvoice.invoiceDetailsTitle"))}
+        title={t(selectorFromPath("emails.incompleteInvoice.invoiceDetailsTitle"))}
         items={[
-          {label: t(selectorFromPath("email.incompleteInvoice.invoiceLabel")), value: invoiceName},
-          {label: t(selectorFromPath("email.incompleteInvoice.analyzedOnLabel")), value: analysisDate},
-          {label: t(selectorFromPath("email.incompleteInvoice.missingFieldsLabel")), value: String(missingFields.length)},
+          {label: t(selectorFromPath("emails.incompleteInvoice.invoiceLabel")), value: invoiceName},
+          {label: t(selectorFromPath("emails.incompleteInvoice.analyzedOnLabel")), value: analysisDate},
+          {label: t(selectorFromPath("emails.incompleteInvoice.missingFieldsLabel")), value: String(missingFields.length)},
         ]}
       />
-      <EmailCard title={t(selectorFromPath("email.incompleteInvoice.whatsMissingTitle"))}>
+      <EmailCard title={t(selectorFromPath("emails.incompleteInvoice.whatsMissingTitle"))}>
         {missingFields.map((field) => {
           const label = t(selectorFromPath(`email.incompleteInvoice.missingFields.${field}.label`));
           const suggestion = t(selectorFromPath(`email.incompleteInvoice.missingFields.${field}.suggestion`));
@@ -147,12 +147,12 @@ const IncompleteInvoiceReminderEmail = async (props: Readonly<Props>): Promise<R
           );
         })}
       </EmailCard>
-      <EmailCard title={t(selectorFromPath("email.incompleteInvoice.tipsTitle"))}>
-        <BulletList items={[t(selectorFromPath("email.incompleteInvoice.tips.0")), t(selectorFromPath("email.incompleteInvoice.tips.1")), t(selectorFromPath("email.incompleteInvoice.tips.2")), t(selectorFromPath("email.incompleteInvoice.tips.3"))]} />
+      <EmailCard title={t(selectorFromPath("emails.incompleteInvoice.tipsTitle"))}>
+        <BulletList items={[t(selectorFromPath("emails.incompleteInvoice.tips.item0")), t(selectorFromPath("emails.incompleteInvoice.tips.item1")), t(selectorFromPath("emails.incompleteInvoice.tips.item2")), t(selectorFromPath("emails.incompleteInvoice.tips.item3"))]} />
       </EmailCard>
-      <Text style={EmailParagraphStyles}>{t(selectorFromPath("email.incompleteInvoice.bodyText"))}</Text>
+      <Text style={EmailParagraphStyles}>{t(selectorFromPath("emails.incompleteInvoice.bodyText"))}</Text>
       <Text style={EmailParagraphStyles}>
-        {t.rich(selectorFromPath("email.incompleteInvoice.feedback"), {
+        {t.rich(selectorFromPath("emails.incompleteInvoice.feedback"), {
           supportEmail: BRAND.supportEmail,
           // eslint-disable-next-line react/no-unstable-nested-components -- emails render server-side via React Email; never mounted, no reconciliation
           link: (chunks) => (
@@ -165,9 +165,9 @@ const IncompleteInvoiceReminderEmail = async (props: Readonly<Props>): Promise<R
         })}
       </Text>
       <Text style={{...EmailParagraphStyles, margin: "0"}}>
-        {t(selectorFromPath("email.incompleteInvoice.signOff.line1"))}
+        {t(selectorFromPath("emails.incompleteInvoice.signOff.line1"))}
         <br />
-        {t(selectorFromPath("email.incompleteInvoice.signOff.line2"), {brand: BRAND.name})}
+        {t(selectorFromPath("emails.incompleteInvoice.signOff.line2"), {brand: BRAND.name})}
       </Text>
     </EmailLayout>
   );

--- a/sites/arolariu.ro/emails/invoices/reminders/UnanalyzedInvoicesReminderEmail.tsx
+++ b/sites/arolariu.ro/emails/invoices/reminders/UnanalyzedInvoicesReminderEmail.tsx
@@ -26,7 +26,7 @@ import {BRAND, BulletList, EmailCard, EmailLayout, EmailLinkStyles, EmailParagra
 import {createEmailTranslator, DEFAULT_LOCALE, type EmailLocale, loadMessages} from "../../_lib/i18n";
 
 /**
- * Represents a single unanalyzed invoice for display in the email.
+ * Represents a single unanalyzed invoice for display in the emails.
  */
 type UnanalyzedInvoice = {
   /** Invoice name or fallback identifier. */
@@ -57,7 +57,7 @@ type Props = {
 };
 
 /**
- * React component that renders the "Unanalyzed Invoices Reminder" email.
+ * React component that renders the "Unanalyzed Invoices Reminder" emails.
  *
  * @remarks
  * **Rendering Context**: React Email.
@@ -88,7 +88,7 @@ const UnanalyzedInvoicesReminderEmail = async (props: Readonly<Props>): Promise<
 
   const locale: EmailLocale = props.locale ?? DEFAULT_LOCALE;
   const messages = await loadMessages(locale);
-  const t = createEmailTranslator({locale, messages, namespace: "email.unanalyzedInvoices"});
+  const t = createEmailTranslator({locale, messages, namespace: "emails.unanalyzedInvoices"});
 
   const name = username?.trim() ? username : "there";
   const effectiveInvoicesUrl = invoicesUrl ?? `${BRAND.url}/domains/invoices/view-invoices`;

--- a/sites/arolariu.ro/emails/invoices/reminders/UnanalyzedInvoicesReminderEmail.tsx
+++ b/sites/arolariu.ro/emails/invoices/reminders/UnanalyzedInvoicesReminderEmail.tsx
@@ -99,26 +99,26 @@ const UnanalyzedInvoicesReminderEmail = async (props: Readonly<Props>): Promise<
     <EmailLayout
       locale={locale}
       title={`${BRAND.name} | Invoices awaiting analysis`}
-      preview={t(selectorFromPath("email.unanalyzedInvoices.preview"), {name, count})}
-      badge={t(selectorFromPath("email.unanalyzedInvoices.badge"))}
-      heading={t(selectorFromPath("email.unanalyzedInvoices.heading"), {count})}
-      primaryCta={{href: effectiveInvoicesUrl, label: t(selectorFromPath("email.unanalyzedInvoices.primaryCta"))}}
+      preview={t(selectorFromPath("emails.unanalyzedInvoices.preview"), {name, count})}
+      badge={t(selectorFromPath("emails.unanalyzedInvoices.badge"))}
+      heading={t(selectorFromPath("emails.unanalyzedInvoices.heading"), {count})}
+      primaryCta={{href: effectiveInvoicesUrl, label: t(selectorFromPath("emails.unanalyzedInvoices.primaryCta"))}}
       secondaryCta={null}
       showUnsubscribe={true}
       unsubscribeUrl={`${BRAND.url}/unsubscribe`}
       managePreferencesUrl={`${BRAND.url}/settings/notifications`}>
-      <Text style={EmailParagraphStyles}>{t(selectorFromPath("email.unanalyzedInvoices.greeting"), {name})}</Text>
-      <Text style={EmailParagraphStyles}>{t(selectorFromPath("email.unanalyzedInvoices.intro"), {count})}</Text>
+      <Text style={EmailParagraphStyles}>{t(selectorFromPath("emails.unanalyzedInvoices.greeting"), {name})}</Text>
+      <Text style={EmailParagraphStyles}>{t(selectorFromPath("emails.unanalyzedInvoices.intro"), {count})}</Text>
       <KeyValueTable
-        title={t(selectorFromPath("email.unanalyzedInvoices.invoicesAwaitingTitle"))}
+        title={t(selectorFromPath("emails.unanalyzedInvoices.invoicesAwaitingTitle"))}
         items={displayInvoices.map((invoice) => ({
           label: invoice.name,
-          value: t(selectorFromPath("email.unanalyzedInvoices.uploadedDate"), {date: invoice.uploadDate}),
+          value: t(selectorFromPath("emails.unanalyzedInvoices.uploadedDate"), {date: invoice.uploadDate}),
         }))}
       />
       {count > 5 ? (
         <Text style={{...EmailParagraphStyles, fontSize: "13px"}}>
-          {t.rich(selectorFromPath("email.unanalyzedInvoices.andMore"), {
+          {t.rich(selectorFromPath("emails.unanalyzedInvoices.andMore"), {
             remaining: count - 5,
             // eslint-disable-next-line react/no-unstable-nested-components -- emails render server-side via React Email; never mounted, no reconciliation
             dashboard: () => (
@@ -131,20 +131,20 @@ const UnanalyzedInvoicesReminderEmail = async (props: Readonly<Props>): Promise<
           })}
         </Text>
       ) : null}
-      <EmailCard title={t(selectorFromPath("email.unanalyzedInvoices.analysisProvidedTitle"))}>
+      <EmailCard title={t(selectorFromPath("emails.unanalyzedInvoices.analysisProvidedTitle"))}>
         <BulletList
           items={[
-            t(selectorFromPath("email.unanalyzedInvoices.analysisProvides.0")),
-            t(selectorFromPath("email.unanalyzedInvoices.analysisProvides.1")),
-            t(selectorFromPath("email.unanalyzedInvoices.analysisProvides.2")),
-            t(selectorFromPath("email.unanalyzedInvoices.analysisProvides.3")),
-            t(selectorFromPath("email.unanalyzedInvoices.analysisProvides.4")),
+            t(selectorFromPath("emails.unanalyzedInvoices.analysisProvides.item0")),
+            t(selectorFromPath("emails.unanalyzedInvoices.analysisProvides.item1")),
+            t(selectorFromPath("emails.unanalyzedInvoices.analysisProvides.item2")),
+            t(selectorFromPath("emails.unanalyzedInvoices.analysisProvides.item3")),
+            t(selectorFromPath("emails.unanalyzedInvoices.analysisProvides.item4")),
           ]}
         />
       </EmailCard>
-      <Text style={EmailParagraphStyles}>{t(selectorFromPath("email.unanalyzedInvoices.bodyText"))}</Text>
+      <Text style={EmailParagraphStyles}>{t(selectorFromPath("emails.unanalyzedInvoices.bodyText"))}</Text>
       <Text style={EmailParagraphStyles}>
-        {t.rich(selectorFromPath("email.unanalyzedInvoices.feedback"), {
+        {t.rich(selectorFromPath("emails.unanalyzedInvoices.feedback"), {
           supportEmail: BRAND.supportEmail,
           // eslint-disable-next-line react/no-unstable-nested-components -- emails render server-side via React Email; never mounted, no reconciliation
           link: (chunks) => (
@@ -157,9 +157,9 @@ const UnanalyzedInvoicesReminderEmail = async (props: Readonly<Props>): Promise<
         })}
       </Text>
       <Text style={{...EmailParagraphStyles, margin: "0"}}>
-        {t(selectorFromPath("email.unanalyzedInvoices.signOff.line1"))}
+        {t(selectorFromPath("emails.unanalyzedInvoices.signOff.line1"))}
         <br />
-        {t(selectorFromPath("email.unanalyzedInvoices.signOff.line2"), {brand: BRAND.name})}
+        {t(selectorFromPath("emails.unanalyzedInvoices.signOff.line2"), {brand: BRAND.name})}
       </Text>
     </EmailLayout>
   );

--- a/sites/arolariu.ro/emails/invoices/reminders/WeeklyUploadReminderEmail.tsx
+++ b/sites/arolariu.ro/emails/invoices/reminders/WeeklyUploadReminderEmail.tsx
@@ -96,30 +96,30 @@ const WeeklyUploadReminderEmail = async (props: Readonly<Props>): Promise<React.
     <EmailLayout
       locale={locale}
       title={`${BRAND.name} | Weekly upload reminder`}
-      preview={t(selectorFromPath("email.weeklyUploadReminder.preview"), {name})}
-      badge={t(selectorFromPath("email.weeklyUploadReminder.badge"))}
-      heading={t(selectorFromPath("email.weeklyUploadReminder.heading"))}
-      primaryCta={{href: effectiveUploadUrl, label: t(selectorFromPath("email.weeklyUploadReminder.primaryCta"))}}
-      secondaryCta={{href: effectiveDashboardUrl, label: t(selectorFromPath("email.weeklyUploadReminder.secondaryCta"))}}
+      preview={t(selectorFromPath("emails.weeklyUploadReminder.preview"), {name})}
+      badge={t(selectorFromPath("emails.weeklyUploadReminder.badge"))}
+      heading={t(selectorFromPath("emails.weeklyUploadReminder.heading"))}
+      primaryCta={{href: effectiveUploadUrl, label: t(selectorFromPath("emails.weeklyUploadReminder.primaryCta"))}}
+      secondaryCta={{href: effectiveDashboardUrl, label: t(selectorFromPath("emails.weeklyUploadReminder.secondaryCta"))}}
       showUnsubscribe={true}
       unsubscribeUrl={`${BRAND.url}/unsubscribe`}
       managePreferencesUrl={`${BRAND.url}/settings/notifications`}>
-      <Text style={EmailParagraphStyles}>{t(selectorFromPath("email.weeklyUploadReminder.greeting"), {name})}</Text>
-      <Text style={EmailParagraphStyles}>{t(selectorFromPath("email.weeklyUploadReminder.intro"))}</Text>
+      <Text style={EmailParagraphStyles}>{t(selectorFromPath("emails.weeklyUploadReminder.greeting"), {name})}</Text>
+      <Text style={EmailParagraphStyles}>{t(selectorFromPath("emails.weeklyUploadReminder.intro"))}</Text>
       <MetricsGrid
         metrics={[
-          {label: t(selectorFromPath("email.weeklyUploadReminder.metricsLabels.thisWeek")), value: String(thisWeekCount)},
-          {label: t(selectorFromPath("email.weeklyUploadReminder.metricsLabels.lastWeek")), value: String(lastWeekCount)},
-          {label: t(selectorFromPath("email.weeklyUploadReminder.metricsLabels.totalInvoices")), value: String(totalInvoices)},
-          {label: t(selectorFromPath("email.weeklyUploadReminder.metricsLabels.totalTracked")), value: totalTracked},
+          {label: t(selectorFromPath("emails.weeklyUploadReminder.metricsLabels.thisWeek")), value: String(thisWeekCount)},
+          {label: t(selectorFromPath("emails.weeklyUploadReminder.metricsLabels.lastWeek")), value: String(lastWeekCount)},
+          {label: t(selectorFromPath("emails.weeklyUploadReminder.metricsLabels.totalInvoices")), value: String(totalInvoices)},
+          {label: t(selectorFromPath("emails.weeklyUploadReminder.metricsLabels.totalTracked")), value: totalTracked},
         ]}
       />
-      <EmailCard title={t(selectorFromPath("email.weeklyUploadReminder.quickTipsTitle"))}>
-        <BulletList items={[t(selectorFromPath("email.weeklyUploadReminder.quickTips.0")), t(selectorFromPath("email.weeklyUploadReminder.quickTips.1")), t(selectorFromPath("email.weeklyUploadReminder.quickTips.2"))]} />
+      <EmailCard title={t(selectorFromPath("emails.weeklyUploadReminder.quickTipsTitle"))}>
+        <BulletList items={[t(selectorFromPath("emails.weeklyUploadReminder.quickTips.item0")), t(selectorFromPath("emails.weeklyUploadReminder.quickTips.item1")), t(selectorFromPath("emails.weeklyUploadReminder.quickTips.item2"))]} />
       </EmailCard>
-      <Text style={EmailParagraphStyles}>{t(selectorFromPath("email.weeklyUploadReminder.bodyText"))}</Text>
+      <Text style={EmailParagraphStyles}>{t(selectorFromPath("emails.weeklyUploadReminder.bodyText"))}</Text>
       <Text style={EmailParagraphStyles}>
-        {t.rich(selectorFromPath("email.weeklyUploadReminder.feedback"), {
+        {t.rich(selectorFromPath("emails.weeklyUploadReminder.feedback"), {
           supportEmail: BRAND.supportEmail,
           // eslint-disable-next-line react/no-unstable-nested-components -- emails render server-side via React Email; never mounted, no reconciliation
           link: (chunks) => (
@@ -132,9 +132,9 @@ const WeeklyUploadReminderEmail = async (props: Readonly<Props>): Promise<React.
         })}
       </Text>
       <Text style={{...EmailParagraphStyles, margin: "0"}}>
-        {t(selectorFromPath("email.weeklyUploadReminder.signOff.line1"))}
+        {t(selectorFromPath("emails.weeklyUploadReminder.signOff.line1"))}
         <br />
-        {t(selectorFromPath("email.weeklyUploadReminder.signOff.line2"), {brand: BRAND.name})}
+        {t(selectorFromPath("emails.weeklyUploadReminder.signOff.line2"), {brand: BRAND.name})}
       </Text>
     </EmailLayout>
   );

--- a/sites/arolariu.ro/emails/invoices/reminders/WeeklyUploadReminderEmail.tsx
+++ b/sites/arolariu.ro/emails/invoices/reminders/WeeklyUploadReminderEmail.tsx
@@ -55,7 +55,7 @@ type Props = {
 };
 
 /**
- * React component that renders the "Weekly Upload Reminder" email.
+ * React component that renders the "Weekly Upload Reminder" emails.
  *
  * @remarks
  * **Rendering Context**: React Email.
@@ -86,7 +86,7 @@ const WeeklyUploadReminderEmail = async (props: Readonly<Props>): Promise<React.
 
   const locale: EmailLocale = props.locale ?? DEFAULT_LOCALE;
   const messages = await loadMessages(locale);
-  const t = createEmailTranslator({locale, messages, namespace: "email.weeklyUploadReminder"});
+  const t = createEmailTranslator({locale, messages, namespace: "emails.weeklyUploadReminder"});
 
   const name = username?.trim() ? username : "there";
   const effectiveUploadUrl = uploadUrl ?? `${BRAND.url}/domains/invoices/upload-scans`;

--- a/sites/arolariu.ro/emails/invoices/statistics/InvoiceStatisticsEmail.tsx
+++ b/sites/arolariu.ro/emails/invoices/statistics/InvoiceStatisticsEmail.tsx
@@ -92,7 +92,7 @@ function rankedItems(items: readonly RankedItem[], currency: string, fallback: s
 }
 
 const InvoiceStatisticsEmail = defineEmailTemplate<InvoiceStatisticsEmailProps>({
-  namespace: "email.invoiceStats",
+  namespace: "emails.invoiceStats",
   render: ({locale, t, props}) => {
     const {
       username,

--- a/sites/arolariu.ro/emails/invoices/statistics/InvoiceStatisticsEmail.tsx
+++ b/sites/arolariu.ro/emails/invoices/statistics/InvoiceStatisticsEmail.tsx
@@ -114,68 +114,68 @@ const InvoiceStatisticsEmail = defineEmailTemplate<InvoiceStatisticsEmailProps>(
     const effectiveInvoicesUrl = invoicesUrl ?? `${BRAND.url}/domains/invoices/view-invoices`;
     const effectiveCreateInvoiceUrl = createInvoiceUrl ?? `${BRAND.url}/domains/invoices/create-invoice`;
 
-    const label = t(selectorFromPath("email.invoiceStats.frequencyLabel"), {frequency});
-    const preview = t(selectorFromPath("email.invoiceStats.preview"), {frequencyLabel: label, name, totalSpend: safeFormatCurrency(totals.totalSpend, currency)});
+    const label = t(selectorFromPath("emails.invoiceStats.frequencyLabel"), {frequency});
+    const preview = t(selectorFromPath("emails.invoiceStats.preview"), {frequencyLabel: label, name, totalSpend: safeFormatCurrency(totals.totalSpend, currency)});
 
     const breakdownSource = categorySpendBreakdown ?? topCategories;
     const breakdownTop = breakdownSource.slice(0, 6);
     const breakdownForChart = breakdownTop.map((item) => ({label: item.name, value: item.totalSpend}));
 
-    const noDataFallback = t(selectorFromPath("email.invoiceStats.noDataFallback"));
+    const noDataFallback = t(selectorFromPath("emails.invoiceStats.noDataFallback"));
 
     return (
       <EmailLayout
-        title={t(selectorFromPath("email.invoiceStats.title"), {frequencyLabel: label})}
+        title={t(selectorFromPath("emails.invoiceStats.title"), {frequencyLabel: label})}
         preview={preview}
-        badge={t(selectorFromPath("email.invoiceStats.badge"))}
-        heading={t(selectorFromPath("email.invoiceStats.heading"), {frequencyLabel: label})}
-        primaryCta={{href: effectiveInvoicesUrl, label: t(selectorFromPath("email.invoiceStats.ctaPrimary"))}}
-        secondaryCta={{href: effectiveCreateInvoiceUrl, label: t(selectorFromPath("email.invoiceStats.ctaSecondary"))}}
+        badge={t(selectorFromPath("emails.invoiceStats.badge"))}
+        heading={t(selectorFromPath("emails.invoiceStats.heading"), {frequencyLabel: label})}
+        primaryCta={{href: effectiveInvoicesUrl, label: t(selectorFromPath("emails.invoiceStats.ctaPrimary"))}}
+        secondaryCta={{href: effectiveCreateInvoiceUrl, label: t(selectorFromPath("emails.invoiceStats.ctaSecondary"))}}
         locale={locale}
         showUnsubscribe={false}
         unsubscribeUrl=''
         managePreferencesUrl=''>
-        <Text style={EmailParagraphStyles}>{t(selectorFromPath("email.invoiceStats.greeting"), {name})}</Text>
+        <Text style={EmailParagraphStyles}>{t(selectorFromPath("emails.invoiceStats.greeting"), {name})}</Text>
         <Text style={EmailParagraphStyles}>
-          {t.rich(selectorFromPath("email.invoiceStats.intro"), {
+          {t.rich(selectorFromPath("emails.invoiceStats.intro"), {
             start: () => <strong>{periodStart}</strong>,
             end: () => <strong>{periodEnd}</strong>,
           })}
         </Text>
         <MetricsGrid
           metrics={[
-            {label: t(selectorFromPath("email.invoiceStats.metrics.invoices")), value: String(totals.invoicesCount)},
-            {label: t(selectorFromPath("email.invoiceStats.metrics.scans")), value: String(totals.scansCount)},
-            {label: t(selectorFromPath("email.invoiceStats.metrics.totalSpend")), value: safeFormatCurrency(totals.totalSpend, currency)},
-            {label: t(selectorFromPath("email.invoiceStats.metrics.averagePerInvoice")), value: safeFormatCurrency(totals.averageSpend, currency)},
+            {label: t(selectorFromPath("emails.invoiceStats.metrics.invoices")), value: String(totals.invoicesCount)},
+            {label: t(selectorFromPath("emails.invoiceStats.metrics.scans")), value: String(totals.scansCount)},
+            {label: t(selectorFromPath("emails.invoiceStats.metrics.totalSpend")), value: safeFormatCurrency(totals.totalSpend, currency)},
+            {label: t(selectorFromPath("emails.invoiceStats.metrics.averagePerInvoice")), value: safeFormatCurrency(totals.averageSpend, currency)},
           ]}
         />
-        <EmailCard title={t(selectorFromPath("email.invoiceStats.reportDetailsTitle"))}>
+        <EmailCard title={t(selectorFromPath("emails.invoiceStats.reportDetailsTitle"))}>
           <KeyValueTable
             title=''
             items={[
-              {label: t(selectorFromPath("email.invoiceStats.reportDetails.period")), value: `${periodStart} → ${periodEnd}`},
-              {label: t(selectorFromPath("email.invoiceStats.reportDetails.currency")), value: currency},
+              {label: t(selectorFromPath("emails.invoiceStats.reportDetails.period")), value: `${periodStart} → ${periodEnd}`},
+              {label: t(selectorFromPath("emails.invoiceStats.reportDetails.currency")), value: currency},
             ]}
           />
         </EmailCard>
-        <EmailCard title={t(selectorFromPath("email.invoiceStats.topMerchantsTitle"))}>
+        <EmailCard title={t(selectorFromPath("emails.invoiceStats.topMerchantsTitle"))}>
           <BulletList items={rankedItems(topMerchants, currency, noDataFallback)} />
         </EmailCard>
-        <EmailCard title={t(selectorFromPath("email.invoiceStats.topCategoriesTitle"))}>
+        <EmailCard title={t(selectorFromPath("emails.invoiceStats.topCategoriesTitle"))}>
           <BulletList items={rankedItems(topCategories, currency, noDataFallback)} />
         </EmailCard>
         {breakdownForChart.length > 0 ? (
-          <EmailCard title={t(selectorFromPath("email.invoiceStats.breakdownCardTitle"))}>
+          <EmailCard title={t(selectorFromPath("emails.invoiceStats.breakdownCardTitle"))}>
             <DonutChart
-              title={t(selectorFromPath("email.invoiceStats.donutChartTitle"))}
+              title={t(selectorFromPath("emails.invoiceStats.donutChartTitle"))}
               data={breakdownForChart}
               chartImageUrl={categorySpendChartUrl ?? ""}
-              alt={t(selectorFromPath("email.invoiceStats.donutChartAlt"))}
+              alt={t(selectorFromPath("emails.invoiceStats.donutChartAlt"))}
             />
 
             <KeyValueTable
-              title={t(selectorFromPath("email.invoiceStats.breakdownTableTitle"))}
+              title={t(selectorFromPath("emails.invoiceStats.breakdownTableTitle"))}
               items={breakdownTop.map((item) => ({
                 label: item.name,
                 value: `${safeFormatCurrency(item.totalSpend, currency)} (${toPercent(item.totalSpend, totals.totalSpend)})`,
@@ -184,14 +184,14 @@ const InvoiceStatisticsEmail = defineEmailTemplate<InvoiceStatisticsEmailProps>(
 
             {categorySpendBreakdown ? null : (
               <Text style={{...EmailParagraphStyles, fontSize: "12px", lineHeight: "18px", margin: "0", color: EMAIL_COLORS.muted}}>
-                {t(selectorFromPath("email.invoiceStats.breakdownNote"))}
+                {t(selectorFromPath("emails.invoiceStats.breakdownNote"))}
               </Text>
             )}
           </EmailCard>
         ) : null}
-        <Text style={EmailParagraphStyles}>{t(selectorFromPath("email.invoiceStats.body"))}</Text>
+        <Text style={EmailParagraphStyles}>{t(selectorFromPath("emails.invoiceStats.body"))}</Text>
         <Text style={EmailParagraphStyles}>
-          {t.rich(selectorFromPath("email.invoiceStats.feedbackPrompt"), {
+          {t.rich(selectorFromPath("emails.invoiceStats.feedbackPrompt"), {
             email: () => (
               <Link
                 href={`mailto:${BRAND.supportEmail}`}
@@ -202,9 +202,9 @@ const InvoiceStatisticsEmail = defineEmailTemplate<InvoiceStatisticsEmailProps>(
           })}
         </Text>
         <Text style={{...EmailParagraphStyles, margin: "0"}}>
-          {t(selectorFromPath("email.invoiceStats.signOff.line1"))}
+          {t(selectorFromPath("emails.invoiceStats.signOff.line1"))}
           <br />
-          {t(selectorFromPath("email.invoiceStats.signOff.line2"), {brand: BRAND.name})}
+          {t(selectorFromPath("emails.invoiceStats.signOff.line2"), {brand: BRAND.name})}
         </Text>
       </EmailLayout>
     );

--- a/sites/arolariu.ro/emails/newsletter/UserHasBeenSubscribedEmail.tsx
+++ b/sites/arolariu.ro/emails/newsletter/UserHasBeenSubscribedEmail.tsx
@@ -41,27 +41,27 @@ const UserHasBeenSubscribedEmail = defineEmailTemplate<Props>({
       <EmailLayout
         locale={locale}
         title={`${BRAND.name} | Newsletter subscription`}
-        preview={t(selectorFromPath("email.newsletterSubscribed.preview"), {name})}
-        badge={t(selectorFromPath("email.newsletterSubscribed.badge"))}
-        heading={t(selectorFromPath("email.newsletterSubscribed.heading"))}
-        primaryCta={{href: BRAND.url, label: t(selectorFromPath("email.newsletterSubscribed.ctaPrimary"))}}
+        preview={t(selectorFromPath("emails.newsletterSubscribed.preview"), {name})}
+        badge={t(selectorFromPath("emails.newsletterSubscribed.badge"))}
+        heading={t(selectorFromPath("emails.newsletterSubscribed.heading"))}
+        primaryCta={{href: BRAND.url, label: t(selectorFromPath("emails.newsletterSubscribed.ctaPrimary"))}}
         secondaryCta={null}
         showUnsubscribe={true}
         unsubscribeUrl={`${BRAND.url}/unsubscribe`}
         managePreferencesUrl=''>
-        <Text style={EmailParagraphStyles}>{t(selectorFromPath("email.newsletterSubscribed.greeting"), {name})}</Text>
+        <Text style={EmailParagraphStyles}>{t(selectorFromPath("emails.newsletterSubscribed.greeting"), {name})}</Text>
         <Text style={EmailParagraphStyles}>
-          {t.rich(selectorFromPath("email.newsletterSubscribed.intro"), {
+          {t.rich(selectorFromPath("emails.newsletterSubscribed.intro"), {
             brandName: BRAND.name,
             brand: (chunks) => <strong>{chunks}</strong>,
           })}
         </Text>
-        <EmailCard title={t(selectorFromPath("email.newsletterSubscribed.whatToExpectTitle"))}>
-          <BulletList items={[t(selectorFromPath("email.newsletterSubscribed.whatToExpect.0")), t(selectorFromPath("email.newsletterSubscribed.whatToExpect.1")), t(selectorFromPath("email.newsletterSubscribed.whatToExpect.2"))]} />
+        <EmailCard title={t(selectorFromPath("emails.newsletterSubscribed.whatToExpectTitle"))}>
+          <BulletList items={[t(selectorFromPath("emails.newsletterSubscribed.whatToExpect.item0")), t(selectorFromPath("emails.newsletterSubscribed.whatToExpect.item1")), t(selectorFromPath("emails.newsletterSubscribed.whatToExpect.item2"))]} />
         </EmailCard>
-        <Text style={EmailParagraphStyles}>{t(selectorFromPath("email.newsletterSubscribed.body"))}</Text>
+        <Text style={EmailParagraphStyles}>{t(selectorFromPath("emails.newsletterSubscribed.body"))}</Text>
         <Text style={EmailParagraphStyles}>
-          {t.rich(selectorFromPath("email.newsletterSubscribed.feedbackPrompt"), {
+          {t.rich(selectorFromPath("emails.newsletterSubscribed.feedbackPrompt"), {
             email: () => (
               <Link
                 href={`mailto:${BRAND.supportEmail}`}
@@ -72,9 +72,9 @@ const UserHasBeenSubscribedEmail = defineEmailTemplate<Props>({
           })}
         </Text>
         <Text style={{...EmailParagraphStyles, margin: "0"}}>
-          {t(selectorFromPath("email.newsletterSubscribed.signOff.line1"))}
+          {t(selectorFromPath("emails.newsletterSubscribed.signOff.line1"))}
           <br />
-          {t(selectorFromPath("email.newsletterSubscribed.signOff.line2"), {brand: BRAND.name})}
+          {t(selectorFromPath("emails.newsletterSubscribed.signOff.line2"), {brand: BRAND.name})}
         </Text>
       </EmailLayout>
     );

--- a/sites/arolariu.ro/emails/newsletter/UserHasBeenSubscribedEmail.tsx
+++ b/sites/arolariu.ro/emails/newsletter/UserHasBeenSubscribedEmail.tsx
@@ -31,7 +31,7 @@ type Props = Readonly<{
  * @returns A rendered React Email template.
  */
 const UserHasBeenSubscribedEmail = defineEmailTemplate<Props>({
-  namespace: "email.newsletterSubscribed",
+  namespace: "emails.newsletterSubscribed",
   render: ({locale, t, props}) => {
     const {username} = props;
 

--- a/sites/arolariu.ro/emails/newsletter/UserHasUnsubscribedEmail.tsx
+++ b/sites/arolariu.ro/emails/newsletter/UserHasUnsubscribedEmail.tsx
@@ -21,7 +21,7 @@ type Props = {
 };
 
 const UserHasUnsubscribedEmail = defineEmailTemplate<Props>({
-  namespace: "email.newsletterUnsubscribed",
+  namespace: "emails.newsletterUnsubscribed",
   render: ({locale, t, props}) => {
     const {username, managePreferencesUrl, resubscribeUrl} = props;
 

--- a/sites/arolariu.ro/emails/newsletter/UserHasUnsubscribedEmail.tsx
+++ b/sites/arolariu.ro/emails/newsletter/UserHasUnsubscribedEmail.tsx
@@ -34,27 +34,27 @@ const UserHasUnsubscribedEmail = defineEmailTemplate<Props>({
       <EmailLayout
         locale={locale}
         title={`${BRAND.name} | Unsubscribed`}
-        preview={t(selectorFromPath("email.newsletterUnsubscribed.preview"), {name})}
-        badge={t(selectorFromPath("email.newsletterUnsubscribed.badge"))}
-        heading={t(selectorFromPath("email.newsletterUnsubscribed.heading"))}
-        primaryCta={{href: effectiveManagePreferencesUrl, label: t(selectorFromPath("email.newsletterUnsubscribed.ctaPrimary"))}}
-        secondaryCta={{href: effectiveResubscribeUrl, label: t(selectorFromPath("email.newsletterUnsubscribed.ctaSecondary"))}}
+        preview={t(selectorFromPath("emails.newsletterUnsubscribed.preview"), {name})}
+        badge={t(selectorFromPath("emails.newsletterUnsubscribed.badge"))}
+        heading={t(selectorFromPath("emails.newsletterUnsubscribed.heading"))}
+        primaryCta={{href: effectiveManagePreferencesUrl, label: t(selectorFromPath("emails.newsletterUnsubscribed.ctaPrimary"))}}
+        secondaryCta={{href: effectiveResubscribeUrl, label: t(selectorFromPath("emails.newsletterUnsubscribed.ctaSecondary"))}}
         showUnsubscribe={false}
         unsubscribeUrl=''
         managePreferencesUrl=''>
-        <Text style={EmailParagraphStyles}>{t(selectorFromPath("email.newsletterUnsubscribed.greeting"), {name})}</Text>
+        <Text style={EmailParagraphStyles}>{t(selectorFromPath("emails.newsletterUnsubscribed.greeting"), {name})}</Text>
         <Text style={EmailParagraphStyles}>
-          {t.rich(selectorFromPath("email.newsletterUnsubscribed.intro"), {
+          {t.rich(selectorFromPath("emails.newsletterUnsubscribed.intro"), {
             brandName: BRAND.name,
             brand: (chunks) => <strong>{chunks}</strong>,
           })}
         </Text>
-        <EmailCard title={t(selectorFromPath("email.newsletterUnsubscribed.whatHappensNextTitle"))}>
-          <BulletList items={[t(selectorFromPath("email.newsletterUnsubscribed.whatHappensNext.0")), t(selectorFromPath("email.newsletterUnsubscribed.whatHappensNext.1")), t(selectorFromPath("email.newsletterUnsubscribed.whatHappensNext.2"))]} />
+        <EmailCard title={t(selectorFromPath("emails.newsletterUnsubscribed.whatHappensNextTitle"))}>
+          <BulletList items={[t(selectorFromPath("emails.newsletterUnsubscribed.whatHappensNext.item0")), t(selectorFromPath("emails.newsletterUnsubscribed.whatHappensNext.item1")), t(selectorFromPath("emails.newsletterUnsubscribed.whatHappensNext.item2"))]} />
         </EmailCard>
-        <Text style={EmailParagraphStyles}>{t(selectorFromPath("email.newsletterUnsubscribed.body"))}</Text>
+        <Text style={EmailParagraphStyles}>{t(selectorFromPath("emails.newsletterUnsubscribed.body"))}</Text>
         <Text style={EmailParagraphStyles}>
-          {t.rich(selectorFromPath("email.newsletterUnsubscribed.feedbackPrompt"), {
+          {t.rich(selectorFromPath("emails.newsletterUnsubscribed.feedbackPrompt"), {
             email: () => (
               <Link
                 href={`mailto:${BRAND.supportEmail}`}
@@ -65,9 +65,9 @@ const UserHasUnsubscribedEmail = defineEmailTemplate<Props>({
           })}
         </Text>
         <Text style={{...EmailParagraphStyles, margin: "0"}}>
-          {t(selectorFromPath("email.newsletterUnsubscribed.signOff.line1"))}
+          {t(selectorFromPath("emails.newsletterUnsubscribed.signOff.line1"))}
           <br />
-          {t(selectorFromPath("email.newsletterUnsubscribed.signOff.line2"), {brand: BRAND.name})}
+          {t(selectorFromPath("emails.newsletterUnsubscribed.signOff.line2"), {brand: BRAND.name})}
         </Text>
       </EmailLayout>
     );

--- a/sites/arolariu.ro/messages/en.json
+++ b/sites/arolariu.ro/messages/en.json
@@ -1,2033 +1,2183 @@
 {
-  "About": {
-    "Author": {
-      "Biography": {
-        "FifthPoint": "Alexandru is open for collaboration in projects that involve any of the Internet of Things, Software Engineering and Network Engineering fields. He has a proven track record of providing high-quality solutions to complex problems and is always looking for new challenges.",
-        "FirstPoint": "Alexandru is a {age} years old software engineer and solution architect. He currently works at Microsoft as a software engineer in the E+D MSAI FAST organization, building solutions that are used by millions of users worldwide.",
-        "FourthPoint": "Alexandru enjoys reading technical books and playing with new technologies. He has built this platform as a \"test-bench\" for new technologies and as a way to learn new things. He is also a big fan of the \"open-source\" movement and has contributed to Microsoft's OSS repositories (dotnet/core, dotnet/docs, azure/docs).",
-        "SecondPoint": "Alexandru was born on the 8th of January, year 2000 in a small city called Curtea de Argeș in Romania. He got his first computer when he was just 5 years old - a Pentium 4 E2200 2.2Ghz Dual-Core  with 512 MB of RAM. Since then, he's been running different versions of Windows (started with Windows 98!), tinkering with his personal computer and developing his computer skills by playing video games. He also learnt a good amount of English and was able to fluently read, write and speak in English by the age of 12!",
-        "ThirdPoint": "Alexandru is a video game enthusiast. He used to be a professional player, ranking at #70 in Romania for the video game called \"DotA 2\". He enjoys playing strategy games that have a focus on mechanics and a technical setting like Age of Empires, Age of Mythology, etc. He also enjoys playing games such as Red Alert, StarCraft, and other RTS games.",
-        "title": "About Alexandru"
+  "app": {
+    "commander": {
+      "groups": {
+        "accessibility": "Accessibility",
+        "fun": "Fun",
+        "language": "Language",
+        "links": "Links",
+        "navigation": "Navigation",
+        "theme": "Theme"
       },
-      "Certifications": {
-        "certificates": {
-          "ab730": {
-            "code": "AB-730",
-            "coreSkills": "# AI Strategy # AI Adoption # Responsible AI # Business Value of AI # Identifying AI Use Cases",
-            "description": "Validates business-focused AI knowledge for professionals leading or influencing AI initiatives within their organization. Targeted at decision-makers, product owners and consultants who shape AI strategy rather than implement it.",
-            "issuer": "Microsoft",
-            "issuerDate": "2026",
-            "link": "https://learn.microsoft.com/en-us/credentials/certifications/ai-business-professional/",
-            "name": "Microsoft Certified: AI Business Professional"
-          },
-          "ab731": {
-            "code": "AB-731",
-            "coreSkills": "# Enterprise AI Transformation # AI Strategy # Change Management # AI Governance # Executive Leadership",
-            "description": "Validates the ability to lead enterprise-scale AI transformation initiatives — defining the strategy, driving organizational change, and establishing governance to operationalize AI across the business.",
-            "issuer": "Microsoft",
-            "issuerDate": "2026",
-            "link": "https://learn.microsoft.com/en-us/credentials/certifications/ai-transformation-leader/",
-            "name": "Microsoft Certified: AI Transformation Leader"
-          },
-          "ai900": {
-            "code": "AI-900",
-            "coreSkills": "# Machine Learning # Computer Vision # Natural Language Processing # Conversational AI # Responsible AI",
-            "description": "Demonstrates knowledge of common AI and machine learning workloads and how to implement them on Azure. This certification is intended for candidates with both technical and non-technical backgrounds.",
-            "issuer": "Microsoft",
-            "issuerDate": "2023",
-            "link": "https://learn.microsoft.com/en-us/certifications/azure-ai-fundamentals/",
-            "name": "Microsoft Certified: Azure AI Fundamentals"
-          },
-          "az900": {
-            "code": "AZ-900",
-            "coreSkills": "# Cloud Concepts # Core Azure Services # Security, Privacy, Compliance, and Trust # Azure Pricing, SLA, and Lifecycle",
-            "description": "Validates foundational knowledge of cloud services and how those services are provided with Microsoft Azure. The certification is intended for candidates who are just beginning to work with cloud-based solutions and services.",
-            "issuer": "Microsoft",
-            "issuerDate": "2023",
-            "link": "https://learn.microsoft.com/en-us/certifications/azure-fundamentals/",
-            "name": "Microsoft Certified: Azure Fundamentals"
-          },
-          "gh100": {
-            "code": "GH-100",
-            "coreSkills": "# Authentication # User & Team Management # Repository Policies # Enterprise Configuration # Security & Compliance",
-            "description": "Validates the skills required to administer GitHub Enterprise organizations — managing users, teams, repositories, policies, and integrations at scale.",
-            "issuer": "GitHub",
-            "issuerDate": "2026",
-            "link": "https://learn.microsoft.com/en-us/credentials/certifications/github-administration/",
-            "name": "GitHub Certified: Administration"
-          },
-          "gh200": {
-            "code": "GH-200",
-            "coreSkills": "# Workflow Authoring # Self-Hosted Runners # Workflow Security # Reusable Workflows # CI/CD Pipelines",
-            "description": "Validates expertise in authoring, configuring, and maintaining GitHub Actions workflows for build, test, and deployment automation across the entire software lifecycle.",
-            "issuer": "GitHub",
-            "issuerDate": "2026",
-            "link": "https://learn.microsoft.com/en-us/credentials/certifications/github-actions/",
-            "name": "GitHub Certified: Actions"
-          },
-          "gh300": {
-            "code": "GH-300",
-            "coreSkills": "# Copilot Plans & Features # Code Suggestions # Prompt Engineering # Responsible AI Use # Copilot Chat",
-            "description": "Validates the skills required to leverage GitHub Copilot effectively for AI-assisted software development — covering features, customization, prompt engineering, and responsible use.",
-            "issuer": "GitHub",
-            "issuerDate": "2026",
-            "link": "https://learn.microsoft.com/en-us/credentials/certifications/github-copilot/",
-            "name": "GitHub Certified: Copilot"
-          },
-          "gh900": {
-            "code": "GH-900",
-            "coreSkills": "# GitHub Basics # Repositories # Collaboration # GitHub Products # Issues, Pull Requests & Workflows",
-            "description": "Validates foundational knowledge of GitHub — covering repositories, collaboration features, the GitHub product family, and core developer workflows.",
-            "issuer": "GitHub",
-            "issuerDate": "2026",
-            "link": "https://learn.microsoft.com/en-us/credentials/certifications/github-foundations/",
-            "name": "GitHub Certified: Foundations"
-          },
-          "sc900": {
-            "code": "SC-900",
-            "coreSkills": "# Security Concepts # Identity Principles # Microsoft Entra # Compliance Solutions # Privacy & Information Protection",
-            "description": "Validates foundational knowledge of security, compliance, and identity concepts, alongside related Microsoft cloud-based solutions covering Entra, Defender, and Purview.",
-            "issuer": "Microsoft",
-            "issuerDate": "2023",
-            "link": "https://learn.microsoft.com/en-us/credentials/certifications/security-compliance-and-identity-fundamentals/",
-            "name": "Microsoft Certified: Security, Compliance & Identity Fundamentals"
-          }
-        },
-        "coreSkillsLabel": "Core Skills Demonstrated:",
-        "subtitle": "Professional certifications and credentials that Alexandru has earned throughout his career.",
-        "title": "Certifications",
-        "viewCertification": "View certification"
-      },
-      "Competencies": {
-        "competences": {
-          "agileMethodologies": {
-            "description": "Alexandru has learned about agile working and agile methodologies since he was a student in his BSc degree. He follows the agile manifesto and is a big fan of the Kanban technique of planning.",
-            "title": "Agile Methodologies"
-          },
-          "algorithmicSkills": {
-            "description": "Alexandru has completed many Hacker Rank, Hacker Earth and Leet Code challenges published from 2019 until 2021. He has a strong algorithmic thinking and is able to construct complex algorithms with ease.",
-            "title": "Algorithmic Skills"
-          },
-          "customerCentric": {
-            "description": "Alexandru has been working with customers for many years, in his tenure at Microsoft. He has gained a lot of knowledge and is able to put himself in the shoes of the customer. He is able to understand the customer's needs and to deliver solutions that are exactly tailored to their needs.",
-            "title": "Customer Centric"
-          },
-          "domainDrivenDesign": {
-            "description": "Alexandru follows domain-driven design principles strongly. He is able to combine DDD with TDD to create complex solutions that are easy to maintain and extend. He is also a big fan of the \"onion architecture\" and \"clean architecture\" approaches.",
-            "title": "Domain-Driven Design (DDD)"
-          },
-          "engineeringExcellence": {
-            "description": "Alexandru is passionate about delivering the best solutions for the problem and for the customer. He is always striving to deliver the best software and to follow understood engineering excellence practices. A perfect solution is a solution that is easy to maintain, extend and understand, not the one that is the most complex.",
-            "title": "Engineering Excellence"
-          },
-          "testDrivenDevelopment": {
-            "description": "Alexandru is a firm believer of test-driven development. He constantly applies this approach to his projects and he is always trying to improve his testing skills. He is also a big fan of the \"red-green-refactor\" approach.",
-            "title": "Test-Driven Development (TDD)"
-          }
-        },
-        "subtitle": "A showcase of Alexandru's technical skills and professional competencies.",
-        "title": "Alexandru's Competences"
-      },
-      "Contact": {
-        "collaborate": {
-          "discipline1": "Software Engineering",
-          "discipline2": "Internet of Things",
-          "discipline3": "Cloud Native Applications",
-          "discipline4": "Network Engineering",
-          "footer": " If you have an interesting project or opportunity that aligns with Alexandru's expertise, don't hesitate to reach out. He's always eager to explore new challenges and collaborations.",
-          "subtitle": "Alexandru is open for collaboration in projects that involve any of the following fields:",
-          "title": "Let's collaborate!"
-        },
-        "footer": "Thank you.",
-        "socials": {
-          "footer": "To reach out to him, use one of the above contact methods.",
-          "subtitle": "Feel free to reach out for collaborations, questions, or just to say hello!",
-          "title": "Get in touch"
-        },
-        "subtitle": "If you would like to get in touch with Alexandru, please use the below ways of contact.",
-        "title": "Connect with Alexandru"
-      },
-      "Education": {
-        "subtitle": "Alexandru's academic background and learning journey.",
-        "title": "Education",
-        "university": {
-          "aseBucharest": {
-            "aboutTheProgram_cta": "See more details",
-            "aboutTheProgram_description": "The BSc in Computer Science at the University of Bucharest is a rigorous program that provides students with a strong foundation in theoretical computer science and practical software development. The curriculum emphasizes problem-solving skills, algorithmic thinking, and software engineering principles.",
-            "aboutTheProgram_learnings": "# Design and analyze algorithms and data structures # Develop software using various programming paradigms # Implement database systems and manage data # Understand computer networks and distributed systems # Apply software engineering principles to real-world problems",
-            "aboutTheProgram_learnings_title": "Key Learning Outcomes",
-            "aboutTheProgram_title": "About the program",
-            "degree": "BSc. Computer Science & Economy",
-            "description": "Bachelor's degree in Computer Science and Economy from the Bucharest University of Economic Studies in Bucharest, Romania. Finished in top 1% according to thesis rating statistics.",
-            "institution": "Academia de Studii Economice",
-            "keyCourses": "# Software Engineering # Computer Networks # Operating Systems # Algorithms & Data Structures # Database Management Systems # Web Development # Mobile Development",
-            "keyCourses_title": "Key courses",
-            "location": "Bucharest, Romania",
-            "period": "2019 - 2022",
-            "status": "Completed"
-          },
-          "malmoSweden": {
-            "aboutTheProgram_cta": "See more details",
-            "aboutTheProgram_description": "The MSc in Internet of Things at Malmö University is a cutting-edge program that prepares students for the challenges and opportunities of the IoT revolution. The curriculum emphasizes hands-on learning, interdisciplinary collaboration, and real-world applications.",
-            "aboutTheProgram_learnings": "# Design and implement IoT systems using various hardware and software platforms # Analyze and manage data generated by IoT devices # Apply machine learning and artificial intelligence techniques to IoT applications # Understand the security and privacy implications of IoT systems # Collaborate with industry partners on real-world projects",
-            "aboutTheProgram_learnings_title": "Key Learning Outcomes",
-            "aboutTheProgram_title": "About the program",
-            "degree": "MSc. Internet of Things",
-            "description": "Previously enrolled in the MSc. Internet of Things program at Malmö University, Sweden. Interrupted due to personal and unforeseen circumstances in 2024.",
-            "institution": "Malmö University",
-            "keyCourses": "# Internet of Things # Cloud Computing # Data Science # Machine Learning # Artificial Intelligence # Computer Vision # Robotics",
-            "keyCourses_title": "Key courses",
-            "location": "Malmö, Sweden",
-            "period": "2023 - 2024",
-            "status": "Interrupted"
-          }
-        }
-      },
-      "Experiences": {
-        "achievementsLabel": "Achievements",
-        "intel": {
-          "achievements": "# Developed color space converters (CSC) in C and Assembly x8086 (YUV->RGB, Grayscale).# Created 10+ types of image filters such as Fish Eye, Sobel, Edge Detection, Box Blur, etc.# Refactored .ASM code to better perform on IoT & Embedded Systems devices.",
-          "company": "Intel",
-          "description": "The Timisoara site addresses several focus areas where software for various hardware components, image processing algorithms, and low-level and high-level implementations of component parts of neural networks are actively being developed.",
-          "location": "Remote (Romania - Timisoara)",
-          "period": "2021 (6 Months)",
-          "responsibilites": "#Mastering skills in the world of image processing. #Gaining a grasp of the domain of Machine Learning (ML). #Practicing the achieved knowledge by developing different color space converters.",
-          "techAndSkills": "# C # C++ #Intel x8086 Assembly # Color Space Converters # Python # Embedded Compute # Internet of Things",
-          "title": "Embedded Engineer"
-        },
-        "microsoft1": {
-          "achievements": "# (Engineering Excellence) Constantly pushed myself to achieve the best customer feedback. (Current score: 4.94 / 5.00) # (Proactive interactions) Provided continuous feedback to the Product Group for the Azure Virtual Desktop (AVD) product, regarding the implementation of specific features and services. # (Customer Experience) Developed the existing documentation about the features of Azure Core services such as Azure Virtual Desktop, Azure Virtual Machines, Azure Networks. # Worked exclusively with TOP 100 & Fortune 500 clients and industry leading professionals.",
-          "company": "Microsoft",
-          "description": "With over 12,000 employees worldwide, the Microsoft Customer Experience & Success (CE&S) organization is responsible for the strategy, design, and implementation of the Microsoft end-to-end customer experience.",
-          "location": "Romania",
-          "period": "03/2021 – 03/2023",
-          "responsibilites": "# Provide knowledge sharing, technical coaching and mentoring to fellow colleagues; # Problem solving through deep troubleshooting, debugging, log analysis, A/B testing; # Identify and respond to business critical customer issues specific to Azure services such as Azure Virtual Desktop; # Work exclusively with Fortune 500 customers to understand their technical needs, and define an action plan to meet them, collaborating with peers or other teams regularly.",
-          "techAndSkills": "# Network Traffic Analysis # Azure # Customer-centric Approach # Business Relationships # Incident Manager",
-          "title": "Azure Technical Engineer"
-        },
-        "microsoft2": {
-          "achievements": "# (Observability-as-a-Service) Fully orchestrated and implemented the three pillars of observability in our microservices architecture using Open Telemetry standards; I've also built automated monitoring and alerting triggers based on p95/p99 statistics for real-time and synthetic traffic. # (Research & Development) Assisted with major contributions to the development of an in-house .NET library that implements the ODataV4 data consumption protocol for NoSQL database engines such as Azure Data Explorer (ADX), using Domain-Driven Design (DDD) practices (e.g. aggregator roots) (patent in progress). # (Development Experience) Took leadership of two key areas for DX: documentation & consumption layers. Built outstanding documentation and leveraged static site generator tools (DocFX) to automatically generate API documentation from code; offered API consumption layers in form of frontend UIs, CLI tooling and OpenAPI spec files. # (Growth) Shadowed and attended hiring interviews for SWE II and Senior SWE positions.",
-          "company": "Microsoft",
-          "description": "As governments today look at technology innovation, there is a need to address the rapidly evolving demands of their citizens while protecting the most sensitive data and delivering on promises of trust and security.",
-          "location": "EMEA",
-          "period": "03/2023 – 12/2024",
-          "responsibilites": "# Deliver one E+C Data Platform that is capable of running cross-clouds and cross-tenant in sovereign environments and air-gapped scenarios. # Manage and assure the wellbeing of the Runtime in Sovereign Environments (RISE) Data Platform operations. # Build a novel data mesh enterprise architecture using data engineering concepts, tools like Azure Data Factory and other data warehouse notions.",
-          "techAndSkills": "# .NET # Azure # Microservices # Cloud-Native Applications # Agile Methodologies # DevOps # Domain-Driven Design # Test-Driven Development # Project Management",
-          "title": "E + D Sovereign Clouds Software Engineer II"
-        },
-        "microsoft3": {
-          "achievements": " ",
-          "company": "Microsoft",
-          "description": "Alexandru is currently working at Microsoft as a software engineer in the E+D MSAI (M365 AI Experiences) organization.",
-          "location": "Remote (Norway)",
-          "period": "11/2024 - Present",
-          "responsibilites": " ",
-          "techAndSkills": "# React # GraphQL # Large-Scale Development # Cloud-Native Applications # Agile Methodologies # Engineering Excellence # Leadership",
-          "title": "E + D M365 AI Fullstack Software Engineer II"
-        },
-        "responsibilitiesLabel": "Responsibilities",
-        "subtitle": "A journey through Alexandru's professional career and the companies he's worked with.",
-        "techSkillsLabel": "Technologies & Skills",
-        "title": "Professional Experience",
-        "ubisoft": {
-          "achievements": "#  I've consistently over-exceeded the quota of reported bugs, glitches and artefacts, ranking as the #1 reporter for a solid 5 months out of the 6 worked. #  Found and reported major code defects that ranged from race conditions to memory resource allocation defects. #  Increased the daily report efficiency by leveraging SQL and JQL filtering capabilities.",
-          "company": "Ubisoft",
-          "description": "I've worked on the Avatar: Frontiers of Pandora™ first person, action-adventure game built using the latest iteration of the Snowdrop engine (C++) by Massive Entertainment - a UBISOFT studio, and tested by UBISOFT Romania.",
-          "location": "Hybrid (Bucharest, Romania)",
-          "period": "2020 - 2021",
-          "responsibilites": "# Managed regression, integration and unit testing with software such as XRAY, TestRail, Bugzilla. # Create high quality test suites and test plans using Atlassian (JIRA / Confluence) products. # Assure communications are stable and clear between production and testing teams.",
-          "techAndSkills": "# Unit Testing # Integration Testing # A/B Testing # Performance Testing # Automatic Testing # E2E Testing",
-          "title": "QA/QC Engineer"
-        }
-      },
-      "metadata": {
-        "description": "Learn more about the author, Alexandru-Razvan Olariu.",
-        "title": "Alexandru-Razvan Olariu"
-      },
-      "Perspectives": {
-        "perspectiveFromX": {
-          "author": "Anonymous",
-          "avatar": " ",
-          "company": "Microsoft",
-          "position": "Senior Software Engineer",
-          "quote": "The thing that I appreciate a lot about you is your relentless pursuit of improvement and your willingness to challenge the status quo. Your commitment to continuous self-development is evident in the way you approach every task with a mindset geared towards innovation and excellence. Your ability to question existing methods and propose better alternatives has been instrumental in driving our projects forward. This proactive attitude not only enhances the quality of our work but also inspires the team to strive for higher standards. I am happy to have worked with you and hope our paths will cross again in the future."
-        },
-        "perspectiveFromXX": {
-          "author": "Anonymous",
-          "avatar": " ",
-          "company": "Microsoft",
-          "position": "Senior Software Engineering Manager",
-          "quote": "Alex is an intelligent engineer whose capabilities shone brightly during our collaboration on our projects. He consistently demonstrates eagerness to assist the team with any request, showcasing his dedication to collective success. His proactive approach to problem-solving and dedication to system stability greatly benefit our team's workflow. Additionally, Alex's availability and willingness to support others during our release flow highlight his value as a colleague who prioritizes teamwork and collaboration."
-        },
-        "perspectiveFromXY": {
-          "author": "Anonymous",
-          "avatar": " ",
-          "company": "Microsoft",
-          "position": "Senior Escalation Engineer",
-          "quote": "Alex, if I am to choose one thing, I value the most about working with you, it has to be your mindset - as it includes multiple aspects. Working with you is genuine, funny, wise and relevant at the same time. It is easy to notice that your daily drivers are commitment, reasoning and continuous learning. I admire your approach, your genuine desire to help, to build on the success of others and to support everyone in their growth which is such a rare value. On top of that I value your patience, as well as the great amount of knowledge you bring into our interactions. The way you manage stressful situations and your overall approach have the power to shape a positive outcome for any matter or topic."
-        },
-        "perspectiveFromXZ": {
-          "author": "Anonymous",
-          "avatar": " ",
-          "company": "Microsoft",
-          "position": "Senior Software Engineer",
-          "quote": "I've been consistently impressed with your work output. You always deliver high-quality work, paying close attention to details and ensuring that everything is done to the best of your abilities, Additionally, you have a deep understanding of the technical aspects of our work, which has been a valuable asset for the team. Your willingness to share your knowledge and experience with others has been invaluable and it's clear that you take pride in mentoring others and helping them grow."
-        },
-        "perspectiveFromY": {
-          "author": "Anonymous",
-          "avatar": " ",
-          "company": "Microsoft",
-          "position": "Software Engineer II",
-          "quote": "I really appreciate your proactive approach and collaborative spirit, and your support and friendly communication style have been very positive to my onboarding experience and to learning the ins and outs of our project. Your ability to communicate effectively and keep everyone in the loop is something I'm looking up to, you are experienced with dealing with cross-functional teams, especially with our partner teams, with learning their needs and solving their problems. Your technical skills are impressive and your attention to detail is commendable."
-        },
-        "perspectiveFromYX": {
-          "author": "Anonymous",
-          "avatar": " ",
-          "company": "Microsoft",
-          "position": "Senior Product Manager",
-          "quote": "Alexandru's depth of character is evident in his passion and commitment towards helping others succeed and nowhere is that clearer that in his mentorship of. I hold Alexandru in high regard - I may have a few years on him, but he should not hesitate to challenge me if he believes there's a better way to approach a problem."
-        },
-        "perspectiveFromYY": {
-          "author": "Anonymous",
-          "avatar": " ",
-          "company": "Microsoft",
-          "position": "Staff Software Engineer",
-          "quote": "I love your attitude and open mindset, I find it easy to work and talk with you. I don't have much for you to leverage these strength further: keep being yourself and you are already doing great work!"
-        },
-        "perspectiveFromYZ": {
-          "author": "Anonymous",
-          "avatar": " ",
-          "company": "Microsoft",
-          "position": "Staff Software Engineer",
-          "quote": "Alexandru is a great software engineer. He's incredibly sharp and I would rate him in the top 1% for his age - at 25 most people struggle to find a job, while Alexandru is delivering impact that translates into millions of dollars. He's extremely talented."
-        },
-        "perspectiveFromZ": {
-          "author": "Anonymous",
-          "avatar": " ",
-          "company": "Microsoft",
-          "position": "Senior Software Engineer",
-          "quote": "You always step up to help, sharing your time generously, even when you have your own pressing tasks. Your quick and helpful replies to any questions are greatly appreciated. You take a prioritized and meticulous approach, providing instant solutions that not only unblock us in the short term but also outline long-term fixes and their implementation timelines. Your solution-oriented mindset is a true asset for our team. Your expertise, willingness to assist, and pleasant personality make you a great colleague. Keep up the great work!"
-        },
-        "subtitle": "Perspectives from colleagues who have worked with or alongside Alexandru.",
-        "title": "Perspectives"
-      },
-      "subtitle": "Alexandru-Razvan Olariu is the author of the platform that you are currently browsing.",
-      "title": "Meet the author."
-    },
-    "cards": {
-      "author": {
-        "cta": "Learn more about the author...",
-        "subtitle": "arolariu is the alias/nickname of the author: Alexandru-Razvan Olariu. Alexandru is a well-tenured software engineer, solution architect and lifelong learner. To learn more about Alexandru, click the button below.",
-        "title": "Who is arolariu?"
-      },
-      "platform": {
-        "cta": "Learn more about the platform...",
-        "subtitle": "The arolariu.ro platform is a collection of applications that are hosted under the arolariu.ro domain. The platform was built with the purpose of providing a unified experience for all of the applications and OSS projects that the author (Alexandru-Razvan Olariu) is working on. To learn more about the technologies that are used in the process and how they interact with each other, click the button below.",
-        "title": "What is arolariu.ro?"
-      }
-    },
-    "footer": "Thank you!",
-    "Hub": {
-      "cta": {
-        "footer": "Built with passion in Romania",
-        "primary": "View on GitHub",
-        "secondary": "Get in Touch",
-        "subtitle": "Start your journey through the platform or connect with the author.",
-        "title": "Ready to Explore?"
-      },
-      "faq": {
-        "questions": {
-          "q1": {
-            "answer": "arolariu.ro is a comprehensive full-stack platform that serves as both a personal portfolio and a technology showcase. It demonstrates modern web development practices using Next.js, .NET, and Azure cloud services.",
-            "question": "What is arolariu.ro?"
-          },
-          "q2": {
-            "answer": "Yes! The entire platform is open source and available on GitHub. You can explore the codebase, learn from it, or even contribute to its development.",
-            "question": "Is this platform open source?"
-          },
-          "q3": {
-            "answer": "The platform uses Next.js 16 with React 19 for the frontend, .NET 10 with ASP.NET Core for the backend, and Azure for cloud infrastructure. It also features a comprehensive component library and extensive testing.",
-            "question": "What technologies are used?"
-          },
-          "q4": {
-            "answer": "Absolutely! The platform is designed to showcase best practices in software engineering. Feel free to use it as a reference for architecture, patterns, and implementation details.",
-            "question": "Can I use this as a reference for my own projects?"
-          }
-        },
-        "subtitle": "Common questions about the platform and its purpose",
-        "title": "Frequently Asked Questions"
-      },
-      "hero": {
-        "badge": "About Us",
-        "ctaPrimary": "Explore the Platform",
-        "ctaSecondary": "Meet the Author",
-        "subtitle": "A modern full-stack platform built with passion, designed for innovation, and crafted with attention to detail.",
-        "title": "Discover arolariu.ro"
-      },
-      "mission": {
-        "description": "arolariu.ro is more than just a website - it's a playground for modern technologies, a showcase of best practices, and a platform that demonstrates what's possible when engineering excellence meets creative vision.",
-        "pillars": {
-          "innovation": {
-            "description": "Embracing cutting-edge technologies and architectural patterns",
-            "title": "Innovation"
-          },
-          "openness": {
-            "description": "Open source, transparent, and community-driven",
-            "title": "Openness"
-          },
-          "quality": {
-            "description": "Maintaining high standards with 90%+ test coverage",
-            "title": "Quality"
-          }
-        },
-        "statement": "To build software that makes a difference.",
-        "title": "Our Mission"
-      },
-      "navigation": {
-        "author": {
-          "cta": "Meet Alexandru",
-          "features": {
-            "0": "Microsoft Engineer",
-            "1": "Solution Architect",
-            "2": "Tech Enthusiast"
-          },
-          "subtitle": "Meet Alexandru-Razvan Olariu, the software engineer behind this platform.",
-          "title": "The Author"
-        },
-        "platform": {
-          "cta": "Explore Platform",
-          "features": {
-            "0": "Next.js 16 Frontend",
-            "1": ".NET 10 Backend",
-            "2": "Azure Cloud Infrastructure"
-          },
-          "subtitle": "Discover the architecture, technology stack, and features that power arolariu.ro.",
-          "title": "The Platform"
-        },
-        "subtitle": "Dive deeper into what makes arolariu.ro unique",
-        "title": "Explore Further"
-      },
-      "stats": {
-        "items": {
-          "linesOfCode": {
-            "description": "Across frontend and backend",
-            "label": "Lines of Code",
-            "value": "50K+"
-          },
-          "technologies": {
-            "description": "Modern tech stack",
-            "label": "Technologies",
-            "value": "25+"
-          },
-          "testCoverage": {
-            "description": "Quality assurance standard",
-            "label": "Test Coverage",
-            "value": "90%"
-          },
-          "yearsActive": {
-            "description": "Continuously evolving since 2022",
-            "label": "Years Active",
-            "value": "3+"
-          }
-        },
-        "subtitle": "Key metrics that showcase our commitment to quality",
-        "title": "By the Numbers"
-      },
-      "values": {
-        "items": {
-          "accessibility": {
-            "description": "Built for everyone with keyboard navigation and screen reader support.",
-            "title": "Accessible Design"
-          },
-          "community": {
-            "description": "Open source at heart, contributing back to the developer community.",
-            "title": "Community First"
-          },
-          "engineering": {
-            "description": "Every feature is built with clean architecture, proper testing, and maintainability in mind.",
-            "title": "Engineering Excellence"
-          },
-          "learning": {
-            "description": "This platform serves as a testing ground for new technologies and approaches.",
-            "title": "Continuous Learning"
-          },
-          "performance": {
-            "description": "Optimized for speed with server-side rendering and edge deployments.",
-            "title": "Performance Driven"
-          },
-          "privacy": {
-            "description": "User data protection and privacy are fundamental, not afterthoughts.",
-            "title": "Privacy Focused"
-          }
-        },
-        "subtitle": "The principles that guide every line of code",
-        "title": "Core Values"
-      }
-    },
-    "metadata": {
-      "description": "Learn more about the author and the platform.",
-      "title": "About Us"
-    },
-    "Platform": {
-      "architecture": {
-        "badge": "Technical Architecture",
-        "description": "A modern cloud-native architecture following domain-driven design principles, The Standard methodology, and industry best practices.",
-        "layers": {
-          "ai": {
-            "description": "Intelligent document processing and natural language understanding",
-            "name": "AI Services",
-            "technologies": "Azure OpenAI,Document Intelligence,Computer Vision"
-          },
-          "api": {
-            "description": "RESTful APIs with OpenAPI documentation and rate limiting",
-            "name": "API Gateway",
-            "technologies": ".NET 10,Minimal APIs,OpenAPI,GraphQL"
-          },
-          "auth": {
-            "description": "Enterprise-grade authentication with multiple providers",
-            "name": "Identity & Security",
-            "technologies": "Azure AD B2C,OAuth 2.0,OIDC,MFA"
-          },
-          "cdn": {
-            "description": "Global content delivery with edge caching and optimization",
-            "name": "Edge & CDN",
-            "technologies": "Azure CDN,Vercel Edge,Static Assets"
-          },
-          "client": {
-            "description": "Modern React-based frontends with SSR and SSG capabilities",
-            "name": "Client Layer",
-            "technologies": "Next.js 16,React 19,TypeScript,SCSS Modules"
-          },
-          "data": {
-            "description": "Multi-model database strategy for optimal performance",
-            "name": "Data Layer",
-            "technologies": "CosmosDB,Azure SQL,Redis Cache,Blob Storage"
-          },
-          "infra": {
-            "description": "Fully managed Azure infrastructure with IaC deployment",
-            "name": "Cloud Infrastructure",
-            "technologies": "Azure,Bicep IaC,Container Apps,Key Vault"
-          },
-          "services": {
-            "description": "Domain-driven design with bounded contexts and clean architecture",
-            "name": "Microservices",
-            "technologies": "DDD,CQRS,Event Sourcing,The Standard"
-          }
-        },
-        "principles": {
-          "appRouter": {
-            "description": "File-based routing with layouts, loading states, and error boundaries",
-            "title": "App Router Architecture"
-          },
-          "cloudNative": {
-            "description": "Containerized microservices with auto-scaling and self-healing capabilities",
-            "title": "Cloud Native Design"
-          },
-          "rsc": {
-            "description": "Leveraging RSC for optimal performance with server-side rendering and streaming",
-            "title": "React Server Components"
-          }
-        },
-        "title": "Built for",
-        "titleHighlight": "scale and reliability"
-      },
-      "callToAction": {
-        "cta": {
-          "createAccount": "Create Account",
-          "exploreApplications": "Explore Applications"
-        },
-        "description": "Explore the platform, try out the features, and join the community. Whether you're here to manage invoices, discover recipes, or just explore, there's something for everyone.",
-        "footer": "Built with passion by",
-        "footerRole": ", a software engineer at Microsoft.",
-        "links": {
-          "getInTouch": "Get in Touch",
-          "meetAuthor": "Meet the Author",
-          "viewSource": "View Source Code"
-        },
-        "title": "Ready to",
-        "titleHighlight": "get started",
-        "trust": {
-          "freeToUse": {
-            "description": "No hidden fees or subscriptions",
-            "title": "Free to Use"
-          },
-          "openSource": {
-            "description": "100% open source with MIT license",
-            "title": "Open Source"
-          },
-          "privacyFirst": {
-            "description": "Your data stays yours, always",
-            "title": "Privacy First"
-          }
-        }
-      },
-      "features": {
-        "badge": "Platform Features",
-        "description": "A comprehensive suite of tools designed for modern personal finance management, recipe organization, and more. Built with cutting-edge technologies and a focus on user experience.",
-        "items": {
-          "ai": {
-            "description": "Intelligent automation at your fingertips",
-            "longDescription": "Powered by Azure OpenAI, our AI assistant helps with document understanding, data extraction, smart categorization, and natural language queries about your data.",
-            "tags": "GPT-4,Azure AI,NLP",
-            "title": "AI Assistant"
-          },
-          "analytics": {
-            "description": "Deep insights into your spending",
-            "longDescription": "Comprehensive analytics dashboard with spending trends, category breakdowns, monthly comparisons, and predictive insights powered by machine learning algorithms.",
-            "tags": "Charts,Trends,Reports",
-            "title": "Expense Analytics"
-          },
-          "auth": {
-            "description": "Flexible and secure sign-in options",
-            "longDescription": "Sign in with Microsoft, Google, GitHub, or email. Azure AD B2C provides enterprise-grade identity management with MFA support and seamless SSO experience.",
-            "tags": "OAuth,MFA,SSO",
-            "title": "Secure Authentication"
-          },
-          "budgets": {
-            "description": "Smart budget tracking and alerts",
-            "longDescription": "Set budgets by category and receive intelligent alerts when approaching limits. Visualize your spending with interactive charts and identify areas for optimization.",
-            "tags": "Budgets,Alerts,Planning",
-            "title": "Budget Management"
-          },
-          "i18n": {
-            "description": "Fully internationalized experience",
-            "longDescription": "The platform supports multiple languages with full RTL support. Currently available in English and Romanian, with more languages planned for future releases.",
-            "tags": "i18n,English,Romanian",
-            "title": "Multi-Language"
-          },
-          "invoices": {
-            "description": "AI-powered invoice analysis and management",
-            "longDescription": "Upload receipt photos and let AI extract merchant details, items, prices, and more. Automatic categorization, expense tracking, and detailed analytics help you understand your spending patterns.",
-            "tags": "AI,OCR,Analytics",
-            "title": "Invoice Processing"
-          },
-          "merchants": {
-            "description": "Automatic merchant detection and insights",
-            "longDescription": "Our AI identifies merchants from receipt data, building a comprehensive database of your shopping patterns. Get insights into where you shop, spending trends, and merchant comparisons.",
-            "tags": "ML,Insights,Tracking",
-            "title": "Merchant Intelligence"
-          },
-          "recipes": {
-            "description": "Organize and discover culinary creations",
-            "longDescription": "Store your favorite recipes, discover new ones, and plan meals efficiently. AI-powered suggestions based on ingredients, dietary preferences, and past cooking history.",
-            "tags": "Cooking,Meal Planning,AI",
-            "title": "Recipe Management"
-          },
-          "security": {
-            "description": "Bank-grade security for your data",
-            "longDescription": "Your data is protected with enterprise-grade encryption, secure authentication via Azure AD B2C, and compliance with GDPR. We never sell or share your personal information.",
-            "tags": "Encryption,GDPR,SSO",
-            "title": "Enterprise Security"
-          }
-        },
-        "modal": {
-          "close": "Close",
-          "exploreFeature": "Explore Feature"
-        },
-        "title": "Everything you need,",
-        "titleHighlight": "beautifully crafted"
-      },
-      "hero": {
-        "cta": {
-          "exploreFeatures": "Explore Features",
-          "viewSource": "View Source"
-        },
-        "description": "A comprehensive full-stack platform combining Next.js, .NET, and Azure cloud services. Built with enterprise-grade architecture, domain-driven design, and a focus on developer experience.",
-        "scrollIndicator": "Scroll to explore",
-        "stats": {
-          "countries": "Countries",
-          "linesOfCode": "Lines of Code",
-          "projects": "Projects",
-          "techStack": "Tech Stack"
-        },
-        "statusBadge": "Open Source Technology Platform",
-        "subtitle": "Modern • Scalable • Open Source",
-        "title": "Welcome to",
-        "trust": {
-          "freeForever": "Free Forever",
-          "openSource": "Open Source",
-          "privacyFirst": "Privacy First"
-        }
-      },
-      "metadata": {
-        "description": "Learn more about the platform, arolariu.ro.",
-        "title": "The platform"
-      },
-      "statistics": {
-        "badge": "Platform Statistics",
-        "description": "A glimpse into the scale and impact of the arolariu.ro platform, from lines of code to global reach.",
-        "items": {
-          "apis": {
-            "description": "Microservices",
-            "label": "APIs",
-            "suffix": "+",
-            "value": "8"
-          },
-          "commits": {
-            "description": "Code contributions",
-            "label": "Commits",
-            "suffix": "+",
-            "value": "2500"
-          },
-          "contributors": {
-            "description": "Open source",
-            "label": "Contributors",
-            "suffix": "+",
-            "value": "5"
-          },
-          "countries": {
-            "description": "Global reach",
-            "label": "Countries",
-            "suffix": "+",
-            "value": "25"
-          },
-          "linesOfCode": {
-            "description": "Across all projects",
-            "label": "Lines of Code",
-            "suffix": "K+",
-            "value": "150"
-          },
-          "projects": {
-            "description": "Active repositories",
-            "label": "Projects",
-            "suffix": "+",
-            "value": "15"
-          },
-          "stars": {
-            "description": "GitHub stars",
-            "label": "Stars",
-            "suffix": "+",
-            "value": "50"
-          },
-          "users": {
-            "description": "Active monthly",
-            "label": "Users",
-            "suffix": "+",
-            "value": "1000"
-          }
-        },
-        "title": "Numbers that",
-        "titleHighlight": "speak for themselves"
-      },
-      "techStack": {
-        "badge": "Technology Stack",
-        "categories": {
-          "backend": {
-            "description": "Scalable server-side technologies and APIs",
-            "name": "Backend"
-          },
-          "cloud": {
-            "description": "Infrastructure and deployment automation",
-            "name": "Cloud & DevOps"
-          },
-          "frontend": {
-            "description": "Modern web technologies for blazing-fast user experiences",
-            "name": "Frontend"
-          },
-          "tooling": {
-            "description": "Tools and frameworks for development excellence",
-            "name": "Developer Tools"
-          }
-        },
-        "description": "A carefully curated technology stack chosen for performance, developer experience, and long-term maintainability.",
-        "stats": {
-          "coverage": {
-            "description": "Unit & E2E tests",
-            "label": "Test Coverage",
-            "value": "90%+"
-          },
-          "security": {
-            "description": "Best practices",
-            "label": "Security Grade",
-            "value": "A+"
-          },
-          "technologies": {
-            "description": "In our stack",
-            "label": "Technologies",
-            "value": "24+"
-          },
-          "typescript": {
-            "description": "Full type safety",
-            "label": "TypeScript",
-            "value": "100%"
-          }
-        },
-        "technologies": {
-          "aspnet": {
-            "description": "High-performance web APIs",
-            "name": "ASP.NET Core"
-          },
-          "azure": {
-            "description": "Primary cloud provider",
-            "name": "Azure"
-          },
-          "azureDevops": {
-            "description": "Project management & pipelines",
-            "name": "Azure DevOps"
-          },
-          "azuresql": {
-            "description": "Managed relational database",
-            "name": "Azure SQL"
-          },
-          "bicep": {
-            "description": "Infrastructure as Code",
-            "name": "Bicep"
-          },
-          "cosmosdb": {
-            "description": "Globally distributed NoSQL database",
-            "name": "CosmosDB"
-          },
-          "docker": {
-            "description": "Containerization platform",
-            "name": "Docker"
-          },
-          "dotnet": {
-            "description": "Primary backend framework",
-            "name": ".NET"
-          },
-          "eslint": {
-            "description": "JavaScript linting with 20+ plugins",
-            "name": "ESLint"
-          },
-          "git": {
-            "description": "Version control system",
-            "name": "Git"
-          },
-          "githubActions": {
-            "description": "CI/CD automation",
-            "name": "GitHub Actions"
-          },
-          "motion": {
-            "description": "Production-ready animations",
-            "name": "Motion"
-          },
-          "nextjs": {
-            "description": "Full-stack React framework with SSR/SSG",
-            "name": "Next.js"
-          },
-          "nodejs": {
-            "description": "BFF and serverless functions",
-            "name": "Node.js"
-          },
-          "playwright": {
-            "description": "E2E testing framework",
-            "name": "Playwright"
-          },
-          "pnpm": {
-            "description": "Package management",
-            "name": "pnpm/npm"
-          },
-          "prettier": {
-            "description": "Code formatting",
-            "name": "Prettier"
-          },
-          "react": {
-            "description": "UI library for building interactive interfaces",
-            "name": "React"
-          },
-          "redis": {
-            "description": "In-memory cache for performance",
-            "name": "Redis"
-          },
-          "scss": {
-            "description": "Component-scoped stylesheets with CSS Modules",
-            "name": "SCSS Modules"
-          },
-          "typescript": {
-            "description": "Type-safe JavaScript for robust code",
-            "name": "TypeScript"
-          },
-          "vercel": {
-            "description": "Frontend deployment platform",
-            "name": "Vercel"
-          },
-          "vitest": {
-            "description": "Unit testing framework",
-            "name": "Vitest"
-          },
-          "zustand": {
-            "description": "Lightweight state management",
-            "name": "Zustand"
-          }
-        },
-        "title": "Powered by",
-        "titleHighlight": "modern technologies"
-      },
-      "timeline": {
-        "badge": "Development Journey",
-        "collapseHint": "Click to collapse",
-        "description": "The journey of arolariu.ro from a simple idea to a full-featured platform, with key milestones along the way.",
-        "events": {
-          "ai": {
-            "date": "June 2024",
-            "description": "Deep integration with Azure OpenAI for intelligent document processing and natural language queries.",
-            "details": "Azure OpenAI GPT-4 integration,Natural language invoice queries,Smart categorization algorithms,Predictive analytics features",
-            "tags": "GPT-4,Azure AI,NLP",
-            "title": "AI Integration"
-          },
-          "backend": {
-            "date": "September 2022",
-            "description": "Complete backend overhaul with .NET and cloud-native architecture implementation.",
-            "details": ".NET 6 API development,Azure cloud infrastructure setup,Database design with CosmosDB,CI/CD pipeline implementation",
-            "tags": ".NET,Azure,API",
-            "title": "Backend Infrastructure"
-          },
-          "expansion": {
-            "date": "January 2023",
-            "description": "Major feature additions including invoice processing and AI-powered analysis capabilities.",
-            "details": "Invoice upload and OCR integration,Azure Document Intelligence integration,Merchant detection algorithms,Budget tracking features",
-            "tags": "AI,OCR,Invoices",
-            "title": "Platform Expansion"
-          },
-          "inception": {
-            "date": "March 2022",
-            "description": "The arolariu.ro platform was conceived as a personal learning project to explore modern web development.",
-            "details": "Initial concept and planning phase,Research into modern web technologies,First repository created on GitHub,Basic HTML/CSS prototype developed",
-            "tags": "Planning,Research",
-            "title": "Project Inception"
-          },
-          "launch": {
-            "date": "June 2023",
-            "description": "Official public launch with a complete set of features and production-ready infrastructure.",
-            "details": "Production deployment to Azure,Custom domain configuration,SSL/TLS security implementation,Performance optimization",
-            "tags": "Launch,Production",
-            "title": "Public Launch"
-          },
-          "nextjs": {
-            "date": "December 2023",
-            "description": "Complete frontend rewrite to Next.js App Router with React Server Components.",
-            "details": "Migration to Next.js 14+,React Server Components adoption,Improved SEO with static generation,Enhanced performance metrics",
-            "tags": "Next.js,RSC,Migration",
-            "title": "Next.js Migration"
-          },
-          "present": {
-            "date": "Present",
-            "description": "Ongoing development with new features, optimizations, and community contributions.",
-            "details": "Regular feature updates,Performance improvements,Community feedback integration,Future roadmap planning",
-            "tags": "Active,Growing",
-            "title": "Continuous Evolution"
-          },
-          "prototype": {
-            "date": "June 2022",
-            "description": "The first working prototype of the platform was developed using React and basic backend services.",
-            "details": "React frontend implementation,Basic authentication flow,Initial UI/UX design,Local development environment setup",
-            "tags": "React,Frontend",
-            "title": "First Prototype"
-          }
-        },
-        "expandHint": "Click to expand",
-        "futureIndicator": "The journey continues...",
-        "keyAchievements": "Key Achievements:",
-        "title": "From idea to",
-        "titleHighlight": "reality"
-      }
-    },
-    "subtitle": " The arolariu.ro story began in 2022, when the author - Alexandru-Razvan Olariu, wanted to understand how websites work. The whole platform and underlying integrations have been developed solely by the author, from what he has learnt along the years. Alexandru currently works as a software engineer at Microsoft. To learn more about him, check the right section of this page. The platform is built using the latest state-of-the-art technologies. To learn more about it, check the left section of this page.",
-    "title": "About Us"
-  },
-  "Acknowledgements": {
-    "contributors": {
       "items": {
-        "c1": {
-          "description": "Observability instrumentation",
-          "name": "OpenTelemetry Authors",
-          "packages": "12"
+        "dark": "Dark",
+        "disco": "Disco Mode",
+        "english": "English",
+        "fontDyslexic": "Dyslexic-Friendly Font",
+        "fontNormal": "Standard Font",
+        "french": "Français",
+        "github": "GitHub",
+        "homepage": "Homepage",
+        "light": "Light",
+        "matrix": "Matrix Mode",
+        "rainbow": "Rainbow Mode",
+        "romanian": "Română",
+        "system": "System"
+      },
+      "noResults": "No results found.",
+      "placeholder": "Type a command or search..."
+    },
+    "errors": {
+      "globalError": {
+        "actions": {
+          "step1": "Try refreshing the page using the button below.",
+          "step2": "Go back to the home page and start over.",
+          "step3": "Contact support if the problem persists.",
+          "whatCanYouDoTitle": "What can you do?"
         },
-        "c2": {
-          "description": "Azure SDKs and tooling",
-          "name": "Microsoft Corporation",
-          "packages": "5"
+        "buttons": {
+          "copied": "Copied!",
+          "copyErrorId": "Copy error ID",
+          "copyErrorIdTitle": "Copy error ID",
+          "returnHome": "Return to home",
+          "tryAgain": "Try again"
         },
-        "c3": {
-          "description": "Authentication solutions",
-          "name": "Clerk",
-          "packages": "2"
+        "copyErrorConsoleMessage": "Failed to copy error ID:",
+        "details": {
+          "errorIdLabel": "Error ID:",
+          "genericDescription": "An error occurred while processing your request.",
+          "title": "Error details",
+          "unknownError": "An unknown error occurred.",
+          "whatHappenedTitle": "What happened?"
         },
-        "c4": {
-          "description": "Testing utilities",
-          "name": "Kent C. Dodds",
-          "packages": "3"
+        "diagnostics": {
+          "loading": "Loading diagnostic information...",
+          "scanLabel": "Scan for diagnostic information:",
+          "stackTraceLabel": "Stack trace:",
+          "technicalSummary": "Technical information (for developers)"
+        },
+        "hero": {
+          "subtitle": "An unexpected error occurred. Our team has been automatically notified.",
+          "title": "Something went wrong"
+        },
+        "metadata": {
+          "title": "Application Error - AROLARIU.RO"
+        },
+        "support": {
+          "contactPrefix": "If this problem continues, please contact us at",
+          "includeErrorId": "and include the error ID:"
         }
       },
-      "packages": "{count, plural, one {# package} other {# packages}}",
-      "subtitle": "Organizations and individuals whose packages we rely on most",
-      "title": "Top Contributors"
-    },
-    "hero": {
-      "badge": "Open Source",
-      "lastUpdate": "Last updated: {date}",
-      "subtitle": "This platform is built on the shoulders of incredible open-source projects. We're grateful to the maintainers and contributors who make their work freely available.",
-      "title": "Acknowledgements"
-    },
-    "lastUpdate": "Last updated on: {date}",
-    "licenses": {
-      "apache": "Apache 2.0",
-      "apacheDescription": "Enterprise-friendly open-source license",
-      "gpl": "GPL License",
-      "gplDescription": "Copyleft license ensuring code remains free",
-      "mit": "MIT License",
-      "mitDescription": "Permissive license allowing broad use",
-      "other": "Other Licenses",
-      "otherDescription": "Custom or miscellaneous open-source licenses",
-      "packages": "{count, plural, one {# package} other {# packages}}",
-      "title": "License Distribution"
-    },
-    "metadata": {
-      "description": "Acknowledgements page for the third-party packages used in this project and collaborators.",
-      "title": "Acknowledgements"
-    },
-    "packages": {
-      "subtitle": "This website could not have been possible without the following third-party packages. I would like to thank the authors of these packages for their hard work and dedication to the open-source community.",
-      "title": "Third-party packages"
-    },
-    "packagesScreen": {
-      "badge": {
-        "development": "Development",
-        "production": "Production"
-      },
-      "card": {
-        "dependencies": "Dependencies:",
-        "license": "License:",
-        "viewDependencies": "View Dependencies",
-        "website": "Website"
-      },
-      "dialog": {
-        "dependencies": "{name} Dependencies",
-        "dependenciesCount": "This package has {count} dependencies."
-      },
-      "emptyState": {
-        "subtitle": "Try adjusting the filters above.",
-        "title": "No packages found."
-      },
-      "filters": {
-        "allPackages": "All Packages",
-        "ascending": "Ascending",
-        "dependenciesCount": "Dependencies Count",
-        "descending": "Descending",
-        "developmentOnly": "Development Only",
-        "filterByType": "Filter by type",
-        "name": "Name",
-        "packageType": "Package Type",
-        "productionOnly": "Production Only",
-        "sortBy": "Sort by",
-        "sortDirection": "Sort direction"
-      },
-      "openSource": {
-        "description": "This project stands on the shoulders of giants. We're grateful for the open-source community and all the developers who have contributed to these packages.",
-        "title": "Open Source Matters"
-      },
-      "search": {
-        "placeholder": "Search..."
-      },
-      "table": {
-        "dependencies": "Dependencies",
-        "description": "Description",
-        "license": "License",
-        "package": "Package",
-        "type": "Type",
-        "version": "Version",
-        "website": "Website"
-      },
-      "views": {
-        "gridView": "Grid View",
-        "tableView": "Table View"
-      }
-    },
-    "stats": {
-      "development": {
-        "description": "Build-time tools",
-        "label": "Development",
-        "value": "{count}"
-      },
-      "mitLicense": {
-        "description": "Most common license",
-        "label": "MIT Licensed",
-        "value": "{count}"
-      },
-      "production": {
-        "description": "Runtime dependencies",
-        "label": "Production",
-        "value": "{count}"
-      },
-      "subtitle": "A snapshot of the open-source ecosystem powering this platform",
-      "title": "Dependency Overview",
-      "total": {
-        "description": "Dependencies used",
-        "label": "Total Packages",
-        "value": "{count}"
-      }
-    },
-    "title": "Acknowledgements"
-  },
-  "Auth": {
-    "Button": {
-      "login": "Login",
-      "logout": "Logout"
-    },
-    "Island": {
-      "callToAction": "Perform auth",
-      "description": "Sign in using our secure OAuth 2.0 auth server. Your profile will be kept in sync during this browser session. You can use your social media accounts to sign in.",
-      "footer": "You can switch providers at any time. Authentication is handled by our trusted identity provider.",
-      "hero": {
-        "badge": "Secure Authentication",
-        "subtitle": "Pick a path and continue with your preferred provider. Everything stays fast, secure, and localized.",
-        "title": "Welcome to the secure entry point"
-      },
-      "signIn": {
-        "bullets": {
-          "first": "Continue with the identity provider you already use.",
-          "second": "Resume where you left off on any device.",
-          "third": "Session stays in sync while you browse."
+      "notFound": {
+        "additionalInfo": "Additional Information:",
+        "buttons": {
+          "returnButton": "Go back to the home page.",
+          "submitErrorButton": "Submit false error."
         },
-        "cta": "Sign in",
-        "description": "Access your account and keep your session synchronized during this browser session.",
-        "illustrationAlt": "Illustration for signing in",
-        "secondaryAction": "Create one",
-        "secondaryPrompt": "Don’t have an account?",
-        "title": "Sign in"
-      },
-      "signUp": {
-        "bullets": {
-          "first": "Create an account in seconds with OAuth providers.",
-          "second": "No passwords to remember.",
-          "third": "Start using the platform right away."
-        },
-        "cta": "Create an account",
-        "description": "Join the platform and unlock member-only experiences across the domain space.",
-        "illustrationAlt": "Illustration for signing up",
-        "secondaryAction": "Sign in",
-        "secondaryPrompt": "Already have an account?",
-        "title": "Sign up"
-      },
-      "step1": "Step 1",
-      "step2": "Step 2",
-      "title": "Authenticate with our secure OAuth 2.0 auth server.",
-      "trust": {
-        "oauth": "OAuth 2.0",
-        "privacy": "Privacy-first",
-        "session": "Session sync"
+        "falsePositive": "If you think that this page should exist and you're facing an error, please report this to the site administrator.",
+        "subtitle": "It seems that the page that you've landed on is not present on the website. If this page should exist, please report this to the site administrator.",
+        "title": "404 - Page not found."
       }
     },
-    "metadata": {
-      "description": "The auth page for the arolariu.ro platform.",
-      "title": "Auth"
+    "footer": {
+      "accessibility": {
+        "brandTitle": "AROLARIU.RO",
+        "goHome": "Go home",
+        "logoAlt": "The arolariu.ro logo."
+      },
+      "builtOn": "Built on ",
+      "commitSha": "Commit SHA:",
+      "copyright": "Copyright",
+      "navigation": {
+        "about": "About",
+        "acknowledgements": "Acknowledgements",
+        "privacyPolicy": "Privacy Policy",
+        "subdomains": "Subdomains",
+        "termsOfService": "Terms of Service",
+        "what": "What is this?"
+      },
+      "socialLinks": {
+        "github": "Select this link to navigate to the author's GitHub page.",
+        "linkedin": "Select this link to navigate to the author's LinkedIn page."
+      },
+      "sourceCode": "Source code is available ",
+      "sourceCodeAnchor": "here (GitHub repo)",
+      "subtitle": "The platform is built using the latest stable, state-of-the-art technologies and with enterprise-grade experience. <br></br> <br></br> We hope that you have a great experience when exploring this platform."
     },
-    "SignIn": {
-      "bullets": {
-        "first": "Fast sign-in with trusted providers.",
-        "second": "Your session stays consistent across the app.",
-        "third": "Designed to work well on mobile and desktop."
-      },
-      "footer": "Protected by enterprise-grade security.",
-      "form": {
-        "kicker": "Sign in with your preferred provider",
-        "secondaryAction": "Create an account",
-        "secondaryPrompt": "New here?"
-      },
-      "hero": {
-        "subtitle": "Use the provider you trust and continue instantly.",
-        "title": "Welcome back"
-      },
-      "illustrationAlt": "Illustration for the sign-in page",
-      "metadata": {
-        "description": "Sign in to continue your session on arolariu.ro.",
-        "title": "Sign In"
-      }
-    },
-    "SignUp": {
-      "bullets": {
-        "first": "Quick onboarding with OAuth providers.",
-        "second": "No credit card required.",
-        "third": "Start exploring the platform right away."
-      },
-      "footer": "Quick and secure registration.",
-      "form": {
-        "kicker": "Create your account with your preferred provider",
-        "secondaryAction": "Sign in",
-        "secondaryPrompt": "Already have an account?"
-      },
-      "hero": {
-        "subtitle": "Create your account in seconds and get started.",
-        "title": "Join us today"
-      },
-      "illustrationAlt": "Illustration for the sign-up page",
-      "metadata": {
-        "description": "Create an account and start using arolariu.ro.",
-        "title": "Sign Up"
-      }
-    }
-  },
-  "Commander": {
-    "groups": {
-      "accessibility": "Accessibility",
-      "fun": "Fun",
-      "language": "Language",
-      "links": "Links",
-      "navigation": "Navigation",
-      "theme": "Theme"
-    },
-    "items": {
-      "dark": "Dark",
-      "disco": "Disco Mode",
-      "english": "English",
-      "fontDyslexic": "Dyslexic-Friendly Font",
-      "fontNormal": "Standard Font",
-      "french": "Français",
-      "github": "GitHub",
-      "homepage": "Homepage",
-      "light": "Light",
-      "matrix": "Matrix Mode",
-      "rainbow": "Rainbow Mode",
-      "romanian": "Română",
-      "system": "System"
-    },
-    "noResults": "No results found.",
-    "placeholder": "Type a command or search..."
-  },
-  "Common": {
-    "accessibility": {
-      "logoAlt": "arolariu.ro logo",
-      "toggleTheme": "Toggle theme"
-    },
-    "states": {
-      "forbidden": {
-        "callToAction": "Join the arolariu.ro domain.",
-        "description": "Unfortunately, this functionality requires you to have an account on our domain. By creating an account on our platform or signing in with an existing account, you will be able to access our whole arsenal of services, including this one.",
-        "title": "You're missing out on the fun!"
-      }
-    }
-  },
-  "Domains": {
-    "metadata": {
-      "description": "Domain Space Services are services that are offered to visitors and members of the `arolariu.ro` domain space",
-      "title": "Domain Space Services"
-    },
-    "services": {
-      "callToAction": "Visit this domain service",
-      "invoices": {
-        "card": {
-          "description": "This domain space service assists with the digital transformation of physical receipts. It allows users to upload receipts, and get carefully-crafted insights into their spending habits.",
-          "imageAlt": "Illustration of the Invoice Management System showing receipt digitization",
-          "title": "Invoice Management System"
-        }
-      }
-    },
-    "subtitle": "The <code>arolariu.ro</code> platform offers a wide range of services under its umbrella. <br></br> Most of the services require that you have an account created on this platform, so that your data can be safely synchronized between all of the domain services. <br></br> <br></br> Here you can see a showcase of all domain services that are available for exploration.",
-    "title": "Domain Space Services"
-  },
-  "Errors": {
-    "globalError": {
-      "actions": {
-        "step1": "Try refreshing the page using the button below.",
-        "step2": "Go back to the home page and start over.",
-        "step3": "Contact support if the problem persists.",
-        "whatCanYouDoTitle": "What can you do?"
-      },
-      "buttons": {
-        "copied": "Copied!",
-        "copyErrorId": "Copy error ID",
-        "copyErrorIdTitle": "Copy error ID",
-        "returnHome": "Return to home",
-        "tryAgain": "Try again"
-      },
-      "copyErrorConsoleMessage": "Failed to copy error ID:",
-      "details": {
-        "errorIdLabel": "Error ID:",
-        "genericDescription": "An error occurred while processing your request.",
-        "title": "Error details",
-        "unknownError": "An unknown error occurred.",
-        "whatHappenedTitle": "What happened?"
-      },
-      "diagnostics": {
-        "loading": "Loading diagnostic information...",
-        "scanLabel": "Scan for diagnostic information:",
-        "stackTraceLabel": "Stack trace:",
-        "technicalSummary": "Technical information (for developers)"
-      },
-      "hero": {
-        "subtitle": "An unexpected error occurred. Our team has been automatically notified.",
-        "title": "Something went wrong"
-      },
-      "metadata": {
-        "title": "Application Error - AROLARIU.RO"
-      },
-      "support": {
-        "contactPrefix": "If this problem continues, please contact us at",
-        "includeErrorId": "and include the error ID:"
-      }
-    },
-    "notFound": {
-      "additionalInfo": "Additional Information:",
-      "buttons": {
-        "returnButton": "Go back to the home page.",
-        "submitErrorButton": "Submit false error."
-      },
-      "falsePositive": "If you think that this page should exist and you're facing an error, please report this to the site administrator.",
-      "subtitle": "It seems that the page that you've landed on is not present on the website. If this page should exist, please report this to the site administrator.",
-      "title": "404 - Page not found."
-    }
-  },
-  "EULA": {
-    "accept": "Accept EULA",
-    "content": "By using this website, you agree to the terms and conditions and to the privacy policy of the End User License Agreement (EULA). Please read the following documents carefully before using the website:",
-    "cookiesPolicy": {
-      "cookies": {
-        "analytics": {
-          "checkbox": "Enabling the analytics cookies to helps us to improve our website.",
-          "description": "These cookies allow us to count visits and traffic sources, so we can measure and improve the performance of our site. They help us know which pages are the most and least popular and see how visitors move around the site. All information these cookies collect is aggregated and therefore can be considered anonymous.",
-          "title": "Analytics Cookies"
-        },
-        "cta": "Save cookies configuration",
-        "essential": {
-          "checkbox": "This option cannot be disabled. Essential cookies are always enabled.",
-          "description": "Essential cookies are necessary for the website to function properly. This category only includes cookies that ensures basic functionalities and security features of the website.",
-          "title": "Essential Cookies"
-        }
-      },
-      "subtitle": "Manage your cookie settings. You can enable or disable different types of cookies below.",
-      "title": "Cookies Preference"
-    },
-    "language": "Language",
-    "privacyPolicy": {
-      "cta": "View Policy",
-      "subtitle": "Our Privacy Policy explains how we collect, use, and protect your personal information when you use our services.",
-      "title": "Privacy Policy"
-    },
-    "subtitle": "Please review our terms and conditions before using the website.",
-    "termsOfService": {
-      "cta": "View Terms",
-      "subtitle": "Our Terms of Service outline the rules and guidelines for using our platform, including user responsibilities and our obligations.",
-      "title": "Terms of Service"
-    },
-    "title": "End User License Agreement (EULA)"
-  },
-  "Footer": {
-    "accessibility": {
-      "brandTitle": "AROLARIU.RO",
-      "goHome": "Go home",
-      "logoAlt": "The arolariu.ro logo."
-    },
-    "builtOn": "Built on ",
-    "commitSha": "Commit SHA:",
-    "copyright": "Copyright",
     "navigation": {
       "about": "About",
-      "acknowledgements": "Acknowledgements",
-      "privacyPolicy": "Privacy Policy",
-      "subdomains": "Subdomains",
-      "termsOfService": "Terms of Service",
-      "what": "What is this?"
-    },
-    "socialLinks": {
-      "github": "Select this link to navigate to the author's GitHub page.",
-      "linkedin": "Select this link to navigate to the author's LinkedIn page."
-    },
-    "sourceCode": "Source code is available ",
-    "sourceCodeAnchor": "here (GitHub repo)",
-    "subtitle": "The platform is built using the latest stable, state-of-the-art technologies and with enterprise-grade experience. <br></br> <br></br> We hope that you have a great experience when exploring this platform."
-  },
-  "Home": {
-    "appreciation": "THANK YOU FOR THE TIME SPENT ON THE WEBSITE.",
-    "cta": "Start Exploring",
-    "featuresTab": {
-      "azure": {
-        "description": "The Microsoft Azure cloud is used to host the platform and all of its services. This ensures that the platform is always available and that it can scale on demand.",
-        "title": "Microsoft Azure"
-      },
-      "csharp": {
-        "description": "The platform is built using .NET 8 LTS - the latest stable version of .NET. This ensures that the platform is fast, reliable, and easy to use. The platform is built using C# and F#.",
-        "title": ".NET 8 LTS"
-      },
-      "description": "The `arolariu.ro` platform is built using the latest stable technologies.",
-      "githubActions": {
-        "description": "The DevOps experience is powered by GitHub Actions. (CI/CD, Testing, etc.)",
-        "title": "GitHub Actions"
-      },
-      "learnMoreBtn": "Interesting? Click here to learn more...",
-      "nextJs": {
-        "description": "The platform is built using NextJS - the most popular React framework for production.  It is designed for production-grade React applications. NextJS is the most popular React framework for a reason: it is fast, reliable, and easy to use.",
-        "title": "Next.JS 15"
-      },
-      "otel": {
-        "description": "Complete observability with integrated metrics, traces, and logs. Everything is instrumented using OpenTelemetry. This allows for a unified telemetry experience across the board. (3PO: metrics, logs, traces)",
-        "title": "Open Telemetry"
-      },
-      "svelte": {
-        "description": "Utilizing Svelte for lightning-fast, reactive UI components. The `cv.arolariu.ro` platform is built exclusively using Svelte and SvelteKit (v5)",
-        "title": "Svelte"
-      },
-      "title": "Key Features"
-    },
-    "subtitle": "This platform was built by Alexandru-Razvan Olariu as a playground for new technologies. The platform is built using state-of-the-art, enterprise-grade technologies. <br> </br> <br> </br> You are welcome to explore all of the applications and services that are hosted on this domain space.",
-    "technologyTab": {
-      "badgeTitle": "Modern Architecture",
-      "description": "This platform leverages the latest in web technology, combining Next.js for the frontend with .NET for robust backend services, all deployed on Microsoft Azure.",
-      "learnMoreBtn": "Explore the Architecture",
-      "points": {
-        "point1": "Serverless architecture for optimal scaling and performance",
-        "point2": "Full-stack TypeScript for type safety across the entire application",
-        "point3": "Comprehensive telemetry and monitoring with OpenTelemetry"
-      },
-      "title": "Built for the Future."
-    },
-    "title": "Welcome to arolariu.ro"
-  },
-  "IMS--Cards": {
-    "budgetImpactCard": {
-      "dailyAllowance": "Daily Allowance",
-      "dailyAllowanceValue": "{amount}/day",
-      "daysLeft": "Days Left",
-      "inMonth": "in {month}",
-      "invoiceUsed": "This invoice used",
-      "monthlyBudget": "Monthly Budget",
-      "ofMonthlyBudget": "of your monthly budget",
-      "overBudget": "Over budget",
-      "remaining": "Remaining",
-      "spent": "{amount} spent",
-      "title": "{month} Budget Impact"
-    },
-    "categorySuggestionCard": {
-      "description": "We couldn't automatically categorize this invoice. Select the right category to unlock insights:",
-      "gamification": "Categorize {goal} invoices to unlock detailed insights!",
-      "moreCategories": "More categories:",
-      "title": "Help Us Categorize This Invoice"
-    },
-    "comparisonStatsCard": {
-      "avgValue": "Avg: {amount} {currency}",
-      "itemCount": "Item Count",
-      "itemCountComparison": "{current} vs avg {average}",
-      "maxValue": "Max: {amount}",
-      "minValue": "Min: {amount}",
-      "positionInRange": "Your position in spending range",
-      "sameStore": "Same Store",
-      "sameStoreComparison": "vs avg {average} {currency}",
-      "subtitle": "Against your last {count} invoices",
-      "thisValue": "This: {amount} {currency}",
-      "title": "How You Compare",
-      "vsAverage": "vs Average"
-    },
-    "diningCard": {
-      "challenge": {
-        "descriptionPrefix": "Skip fast food for 7 days and save",
-        "descriptionSuffix": "",
-        "title": "Weekly Challenge"
-      },
-      "estimatedNutrition": {
-        "calories": "Calories",
-        "caloriesValue": "~{value} kcal",
-        "carbs": "Carbs",
-        "carbsValue": "~{value}g",
-        "protein": "Protein",
-        "proteinValue": "~{value}g",
-        "sodium": "Sodium",
-        "title": "Estimated Nutrition"
-      },
-      "habits": {
-        "avgSpend": "Avg Spend",
-        "favorite": "Favorite",
-        "frequency": "Frequency",
-        "frequencyDiff": "+1 vs avg",
-        "frequencyValue": "{count}x/month",
-        "title": "Your Fast Food Habits",
-        "visits": "{count} visits"
-      },
-      "sodium": {
-        "high": "High",
-        "low": "Low",
-        "medium": "Medium"
-      },
-      "swaps": {
-        "caloriesSaved": "-{count} cal",
-        "grilled": "Grilled instead of fried",
-        "moneySaved": ", saves {amount}",
-        "salad": "Side salad instead of fries",
-        "title": "Healthier Swaps",
-        "water": "Water instead of soda"
-      },
-      "title": "Dining Insights"
-    },
-    "generalExpenseCard": {
-      "aria": {
-        "changeCategory": "Change detected category",
-        "confirmCategory": "Confirm category detection is correct",
-        "export": "Export expense data",
-        "organize": "Organize this expense into categories"
-      },
-      "budgetCategories": {
-        "electronics": "Electronics",
-        "entertainment": "Entertainment",
-        "shopping": "Shopping"
-      },
-      "buttons": {
-        "change": "Change",
-        "correct": "Correct",
-        "export": "Export",
-        "organize": "Organize"
-      },
-      "confidence": "Confidence: {value}%",
-      "detectedCategory": "Electronics / Technology",
-      "nearLimitAlert": "{name}: {percent}% used (10 days left in month)",
-      "options": {
-        "businessExpense": "Mark as business expense",
-        "insuranceInventory": "Add to insurance inventory",
-        "trackWarranty": "Track warranty (24 months standard)"
-      },
-      "sections": {
-        "autoDetectedCategory": "Auto-detected category",
-        "budgetImpact": "Budget impact",
-        "similarPurchases": "Similar past purchases",
-        "taxBusiness": "Tax & Business options"
-      },
-      "title": "Expense intelligence",
-      "vatReclaimable": "VAT reclaimable"
-    },
-    "homeInventoryCard": {
-      "bulk": {
-        "description": "5L detergent vs 2L saves 18% ({amount}/year)",
-        "title": "Bulk Buying Savings"
-      },
-      "eco": {
-        "productsWithEcoLabels": "{count} products with eco-labels",
-        "recyclablePackaging": "{count} product with recyclable packaging",
-        "tip": "Tip: Eco alternatives save 2kg plastic/year",
-        "title": "Eco-Friendliness Score"
-      },
-      "stockLevels": {
-        "daysRemaining": "~{count} days",
-        "title": "Supply Stock Levels (estimated)"
-      },
-      "supplyNames": {
-        "dishSoap": "Dish Soap",
-        "floorCleaner": "Floor Cleaner",
-        "laundryDetergent": "Laundry Detergent",
-        "paperProducts": "Paper Products"
-      },
-      "title": "Home Inventory & Supplies"
-    },
-    "imageCard": {
-      "aria": {
-        "expandImage": "Click to expand image"
-      },
-      "buttons": {
-        "addScan": "Add scan",
-        "expand": "Expand image",
-        "next": "Next",
-        "previous": "Previous",
-        "remove": "Remove"
-      },
-      "dialogTitle": "Receipt image",
-      "dialogTitleWithIndex": "Receipt image ({current}/{total})",
-      "scanAlt": "Receipt scan {index}",
-      "scanAltFullSize": "Receipt scan {index} - full size",
-      "title": "Receipt scan",
-      "titleWithIndex": "Receipt scan ({current}/{total})",
-      "tooltips": {
-        "addScan": "Upload and attach a new receipt scan",
-        "expand": "View the receipt image in full size",
-        "next": "View the next receipt scan",
-        "previous": "View the previous receipt scan",
-        "remove": "Remove the current receipt scan"
-      }
-    },
-    "invoiceCard": {
-      "descriptionPlaceholder": "Enter invoice description...",
-      "fromMerchant": "From {merchant}",
-      "importantBadge": "IMPORTANT",
-      "labels": {
-        "category": "Category",
-        "dateUtc": "Date (UTC)",
-        "hours": "Hours",
-        "minutes": "Minutes",
-        "paymentMethod": "Payment method",
-        "totalAmount": "Total amount",
-        "utc": "UTC"
-      },
-      "markImportant": "Mark as important",
-      "placeholders": {
-        "selectCategory": "Select category",
-        "selectPaymentType": "Select payment type"
-      },
-      "title": "Invoice details",
-      "tooltips": {
-        "markFavorite": "Click to mark as favorite",
-        "unmarkFavorite": "Click to unmark as favorite"
-      }
-    },
-    "invoiceDetailsCard": {
-      "itemsTitle": "Items ({count})",
-      "labels": {
-        "category": "Category",
-        "countryRegion": "Country/Region",
-        "dateUtc": "Date (UTC)",
-        "payment": "Payment",
-        "receiptType": "Receipt Type",
-        "ronEquivalent": "RON Equivalent",
-        "subtotal": "Subtotal",
-        "tip": "Tip",
-        "totalAmount": "Total Amount"
-      },
-      "pagination": {
-        "next": "Next",
-        "pageOf": "Page {current} of {total}",
-        "previous": "Previous"
-      },
-      "sections": {
-        "paymentMethods": "Payment Methods",
-        "taxBreakdown": "Tax Breakdown"
-      },
-      "table": {
-        "grandTotal": "Grand Total",
-        "item": "Item",
-        "price": "Price",
-        "qty": "Qty",
-        "total": "Total",
-        "unit": "Unit"
-      },
-      "taxLabels": {
-        "net": "Net",
-        "tax": "Tax"
-      },
-      "title": "Invoice Details",
-      "tooltips": {
-        "exchangeRate": "1 {fromCurrency} = {rate} RON (avg. {year})"
-      }
-    },
-    "merchantCard": {
-      "addressLabel": "Address: {address}",
-      "buttons": {
-        "viewAllReceipts": "View All Receipts",
-        "viewMerchantDetails": "View Merchant Details"
-      },
-      "noMerchantLinked": "No merchant linked to this invoice",
-      "title": "Merchant",
-      "tooltips": {
-        "viewAllReceipts": "View all receipts from this merchant",
-        "viewMerchantDetails": "See detailed information about this merchant"
-      }
-    },
-    "merchantInfoCard": {
-      "categoryDistribution": "Category Distribution",
-      "noMerchantLinked": "No merchant linked to this invoice",
-      "spendingHistory": "Spending History",
-      "stats": {
-        "avgSpend": "Avg Spend",
-        "daysAgo": "days ago",
-        "visits": "visits"
-      },
-      "title": "Merchant Information",
-      "viewAllInvoices": "View All Invoices",
-      "viewAllReceipts": "View All Receipts",
-      "viewOnMap": "View on Map"
-    },
-    "nutritionCard": {
-      "allergens": {
-        "foundInItems": "Found in {count} item(s)",
-        "title": "Allergens Detected"
-      },
-      "composition": {
-        "dairyOther": "Dairy/Other",
-        "processed": "Processed",
-        "title": "Your Basket Composition",
-        "wholeFoods": "Whole Foods"
-      },
-      "foodGroups": {
-        "fruits": "Fruits",
-        "grains": "Grains",
-        "itemsCount": "{count} item(s)",
-        "protein": "Protein",
-        "vegetables": "Vegetables"
-      },
-      "score": {
-        "excellent": "Excellent",
-        "fair": "Fair",
-        "good": "Good",
-        "needsWork": "Needs Work",
-        "title": "Food Balance Score"
-      },
-      "suggestions": {
-        "addFruits": "Adding some fruits would improve nutritional balance",
-        "addFruitsAndVegetables": "Add more fruits and vegetables to balance your basket",
-        "addVegetables": "Consider adding vegetables for a more balanced diet",
-        "greatBalance": "Great balanced shopping!",
-        "swapProcessed": "Try swapping some processed items for whole foods"
-      },
-      "title": "Nutrition Overview"
-    },
-    "receiptScanCard": {
-      "buttons": {
-        "expand": "Expand Image",
-        "nextScan": "Next Scan",
-        "previousScan": "Previous Scan"
-      },
-      "controls": {
-        "download": "Download",
-        "fullScreen": "Full Screen",
-        "reset": "Reset Zoom",
-        "rotate": "Rotate",
-        "toggleZoom": "Click to toggle zoom",
-        "zoomIn": "Zoom In",
-        "zoomOut": "Zoom Out"
-      },
-      "dialogTitle": "Receipt Image",
-      "dialogTitleWithIndex": "Receipt Image ({current}/{total})",
-      "navigation": {
-        "next": "Next",
-        "of": "of",
-        "previous": "Previous"
-      },
-      "scanAlt": "Receipt scan {index}",
-      "scanAltFullSize": "Receipt scan {index} - full size",
-      "title": "Receipt Scan",
-      "titleWithIndex": "Receipt Scan ({current}/{total})",
-      "tooltips": {
-        "expand": "View the receipt image in full size",
-        "nextScan": "View the next receipt scan",
-        "previousScan": "View the previous receipt scan"
-      }
-    },
-    "recipeCard": {
-      "buttons": {
-        "viewRecipe": "View Recipe",
-        "visitReference": "Visit Reference"
-      },
-      "complexity": {
-        "easy": "Easy",
-        "hard": "Hard",
-        "normal": "Normal",
-        "unknown": "Unknown"
-      },
-      "dropdown": {
-        "delete": "Delete",
-        "edit": "Edit",
-        "markAsFavorite": "Mark as Favorite",
-        "share": "Share",
-        "view": "View"
-      },
-      "ingredients": {
-        "additionalLabel": "Additional ingredients:",
-        "label": "Ingredients:",
-        "more": "+{count} more"
-      },
-      "timing": {
-        "cookLabel": "Cook: {minutes}′",
-        "cookTooltip": "Cooking time is {minutes} minutes.",
-        "prepLabel": "Prep: {minutes}′",
-        "prepTooltip": "Preparation time is {minutes} minutes."
-      }
-    },
-    "seasonalInsightsCard": {
-      "insights": {
-        "holidaySeason": {
-          "description": "December spending is typically 35% higher",
-          "title": "Holiday Season"
-        },
-        "insufficientData": {
-          "description": "Add more invoices to see seasonal insights and spending patterns",
-          "title": "Building Your Spending Profile"
-        },
-        "normalPattern": {
-          "description": "Your spending is within typical range",
-          "title": "Normal Shopping Pattern"
-        },
-        "spike": {
-          "description": "+{percent}% vs your average",
-          "title": "{category} Spike"
-        },
-        "stockUpTip": {
-          "description": "Prices increase ~15% after Dec 15th",
-          "title": "Stock Up Tip"
-        }
-      },
-      "month": {
-        "spendingSoFar": "{month} so far",
-        "vsAverage": "vs {month} avg: {amount}"
-      },
-      "title": "Seasonal Insight"
-    },
-    "sharingCard": {
-      "buttons": {
-        "manageSharing": "Manage Sharing",
-        "markAsPrivate": "Mark as Private",
-        "revokingAccess": "Revoking Access...",
-        "shareInvoice": "Share Invoice"
-      },
-      "emptyShared": {
-        "private": "Not shared with anyone",
-        "public": "No additional users have direct access"
-      },
-      "owner": "Owner",
-      "ownerAvatarAlt": "User",
-      "publicInvoice": {
-        "description": "This invoice is publicly accessible. Anyone with the link can view it.",
-        "title": "Public Invoice"
-      },
-      "sharedWith": "Shared With",
-      "title": "Sharing",
-      "toasts": {
-        "removeAccessComingSoon": {
-          "description": "This feature is currently under development.",
-          "title": "Remove access feature coming soon"
-        },
-        "revoke": {
-          "error": "Failed to mark private: {message}",
-          "loading": "Revoking public access...",
-          "success": "Invoice is now private. Existing links will no longer work."
-        }
-      },
-      "tooltips": {
-        "manageSharing": "Manage sharing settings for this invoice",
-        "markAsPrivate": "Mark the invoice as private",
-        "removeAccess": "Remove access",
-        "shareInvoice": "Share this invoice with other users"
-      },
-      "userWithId": "User {id}"
-    },
-    "shoppingCalendarCard": {
-      "insights": {
-        "days": "{count} days",
-        "mostActiveOn": "Most active on",
-        "onAverage": "on average",
-        "perTrip": " per trip",
-        "shopEveryPrefix": "You shop every",
-        "spendingPrefix": ", spending",
-        "weekdayLabel": "{weekday}s"
-      },
-      "legend": {
-        "less": "Less",
-        "more": "More"
-      },
-      "stats": {
-        "monthTotal": "Month Total",
-        "shoppingDays": "Shopping Days"
-      },
-      "title": "Shopping Calendar",
-      "tooltip": {
-        "basedOnCachedInvoices": "Based on {count} cached invoices",
-        "currentInvoice": "Current invoice",
-        "currentInvoiceOnly": "Showing current invoice only",
-        "invoiceCount": "{count} invoice(s)",
-        "more": "+{count} more",
-        "vsAverage": "vs avg ({years}y data)"
-      }
-    },
-    "summaryStatsCard": {
-      "description": "Key statistics at a glance",
-      "extremes": {
-        "highest": "Highest",
-        "lowest": "Lowest"
-      },
-      "stats": {
-        "averagePrice": {
-          "description": "{currency} per item",
-          "label": "Avg. Price"
-        },
-        "categories": {
-          "description": "Unique categories",
-          "label": "Categories"
-        },
-        "taxRate": {
-          "description": "{amount} {currency}",
-          "label": "Tax Rate"
-        },
-        "totalItems": {
-          "description": "Products purchased",
-          "label": "Total Items"
-        }
-      },
-      "title": "Invoice Summary"
-    },
-    "vehicleCard": {
-      "buttons": {
-        "addVehicle": "Add Vehicle",
-        "fullReport": "Full Report"
-      },
-      "chart": {
-        "amount": "Amount",
-        "title": "Monthly Fuel Spending"
-      },
-      "details": {
-        "liters": "Liters",
-        "notSet": "Not set",
-        "pricePerLiter": "Price/L",
-        "station": "Station",
-        "vehicle": "Vehicle"
-      },
-      "expenseType": "Expense Type: Fuel",
-      "maintenance": {
-        "title": "Maintenance Reminders"
-      },
-      "months": {
-        "dec": "Dec",
-        "nov": "Nov",
-        "oct": "Oct",
-        "sep": "Sep"
-      },
-      "reminders": {
-        "oilChange": "Oil change due in ~1,200 km",
-        "tireRotation": "Tire rotation recommended"
-      },
-      "stats": {
-        "costPerKm": "Cost/km",
-        "estimated": "estimated",
-        "fillUps": "{count} fill-ups",
-        "fuelPrice": "Fuel Price",
-        "thisMonth": "This Month",
-        "thisMonthSuffix": "this month"
-      },
-      "tip": {
-        "perLiter": "L",
-        "title": "Cheapest Nearby"
-      },
-      "title": "Vehicle Expense Analysis"
-    }
-  },
-  "IMS--Common": {
-    "commandPalette": {
-      "actions": {
-        "createInvoice": "Create Invoice",
-        "uploadScans": "Upload Scans",
-        "viewAll": "View All Invoices",
-        "viewStatistics": "View Statistics"
-      },
-      "groups": {
-        "quickActions": "Quick Actions",
-        "recentInvoices": "Recent Invoices",
-        "searchResults": "Search Results"
-      },
-      "noResults": "No results found",
-      "placeholder": "Search invoices, merchants, items..."
-    },
-    "invoiceHeader": {
-      "buttons": {
-        "analyzeWithAi": "Analyze with AI",
-        "delete": "Delete",
-        "discard": "Discard",
-        "edit": "Edit",
-        "export": "Export",
-        "print": "Print",
-        "save": "Save",
-        "saving": "Saving..."
-      },
-      "id": "ID: {id}",
-      "tooltips": {
-        "analyzeSpendingPatterns": "Analyze spending patterns for this invoice",
-        "delete": "Delete this invoice permanently",
-        "deleteInvoicePermanently": "Delete this invoice permanently",
-        "discardAllPendingChanges": "Discard all pending changes",
-        "edit": "Edit this invoice",
-        "export": "Export invoice data in various formats",
-        "importantInvoice": "Important Invoice",
-        "print": "Print this invoice",
-        "printInvoiceWithAllDetails": "Print this invoice with all details",
-        "saveAllPendingChanges": "Save all pending changes"
-      }
-    },
-    "invoicesNotFound": {
-      "cta": "Upload an invoice here.",
-      "description": "It seems that you do not have any invoices associated with your account. Please upload some invoices and come back later.",
-      "title": "Something is missing here..."
-    },
-    "loadingInvoices": {
-      "description": "Loading invoices...",
-      "title": "Loading invoices"
-    },
-    "mobileNav": {
-      "ariaLabel": "Mobile navigation",
-      "home": "Home",
+      "domains": "Domains",
       "invoices": "Invoices",
-      "profile": "Profile",
-      "scan": "Scan"
-    },
-    "notifications": {
-      "markAllRead": "Mark all as read",
-      "noNotifications": "No notifications yet",
-      "timeAgo": {
-        "days": "{count, plural, one {# day ago} other {# days ago}}",
-        "hours": "{count, plural, one {# hour ago} other {# hours ago}}",
-        "minutes": "{count, plural, one {# minute ago} other {# minutes ago}}",
-        "now": "Just now"
+      "mobile": {
+        "closeNavigation": "Close navigation",
+        "openNavigation": "Open navigation",
+        "title": "Navigation"
       },
-      "title": "Notifications",
-      "types": {
-        "analysisComplete": "AI analysis complete",
-        "invoiceCreated": "Invoice created",
-        "monthlyReport": "Monthly report ready"
-      }
-    },
-    "onboarding": {
-      "back": "Back",
-      "dontShowAgain": "Don't show this again",
-      "getStarted": "Get Started",
-      "next": "Next",
-      "skip": "Skip",
-      "stepOf": "Step {current} of {total}",
-      "steps": {
-        "analyze": {
-          "description": "Our AI-powered system automatically extracts merchant names, dates, amounts, and line items from your receipts with high accuracy.",
-          "title": "AI Extracts the Details"
-        },
-        "track": {
-          "description": "View detailed analytics and insights into your spending patterns. Understand where your money goes with interactive charts and reports.",
-          "title": "Track Your Spending"
-        },
-        "upload": {
-          "description": "Take a photo or upload a PDF of your receipt. Our system supports multiple formats and can process batches of receipts at once.",
-          "title": "Upload Your Receipts"
-        }
-      }
-    },
-    "preferences": {
-      "currency": "Currency",
-      "defaultView": "Default View",
-      "pageSize": "Items per Page",
-      "save": "Save Preferences",
-      "saved": "Preferences saved successfully",
-      "showStats": "Show statistics on home",
-      "sortBy": "Sort By",
-      "sortOptions": {
-        "amountAsc": "Amount (Low to High)",
-        "amountDesc": "Amount (High to Low)",
-        "dateAsc": "Date (Oldest First)",
-        "dateDesc": "Date (Newest First)",
-        "nameAsc": "Name (A to Z)"
-      },
-      "title": "Invoice Preferences",
-      "views": {
-        "grid": "Grid View",
-        "table": "Table View"
-      }
-    },
-    "shortcuts": {
-      "close": "Close",
-      "closeDialog": "Close dialog",
-      "description": "Quick access to common actions using your keyboard",
-      "newInvoice": "New invoice",
-      "openSearch": "Open search",
-      "showHelp": "Show this help",
-      "title": "Keyboard Shortcuts",
-      "uploadScan": "Upload scan"
-    },
-    "statesLoading": {
-      "description": "Loading the invoice with the identifier {invoiceIdentifier}.",
-      "title": "Loading Invoice"
-    },
-    "statesNotFound": {
-      "description": "The invoice with the identifier {invoiceIdentifier} was not found.",
-      "title": "Invoice Not Found"
-    },
-    "unknownMerchant": "Unknown Merchant",
-    "workflowProgress": {
-      "create": "Create",
-      "review": "Review",
-      "upload": "Upload"
+      "myInvoices": "My Invoices",
+      "myProfile": "My Profile",
+      "theAuthor": "The Author",
+      "thePlatform": "The Platform",
+      "uploadScans": "Upload Scans",
+      "viewScans": "View Scans"
     }
   },
-  "IMS--Create": {
-    "detailsForm": {
-      "fields": {
+  "cards": {
+    "invoices": {
+      "budgetImpactCard": {
+        "dailyAllowance": "Daily Allowance",
+        "dailyAllowanceValue": "{amount}/day",
+        "daysLeft": "Days Left",
+        "inMonth": "in {month}",
+        "invoiceUsed": "This invoice used",
+        "monthlyBudget": "Monthly Budget",
+        "ofMonthlyBudget": "of your monthly budget",
+        "overBudget": "Over budget",
+        "remaining": "Remaining",
+        "spent": "{amount} spent",
+        "title": "{month} Budget Impact"
+      },
+      "categorySuggestionCard": {
+        "description": "We couldn't automatically categorize this invoice. Select the right category to unlock insights:",
+        "gamification": "Categorize {goal} invoices to unlock detailed insights!",
+        "moreCategories": "More categories:",
+        "title": "Help Us Categorize This Invoice"
+      },
+      "comparisonStatsCard": {
+        "avgValue": "Avg: {amount} {currency}",
+        "itemCount": "Item Count",
+        "itemCountComparison": "{current} vs avg {average}",
+        "maxValue": "Max: {amount}",
+        "minValue": "Min: {amount}",
+        "positionInRange": "Your position in spending range",
+        "sameStore": "Same Store",
+        "sameStoreComparison": "vs avg {average} {currency}",
+        "subtitle": "Against your last {count} invoices",
+        "thisValue": "This: {amount} {currency}",
+        "title": "How You Compare",
+        "vsAverage": "vs Average"
+      },
+      "diningCard": {
+        "challenge": {
+          "descriptionPrefix": "Skip fast food for 7 days and save",
+          "descriptionSuffix": "Review this item to complete the dining insight.",
+          "title": "Weekly Challenge"
+        },
+        "estimatedNutrition": {
+          "calories": "Calories",
+          "caloriesValue": "~{value} kcal",
+          "carbs": "Carbs",
+          "carbsValue": "~{value}g",
+          "protein": "Protein",
+          "proteinValue": "~{value}g",
+          "sodium": "Sodium",
+          "title": "Estimated Nutrition"
+        },
+        "habits": {
+          "avgSpend": "Avg Spend",
+          "favorite": "Favorite",
+          "frequency": "Frequency",
+          "frequencyDiff": "+1 vs avg",
+          "frequencyValue": "{count}x/month",
+          "title": "Your Fast Food Habits",
+          "visits": "{count} visits"
+        },
+        "sodium": {
+          "high": "High",
+          "low": "Low",
+          "medium": "Medium"
+        },
+        "swaps": {
+          "caloriesSaved": "-{count} cal",
+          "grilled": "Grilled instead of fried",
+          "moneySaved": ", saves {amount}",
+          "salad": "Side salad instead of fries",
+          "title": "Healthier Swaps",
+          "water": "Water instead of soda"
+        },
+        "title": "Dining Insights"
+      },
+      "generalExpenseCard": {
+        "aria": {
+          "changeCategory": "Change detected category",
+          "confirmCategory": "Confirm category detection is correct",
+          "export": "Export expense data",
+          "organize": "Organize this expense into categories"
+        },
+        "budgetCategories": {
+          "electronics": "Electronics",
+          "entertainment": "Entertainment",
+          "shopping": "Shopping"
+        },
+        "buttons": {
+          "change": "Change",
+          "correct": "Correct",
+          "export": "Export",
+          "organize": "Organize"
+        },
+        "confidence": "Confidence: {value}%",
+        "detectedCategory": "Electronics / Technology",
+        "nearLimitAlert": "{name}: {percent}% used (10 days left in month)",
+        "options": {
+          "businessExpense": "Mark as business expense",
+          "insuranceInventory": "Add to insurance inventory",
+          "trackWarranty": "Track warranty (24 months standard)"
+        },
+        "sections": {
+          "autoDetectedCategory": "Auto-detected category",
+          "budgetImpact": "Budget impact",
+          "similarPurchases": "Similar past purchases",
+          "taxBusiness": "Tax & Business options"
+        },
+        "title": "Expense intelligence",
+        "vatReclaimable": "VAT reclaimable"
+      },
+      "homeInventoryCard": {
+        "bulk": {
+          "description": "5L detergent vs 2L saves 18% ({amount}/year)",
+          "title": "Bulk Buying Savings"
+        },
+        "eco": {
+          "productsWithEcoLabels": "{count} products with eco-labels",
+          "recyclablePackaging": "{count} product with recyclable packaging",
+          "tip": "Tip: Eco alternatives save 2kg plastic/year",
+          "title": "Eco-Friendliness Score"
+        },
+        "stockLevels": {
+          "daysRemaining": "~{count} days",
+          "title": "Supply Stock Levels (estimated)"
+        },
+        "supplyNames": {
+          "dishSoap": "Dish Soap",
+          "floorCleaner": "Floor Cleaner",
+          "laundryDetergent": "Laundry Detergent",
+          "paperProducts": "Paper Products"
+        },
+        "title": "Home Inventory & Supplies"
+      },
+      "imageCard": {
+        "aria": {
+          "expandImage": "Click to expand image"
+        },
+        "buttons": {
+          "addScan": "Add scan",
+          "expand": "Expand image",
+          "next": "Next",
+          "previous": "Previous",
+          "remove": "Remove"
+        },
+        "dialogTitle": "Receipt image",
+        "dialogTitleWithIndex": "Receipt image ({current}/{total})",
+        "scanAlt": "Receipt scan {index}",
+        "scanAltFullSize": "Receipt scan {index} - full size",
+        "title": "Receipt scan",
+        "titleWithIndex": "Receipt scan ({current}/{total})",
+        "tooltips": {
+          "addScan": "Upload and attach a new receipt scan",
+          "expand": "View the receipt image in full size",
+          "next": "View the next receipt scan",
+          "previous": "View the previous receipt scan",
+          "remove": "Remove the current receipt scan"
+        }
+      },
+      "invoiceCard": {
+        "descriptionPlaceholder": "Enter invoice description...",
+        "fromMerchant": "From {merchant}",
+        "importantBadge": "IMPORTANT",
+        "labels": {
+          "category": "Category",
+          "dateUtc": "Date (UTC)",
+          "hours": "Hours",
+          "minutes": "Minutes",
+          "paymentMethod": "Payment method",
+          "totalAmount": "Total amount",
+          "utc": "UTC"
+        },
+        "markImportant": "Mark as important",
+        "placeholders": {
+          "selectCategory": "Select category",
+          "selectPaymentType": "Select payment type"
+        },
+        "title": "Invoice details",
+        "tooltips": {
+          "markFavorite": "Click to mark as favorite",
+          "unmarkFavorite": "Click to unmark as favorite"
+        }
+      },
+      "invoiceDetailsCard": {
+        "itemsTitle": "Items ({count})",
+        "labels": {
+          "category": "Category",
+          "countryRegion": "Country/Region",
+          "dateUtc": "Date (UTC)",
+          "payment": "Payment",
+          "receiptType": "Receipt Type",
+          "ronEquivalent": "RON Equivalent",
+          "subtotal": "Subtotal",
+          "tip": "Tip",
+          "totalAmount": "Total Amount"
+        },
+        "pagination": {
+          "next": "Next",
+          "pageOf": "Page {current} of {total}",
+          "previous": "Previous"
+        },
+        "sections": {
+          "paymentMethods": "Payment Methods",
+          "taxBreakdown": "Tax Breakdown"
+        },
+        "table": {
+          "grandTotal": "Grand Total",
+          "item": "Item",
+          "price": "Price",
+          "qty": "Qty",
+          "total": "Total",
+          "unit": "Unit"
+        },
+        "taxLabels": {
+          "net": "Net",
+          "tax": "Tax"
+        },
+        "title": "Invoice Details",
+        "tooltips": {
+          "exchangeRate": "1 {fromCurrency} = {rate} RON (avg. {year})"
+        }
+      },
+      "merchantCard": {
+        "addressLabel": "Address: {address}",
+        "buttons": {
+          "viewAllReceipts": "View All Receipts",
+          "viewMerchantDetails": "View Merchant Details"
+        },
+        "noMerchantLinked": "No merchant linked to this invoice",
+        "title": "Merchant",
+        "tooltips": {
+          "viewAllReceipts": "View all receipts from this merchant",
+          "viewMerchantDetails": "See detailed information about this merchant"
+        }
+      },
+      "merchantInfoCard": {
+        "categoryDistribution": "Category Distribution",
+        "noMerchantLinked": "No merchant linked to this invoice",
+        "spendingHistory": "Spending History",
+        "stats": {
+          "avgSpend": "Avg Spend",
+          "daysAgo": "days ago",
+          "visits": "visits"
+        },
+        "title": "Merchant Information",
+        "viewAllInvoices": "View All Invoices",
+        "viewAllReceipts": "View All Receipts",
+        "viewOnMap": "View on Map"
+      },
+      "nutritionCard": {
+        "allergens": {
+          "foundInItems": "Found in {count} item(s)",
+          "title": "Allergens Detected"
+        },
+        "composition": {
+          "dairyOther": "Dairy/Other",
+          "processed": "Processed",
+          "title": "Your Basket Composition",
+          "wholeFoods": "Whole Foods"
+        },
+        "foodGroups": {
+          "fruits": "Fruits",
+          "grains": "Grains",
+          "itemsCount": "{count} item(s)",
+          "protein": "Protein",
+          "vegetables": "Vegetables"
+        },
+        "score": {
+          "excellent": "Excellent",
+          "fair": "Fair",
+          "good": "Good",
+          "needsWork": "Needs Work",
+          "title": "Food Balance Score"
+        },
+        "suggestions": {
+          "addFruits": "Adding some fruits would improve nutritional balance",
+          "addFruitsAndVegetables": "Add more fruits and vegetables to balance your basket",
+          "addVegetables": "Consider adding vegetables for a more balanced diet",
+          "greatBalance": "Great balanced shopping!",
+          "swapProcessed": "Try swapping some processed items for whole foods"
+        },
+        "title": "Nutrition Overview"
+      },
+      "receiptScanCard": {
+        "buttons": {
+          "expand": "Expand Image",
+          "nextScan": "Next Scan",
+          "previousScan": "Previous Scan"
+        },
+        "controls": {
+          "download": "Download",
+          "fullScreen": "Full Screen",
+          "reset": "Reset Zoom",
+          "rotate": "Rotate",
+          "toggleZoom": "Click to toggle zoom",
+          "zoomIn": "Zoom In",
+          "zoomOut": "Zoom Out"
+        },
+        "dialogTitle": "Receipt Image",
+        "dialogTitleWithIndex": "Receipt Image ({current}/{total})",
+        "navigation": {
+          "next": "Next",
+          "of": "of",
+          "previous": "Previous"
+        },
+        "scanAlt": "Receipt scan {index}",
+        "scanAltFullSize": "Receipt scan {index} - full size",
+        "title": "Receipt Scan",
+        "titleWithIndex": "Receipt Scan ({current}/{total})",
+        "tooltips": {
+          "expand": "View the receipt image in full size",
+          "nextScan": "View the next receipt scan",
+          "previousScan": "View the previous receipt scan"
+        }
+      },
+      "recipeCard": {
+        "buttons": {
+          "viewRecipe": "View Recipe",
+          "visitReference": "Visit Reference"
+        },
+        "complexity": {
+          "easy": "Easy",
+          "hard": "Hard",
+          "normal": "Normal",
+          "unknown": "Unknown"
+        },
+        "dropdown": {
+          "delete": "Delete",
+          "edit": "Edit",
+          "markAsFavorite": "Mark as Favorite",
+          "share": "Share",
+          "view": "View"
+        },
+        "ingredients": {
+          "additionalLabel": "Additional ingredients:",
+          "label": "Ingredients:",
+          "more": "+{count} more"
+        },
+        "timing": {
+          "cookLabel": "Cook: {minutes}′",
+          "cookTooltip": "Cooking time is {minutes} minutes.",
+          "prepLabel": "Prep: {minutes}′",
+          "prepTooltip": "Preparation time is {minutes} minutes."
+        }
+      },
+      "seasonalInsightsCard": {
+        "insights": {
+          "holidaySeason": {
+            "description": "December spending is typically 35% higher",
+            "title": "Holiday Season"
+          },
+          "insufficientData": {
+            "description": "Add more invoices to see seasonal insights and spending patterns",
+            "title": "Building Your Spending Profile"
+          },
+          "normalPattern": {
+            "description": "Your spending is within typical range",
+            "title": "Normal Shopping Pattern"
+          },
+          "spike": {
+            "description": "+{percent}% vs your average",
+            "title": "{category} Spike"
+          },
+          "stockUpTip": {
+            "description": "Prices increase ~15% after Dec 15th",
+            "title": "Stock Up Tip"
+          }
+        },
+        "month": {
+          "spendingSoFar": "{month} so far",
+          "vsAverage": "vs {month} avg: {amount}"
+        },
+        "title": "Seasonal Insight"
+      },
+      "sharingCard": {
+        "buttons": {
+          "manageSharing": "Manage Sharing",
+          "markAsPrivate": "Mark as Private",
+          "revokingAccess": "Revoking Access...",
+          "shareInvoice": "Share Invoice"
+        },
+        "emptyShared": {
+          "private": "Not shared with anyone",
+          "public": "No additional users have direct access"
+        },
+        "owner": "Owner",
+        "ownerAvatarAlt": "User",
+        "publicInvoice": {
+          "description": "This invoice is publicly accessible. Anyone with the link can view it.",
+          "title": "Public Invoice"
+        },
+        "sharedWith": "Shared With",
+        "title": "Sharing",
+        "toasts": {
+          "removeAccessComingSoon": {
+            "description": "This feature is currently under development.",
+            "title": "Remove access feature coming soon"
+          },
+          "revoke": {
+            "error": "Failed to mark private: {message}",
+            "loading": "Revoking public access...",
+            "success": "Invoice is now private. Existing links will no longer work."
+          }
+        },
+        "tooltips": {
+          "manageSharing": "Manage sharing settings for this invoice",
+          "markAsPrivate": "Mark the invoice as private",
+          "removeAccess": "Remove access",
+          "shareInvoice": "Share this invoice with other users"
+        },
+        "userWithId": "User {id}"
+      },
+      "shoppingCalendarCard": {
+        "insights": {
+          "days": "{count} days",
+          "mostActiveOn": "Most active on",
+          "onAverage": "on average",
+          "perTrip": " per trip",
+          "shopEveryPrefix": "You shop every",
+          "spendingPrefix": ", spending",
+          "weekdayLabel": "{weekday}s"
+        },
+        "legend": {
+          "less": "Less",
+          "more": "More"
+        },
+        "stats": {
+          "monthTotal": "Month Total",
+          "shoppingDays": "Shopping Days"
+        },
+        "title": "Shopping Calendar",
+        "tooltip": {
+          "basedOnCachedInvoices": "Based on {count} cached invoices",
+          "currentInvoice": "Current invoice",
+          "currentInvoiceOnly": "Showing current invoice only",
+          "invoiceCount": "{count} invoice(s)",
+          "more": "+{count} more",
+          "vsAverage": "vs avg ({years}y data)"
+        }
+      },
+      "statistics": {
+        "allergenSummary": {
+          "ariaLabel": "Allergen frequency summary",
+          "description": "Allergen exposure across products",
+          "empty": "No allergens detected in your purchases",
+          "stats": {
+            "ofTotal": "of total",
+            "products": "products"
+          },
+          "title": "Allergen Summary"
+        },
+        "calendarHeatmap": {
+          "aria": {
+            "calendarGrid": "Daily spending calendar"
+          },
+          "days": {
+            "fri": "Fri",
+            "mon": "Mon",
+            "sat": "Sat",
+            "sun": "Sun",
+            "thu": "Thu",
+            "tue": "Tue",
+            "wed": "Wed"
+          },
+          "description": "Daily spending intensity over time",
+          "legend": {
+            "less": "Less",
+            "more": "More"
+          },
+          "navigation": {
+            "next": "Next month",
+            "previous": "Previous month"
+          },
+          "title": "Spending Calendar",
+          "tooltip": {
+            "amount": "Spent",
+            "invoices": "{count} invoices",
+            "noSpending": "No spending"
+          }
+        },
+        "categoryBreakdown": {
+          "description": "Distribution across categories",
+          "title": "Spending by Category",
+          "tooltip": {
+            "invoiceCount": "{count} invoices"
+          },
+          "totalLabel": "Total Spending"
+        },
+        "comparison": {
+          "decrease": "decrease",
+          "description": "Comparison with previous month",
+          "discovered": "discovered",
+          "increase": "increase",
+          "invoiceCount": "Invoice Count",
+          "newMerchants": "New Merchants",
+          "none": "none",
+          "spendingDelta": "Spending Change",
+          "title": "Month-over-Month"
+        },
+        "currencyDistribution": {
+          "description": "Spending breakdown by currency with RON conversion",
+          "invoiceCount": "Invoices",
+          "originalAmount": "Original",
+          "ronEquivalent": "RON equivalent",
+          "showOriginal": "Show Original",
+          "showRON": "Show RON",
+          "singleCurrency": "All invoices in {currency} ({symbol})",
+          "title": "Currency Distribution",
+          "toggleLabel": "Toggle currency view",
+          "totalAmount": "Total Amount",
+          "totalCurrencies": "Total Currencies",
+          "totalSpending": "Total Spending"
+        },
+        "empty": {
+          "cta": "Upload Receipt",
+          "subtitle": "Upload receipts to see analytics",
+          "title": "No Statistics Yet"
+        },
+        "kpi": {
+          "acrossInvoices": "across {count} invoices",
+          "averageItems": "Avg. Items",
+          "avgPerInvoice": "avg {amount} per invoice",
+          "invoiceCount": "Invoice Count",
+          "noneYet": "No data yet",
+          "topMerchant": "Top Merchant",
+          "totalSpending": "Total Spending",
+          "visits": "{count} visits",
+          "vsLastMonth": "{delta}% vs last month"
+        },
+        "merchantLeaderboard": {
+          "description": "Where you spend most",
+          "empty": "No merchant data available yet",
+          "labels": {
+            "totalSpent": "Total Spent"
+          },
+          "title": "Top Merchants",
+          "tooltip": {
+            "invoiceCount": "{count} invoices"
+          },
+          "unknownMerchant": "Unknown Merchant"
+        },
+        "merchantTrends": {
+          "aria": {
+            "sparkline": "Spending trend for {merchant}"
+          },
+          "description": "Monthly spending patterns for top merchants",
+          "empty": "No merchant data available yet",
+          "labels": {
+            "merchant": "Merchant",
+            "totalSpend": "Total Spend",
+            "trend": "Trend (Last 6 Months)"
+          },
+          "title": "Merchant Spending Trends"
+        },
+        "merchantVisit": {
+          "description": "Shopping frequency and basket insights",
+          "empty": "No visit data available yet",
+          "metrics": {
+            "avgSpend": "Avg Spend/Visit",
+            "basketSize": "Avg Basket",
+            "preferredDay": "Preferred Day",
+            "totalVisits": "Total Visits",
+            "visitsPerMonth": "Visits/Month"
+          },
+          "title": "Merchant Visit Patterns"
+        },
+        "priceDistribution": {
+          "description": "Item price distribution",
+          "labels": {
+            "itemCount": "Item Count"
+          },
+          "title": "Price Distribution",
+          "tooltip": {
+            "itemCount": "{count} items"
+          }
+        },
+        "productAnalytics": {
+          "subtitle": "Insights into your purchased items",
+          "title": "Product-Level Analytics"
+        },
+        "productCategory": {
+          "description": "Spending breakdown by product type",
+          "empty": "No products to analyze yet",
+          "title": "Product Category Spending",
+          "tooltip": {
+            "productCount": "{count} products"
+          }
+        },
+        "spendingOverTime": {
+          "description": "Track your spending trends",
+          "labels": {
+            "amount": "Amount"
+          },
+          "title": "Spending Over Time",
+          "tooltip": {
+            "andMore": "and {count} more...",
+            "invoiceCount": "{count} invoices"
+          }
+        },
+        "subtitle": "Manage your receipts and track your spending habits",
+        "timeOfDay": {
+          "description": "When you shop",
+          "labels": {
+            "invoiceCount": "Invoice Count"
+          },
+          "title": "Shopping Patterns",
+          "tooltip": {
+            "invoiceCount": "{count} invoices"
+          }
+        },
+        "title": "Invoice Statistics",
+        "topProducts": {
+          "ariaLabel": "Top products leaderboard",
+          "description": "Most purchased items",
+          "empty": "No products purchased yet",
+          "headers": {
+            "avgPrice": "Avg Price",
+            "product": "Product",
+            "purchases": "Purchases",
+            "quantity": "Qty",
+            "rank": "#",
+            "totalSpent": "Total"
+          },
+          "title": "Top Products"
+        }
+      },
+      "summaryStatsCard": {
+        "description": "Key statistics at a glance",
+        "extremes": {
+          "highest": "Highest",
+          "lowest": "Lowest"
+        },
+        "stats": {
+          "averagePrice": {
+            "description": "{currency} per item",
+            "label": "Avg. Price"
+          },
+          "categories": {
+            "description": "Unique categories",
+            "label": "Categories"
+          },
+          "taxRate": {
+            "description": "{amount} {currency}",
+            "label": "Tax Rate"
+          },
+          "totalItems": {
+            "description": "Products purchased",
+            "label": "Total Items"
+          }
+        },
+        "title": "Invoice Summary"
+      },
+      "vehicleCard": {
+        "buttons": {
+          "addVehicle": "Add Vehicle",
+          "fullReport": "Full Report"
+        },
+        "chart": {
+          "amount": "Amount",
+          "title": "Monthly Fuel Spending"
+        },
+        "details": {
+          "liters": "Liters",
+          "notSet": "Not set",
+          "pricePerLiter": "Price/L",
+          "station": "Station",
+          "vehicle": "Vehicle"
+        },
+        "expenseType": "Expense Type: Fuel",
+        "maintenance": {
+          "title": "Maintenance Reminders"
+        },
+        "months": {
+          "dec": "Dec",
+          "nov": "Nov",
+          "oct": "Oct",
+          "sep": "Sep"
+        },
+        "reminders": {
+          "oilChange": "Oil change due in ~1,200 km",
+          "tireRotation": "Tire rotation recommended"
+        },
+        "stats": {
+          "costPerKm": "Cost/km",
+          "estimated": "estimated",
+          "fillUps": "{count} fill-ups",
+          "fuelPrice": "Fuel Price",
+          "thisMonth": "This Month",
+          "thisMonthSuffix": "this month"
+        },
+        "tip": {
+          "perLiter": "L",
+          "title": "Cheapest Nearby"
+        },
+        "title": "Vehicle Expense Analysis"
+      }
+    }
+  },
+  "dialogs": {
+    "invoices": {
+      "addScanDialog": {
+        "buttons": {
+          "cancel": "Cancel",
+          "upload": "Upload scan",
+          "uploading": "Uploading..."
+        },
+        "description": "Upload a new receipt image or document to attach to this invoice.",
+        "dropzone": {
+          "dragAndDrop": "Drag & drop a file here",
+          "dropHere": "Drop the file here...",
+          "formats": "JPEG, PNG, PDF (max 10MB)",
+          "orClickBrowse": "or click to browse"
+        },
+        "scanType": {
+          "jpeg": "JPEG image",
+          "label": "Scan type",
+          "other": "Other",
+          "pdf": "PDF document",
+          "placeholder": "Select scan type",
+          "png": "PNG image"
+        },
+        "title": "Add new scan",
+        "toasts": {
+          "fileTooLargeDescription": "Maximum file size is 10MB",
+          "fileTooLargeTitle": "File too large"
+        }
+      },
+      "allergenDialog": {
+        "aria": {
+          "removeAllergen": "Remove {name} allergen"
+        },
+        "buttons": {
+          "add": "Add",
+          "cancel": "Cancel",
+          "save": "Save Changes",
+          "saving": "Saving..."
+        },
+        "defaultDescription": "Contains {name}",
+        "description": "Manage allergens for {productName}",
+        "empty": {
+          "noAllergens": "No allergens detected"
+        },
+        "errors": {
+          "duplicate": "Allergen {name} already added",
+          "emptyName": "Allergen name cannot be empty",
+          "missingData": "Missing product data",
+          "saveFailed": "Failed to save allergens"
+        },
+        "labels": {
+          "currentAllergens": "Current Allergens",
+          "customAllergen": "Add Custom Allergen",
+          "quickAdd": "Quick Add Common Allergens"
+        },
+        "placeholders": {
+          "customAllergen": "Enter allergen name..."
+        },
+        "success": {
+          "added": "Added allergen: {name}",
+          "removed": "Removed allergen: {name}",
+          "saved": "Allergens updated successfully"
+        },
+        "title": "Edit Allergens"
+      },
+      "analyzeDialog": {
+        "analysisSteps": {
+          "analyzingWithAi": "Analyzing with AI...",
+          "categorizingItems": "Categorizing items...",
+          "finalizingResults": "Finalizing results...",
+          "preparingDocument": "Preparing document...",
+          "processing": "Processing...",
+          "runningOcrExtraction": "Running OCR extraction..."
+        },
+        "analyzing": {
+          "progressComplete": "{progress}% complete",
+          "title": "Analyzing Invoice"
+        },
+        "badges": {
+          "recommended": "Recommended"
+        },
+        "buttons": {
+          "analyzing": "Analyzing...",
+          "cancel": "Cancel",
+          "startAnalysis": "Start Analysis"
+        },
+        "enhancements": {
+          "priceComparison": {
+            "description": "Compare prices with historical data",
+            "label": "Price Comparison"
+          },
+          "quickExtract": {
+            "description": "Prioritize speed over accuracy",
+            "label": "Quick Extract Mode"
+          },
+          "savingsTips": {
+            "description": "Get AI-powered saving recommendations",
+            "label": "Savings Suggestions"
+          }
+        },
+        "header": {
+          "description": "Configure AI-powered analysis for invoice",
+          "title": "Analyze Invoice"
+        },
+        "options": {
+          "completeAnalysis": {
+            "description": "Full AI-powered analysis including all invoice data, items, and merchant information.",
+            "estimatedTime": "2-3 min",
+            "features": {
+              "itemCategorization": "Item categorization",
+              "merchantIdentification": "Merchant identification",
+              "ocrExtraction": "OCR extraction",
+              "priceAnalysis": "Price analysis",
+              "receiptValidation": "Receipt validation"
+            },
+            "title": "Complete Analysis"
+          },
+          "invoiceOnly": {
+            "description": "Analyze basic invoice information like totals, dates, and payment details.",
+            "estimatedTime": "30-60 sec",
+            "features": {
+              "dateParsing": "Date parsing",
+              "paymentMethodDetection": "Payment method detection",
+              "totalExtraction": "Total extraction"
+            },
+            "title": "Invoice Data Only"
+          },
+          "itemsOnly": {
+            "description": "Focus on extracting and categorizing individual line items from the invoice.",
+            "estimatedTime": "1-2 min",
+            "features": {
+              "categoryAssignment": "Category assignment",
+              "itemExtraction": "Item extraction",
+              "pricePerItem": "Price per item",
+              "quantityDetection": "Quantity detection"
+            },
+            "title": "Items Analysis"
+          },
+          "merchantOnly": {
+            "description": "Identify and analyze merchant information including location and category.",
+            "estimatedTime": "30-45 sec",
+            "features": {
+              "businessCategory": "Business category",
+              "contactInfo": "Contact info",
+              "locationExtraction": "Location extraction",
+              "merchantIdentification": "Merchant identification"
+            },
+            "title": "Merchant Analysis"
+          }
+        },
+        "sections": {
+          "analysisType": "Analysis Type",
+          "enhancementsOptional": "Enhancements (Optional)",
+          "includedFeatures": "Included Features"
+        },
+        "summary": {
+          "enhancementsSelected": "+ {count} enhancement(s)",
+          "estimatedTime": "Estimated time",
+          "noEnhancementsSelected": "No enhancements selected"
+        },
+        "toasts": {
+          "analysisComplete": {
+            "description": "Your invoice has been analyzed successfully.",
+            "title": "Analysis Complete"
+          },
+          "analysisFailed": {
+            "description": "We couldn't analyze your invoice. Please try again.",
+            "title": "Analysis Failed"
+          }
+        }
+      },
+      "bulkCategoryDialog": {
+        "buttons": {
+          "cancel": "Cancel",
+          "save": "Apply to All",
+          "saving": "Saving..."
+        },
+        "description": "{count, plural, one {Change category for # product} other {Change category for # products}}",
+        "errors": {
+          "allFailed": "All products failed to update",
+          "missingData": "Missing data",
+          "noProducts": "No products selected",
+          "saveFailed": "Failed to update categories"
+        },
+        "labels": {
+          "andMore": "...and {count} more",
+          "newCategory": "New Category",
+          "progress": "Progress",
+          "selectedProducts": "Selected Products"
+        },
+        "placeholders": {
+          "selectCategory": "Select a category"
+        },
+        "progress": {
+          "updating": "Updating {current} of {total}..."
+        },
+        "success": {
+          "partialSuccess": "Updated {success} products, {failed} failed",
+          "saved": "{count, plural, one {Category updated for # product} other {Category updated for # products}}"
+        },
+        "title": "Change Category"
+      },
+      "createInvoiceDialog": {
+        "batchMode": {
+          "description": "Creates 1 invoice with all {count} scans attached. Best for multi-page receipts.",
+          "title": "Combine into one invoice"
+        },
+        "buttons": {
+          "cancel": "Cancel",
+          "close": "Close",
+          "createMultiple": "Start analysis on {count} scans",
+          "createSingle": "Start analysis"
+        },
+        "chooseMode": "Choose Creation Mode",
+        "complete": {
+          "description": "Your invoice is ready for viewing and editing.",
+          "descriptionPlural": "Your invoices are ready for viewing and editing.",
+          "errorsLabel": "Failed Scans:",
+          "failureDescription": "We couldn't create any invoices. Please review the errors below and try again.",
+          "failureTitle": "Creation Failed",
+          "nextSteps": "Next steps:",
+          "nextStepsDescription": "Review your invoice, verify the extracted data, and make any necessary edits. You can also request AI analysis for spending insights.",
+          "nextStepsDescriptionPlural": "Review your invoices, verify the extracted data, and make any necessary edits. You can also request AI analysis for spending insights.",
+          "partialDescription": "Some scans couldn't be processed. Successfully created invoices are ready for viewing.",
+          "partialTitle": "{created} of {total} Invoices Created",
+          "retryButton": "Try Again",
+          "title": "{count} Invoice Created!",
+          "titlePlural": "{count} Invoices Created!",
+          "viewButton": "View Invoice",
+          "viewButtonPlural": "View Invoices"
+        },
+        "creating": {
+          "processing": "Processing {count} scan...",
+          "processingPlural": "Processing {count} scans...",
+          "step1Description": "Sending your scans to our servers",
+          "step1Title": "Uploading scans",
+          "step2Description": "Setting up invoice data structures",
+          "step2Title": "Creating invoice records",
+          "step3Description": "Preparing invoices for viewing",
+          "step3Title": "Finalizing",
+          "title": "Creating Your Invoice",
+          "titlePlural": "Creating Your Invoices"
+        },
+        "description": "Transform your scans into structured invoice data.",
+        "errors": {
+          "createFailed": "Failed to create invoices: {message}",
+          "partialFail": "Failed to create {count} invoice(s)",
+          "unknown": "Unknown error"
+        },
+        "selectedScans": "Selected Scans",
+        "singleMode": {
+          "description": "Creates {count} separate invoices. Best when each scan is a different receipt.",
+          "title": "One invoice per scan"
+        },
+        "singleScanInfo": {
+          "description": "Our AI will analyze your scan and automatically extract merchant details, items, prices, and totals. You can review and edit the results afterward.",
+          "title": "What happens next?"
+        },
+        "title": "Start AI analysis",
+        "titlePlural": "Start AI analysis",
+        "totalSize": "total"
+      },
+      "deleteInvoiceDialog": {
+        "buttons": {
+          "cancel": "Cancel",
+          "deletePermanently": "Delete permanently",
+          "deleting": "Deleting..."
+        },
+        "confirmation": {
+          "typeToConfirm": "Type <highlight>{name}</highlight> to confirm:",
+          "understoodDescription": "This invoice and all its data will be permanently deleted and cannot be recovered.",
+          "understoodLabel": "I understand this action is permanent"
+        },
+        "console": {
+          "deleteError": "Error deleting invoice:"
+        },
+        "deleting": {
+          "description": "Please wait while we remove all associated data.",
+          "title": "Deleting invoice..."
+        },
+        "description": "This action cannot be undone. Please review carefully before proceeding.",
+        "impact": {
+          "intro": "The following data will be permanently deleted:",
+          "invoiceRecord": "Invoice record and metadata",
+          "lineItems": "{count} line item(s)",
+          "sharedAccess": "Shared access for {count} user(s)",
+          "title": "Permanent deletion",
+          "uploadedScans": "{count} uploaded scan(s)"
+        },
+        "title": "Delete invoice",
+        "toasts": {
+          "deletedDescription": "The invoice was deleted successfully.",
+          "deletedTitle": "Invoice deleted",
+          "deleteFailedDescription": "We couldn't delete this invoice. Please try again.",
+          "deleteFailedTitle": "Delete failed"
+        }
+      },
+      "exportDialog": {
+        "buttons": {
+          "cancel": "Cancel",
+          "copied": "Copied!",
+          "copy": "Copy to Clipboard",
+          "export": "Export"
+        },
+        "description": "Export {count} invoices in your preferred format.",
+        "estimate": {
+          "label": "Estimated file size:"
+        },
+        "filename": {
+          "hint": "The file will be saved with the extension based on format",
+          "label": "Filename"
+        },
+        "format": {
+          "descriptions": {
+            "csv": "Spreadsheet format, compatible with Excel",
+            "json": "Structured data format",
+            "pdf": "Printable document format"
+          },
+          "labels": {
+            "csv": "CSV",
+            "json": "JSON",
+            "pdf": "PDF"
+          },
+          "title": "Export Format"
+        },
+        "options": {
+          "csv": {
+            "delimiterLabel": "CSV Delimiter Override (optional):",
+            "delimiterPlaceholder": ",",
+            "includeHeaders": "Include CSV Headers"
+          },
+          "includeMerchant": "Include merchant",
+          "includeMetadata": "Include metadata",
+          "includeProducts": "Include products",
+          "json": {
+            "prettyPrint": "Pretty Print (2 spaces)"
+          },
+          "title": "Options"
+        },
+        "title": "Export Invoices"
+      },
+      "feedbackDialog": {
+        "buttons": {
+          "cancel": "Cancel",
+          "submit": "Submit Feedback"
+        },
+        "commentsPlaceholder": "Share your thoughts about the analytics...",
+        "description": "Help us improve analytics for {merchant} by sharing your thoughts",
+        "features": {
+          "categoryBreakdown": "Category Breakdown",
+          "merchantAnalysis": "Merchant Analysis",
+          "priceComparisons": "Price Comparisons",
+          "savingsTips": "Savings Tips",
+          "spendingTrends": "Spending Trends",
+          "visualCharts": "Visual Charts"
+        },
+        "sections": {
+          "comments": "Additional comments (optional)",
+          "features": "Which features were most helpful? (Select all that apply)",
+          "rating": "How would you rate the analytics?"
+        },
+        "title": "Provide Feedback",
+        "toasts": {
+          "error": {
+            "description": "Please try again later.",
+            "title": "An error occurred while submitting feedback"
+          },
+          "ratingRequired": {
+            "description": "Please provide a star rating before submitting",
+            "title": "Rating required"
+          },
+          "sending": {
+            "description": "Please wait while we submit your feedback.",
+            "title": "Sending feedback..."
+          },
+          "success": {
+            "description": "Feedback sent successfully",
+            "title": "Feedback sent!"
+          }
+        }
+      },
+      "imageDialog": {
+        "imageAlt": "Photo of receipt",
+        "title": "Image ({image})"
+      },
+      "importDialog": {
+        "buttons": {
+          "cancel": "Cancel",
+          "import": "Import",
+          "importWithCount": "Import ({count})"
+        },
+        "description": "Upload your invoice files to import them into the system.",
+        "dropzone": {
+          "acceptsCsv": "Accepts .csv files (max 10MB)",
+          "acceptsPdf": "Accepts .pdf files (max 10MB)",
+          "acceptsXlsx": "Accepts .xlsx and .xls files (max 10MB)",
+          "dragAndDrop": "Drag & drop files here",
+          "dropHere": "Drop files here...",
+          "orClickBrowse": "or click to browse files"
+        },
+        "remove": "Remove",
+        "selectedFiles": "Selected Files",
+        "status": {
+          "error": "Error importing files. Please try again.",
+          "success": "Files imported successfully!"
+        },
+        "tabs": {
+          "csv": "CSV",
+          "pdf": "PDF",
+          "xlsx": "Excel"
+        },
+        "title": "Import Invoices"
+      },
+      "itemsDialog": {
+        "aria": {
+          "addItem": "Add a new item to the invoice",
+          "cancel": "Cancel editing and close dialog",
+          "deleteItem": "Delete item: {name}",
+          "nextPage": "Go to next page (page {page})",
+          "previousPage": "Go to previous page (page {page})",
+          "save": "Save changes to invoice items",
+          "unnamedItem": "unnamed item"
+        },
+        "buttons": {
+          "addItem": "Add item",
+          "cancel": "Cancel",
+          "next": "Next",
+          "previous": "Previous",
+          "saveChanges": "Save changes"
+        },
+        "description": "Update quantities, prices, or add new items to this invoice",
+        "footer": {
+          "itemsFound": "{total} items found (showing {shown})",
+          "itemsTotal": "{count, plural, one {# item in total} other {# items in total}}",
+          "page": "Page {current} of {total}"
+        },
+        "table": {
+          "actions": "Actions",
+          "item": "Item",
+          "price": "Price",
+          "quantity": "Quantity",
+          "total": "Total",
+          "unit": "Unit"
+        },
+        "title": "Edit invoice items"
+      },
+      "merchantDialog": {
+        "buttons": {
+          "openInMaps": "Open in Maps"
+        },
+        "description": "Information about {merchantName}",
+        "fields": {
+          "address": "Address",
+          "parentCompany": "Parent Company",
+          "phone": "Phone"
+        },
+        "noMerchantLinked": "No merchant linked to this invoice",
+        "title": "Merchant Details"
+      },
+      "merchantReceiptsDialog": {
+        "buttons": {
+          "next": "Next",
+          "previous": "Previous"
+        },
+        "dateOptions": {
+          "allTime": "All time",
+          "last30Days": "Last 30 days",
+          "last90Days": "Last 90 days",
+          "thisYear": "This year"
+        },
+        "description": "View and filter all your receipts from this merchant",
+        "filters": {
+          "date": "Date",
+          "sort": "Sort"
+        },
+        "footer": {
+          "page": "Page {current} of {total}",
+          "receiptsFound": "{count} receipts found (showing {showing})"
+        },
+        "searchPlaceholder": "Search receipts...",
+        "sortOptions": {
+          "newest": "Newest first",
+          "oldest": "Oldest first"
+        },
+        "table": {
+          "actions": "Actions",
+          "date": "Date",
+          "itemsCount": "Items #",
+          "receipt": "Receipt",
+          "view": "View"
+        },
+        "title": "All receipts from {merchant}"
+      },
+      "metadataDialog": {
+        "add": {
+          "description": "Add additional information to this invoice",
+          "title": "Add metadata"
+        },
+        "buttons": {
+          "cancel": "Cancel",
+          "delete": "Delete",
+          "save": "Save"
+        },
+        "delete": {
+          "description": "Are you sure you want to delete this metadata?",
+          "title": "Delete metadata"
+        },
+        "edit": {
+          "description": "Update the value of this metadata field",
+          "fieldLabel": "Metadata field",
+          "title": "Edit metadata"
+        },
+        "fields": {
+          "keyLabel": "Metadata key",
+          "keyPlaceholder": "Enter key",
+          "valueLabel": "Metadata value",
+          "valuePlaceholder": "Enter value"
+        }
+      },
+      "recipeDialog": {
+        "actions": {
+          "enhanceInstructions": "Enhance instructions",
+          "generateName": "Generate name",
+          "unavailable": "This recipe assistant action is not available yet"
+        },
+        "buttons": {
+          "add": "Add",
+          "cancel": "Cancel",
+          "close": "Close",
+          "delete": "Delete",
+          "deleting": "Deleting...",
+          "save": "Save",
+          "saving": "Saving..."
+        },
+        "create": {
+          "description": "Fill in the details to create a recipe.",
+          "error": "Failed to create recipe",
+          "success": "Recipe created successfully",
+          "title": "Add new recipe"
+        },
+        "delete": {
+          "description": "This action cannot be undone. This will permanently delete the recipe <strong>{name}</strong> and all its associated data.",
+          "error": "Failed to delete recipe",
+          "missingRecipe": "Recipe details are unavailable.",
+          "success": "Recipe deleted successfully",
+          "title": "Are you sure?"
+        },
+        "difficulty": {
+          "easy": "Easy",
+          "hard": "Hard",
+          "medium": "Medium"
+        },
+        "fields": {
+          "complexity": "Complexity level",
+          "cookTime": "Cook time",
+          "description": "Description",
+          "difficulty": "Difficulty level",
+          "ingredients": "Ingredients",
+          "instructions": "Instructions",
+          "prepTime": "Prep time",
+          "recipeName": "Recipe name",
+          "totalDuration": "Total Duration"
+        },
+        "minutes": "minutes",
+        "placeholders": {
+          "cookTime": "e.g. 30 minutes",
+          "description": "Enter a brief description of the recipe",
+          "instructions": "Enter cooking instructions",
+          "prepTime": "e.g. 15 minutes",
+          "recipeName": "Enter recipe name",
+          "selectDifficulty": "Select difficulty"
+        },
+        "read": {
+          "description": "Recipe details and cooking instructions",
+          "missingRecipe": "Recipe details are unavailable.",
+          "noDescription": "No description provided.",
+          "notSpecified": "Not specified"
+        },
+        "share": {
+          "copied": "Recipe link copied",
+          "copy": "Copy link",
+          "copyFailed": "Failed to copy recipe link",
+          "description": "Share the recipe reference link when one is available.",
+          "missingRecipe": "Recipe details are unavailable.",
+          "title": "Share recipe",
+          "unavailable": "Recipe sharing is not available for this recipe yet."
+        },
+        "tooltips": {
+          "enhanceInstructions": "Use AI to enhance your instructions with more details",
+          "generateName": "Generate a recipe name based on your ingredients and difficulty level using AI"
+        },
+        "update": {
+          "description": "Update recipe details.",
+          "error": "Failed to update recipe",
+          "missingRecipe": "Recipe details are unavailable.",
+          "success": "Recipe updated successfully",
+          "title": "Update recipe"
+        }
+      },
+      "removeScanDialog": {
+        "buttons": {
+          "cancel": "Cancel",
+          "remove": "Remove scan",
+          "removing": "Removing..."
+        },
+        "console": {
+          "deleteError": "Error deleting scan:"
+        },
+        "description": "Are you sure you want to remove scan {current} of {total}?",
+        "descriptionLastScan": "This is the only scan attached to this invoice. You cannot remove it.",
+        "errors": {
+          "unknown": "Unknown error occurred"
+        },
+        "scanAlt": "Scan {index}",
+        "scanCaption": "Scan {index}",
+        "title": "Remove scan",
+        "toasts": {
+          "cannotDeleteLastDescription": "An invoice must have at least one scan attached",
+          "cannotDeleteLastTitle": "Cannot delete last scan",
+          "removedDescription": "The scan has been removed from the invoice",
+          "removedTitle": "Scan removed successfully",
+          "removeFailedTitle": "Failed to remove scan"
+        },
+        "warning": {
+          "description": "Every invoice must have at least one scan attached. Add another scan before removing this one.",
+          "title": "Cannot remove last scan"
+        }
+      },
+      "shareAnalyticsDialog": {
+        "description": "Share your spending analytics for {merchant} with others.",
+        "email": {
+          "description": "Send the analytics to an email address.",
+          "label": "Email address",
+          "placeholder": "name@example.com",
+          "send": "Send Email"
+        },
+        "image": {
+          "copyToClipboard": "Copy graph to clipboard",
+          "description": "Download or copy the analytics graph as a PNG image that you can share or save.",
+          "download": "Download graph",
+          "previewPlaceholder": "Analytics Preview"
+        },
+        "tabs": {
+          "email": "Email",
+          "image": "Image"
+        },
+        "title": "Share Analytics",
+        "toasts": {
+          "emailSent": {
+            "description": "Analytics report sent to {email}",
+            "title": "Email sent!"
+          },
+          "imageCopied": {
+            "description": "The analytics image has been copied to your clipboard",
+            "title": "Image copied!"
+          },
+          "imageSaved": {
+            "description": "Spending analytics for {merchant} has been downloaded as PNG",
+            "title": "Image saved!"
+          }
+        }
+      },
+      "shareInvoiceDialog": {
+        "dialogDescription": {
+          "currentlyPublic": "\"{invoiceName}\" is currently public",
+          "private": "Send \"{invoiceName}\" privately",
+          "public": "Share \"{invoiceName}\" publicly",
+          "selection": "Choose how to share \"{invoiceName}\""
+        },
+        "errors": {
+          "qrNotFound": "QR code element not found"
+        },
+        "selection": {
+          "description": "Choose how you want to share this invoice. Your choice affects who can access it.",
+          "privacyNoticeDescription": "Public links can be accessed by anyone who has the URL. Private sharing restricts access to the specific recipient.",
+          "privacyNoticeTitle": "Privacy notice",
+          "privateDescription": "Send an email invitation to a <strong>specific person</strong>. Only they will have access.",
+          "privateTitle": "Private sharing",
+          "publicDescription": "Generate a link or QR code that <strong>anyone</strong> can use to view this invoice.",
+          "publicTitle": "Public sharing"
+        },
+        "title": "Share invoice",
+        "toasts": {
+          "copyLink": {
+            "error": "Failed: {message}",
+            "loadingMakePublic": "Making invoice public...",
+            "loadingPublic": "Copying link...",
+            "successMadePublic": "Invoice is now public! Link copied to clipboard.",
+            "successPublic": "Link copied to clipboard!"
+          },
+          "copyQr": {
+            "error": "Failed: {message}",
+            "loadingMakePublic": "Making invoice public...",
+            "loadingPublic": "Copying QR code...",
+            "successMadePublic": "Invoice is now public! QR code copied to clipboard.",
+            "successPublic": "QR code copied to clipboard!"
+          },
+          "revoke": {
+            "error": "Failed to revoke access: {message}",
+            "loading": "Sending revoke request to backend...",
+            "success": "Invoice is now private. Existing links will no longer work."
+          },
+          "sendEmail": {
+            "comingSoon": "Email sharing is coming soon",
+            "error": "Failed: {message}",
+            "loading": "Sending invitation to {email}...",
+            "success": "Invitation sent to {email}!"
+          }
+        }
+      },
+      "shareInvoiceDialogPrivate": {
+        "backToOptions": "Back to options",
+        "comingSoonTooltip": "Email sharing feature is coming soon",
+        "description": "The invitation will be sent directly to the email address you specify. Only this recipient will receive access to view the invoice.",
+        "emailHint": "An email invitation will be sent to this address with a private link to view the invoice.",
+        "emailLabel": "Recipient's email address",
+        "emailPlaceholder": "name@example.com",
+        "sending": "Sending invitation...",
+        "sendInvitation": "Send private invitation",
+        "title": "Private sharing"
+      },
+      "shareInvoiceDialogPublic": {
+        "alreadyPublic": {
+          "description": "This invoice is publicly accessible. <strong>Anyone with the link can view it</strong>, including all invoice details, items, and amounts. You can revoke public access at any time to make it private again.",
+          "revoke": "Revoke public access",
+          "revokeHint": "This will make the invoice private. Existing links will stop working.",
+          "revoking": "Revoking access...",
+          "title": "This invoice is currently public"
+        },
+        "backToOptions": "Back to options",
+        "copyQrImage": "Copy QR code as image",
+        "hints": {
+          "link": "Copy this link and share it. Anyone who receives it will be able to view the invoice.",
+          "qr": "Anyone who scans this QR code will be directed to view the invoice."
+        },
+        "tabs": {
+          "directLink": "Direct link",
+          "qrCode": "QR code"
+        },
+        "warning": {
+          "description": "By sharing this invoice publicly, <strong>anyone with the link will be able to view it</strong>. This includes all invoice details, items, and amounts. Only proceed if you intend to make this invoice accessible to the public.",
+          "title": "Public access warning"
+        }
+      }
+    }
+  },
+  "emails": {
+    "accountInactivity": {
+      "badge": "Account",
+      "cta": {
+        "primary": "Sign in",
+        "secondary": "Contact support"
+      },
+      "footnote": "Note: This notice is informational and intended to help you avoid losing access. Actual account retention policies may vary by region and product.",
+      "greeting": "Hi {name},",
+      "heading": "Account inactivity notice",
+      "intro": "This is a heads-up that your account has been inactive for <count>{inactiveDays}</count> days.",
+      "preview": "Hi {name} — your account has been inactive for {inactiveDays} days.",
+      "signOff": {
+        "line1": "Best regards,",
+        "line2": "The {brand} Team"
+      },
+      "subject": "We miss you at {brand}",
+      "supportPrompt": "If you believe you received this message in error, or you need assistance, please contact <link>{supportEmail}</link>.",
+      "timeline": {
+        "daysValue": "{days} days",
+        "inactiveFor": "Inactive for",
+        "timeRemaining": "Time remaining",
+        "title": "Timeline"
+      },
+      "whatThisMeans": {
+        "bullet1": "Signing in will keep your account active.",
+        "bullet2": "If there's no activity for the next {daysUntilClosure} days, the account may be scheduled for closure.",
+        "bullet3": "If you want to keep your data, please take action before the deadline.",
+        "title": "What this means"
+      }
+    },
+    "firstInvoiceUploaded": {
+      "badge": "Milestone",
+      "body": "The more invoices you upload, the richer your spending insights become. Try uploading a few more receipts this week to see your dashboard come to life.",
+      "ctaPrimary": "View your invoice",
+      "ctaSecondary": "Upload another receipt",
+      "featuresToExplore": {
+        "item0": "Share invoices with family or colleagues for joint expense tracking",
+        "item1": "View AI-generated recipe suggestions from your grocery items",
+        "item2": "Check allergen warnings on detected food products",
+        "item3": "Track spending patterns across merchants, categories, and time periods"
+      },
+      "featuresToExploreTitle": "Features to explore",
+      "feedbackPrompt": "Need help or have feedback? Reach us at <email></email>.",
+      "greeting": "Hi {name},",
+      "heading": "Your first invoice is in!",
+      "intro": "Congratulations on uploading your first invoice! You've taken the first step toward organized, insightful spending tracking. Here's what we've got so far:",
+      "invoiceSummary": {
+        "invoiceName": "Invoice name",
+        "status": "Status",
+        "uploaded": "Uploaded"
+      },
+      "invoiceSummaryTitle": "Your First Invoice",
+      "preview": "Congratulations, {name}! Your first invoice is in.",
+      "signOff": {
+        "line1": "Cheers,",
+        "line2": "The {brand} Team"
+      },
+      "statusValue": "Ready for analysis",
+      "subject": "Your first invoice is in!",
+      "untitledFallback": "Untitled",
+      "whatHappensNext": {
+        "item0": "We analyze your receipt — our AI extracts items, prices, and merchant info",
+        "item1": "You review the results — check the analysis and correct anything that looks off",
+        "item2": "Your dashboard updates — spending charts, category breakdowns, and trends start building"
+      },
+      "whatHappensNextTitle": "What happens next"
+    },
+    "incompleteInvoice": {
+      "analyzedOnLabel": "Analyzed on",
+      "badge": "Reminder",
+      "bodyText": "Completing these details takes less than a minute and ensures your spending reports stay accurate.",
+      "feedback": "Stuck or need help? Reach out at <link>{supportEmail}</link>.",
+      "greeting": "Hi {name},",
+      "heading": "Your invoice needs a quick update",
+      "intro": "We analyzed your invoice {invoiceName} but couldn't extract everything. A few details are missing, and completing them will give you better spending insights and more accurate dashboards.",
+      "invoiceDetailsTitle": "Invoice Details",
+      "invoiceLabel": "Invoice",
+      "missingFields": {
         "category": {
-          "label": "Category",
-          "options": {
+          "label": "Invoice category",
+          "suggestion": "Select a category (groceries, fast food, household, etc.)"
+        },
+        "items": {
+          "label": "Line items",
+          "suggestion": "Try re-uploading a clearer photo, or add items manually"
+        },
+        "merchant": {
+          "label": "Merchant",
+          "suggestion": "Add the store name manually in the edit view"
+        },
+        "payment": {
+          "label": "Payment info",
+          "suggestion": "Enter the total amount and payment method in the edit view"
+        },
+        "unknown": {
+          "label": "{field}",
+          "suggestion": "Please review and update this information"
+        }
+      },
+      "missingFieldsLabel": "Missing fields",
+      "preview": "{name}, your invoice \"{invoiceName}\" needs some attention.",
+      "primaryCta": "Complete your invoice",
+      "secondaryCta": "Re-run analysis",
+      "signOff": {
+        "line1": "Best regards,",
+        "line2": "The {brand} Team"
+      },
+      "subject": "You have incomplete invoices",
+      "tips": {
+        "item0": "Use a well-lit, flat surface when photographing receipts",
+        "item1": "Ensure the entire receipt is visible and in focus",
+        "item2": "PDF receipts from online orders tend to analyze best",
+        "item3": "You can always add or correct details manually after analysis"
+      },
+      "tipsTitle": "Tips for better analysis",
+      "whatsMissingTitle": "What's missing"
+    },
+    "invoiceAnalyzed": {
+      "badge": "Invoices • Analysis Complete",
+      "body": "Click the button above to view the complete analysis. If anything looks off—perhaps a product was miscategorized or a price wasn't detected correctly—you can edit the invoice directly in your dashboard and the insights will update automatically.",
+      "ctaPrimary": "View full analysis",
+      "feedbackPrompt": "Have questions about your analysis, or need help? Contact us at <email></email>.",
+      "greeting": "Hi {name},",
+      "heading": "Your invoice analysis is ready",
+      "intro": "Great news! Our AI has finished analyzing your invoice. We've extracted all the key information, categorized your items, and generated spending insights to help you track your finances.",
+      "preview": "Your invoice is ready, {name}. Analysis complete!",
+      "signOff": {
+        "line1": "Cheers,",
+        "line2": "The {brand} Team"
+      },
+      "subject": "Your invoice has been analyzed",
+      "summary": {
+        "invoiceName": "Invoice name",
+        "itemsDetected": "Items detected",
+        "merchantId": "Merchant ID",
+        "notIdentified": "Not identified yet",
+        "totalAmount": "Total amount"
+      },
+      "summaryTitle": "Invoice Summary",
+      "whatWasAnalyzed": {
+        "item0": "Merchant identification and categorization",
+        "item1": "Line-by-line item extraction with pricing",
+        "item2": "Automatic product categorization (groceries, beverages, household, etc.)",
+        "item3": "Currency detection and amount validation",
+        "item4": "Date and time extraction when available"
+      },
+      "whatWasAnalyzedTitle": "What was analyzed"
+    },
+    "invoiceDeleted": {
+      "badge": "Invoices • Deleted",
+      "body": "If you didn't initiate this deletion, or if you need to recover the invoice, please contact us immediately at <email></email>. We're here to help.",
+      "ctaPrimary": "View your invoices",
+      "details": {
+        "invoice": "Invoice",
+        "invoiceId": "Invoice ID",
+        "status": "Status"
+      },
+      "detailsTitle": "Deletion Details",
+      "greeting": "Hi {name},",
+      "heading": "Invoice removed from your account",
+      "intro": "This email confirms that an invoice has been removed from your {brand} account. The deletion was processed successfully.",
+      "placeholder": "—",
+      "preview": "Invoice {invoiceLabel} has been removed from your account.",
+      "signOff": {
+        "line1": "Cheers,",
+        "line2": "The {brand} Team"
+      },
+      "statusValue": "Deleted (soft delete)",
+      "subject": "Your invoice was deleted",
+      "whatYouShouldKnow": {
+        "item0": "This is a soft delete—the invoice data may be retained for 30 days for recovery purposes.",
+        "item1": "Any shared access to this invoice has been automatically revoked.",
+        "item2": "Statistics and insights will be recalculated to exclude this invoice.",
+        "item3": "If you need to recover this invoice, contact support within 30 days."
+      },
+      "whatYouShouldKnowTitle": "What you should know"
+    },
+    "invoiceInactivity": {
+      "badge": {
+        "item14": "Inactivity • 14 days",
+        "item3": "Inactivity • 3 days",
+        "item30": "Inactivity • 30 days",
+        "item7": "Inactivity • 7 days"
+      },
+      "cta": {
+        "primary": "Upload an invoice",
+        "secondary": "View invoices"
+      },
+      "greeting": "Hi {name},",
+      "heading": {
+        "item14": "Let's get you back on track",
+        "item3": "Quick check-in",
+        "item30": "It's been a while",
+        "item7": "A gentle reminder"
+      },
+      "helpPrompt": "Need help or have questions? Email <link>{supportEmail}</link>.",
+      "important": {
+        "message": "If you're stuck or something isn't working, reply to this email or contact support — we'll help.",
+        "title": "Important"
+      },
+      "intro": {
+        "item14": "Two weeks without uploads — want a quick nudge to restart the habit?",
+        "item3": "We noticed you haven't uploaded any invoices recently.",
+        "item30": "It's been about a month since your last upload — we can help you pick up where you left off.",
+        "item7": "Looks like it's been a week since your last invoice upload."
+      },
+      "preview": "Hi {name} — {days} days since your last upload.",
+      "signOff": {
+        "line1": "Best regards",
+        "line2": "The {brand} Team"
+      },
+      "status": {
+        "daysWithoutUpload": "Days without upload",
+        "lastUpload": "Last upload",
+        "title": "Status"
+      },
+      "subject": "It's been {daysWithoutUpload} days since your last invoice",
+      "tip": {
+        "message": "Upload one recent invoice today — small consistency beats big catch-up.",
+        "title": "Tip (30 seconds)"
+      },
+      "whyWorthIt": {
+        "bullet1": "Keep your spending timeline accurate.",
+        "bullet2": "Get cleaner totals by merchant and category.",
+        "bullet3": "Find receipts faster when you need them.",
+        "title": "Why it's worth it"
+      }
+    },
+    "invoiceMadePublic": {
+      "accessValue": "Public (anyone with link)",
+      "badge": "Invoices • Public Link",
+      "ctaPrimary": "Open public invoice",
+      "details": {
+        "access": "Access",
+        "created": "Created",
+        "invoiceId": "Invoice ID",
+        "invoiceName": "Invoice name",
+        "merchant": "Merchant",
+        "total": "Total"
+      },
+      "detailsTitle": "Invoice details",
+      "directLinkLabel": "Direct link:",
+      "feedbackPrompt": "Questions about sharing or privacy settings? Contact us at <email></email>.",
+      "greeting": "Hi {name},",
+      "heading": "Your invoice is now public",
+      "howToShare": {
+        "item0": "Copy the direct link below and send via email or message",
+        "item1": "Print or screenshot the QR code for in-person sharing",
+        "item2": "Include in expense reports or reimbursement requests"
+      },
+      "howToShareTitle": "How to share",
+      "intro": "You've successfully made your invoice public. Anyone with the link or QR code below can now view this invoice—no login required. This is perfect for sharing receipts with colleagues, accountants, or for expense reporting.",
+      "preview": "Your invoice \"{invoiceName}\" is now public and shareable.",
+      "privacyNoticeBody": "Public invoices can be accessed by anyone who has the URL or QR code. To make this invoice private again, update the sharing settings from your invoice page at any time.",
+      "privacyNoticeTitle": "Privacy Notice",
+      "qrAlt": "QR Code for invoice access",
+      "qrSubText": "Scan with your phone camera for instant access.",
+      "qrTitle": "Quick Access QR Code",
+      "signOff": {
+        "line1": "Cheers,",
+        "line2": "The {brand} Team"
+      },
+      "subject": "Your invoice is now public"
+    },
+    "invoiceShared": {
+      "badge": "Invoices • Shared",
+      "body": "Click the button above to access the shared invoice. This link will remain active as long as the sharing permissions are in place.",
+      "ctaPrimary": "View shared invoice",
+      "details": {
+        "invoiceId": "Invoice ID",
+        "sharedBy": "Shared by"
+      },
+      "detailsTitle": "Share details",
+      "feedbackPrompt": "Have questions about this share, or need help? Contact us at <email></email>.",
+      "greeting": "Hi {toName},",
+      "heading": "An invoice was shared with you",
+      "intro": "Great news! <from></from> has shared an invoice with you on {brand}. This gives you access to view all the invoice details, including itemized products, merchant information, and analysis insights.",
+      "preview": "{fromName} shared an invoice with you.",
+      "signOff": {
+        "line1": "Cheers,",
+        "line2": "The {brand} Team"
+      },
+      "subject": "{fromName} shared an invoice with you",
+      "whatYouCanDo": {
+        "item0": "View the complete invoice details and itemized breakdown",
+        "item1": "See analysis insights and spending categories",
+        "item2": "Download or print the invoice for your records"
+      },
+      "whatYouCanDoTitle": "What you can do"
+    },
+    "invoiceStats": {
+      "badge": "Invoices",
+      "body": "For a complete breakdown of your spending, visit your invoices list to review trends, merchants, categories, and totals over time. These insights can help you identify spending patterns and make more informed financial decisions.",
+      "breakdownCardTitle": "Spending breakdown (by category)",
+      "breakdownNote": "Note: This chart uses the available category ranking data for the period.",
+      "breakdownTableTitle": "Breakdown",
+      "ctaPrimary": "View invoices",
+      "ctaSecondary": "Upload a new invoice",
+      "donutChartAlt": "Donut chart showing spending distribution by category.",
+      "donutChartTitle": "Category spend distribution",
+      "feedbackPrompt": "Questions or something looks off? Email <email></email>.",
+      "frequencyLabel": "{frequency, select, daily {Daily} weekly {Weekly} monthly {Monthly} yearly {Yearly} other {Periodic}}",
+      "greeting": "Hi {name},",
+      "heading": "{frequencyLabel} invoice statistics",
+      "intro": "This is your invoice activity and spending summary for <start></start> → <end></end>.",
+      "metrics": {
+        "averagePerInvoice": "Avg / invoice",
+        "invoices": "Invoices",
+        "scans": "Scans",
+        "totalSpend": "Total spend"
+      },
+      "noDataFallback": "No data yet — upload a couple of invoices to unlock insights.",
+      "preview": "{frequencyLabel} stats for {name} — {totalSpend} total.",
+      "reportDetails": {
+        "currency": "Currency",
+        "period": "Period"
+      },
+      "reportDetailsTitle": "Report details",
+      "signOff": {
+        "line1": "Cheers,",
+        "line2": "The {brand} Team"
+      },
+      "subject": "Your {frequency, select, daily {daily} weekly {weekly} monthly {monthly} yearly {yearly} other {periodic}} invoice statistics",
+      "title": "{frequencyLabel} invoice stats",
+      "topCategoriesTitle": "Top categories",
+      "topMerchantsTitle": "Top merchants"
+    },
+    "invoiceUnshared": {
+      "badge": "Invoices • Access Revoked",
+      "body": "If you believe this change was made in error, please reach out to <from></from> or contact our support team. Access revocations are sometimes accidental, and we're happy to help facilitate communication if needed.",
+      "ctaPrimary": "View your invoices",
+      "ctaSecondary": "Contact support",
+      "details": {
+        "accessRevoked": "Revoked",
+        "invoiceId": "Invoice ID",
+        "notProvided": "—",
+        "revokedAt": "Revoked at",
+        "revokedBy": "Revoked by",
+        "yourAccess": "Your access"
+      },
+      "detailsTitle": "Revocation Details",
+      "feedbackPrompt": "Need assistance? Email us at <email></email>.",
+      "greeting": "Hi {toName},",
+      "heading": "Your access to an invoice was revoked",
+      "intro": "We're writing to let you know that <from></from> has revoked your access to an invoice that was previously shared with you. This means you will no longer be able to view this invoice.",
+      "preview": "{fromName} revoked your access to a shared invoice.",
+      "signOff": {
+        "line1": "Cheers,",
+        "line2": "The {brand} Team"
+      },
+      "subject": "Access to a shared invoice was revoked",
+      "whatThisMeans": {
+        "item0": "Any bookmarked links to this invoice will no longer work for you.",
+        "item1": "This invoice will not appear in your shared invoices list.",
+        "item2": "If you need access again, contact the invoice owner directly."
+      },
+      "whatThisMeansTitle": "What this means"
+    },
+    "layout": {
+      "allRightsReserved": "© 2022-{year} {brand}. All rights reserved.",
+      "buttonFallback": "If the button doesn't work, open this link:",
+      "managePreferences": "Manage email preferences",
+      "secondaryFallback": "Or:",
+      "tagline": "Practical tools. Clean insights. Built for everyday spending.",
+      "unsubscribe": "Unsubscribe"
+    },
+    "newsletterSubscribed": {
+      "badge": "Newsletter",
+      "body": "Your inbox is sacred—I respect that. Every email is crafted to provide genuine value, whether it's a tip that saves you hours or an insight that shifts your perspective on personal finance.",
+      "ctaPrimary": "Visit arolariu.ro",
+      "feedbackPrompt": "Questions, feedback, or just want to say hello? Reply to this email or reach me directly at <email></email>.",
+      "greeting": "Hi {name},",
+      "heading": "You're in — welcome aboard",
+      "intro": "Thanks for subscribing to the <brand>{brandName}</brand> newsletter. I'm genuinely excited to have you here. I'll keep communications lightweight, meaningful, and worth your time.",
+      "preview": "Welcome, {name} — you're subscribed.",
+      "signOff": {
+        "line1": "Best regards",
+        "line2": "The {brand} Team"
+      },
+      "subject": "You're subscribed!",
+      "whatToExpect": {
+        "item0": "Product updates & new features as they launch",
+        "item1": "New articles & write-ups about technology, productivity, and personal finance",
+        "item2": "Occasional highlights and curated resources (1–2 emails per quarter)"
+      },
+      "whatToExpectTitle": "What to expect"
+    },
+    "newsletterUnsubscribed": {
+      "badge": "Newsletter",
+      "body": "I appreciate the time you spent with us. If you have feedback about why you left or how I can improve, I'd genuinely love to hear it—just reply to this email.",
+      "ctaPrimary": "Review preferences",
+      "ctaSecondary": "Resubscribe",
+      "feedbackPrompt": "If you didn't request this unsubscription, or you need help with anything, please contact <email></email>.",
+      "greeting": "Hi {name},",
+      "heading": "You've been unsubscribed",
+      "intro": "This email confirms you've been removed from the <brand>{brandName}</brand> newsletter list. I'm sorry to see you go.",
+      "preview": "Hi {name} — you've been unsubscribed.",
+      "signOff": {
+        "line1": "Best regards",
+        "line2": "The {brand} Team"
+      },
+      "subject": "You've been unsubscribed",
+      "whatHappensNext": {
+        "item0": "You won't receive newsletter updates from us going forward.",
+        "item1": "You may still receive essential account and service emails if you use the product.",
+        "item2": "Changed your mind? You can resubscribe at any time using the button above."
+      },
+      "whatHappensNextTitle": "What happens next"
+    },
+    "spendingAlert": {
+      "badge": "Spending Alert • {percent}%",
+      "chartAlt": "Spending breakdown by category for {period}",
+      "chartTitle": "Spending by category",
+      "ctaPrimary": "View dashboard",
+      "detailsLabels": {
+        "budget": "Budget",
+        "category": "Category",
+        "period": "Period",
+        "spent": "Spent"
+      },
+      "detailsTitle": "Budget Details",
+      "feedbackPrompt": "Questions? Reach us at <email></email>.",
+      "greeting": "Hi {name},",
+      "heading": "{percent, select, 80 {Heads up: approaching your budget limit} 90 {Almost there: 90% of your budget used} 100 {Budget reached: you've hit your spending limit} other {Spending alert}}",
+      "intro": "{state, select, over {You've reached your spending limit for {category} in {period}. Here's a summary of where you stand.} other {You've used {percent}% of your {category} budget for {period}. Here's a quick summary to help you plan the rest of the period.}}",
+      "metricsLabels": {
+        "budgetLimit": "Budget limit",
+        "currentSpending": "Current spending",
+        "remaining": "Remaining",
+        "threshold": "Threshold"
+      },
+      "notificationsLink": "notification settings",
+      "notificationsParagraph": "You can adjust your budget thresholds and notification preferences in your <settings></settings>.",
+      "overBudgetValue": "Over budget",
+      "overBudgetWarning": "Your spending has reached or exceeded the budget you set. Review your recent purchases to stay on track.",
+      "preview": "{name}, you've used {percent}% of your {category} budget for {period}.",
+      "signOff": {
+        "line1": "Best regards",
+        "line2": "The {brand} Team"
+      },
+      "subject": "Spending threshold alert",
+      "tipsOnTrack": {
+        "item0": "Check your recent purchases to see where the bulk is going",
+        "item1": "Prioritize essential spending for the rest of the period",
+        "item2": "Consider cooking at home more if dining is driving costs up"
+      },
+      "tipsOverBudget": {
+        "item0": "Review recent purchases to identify non-essential spending",
+        "item1": "Consider adjusting your budget if it no longer reflects reality",
+        "item2": "Set a stricter threshold (e.g., 80%) for earlier warnings"
+      },
+      "tipsTitle": "{state, select, over {What you can do} other {Tips to stay on track}}"
+    },
+    "unanalyzedInvoices": {
+      "analysisProvidedTitle": "What analysis provides",
+      "analysisProvides": {
+        "item0": "Line-by-line item extraction with prices and categories",
+        "item1": "Merchant identification and categorization",
+        "item2": "Allergen detection on food products",
+        "item3": "Recipe suggestions based on your grocery items",
+        "item4": "Automatic spending categorization for dashboard insights"
+      },
+      "andMore": "…and {remaining} more. View all in your <dashboard></dashboard>.",
+      "badge": "Reminder",
+      "bodyText": "Analysis typically takes under a minute per invoice. Once complete, you'll receive a notification with the results.",
+      "feedback": "Need help? Contact us at <link>{supportEmail}</link>.",
+      "greeting": "Hi {name},",
+      "heading": "{count, plural, =1 {1 invoice waiting for analysis} other {# invoices waiting for analysis}}",
+      "intro": "{count, plural, =1 {You have 1 invoice that hasn't been analyzed yet. Running our AI analysis unlocks the full value of your uploaded receipts.} other {You have # invoices that haven't been analyzed yet. Running our AI analysis unlocks the full value of your uploaded receipts.}}",
+      "invoicesAwaitingTitle": "Invoices awaiting analysis",
+      "preview": "{name}, you have {count, plural, =1 {1 invoice} other {# invoices}} waiting for AI analysis.",
+      "primaryCta": "View invoices",
+      "signOff": {
+        "line1": "Best regards,",
+        "line2": "The {brand} Team"
+      },
+      "subject": "You have unanalyzed invoices",
+      "uploadedDate": "Uploaded {date}"
+    },
+    "weeklyUploadReminder": {
+      "badge": "Weekly Reminder",
+      "bodyText": "Every receipt you track makes your spending insights more accurate and your dashboards more useful.",
+      "feedback": "Questions or feedback? Reach us at <link>{supportEmail}</link>.",
+      "greeting": "Hi {name},",
+      "heading": "Your weekly receipt check-in",
+      "intro": "Here's a quick look at your receipt tracking activity. Consistent uploading gives you the most accurate spending insights.",
+      "metricsLabels": {
+        "lastWeek": "Last week",
+        "thisWeek": "This week",
+        "totalInvoices": "Total invoices",
+        "totalTracked": "Total tracked"
+      },
+      "preview": "Hi {name} — here's your weekly receipt check-in.",
+      "primaryCta": "Upload this week's receipts",
+      "quickTips": {
+        "item0": "Upload receipts right after shopping — it takes under 30 seconds",
+        "item1": "Batch upload at the end of the day if you prefer",
+        "item2": "Even small purchases help build a complete spending picture"
+      },
+      "quickTipsTitle": "Quick tips",
+      "secondaryCta": "View dashboard",
+      "signOff": {
+        "line1": "Best regards,",
+        "line2": "The {brand} Team"
+      },
+      "subject": "Your weekly upload reminder"
+    },
+    "welcome": {
+      "badge": "Welcome",
+      "body": "Ready to get started? Upload your first receipt and watch the magic happen. The whole process takes less than a minute.",
+      "ctaPrimary": "Upload your first receipt",
+      "ctaSecondary": "Explore the dashboard",
+      "feedbackPrompt": "Questions or feedback? We'd love to hear from you at <email></email>.",
+      "greeting": "Hi {name},",
+      "heading": "Welcome to {brand}",
+      "howItWorks": {
+        "item0": "Upload — snap a photo or upload a PDF of any receipt",
+        "item1": "Analyze — our AI extracts items, prices, merchants, and even suggests recipes from grocery receipts",
+        "item2": "Track — view spending dashboards by merchant, category, month, or year"
+      },
+      "howItWorksTitle": "How it works",
+      "intro": "Thanks for joining {brand}. We're glad you're here. Our platform helps you turn everyday receipts into organized financial insights — powered by AI analysis.",
+      "preview": "Welcome to {brand}, {name}! Let's get started.",
+      "signOff": {
+        "line1": "Cheers,",
+        "line2": "The {brand} Team"
+      },
+      "subject": "Welcome to {brand}",
+      "whatYouCanDo": {
+        "item0": "Get allergen alerts on food products",
+        "item1": "Share invoices with family members or colleagues",
+        "item2": "Export statistics and spending reports",
+        "item3": "Access your data from any device"
+      },
+      "whatYouCanDoTitle": "What you can do"
+    }
+  },
+  "forms": {
+    "invoices": {
+      "createInvoice": {
+        "detailsForm": {
+          "fields": {
+            "category": {
+              "label": "Category",
+              "options": {
+                "carAuto": "Auto & Vehicle",
+                "fastFood": "Dining",
+                "grocery": "Grocery",
+                "homeCleaning": "Home & Cleaning",
+                "notDefined": "Uncategorized",
+                "other": "Other"
+              },
+              "placeholder": "Select a category"
+            },
+            "description": {
+              "hint": "Optional notes about this purchase",
+              "label": "Description",
+              "placeholder": "Add any notes about this invoice (optional)"
+            },
+            "name": {
+              "hint": "Give your invoice a descriptive name",
+              "label": "Invoice Name",
+              "placeholder": "e.g., Weekly Groceries"
+            },
+            "paymentType": {
+              "label": "Payment Method",
+              "options": {
+                "card": "Card",
+                "cash": "Cash",
+                "mobilePayment": "Mobile Payment",
+                "other": "Other",
+                "transfer": "Bank Transfer",
+                "unknown": "Unknown",
+                "voucher": "Voucher"
+              },
+              "placeholder": "Select payment method"
+            },
+            "transactionDate": {
+              "label": "Transaction Date"
+            }
+          },
+          "scanPreview": {
+            "title": "Scan Preview"
+          },
+          "subtitle": "Provide the details for your new invoice",
+          "title": "Invoice Details"
+        },
+        "emptyState": {
+          "description": "Upload some receipt scans first to create an invoice.",
+          "title": "No Scans Available",
+          "uploadButton": "Upload Scans",
+          "viewScansButton": "View Scans"
+        },
+        "header": {
+          "backToInvoices": "Back to Invoices",
+          "subtitle": "Follow the steps below to create a new invoice from your scans",
+          "title": "Create Invoice"
+        },
+        "metadata": {
+          "description": "Create a new invoice from your uploaded scans.",
+          "title": "Invoice Management System - Create Invoice"
+        },
+        "navigation": {
+          "back": "Back",
+          "next": "Next"
+        },
+        "reviewStep": {
+          "actions": {
+            "create": "Create Invoice",
+            "creating": "Creating invoice...",
+            "hint": "This will create the invoice and upload the selected scans."
+          },
+          "categories": {
             "carAuto": "Auto & Vehicle",
             "fastFood": "Dining",
             "grocery": "Grocery",
@@ -2035,21 +2185,7 @@
             "notDefined": "Uncategorized",
             "other": "Other"
           },
-          "placeholder": "Select a category"
-        },
-        "description": {
-          "hint": "Optional notes about this purchase",
-          "label": "Description",
-          "placeholder": "Add any notes about this invoice (optional)"
-        },
-        "name": {
-          "hint": "Give your invoice a descriptive name",
-          "label": "Invoice Name",
-          "placeholder": "e.g., Weekly Groceries"
-        },
-        "paymentType": {
-          "label": "Payment Method",
-          "options": {
+          "paymentTypes": {
             "card": "Card",
             "cash": "Cash",
             "mobilePayment": "Mobile Payment",
@@ -2058,1265 +2194,51 @@
             "unknown": "Unknown",
             "voucher": "Voucher"
           },
-          "placeholder": "Select payment method"
-        },
-        "transactionDate": {
-          "label": "Transaction Date"
-        }
-      },
-      "scanPreview": {
-        "title": "Scan Preview"
-      },
-      "subtitle": "Provide the details for your new invoice",
-      "title": "Invoice Details"
-    },
-    "emptyState": {
-      "description": "Upload some receipt scans first to create an invoice.",
-      "title": "No Scans Available",
-      "uploadButton": "Upload Scans",
-      "viewScansButton": "View Scans"
-    },
-    "header": {
-      "backToInvoices": "Back to Invoices",
-      "subtitle": "Follow the steps below to create a new invoice from your scans",
-      "title": "Create Invoice"
-    },
-    "metadata": {
-      "description": "Create a new invoice from your uploaded scans.",
-      "title": "Invoice Management System - Create Invoice"
-    },
-    "navigation": {
-      "back": "Back",
-      "next": "Next"
-    },
-    "reviewStep": {
-      "actions": {
-        "create": "Create Invoice",
-        "creating": "Creating invoice...",
-        "hint": "This will create the invoice and upload the selected scans."
-      },
-      "categories": {
-        "carAuto": "Auto & Vehicle",
-        "fastFood": "Dining",
-        "grocery": "Grocery",
-        "homeCleaning": "Home & Cleaning",
-        "notDefined": "Uncategorized",
-        "other": "Other"
-      },
-      "paymentTypes": {
-        "card": "Card",
-        "cash": "Cash",
-        "mobilePayment": "Mobile Payment",
-        "other": "Other",
-        "transfer": "Bank Transfer",
-        "unknown": "Unknown",
-        "voucher": "Voucher"
-      },
-      "sections": {
-        "details": {
-          "category": "Category",
-          "description": "Description",
-          "name": "Name",
-          "paymentType": "Payment Method",
-          "title": "Invoice Details",
-          "transactionDate": "Transaction Date"
-        },
-        "scans": {
-          "title": "Scans"
-        }
-      },
-      "subtitle": "Review your invoice details before creating",
-      "title": "Review & Create"
-    },
-    "scanSelector": {
-      "clearAll": "Clear",
-      "next": "Next",
-      "noScans": "No scans available",
-      "previous": "Previous",
-      "scansCount": "scans",
-      "selectAll": "Select All",
-      "selectedCount": "{count} selected",
-      "subtitle": "Choose the scans that belong to this invoice",
-      "title": "Select Scans"
-    },
-    "steps": {
-      "details": "Invoice Details",
-      "detailsDesc": "Fill in invoice info",
-      "review": "Review & Create",
-      "reviewDesc": "Confirm and create",
-      "selectScans": "Select Scans",
-      "selectScansDesc": "Choose receipt scans"
-    }
-  },
-  "IMS--Dialogs": {
-    "addScanDialog": {
-      "buttons": {
-        "cancel": "Cancel",
-        "upload": "Upload scan",
-        "uploading": "Uploading..."
-      },
-      "console": {
-        "uploadError": "Error uploading scan:"
-      },
-      "description": "Upload a new receipt image or document to attach to this invoice.",
-      "dropzone": {
-        "dragAndDrop": "Drag & drop a file here",
-        "dropHere": "Drop the file here...",
-        "formats": "JPEG, PNG, PDF (max 10MB)",
-        "orClickBrowse": "or click to browse"
-      },
-      "errors": {
-        "unknown": "Unknown error occurred",
-        "uploadStorageFailed": "Failed to upload scan to storage"
-      },
-      "scanType": {
-        "jpeg": "JPEG image",
-        "label": "Scan type",
-        "other": "Other",
-        "pdf": "PDF document",
-        "placeholder": "Select scan type",
-        "png": "PNG image"
-      },
-      "title": "Add new scan",
-      "toasts": {
-        "fileTooLargeDescription": "Maximum file size is 10MB",
-        "fileTooLargeTitle": "File too large",
-        "scanAddedDescription": "The scan has been attached to the invoice",
-        "scanAddedTitle": "Scan added successfully",
-        "scanFailedTitle": "Failed to add scan"
-      }
-    },
-    "allergenDialog": {
-      "aria": {
-        "removeAllergen": "Remove {name} allergen"
-      },
-      "buttons": {
-        "add": "Add",
-        "cancel": "Cancel",
-        "save": "Save Changes",
-        "saving": "Saving..."
-      },
-      "defaultDescription": "Contains {name}",
-      "description": "Manage allergens for {productName}",
-      "empty": {
-        "noAllergens": "No allergens detected"
-      },
-      "errors": {
-        "duplicate": "Allergen {name} already added",
-        "emptyName": "Allergen name cannot be empty",
-        "missingData": "Missing product data",
-        "saveFailed": "Failed to save allergens"
-      },
-      "labels": {
-        "currentAllergens": "Current Allergens",
-        "customAllergen": "Add Custom Allergen",
-        "quickAdd": "Quick Add Common Allergens"
-      },
-      "placeholders": {
-        "customAllergen": "Enter allergen name..."
-      },
-      "success": {
-        "added": "Added allergen: {name}",
-        "removed": "Removed allergen: {name}",
-        "saved": "Allergens updated successfully"
-      },
-      "title": "Edit Allergens"
-    },
-    "analyzeDialog": {
-      "analysisSteps": {
-        "analyzingWithAi": "Analyzing with AI...",
-        "categorizingItems": "Categorizing items...",
-        "finalizingResults": "Finalizing results...",
-        "preparingDocument": "Preparing document...",
-        "processing": "Processing...",
-        "runningOcrExtraction": "Running OCR extraction..."
-      },
-      "analyzing": {
-        "progressComplete": "{progress}% complete",
-        "title": "Analyzing Invoice"
-      },
-      "badges": {
-        "recommended": "Recommended"
-      },
-      "buttons": {
-        "analyzing": "Analyzing...",
-        "cancel": "Cancel",
-        "startAnalysis": "Start Analysis"
-      },
-      "enhancements": {
-        "priceComparison": {
-          "description": "Compare prices with historical data",
-          "label": "Price Comparison"
-        },
-        "quickExtract": {
-          "description": "Prioritize speed over accuracy",
-          "label": "Quick Extract Mode"
-        },
-        "savingsTips": {
-          "description": "Get AI-powered saving recommendations",
-          "label": "Savings Suggestions"
-        }
-      },
-      "header": {
-        "description": "Configure AI-powered analysis for invoice",
-        "title": "Analyze Invoice"
-      },
-      "options": {
-        "completeAnalysis": {
-          "description": "Full AI-powered analysis including all invoice data, items, and merchant information.",
-          "estimatedTime": "2-3 min",
-          "features": {
-            "itemCategorization": "Item categorization",
-            "merchantIdentification": "Merchant identification",
-            "ocrExtraction": "OCR extraction",
-            "priceAnalysis": "Price analysis",
-            "receiptValidation": "Receipt validation"
+          "sections": {
+            "details": {
+              "category": "Category",
+              "description": "Description",
+              "name": "Name",
+              "paymentType": "Payment Method",
+              "title": "Invoice Details",
+              "transactionDate": "Transaction Date"
+            },
+            "scans": {
+              "title": "Scans"
+            }
           },
-          "title": "Complete Analysis"
+          "subtitle": "Review your invoice details before creating",
+          "title": "Review & Create"
         },
-        "invoiceOnly": {
-          "description": "Analyze basic invoice information like totals, dates, and payment details.",
-          "estimatedTime": "30-60 sec",
-          "features": {
-            "dateParsing": "Date parsing",
-            "paymentMethodDetection": "Payment method detection",
-            "totalExtraction": "Total extraction"
-          },
-          "title": "Invoice Data Only"
+        "scanSelector": {
+          "clearAll": "Clear",
+          "next": "Next",
+          "noScans": "No scans available",
+          "previous": "Previous",
+          "scansCount": "scans",
+          "selectAll": "Select All",
+          "selectedCount": "{count} selected",
+          "subtitle": "Choose the scans that belong to this invoice",
+          "title": "Select Scans"
         },
-        "itemsOnly": {
-          "description": "Focus on extracting and categorizing individual line items from the invoice.",
-          "estimatedTime": "1-2 min",
-          "features": {
-            "categoryAssignment": "Category assignment",
-            "itemExtraction": "Item extraction",
-            "pricePerItem": "Price per item",
-            "quantityDetection": "Quantity detection"
-          },
-          "title": "Items Analysis"
-        },
-        "merchantOnly": {
-          "description": "Identify and analyze merchant information including location and category.",
-          "estimatedTime": "30-45 sec",
-          "features": {
-            "businessCategory": "Business category",
-            "contactInfo": "Contact info",
-            "locationExtraction": "Location extraction",
-            "merchantIdentification": "Merchant identification"
-          },
-          "title": "Merchant Analysis"
+        "steps": {
+          "details": "Invoice Details",
+          "detailsDesc": "Fill in invoice info",
+          "review": "Review & Create",
+          "reviewDesc": "Confirm and create",
+          "selectScans": "Select Scans",
+          "selectScansDesc": "Choose receipt scans"
         }
-      },
-      "sections": {
-        "analysisType": "Analysis Type",
-        "enhancementsOptional": "Enhancements (Optional)",
-        "includedFeatures": "Included Features"
-      },
-      "summary": {
-        "enhancementsSelected": "+ {count} enhancement(s)",
-        "estimatedTime": "Estimated time",
-        "noEnhancementsSelected": "No enhancements selected"
-      },
-      "toasts": {
-        "analysisComplete": {
-          "description": "Your invoice has been analyzed successfully.",
-          "title": "Analysis Complete"
-        },
-        "analysisFailed": {
-          "description": "We couldn't analyze your invoice. Please try again.",
-          "title": "Analysis Failed"
-        }
-      }
-    },
-    "bulkCategoryDialog": {
-      "buttons": {
-        "cancel": "Cancel",
-        "save": "Apply to All",
-        "saving": "Saving..."
-      },
-      "description": "{count, plural, one {Change category for # product} other {Change category for # products}}",
-      "errors": {
-        "allFailed": "All products failed to update",
-        "missingData": "Missing data",
-        "noProducts": "No products selected",
-        "saveFailed": "Failed to update categories"
-      },
-      "labels": {
-        "andMore": "...and {count} more",
-        "newCategory": "New Category",
-        "progress": "Progress",
-        "selectedProducts": "Selected Products"
-      },
-      "placeholders": {
-        "selectCategory": "Select a category"
-      },
-      "progress": {
-        "updating": "Updating {current} of {total}..."
-      },
-      "success": {
-        "partialSuccess": "Updated {success} products, {failed} failed",
-        "saved": "{count, plural, one {Category updated for # product} other {Category updated for # products}}"
-      },
-      "title": "Change Category"
-    },
-    "createInvoiceDialog": {
-      "batchMode": {
-        "description": "Creates 1 invoice with all {count} scans attached. Best for multi-page receipts.",
-        "title": "Combine into one invoice"
-      },
-      "buttons": {
-        "cancel": "Cancel",
-        "close": "Close",
-        "createMultiple": "Start analysis on {count} scans",
-        "createSingle": "Start analysis"
-      },
-      "chooseMode": "Choose Creation Mode",
-      "complete": {
-        "description": "Your invoice is ready for viewing and editing.",
-        "descriptionPlural": "Your invoices are ready for viewing and editing.",
-        "errorsLabel": "Failed Scans:",
-        "failureDescription": "We couldn't create any invoices. Please review the errors below and try again.",
-        "failureTitle": "Creation Failed",
-        "nextSteps": "Next steps:",
-        "nextStepsDescription": "Review your invoice, verify the extracted data, and make any necessary edits. You can also request AI analysis for spending insights.",
-        "nextStepsDescriptionPlural": "Review your invoices, verify the extracted data, and make any necessary edits. You can also request AI analysis for spending insights.",
-        "partialDescription": "Some scans couldn't be processed. Successfully created invoices are ready for viewing.",
-        "partialTitle": "{created} of {total} Invoices Created",
-        "retryButton": "Try Again",
-        "title": "{count} Invoice Created!",
-        "titlePlural": "{count} Invoices Created!",
-        "viewButton": "View Invoice",
-        "viewButtonPlural": "View Invoices"
-      },
-      "creating": {
-        "processing": "Processing {count} scan...",
-        "processingPlural": "Processing {count} scans...",
-        "step1Description": "Sending your scans to our servers",
-        "step1Title": "Uploading scans",
-        "step2Description": "Setting up invoice data structures",
-        "step2Title": "Creating invoice records",
-        "step3Description": "Preparing invoices for viewing",
-        "step3Title": "Finalizing",
-        "title": "Creating Your Invoice",
-        "titlePlural": "Creating Your Invoices"
-      },
-      "description": "Transform your scans into structured invoice data.",
-      "errors": {
-        "createFailed": "Failed to create invoices: {message}",
-        "partialFail": "Failed to create {count} invoice(s)",
-        "unknown": "Unknown error"
-      },
-      "selectedScans": "Selected Scans",
-      "singleMode": {
-        "description": "Creates {count} separate invoices. Best when each scan is a different receipt.",
-        "title": "One invoice per scan"
-      },
-      "singleScanInfo": {
-        "description": "Our AI will analyze your scan and automatically extract merchant details, items, prices, and totals. You can review and edit the results afterward.",
-        "title": "What happens next?"
-      },
-      "title": "Start AI analysis",
-      "titlePlural": "Start AI analysis",
-      "totalSize": "total"
-    },
-    "deleteInvoiceDialog": {
-      "buttons": {
-        "cancel": "Cancel",
-        "deletePermanently": "Delete permanently",
-        "deleting": "Deleting..."
-      },
-      "confirmation": {
-        "typeToConfirm": "Type <highlight>{name}</highlight> to confirm:",
-        "understoodDescription": "This invoice and all its data will be permanently deleted and cannot be recovered.",
-        "understoodLabel": "I understand this action is permanent"
-      },
-      "console": {
-        "deleteError": "Error deleting invoice:"
-      },
-      "deleting": {
-        "description": "Please wait while we remove all associated data.",
-        "title": "Deleting invoice..."
-      },
-      "description": "This action cannot be undone. Please review carefully before proceeding.",
-      "impact": {
-        "intro": "The following data will be permanently deleted:",
-        "invoiceRecord": "Invoice record and metadata",
-        "lineItems": "{count} line item(s)",
-        "sharedAccess": "Shared access for {count} user(s)",
-        "title": "Permanent deletion",
-        "uploadedScans": "{count} uploaded scan(s)"
-      },
-      "title": "Delete invoice",
-      "toasts": {
-        "deletedDescription": "The invoice was deleted successfully.",
-        "deletedTitle": "Invoice deleted",
-        "deleteFailedDescription": "We couldn't delete this invoice. Please try again.",
-        "deleteFailedTitle": "Delete failed"
-      }
-    },
-    "exportDialog": {
-      "buttons": {
-        "cancel": "Cancel",
-        "copied": "Copied!",
-        "copy": "Copy to Clipboard",
-        "export": "Export"
-      },
-      "description": "Export {count} invoices in your preferred format.",
-      "estimate": {
-        "label": "Estimated file size:"
-      },
-      "filename": {
-        "hint": "The file will be saved with the extension based on format",
-        "label": "Filename"
-      },
-      "format": {
-        "descriptions": {
-          "csv": "Spreadsheet format, compatible with Excel",
-          "json": "Structured data format",
-          "pdf": "Printable document format"
-        },
-        "labels": {
-          "csv": "CSV",
-          "json": "JSON",
-          "pdf": "PDF"
-        },
-        "title": "Export Format"
-      },
-      "options": {
-        "csv": {
-          "delimiterLabel": "CSV Delimiter Override (optional):",
-          "delimiterPlaceholder": ",",
-          "includeHeaders": "Include CSV Headers"
-        },
-        "includeMerchant": "Include merchant",
-        "includeMetadata": "Include metadata",
-        "includeProducts": "Include products",
-        "json": {
-          "prettyPrint": "Pretty Print (2 spaces)"
-        },
-        "title": "Options"
-      },
-      "title": "Export Invoices"
-    },
-    "feedbackDialog": {
-      "buttons": {
-        "cancel": "Cancel",
-        "submit": "Submit Feedback"
-      },
-      "commentsPlaceholder": "Share your thoughts about the analytics...",
-      "description": "Help us improve analytics for {merchant} by sharing your thoughts",
-      "features": {
-        "categoryBreakdown": "Category Breakdown",
-        "merchantAnalysis": "Merchant Analysis",
-        "priceComparisons": "Price Comparisons",
-        "savingsTips": "Savings Tips",
-        "spendingTrends": "Spending Trends",
-        "visualCharts": "Visual Charts"
-      },
-      "sections": {
-        "comments": "Additional comments (optional)",
-        "features": "Which features were most helpful? (Select all that apply)",
-        "rating": "How would you rate the analytics?"
-      },
-      "title": "Provide Feedback",
-      "toasts": {
-        "error": {
-          "description": "Please try again later.",
-          "title": "An error occurred while submitting feedback"
-        },
-        "ratingRequired": {
-          "description": "Please provide a star rating before submitting",
-          "title": "Rating required"
-        },
-        "sending": {
-          "description": "Please wait while we submit your feedback.",
-          "title": "Sending feedback..."
-        },
-        "success": {
-          "description": "Feedback sent successfully",
-          "title": "Feedback sent!"
-        }
-      }
-    },
-    "imageDialog": {
-      "imageAlt": "Photo of receipt",
-      "title": "Image ({image})"
-    },
-    "importDialog": {
-      "buttons": {
-        "cancel": "Cancel",
-        "import": "Import",
-        "importWithCount": "Import ({count})"
-      },
-      "description": "Upload your invoice files to import them into the system.",
-      "dropzone": {
-        "acceptsCsv": "Accepts .csv files (max 10MB)",
-        "acceptsPdf": "Accepts .pdf files (max 10MB)",
-        "acceptsXlsx": "Accepts .xlsx and .xls files (max 10MB)",
-        "dragAndDrop": "Drag & drop files here",
-        "dropHere": "Drop files here...",
-        "orClickBrowse": "or click to browse files"
-      },
-      "remove": "Remove",
-      "selectedFiles": "Selected Files",
-      "status": {
-        "error": "Error importing files. Please try again.",
-        "success": "Files imported successfully!"
-      },
-      "tabs": {
-        "csv": "CSV",
-        "pdf": "PDF",
-        "xlsx": "Excel"
-      },
-      "title": "Import Invoices"
-    },
-    "itemsDialog": {
-      "aria": {
-        "addItem": "Add a new item to the invoice",
-        "cancel": "Cancel editing and close dialog",
-        "deleteItem": "Delete item: {name}",
-        "nextPage": "Go to next page (page {page})",
-        "previousPage": "Go to previous page (page {page})",
-        "save": "Save changes to invoice items",
-        "unnamedItem": "unnamed item"
-      },
-      "buttons": {
-        "addItem": "Add item",
-        "cancel": "Cancel",
-        "next": "Next",
-        "previous": "Previous",
-        "saveChanges": "Save changes"
-      },
-      "description": "Update quantities, prices, or add new items to this invoice",
-      "footer": {
-        "itemsFound": "{total} items found (showing {shown})",
-        "itemsTotal": "{count, plural, one {# item in total} other {# items in total}}",
-        "page": "Page {current} of {total}"
-      },
-      "table": {
-        "actions": "Actions",
-        "item": "Item",
-        "price": "Price",
-        "quantity": "Quantity",
-        "total": "Total",
-        "unit": "Unit"
-      },
-      "title": "Edit invoice items"
-    },
-    "merchantDialog": {
-      "buttons": {
-        "openInMaps": "Open in Maps"
-      },
-      "description": "Information about {merchantName}",
-      "fields": {
-        "address": "Address",
-        "parentCompany": "Parent Company",
-        "phone": "Phone"
-      },
-      "noMerchantLinked": "No merchant linked to this invoice",
-      "title": "Merchant Details"
-    },
-    "merchantReceiptsDialog": {
-      "buttons": {
-        "next": "Next",
-        "previous": "Previous"
-      },
-      "dateOptions": {
-        "allTime": "All time",
-        "last30Days": "Last 30 days",
-        "last90Days": "Last 90 days",
-        "thisYear": "This year"
-      },
-      "description": "View and filter all your receipts from this merchant",
-      "filters": {
-        "date": "Date",
-        "sort": "Sort"
-      },
-      "footer": {
-        "page": "Page {current} of {total}",
-        "receiptsFound": "{count} receipts found (showing {showing})"
-      },
-      "searchPlaceholder": "Search receipts...",
-      "sortOptions": {
-        "newest": "Newest first",
-        "oldest": "Oldest first"
-      },
-      "table": {
-        "actions": "Actions",
-        "date": "Date",
-        "itemsCount": "Items #",
-        "receipt": "Receipt",
-        "view": "View"
-      },
-      "title": "All receipts from {merchant}"
-    },
-    "metadataDialog": {
-      "add": {
-        "description": "Add additional information to this invoice",
-        "title": "Add metadata"
-      },
-      "buttons": {
-        "cancel": "Cancel",
-        "delete": "Delete",
-        "save": "Save"
-      },
-      "delete": {
-        "description": "Are you sure you want to delete this metadata?",
-        "title": "Delete metadata"
-      },
-      "edit": {
-        "description": "Update the value of this metadata field",
-        "fieldLabel": "Metadata field",
-        "title": "Edit metadata"
-      },
-      "fields": {
-        "keyLabel": "Metadata key",
-        "keyPlaceholder": "Enter key",
-        "valueLabel": "Metadata value",
-        "valuePlaceholder": "Enter value"
-      }
-    },
-    "recipeDialog": {
-      "actions": {
-        "enhanceInstructions": "Enhance instructions",
-        "generateName": "Generate name"
-      },
-      "buttons": {
-        "add": "Add",
-        "cancel": "Cancel",
-        "close": "Close",
-        "delete": "Delete",
-        "save": "Save",
-        "saving": "Saving..."
-      },
-      "create": {
-        "description": "Fill in the details to create a recipe.",
-        "error": "Failed to create recipe",
-        "success": "Recipe created successfully",
-        "title": "Add new recipe"
-      },
-      "delete": {
-        "description": "This action cannot be undone. This will permanently delete the recipe <strong>{name}</strong> and all its associated data.",
-        "title": "Are you sure?"
-      },
-      "difficulty": {
-        "easy": "Easy",
-        "hard": "Hard",
-        "medium": "Medium"
-      },
-      "fields": {
-        "complexity": "Complexity level",
-        "cookTime": "Cook time",
-        "description": "Description",
-        "difficulty": "Difficulty level",
-        "ingredients": "Ingredients",
-        "instructions": "Instructions",
-        "prepTime": "Prep time",
-        "recipeName": "Recipe name",
-        "totalDuration": "Total Duration"
-      },
-      "minutes": "minutes",
-      "placeholders": {
-        "cookTime": "e.g. 30 minutes",
-        "description": "Enter a brief description of the recipe",
-        "instructions": "Enter cooking instructions",
-        "prepTime": "e.g. 15 minutes",
-        "recipeName": "Enter recipe name",
-        "selectDifficulty": "Select difficulty"
-      },
-      "read": {
-        "description": "Recipe details and cooking instructions",
-        "noDescription": "No description provided.",
-        "notSpecified": "Not specified"
-      },
-      "tooltips": {
-        "enhanceInstructions": "Use AI to enhance your instructions with more details",
-        "generateName": "Generate a recipe name based on your ingredients and difficulty level using AI"
-      },
-      "update": {
-        "description": "Update recipe details.",
-        "title": "Update recipe"
-      }
-    },
-    "removeScanDialog": {
-      "buttons": {
-        "cancel": "Cancel",
-        "remove": "Remove scan",
-        "removing": "Removing..."
-      },
-      "console": {
-        "deleteError": "Error deleting scan:"
-      },
-      "description": "Are you sure you want to remove scan {current} of {total}?",
-      "descriptionLastScan": "This is the only scan attached to this invoice. You cannot remove it.",
-      "errors": {
-        "unknown": "Unknown error occurred"
-      },
-      "scanAlt": "Scan {index}",
-      "scanCaption": "Scan {index}",
-      "title": "Remove scan",
-      "toasts": {
-        "cannotDeleteLastDescription": "An invoice must have at least one scan attached",
-        "cannotDeleteLastTitle": "Cannot delete last scan",
-        "removedDescription": "The scan has been removed from the invoice",
-        "removedTitle": "Scan removed successfully",
-        "removeFailedTitle": "Failed to remove scan"
-      },
-      "warning": {
-        "description": "Every invoice must have at least one scan attached. Add another scan before removing this one.",
-        "title": "Cannot remove last scan"
-      }
-    },
-    "shareAnalyticsDialog": {
-      "description": "Share your spending analytics for {merchant} with others.",
-      "email": {
-        "description": "Send the analytics to an email address.",
-        "label": "Email address",
-        "placeholder": "name@example.com",
-        "send": "Send Email"
-      },
-      "image": {
-        "copyToClipboard": "Copy graph to clipboard",
-        "description": "Download or copy the analytics graph as a PNG image that you can share or save.",
-        "download": "Download graph",
-        "previewPlaceholder": "Analytics Preview"
-      },
-      "tabs": {
-        "email": "Email",
-        "image": "Image"
-      },
-      "title": "Share Analytics",
-      "toasts": {
-        "emailSent": {
-          "description": "Analytics report sent to {email}",
-          "title": "Email sent!"
-        },
-        "imageCopied": {
-          "description": "The analytics image has been copied to your clipboard",
-          "title": "Image copied!"
-        },
-        "imageSaved": {
-          "description": "Spending analytics for {merchant} has been downloaded as PNG",
-          "title": "Image saved!"
-        }
-      }
-    },
-    "shareInvoiceDialog": {
-      "dialogDescription": {
-        "currentlyPublic": "\"{invoiceName}\" is currently public",
-        "private": "Send \"{invoiceName}\" privately",
-        "public": "Share \"{invoiceName}\" publicly",
-        "selection": "Choose how to share \"{invoiceName}\""
-      },
-      "errors": {
-        "qrNotFound": "QR code element not found"
-      },
-      "selection": {
-        "description": "Choose how you want to share this invoice. Your choice affects who can access it.",
-        "privacyNoticeDescription": "Public links can be accessed by anyone who has the URL. Private sharing restricts access to the specific recipient.",
-        "privacyNoticeTitle": "Privacy notice",
-        "privateDescription": "Send an email invitation to a <strong>specific person</strong>. Only they will have access.",
-        "privateTitle": "Private sharing",
-        "publicDescription": "Generate a link or QR code that <strong>anyone</strong> can use to view this invoice.",
-        "publicTitle": "Public sharing"
-      },
-      "title": "Share invoice",
-      "toasts": {
-        "copyLink": {
-          "error": "Failed: {message}",
-          "loadingMakePublic": "Making invoice public...",
-          "loadingPublic": "Copying link...",
-          "successMadePublic": "Invoice is now public! Link copied to clipboard.",
-          "successPublic": "Link copied to clipboard!"
-        },
-        "copyQr": {
-          "error": "Failed: {message}",
-          "loadingMakePublic": "Making invoice public...",
-          "loadingPublic": "Copying QR code...",
-          "successMadePublic": "Invoice is now public! QR code copied to clipboard.",
-          "successPublic": "QR code copied to clipboard!"
-        },
-        "revoke": {
-          "error": "Failed to revoke access: {message}",
-          "loading": "Sending revoke request to backend...",
-          "success": "Invoice is now private. Existing links will no longer work."
-        },
-        "sendEmail": {
-          "comingSoon": "Email sharing is coming soon",
-          "error": "Failed: {message}",
-          "loading": "Sending invitation to {email}...",
-          "success": "Invitation sent to {email}!"
-        }
-      }
-    },
-    "shareInvoiceDialogPrivate": {
-      "backToOptions": "Back to options",
-      "comingSoonTooltip": "Email sharing feature is coming soon",
-      "description": "The invitation will be sent directly to the email address you specify. Only this recipient will receive access to view the invoice.",
-      "emailHint": "An email invitation will be sent to this address with a private link to view the invoice.",
-      "emailLabel": "Recipient's email address",
-      "emailPlaceholder": "name@example.com",
-      "sending": "Sending invitation...",
-      "sendInvitation": "Send private invitation",
-      "title": "Private sharing"
-    },
-    "shareInvoiceDialogPublic": {
-      "alreadyPublic": {
-        "description": "This invoice is publicly accessible. <strong>Anyone with the link can view it</strong>, including all invoice details, items, and amounts. You can revoke public access at any time to make it private again.",
-        "revoke": "Revoke public access",
-        "revokeHint": "This will make the invoice private. Existing links will stop working.",
-        "revoking": "Revoking access...",
-        "title": "This invoice is currently public"
-      },
-      "backToOptions": "Back to options",
-      "copyQrImage": "Copy QR code as image",
-      "hints": {
-        "link": "Copy this link and share it. Anyone who receives it will be able to view the invoice.",
-        "qr": "Anyone who scans this QR code will be directed to view the invoice."
-      },
-      "tabs": {
-        "directLink": "Direct link",
-        "qrCode": "QR code"
-      },
-      "warning": {
-        "description": "By sharing this invoice publicly, <strong>anyone with the link will be able to view it</strong>. This includes all invoice details, items, and amounts. Only proceed if you intend to make this invoice accessible to the public.",
-        "title": "Public access warning"
-      }
-    }
-  },
-  "IMS--Edit": {
-    "changeHistory": {
-      "changes": {
-        "categoryUpdated": "Category updated",
-        "descriptionChanged": "Description changed",
-        "importanceChanged": "Importance changed",
-        "markedImportant": "Marked as important",
-        "nameChanged": "Name changed",
-        "paymentTypeChanged": "Payment type changed",
-        "transactionDateChanged": "Transaction date changed",
-        "unmarkedImportant": "Unmarked as important"
-      },
-      "created": "Invoice created",
-      "modified": "Last modified",
-      "pending": "Pending",
-      "time": {
-        "daysAgo": "{days} days ago",
-        "hoursAgo": "{hours} hours ago",
-        "justNow": "Just now",
-        "minutesAgo": "{minutes} minutes ago",
-        "secondsAgo": "{seconds} seconds ago"
-      },
-      "title": "Change History",
-      "unsavedChanges": "Unsaved changes"
-    },
-    "editInvoiceContext": {
-      "console": {
-        "saveFailed": "Failed to save invoice:"
-      },
-      "toasts": {
-        "noChanges": "No changes to save",
-        "saveFailed": "Failed to save changes",
-        "updated": "Invoice updated successfully"
-      }
-    },
-    "guidedEditBanner": {
-      "actions": {
-        "dismiss": "Dismiss",
-        "reviewAll": "Review All"
-      },
-      "badges": {
-        "lowConfidence": "{count, plural, one {# low confidence} other {# low confidence}}",
-        "missingName": "{count, plural, one {# missing name} other {# missing name}}",
-        "uncategorized": "{count, plural, one {# uncategorized} other {# uncategorized}}"
-      },
-      "summary": {
-        "lowConfidence": "{count, plural, one {# low confidence} other {# low confidence}}",
-        "missingName": "{count, plural, one {# missing name} other {# missing name}}",
-        "uncategorized": "{count, plural, one {# uncategorized} other {# uncategorized}}"
-      },
-      "title": "{count, plural, one {# product needs review} other {# products need review}}"
-    },
-    "itemsTable": {
-      "actions": {
-        "editAllergens": "Edit allergens",
-        "remove": "Remove item",
-        "restore": "Restore item"
-      },
-      "bulkCategory": {
-        "noSelection": "Please select at least one product"
-      },
-      "bulkToolbar": {
-        "changeCategory": "Change Category",
-        "deleteSelected": "Delete Selected",
-        "noSelection": "No products selected",
-        "selectedCount": "{count, plural, one {# item selected} other {# items selected}}"
-      },
-      "buttons": {
-        "addItem": "Add Item",
-        "editItems": "Edit Items"
-      },
-      "columns": {
-        "actions": "Actions",
-        "name": "Name",
-        "price": "Price",
-        "quantity": "Quantity",
-        "selectAll": "Select all items",
-        "selectRow": "Select {name}",
-        "total": "Total",
-        "unit": "Unit"
-      },
-      "deleteConfirm": {
-        "cancel": "Cancel",
-        "confirm": "Delete",
-        "description": "{count, plural, one {Are you sure you want to delete this item?} other {Are you sure you want to delete # items?}}",
-        "success": "{count, plural, one {# item deleted} other {# items deleted}}",
-        "title": "Delete Items"
-      },
-      "editing": {
-        "cancel": "Edit canceled",
-        "fieldLabel": "Edit {field} for {name}",
-        "saved": "Item updated successfully"
-      },
-      "footer": {
-        "total": "Total"
-      },
-      "indicators": {
-        "allergens": "{count, plural, one {# allergen} other {# allergens}}",
-        "edited": "Edited",
-        "editedTooltip": "This product has been manually modified",
-        "lowConfidence": "Low confidence",
-        "lowConfidenceTooltip": "OCR confidence is {confidence}% - manual review recommended",
-        "missingName": "Missing name",
-        "missingNameTooltip": "Generic name translation is missing or identical to raw OCR text",
-        "uncategorized": "Uncategorized",
-        "uncategorizedTooltip": "This product needs a category assigned for better spending tracking"
-      },
-      "newItem": {
-        "added": "New item added",
-        "defaultName": "New Item"
-      },
-      "pagination": {
-        "next": "Next",
-        "pageOf": "Page {currentPage} of {totalPages}",
-        "previous": "Previous",
-        "totalItems": "{count, plural, one {# item in total} other {# items in total}}"
-      },
-      "restore": {
-        "error": "Failed to restore item",
-        "success": "Item {name} restored"
-      },
-      "search": {
-        "placeholder": "Search items..."
-      },
-      "softDelete": {
-        "error": "Failed to remove item",
-        "success": "Item {name} removed"
-      },
-      "tableHeaders": {
-        "item": "Item",
-        "price": "Price",
-        "quantity": "Qty",
-        "total": "Total"
-      },
-      "title": "Items",
-      "tooltips": {
-        "editInvoiceItemsAndQuantities": "Edit invoice items and quantities"
-      }
-    },
-    "metadata": {
-      "description": "View and edit your invoice details, items, recipes, and sharing settings.",
-      "title": "Invoice Management System - Edit Invoice"
-    },
-    "metadataTab": {
-      "badges": {
-        "readonly": "Readonly"
-      },
-      "buttons": {
-        "addField": "Add Field",
-        "addFirstMetadataField": "Add Your First Metadata Field"
-      },
-      "dropdown": {
-        "delete": "Delete",
-        "edit": "Edit"
-      },
-      "emptyState": {
-        "noMetadataFields": "No metadata fields added yet"
-      },
-      "header": {
-        "description": "Metadata associated with this invoice",
-        "title": "Additional Information"
-      },
-      "tooltips": {
-        "addCustomMetadata": "Add custom metadata to this invoice"
-      }
-    },
-    "recipesTab": {
-      "buttons": {
-        "addRecipe": "Add Recipe",
-        "createFirstRecipe": "Create Your First Recipe",
-        "generate": "Generate"
-      },
-      "emptyState": {
-        "noRecipesAvailable": "No recipes available yet"
-      },
-      "header": {
-        "description": "Based on items in this invoice",
-        "title": "Recipes You Can Make"
-      },
-      "pagination": {
-        "next": "Next",
-        "pageOf": "Page {currentPage} of {totalPages}",
-        "previous": "Previous"
-      },
-      "toasts": {
-        "aiGenerationComingSoon": {
-          "description": "This feature is currently under development.",
-          "title": "AI recipe generation coming soon"
-        }
-      },
-      "tooltips": {
-        "createRecipeWithIngredients": "Create a new recipe with these ingredients",
-        "generateRecipeUsingAi": "Generate a recipe using AI!"
-      }
-    },
-    "triviaTips": {
-      "banner": {
-        "hint": "Apply these tips to save on your next visit to {merchantName}",
-        "potentialSavingsLabel": "Potential Savings"
-      },
-      "buttons": {
-        "viewMoreSavingsTips": "View More Savings Tips"
-      },
-      "completeLabel": "Invoice is fully complete!",
-      "completeness": "Invoice is {percentage}% complete",
-      "contextActions": {
-        "addDescription": "Add Description",
-        "analyze": "Run Analysis",
-        "setCategory": "Set Category"
-      },
-      "contextTips": {
-        "defaultCategory": "Change the category from 'Uncategorized' to track better",
-        "noCategory": "Set a category to track spending patterns",
-        "noDescription": "Add a description to help you remember this purchase",
-        "noItems": "Run AI analysis to extract items from your receipt",
-        "noRecipes": "AI can suggest recipes based on your grocery items"
-      },
-      "difficulty": {
-        "easy": "Easy",
-        "medium": "Medium"
-      },
-      "disclaimer": "Savings are estimates based on average prices and promotions",
-      "tips": {
-        "bulkPurchase": {
-          "description": "Purchase non-perishable items in bulk to save on per-unit costs.",
-          "title": "Buy in Bulk"
-        },
-        "digitalCoupons": {
-          "description": "Check {merchantName}'s app for digital coupons before shopping.",
-          "title": "Use Digital Coupons"
-        },
-        "loyaltyProgram": {
-          "description": "Sign up for {merchantName}'s loyalty program to earn points on every purchase.",
-          "title": "Join Loyalty Program"
-        }
-      },
-      "title": "Savings Tips",
-      "tooltips": {
-        "estimatedSavings": "Estimated savings with this tip"
-      }
-    }
-  },
-  "IMS--Landing": {
-    "bento": {
-      "ai": {
-        "description": "GPT-4 extraction",
-        "title": "AI-Powered"
-      },
-      "analyticsCard": {
-        "description": "Spending insights",
-        "title": "Analytics"
-      },
-      "cloud": {
-        "description": "Access anywhere",
-        "title": "Cloud Sync"
-      },
-      "description": "Powerful features designed to make invoice management effortless",
-      "mobile": "Works beautifully on mobile devices",
-      "ocr": {
-        "description": "Auto data capture",
-        "title": "Smart OCR"
-      },
-      "secure": {
-        "description": "Bank-grade encryption",
-        "title": "Secure"
-      },
-      "share": {
-        "description": "Collaborate easily",
-        "title": "Share"
-      },
-      "title": "Everything You Need"
-    },
-    "cta": {
-      "badges": {
-        "ai": "AI-Powered",
-        "cloud": "Cloud Synced",
-        "secure": "Secure & Private"
-      },
-      "description": "Upload your first scan and experience the magic of AI-powered invoice management.",
-      "learnMore": "Learn More",
-      "title": "Ready to Get Started?",
-      "uploadButton": "Upload Your First Scan"
-    },
-    "features": {
-      "analytics": {
-        "description": "Get detailed insights into your spending patterns with charts and reports.",
-        "title": "Spending Analytics"
-      },
-      "batch": {
-        "description": "Process multiple scans at once - create individual invoices or combine them into one.",
-        "title": "Batch Processing"
-      },
-      "description": "Everything you need to manage your invoices efficiently",
-      "imageAlt": "Invoice features illustration",
-      "ocr": {
-        "description": "Our AI automatically extracts merchant names, dates, amounts, and line items from your scans.",
-        "title": "Smart OCR Extraction"
-      },
-      "signIn": "Sign in",
-      "signInPrompt": "Sign in to save your invoices permanently and access them from any device.",
-      "title": "Powerful Features"
-    },
-    "hero": {
-      "description": "Upload your receipts and bills, organize them into invoices, and gain insights into your spending habits. Our AI-powered system extracts data automatically.",
-      "getStarted": "Get Started",
-      "imageAlt": "Invoice management illustration",
-      "title": "Manage Your",
-      "titleHighlight": "Invoices",
-      "titleSuffix": "with Ease",
-      "viewMyInvoices": "View My Invoices"
-    },
-    "metadata": {
-      "description": "Manage receipts, create invoices, and gain insights into your spending habits.",
-      "title": "Invoice Management System"
-    },
-    "workflow": {
-      "description": "Three simple steps to digitize and organize your financial documents",
-      "step1": {
-        "button": "Upload Now",
-        "description": "Drag and drop your receipts, invoices, or bills. We support JPG, PNG, and PDF files up to 10MB each.",
-        "title": "Upload Scans"
-      },
-      "step2": {
-        "button": "View Scans",
-        "description": "Review your uploaded scans, select the ones you want, and create invoices from them individually or in batches.",
-        "title": "View & Organize"
-      },
-      "step3": {
-        "button": "View Invoices",
-        "description": "View your invoices, analyze spending patterns, and get AI-powered insights into your financial habits.",
-        "title": "Manage Invoices"
-      },
-      "title": "How It Works"
-    }
-  },
-  "IMS--List": {
-    "bulkActions": {
-      "categories": {
-        "carAuto": "Car & Auto",
-        "fastFood": "Fast Food",
-        "grocery": "Groceries",
-        "homeCleaning": "Home Cleaning",
-        "notDefined": "Not Defined",
-        "other": "Other"
-      },
-      "categoryChanged": "{count, plural, one {Invoice category updated successfully} other {# invoice categories updated successfully}}",
-      "categoryChangeError": "Failed to update invoice categories. Please try again.",
-      "categoryPartialSuccess": "{success} invoice(s) updated, {failed} failed",
-      "changeCategory": "Change Category",
-      "clearSelection": "Clear selection",
-      "delete": "Delete",
-      "deleteConfirm": {
-        "cancel": "Cancel",
-        "confirm": "Delete",
-        "description": "{count, plural, one {Are you sure you want to delete this invoice? This action cannot be undone.} other {Are you sure you want to delete these # invoices? This action cannot be undone.}}",
-        "title": "Delete Invoices"
-      },
-      "deleteError": "Failed to delete invoices. Please try again.",
-      "deletePartialSuccess": "{success} invoice(s) deleted, {failed} failed",
-      "deleteSuccess": "{count, plural, one {Invoice deleted successfully} other {# invoices deleted successfully}}",
-      "export": "Export",
-      "selected": "{count, plural, one {# invoice selected} other {# invoices selected}}"
-    },
-    "generativeView": {
-      "chatDescription": "Chat with AI to analyze your invoices and get insights. Try commands like /find to search invoices.",
-      "help": "Help",
-      "settings": {
-        "allowInvoiceData": "Allow access to invoice data",
-        "allowMerchantData": "Allow access to merchant data",
-        "dataAccessTitle": "Data access",
-        "description": "Configure your AI assistant preferences",
-        "historyLabel": "Chat history",
-        "notificationPreferences": "Notification preferences",
-        "notifyInsights": "Notify me about new insights",
-        "retention": {
-          "30": "Keep for 30 days",
-          "60": "Keep for 60 days",
-          "90": "Keep for 90 days",
-          "none": "Don't save history"
-        },
-        "retentionPlaceholder": "Select retention period",
-        "save": "Save settings",
-        "title": "Chat settings"
-      },
-      "subtitle": "Chat with AI to analyze your invoices and get insights",
-      "tabs": {
-        "chat": "Chat",
-        "settings": "Settings"
-      },
-      "title": "Live analysis",
-      "welcomeMessage": "Hello! I'm your invoice analysis assistant. How can I help you today? Try commands like /find to search invoices."
-    },
-    "gridView": {
-      "itemCount": "{count, plural, one {# item} other {# items}}",
-      "tooltips": {
-        "viewDetails": "View Details"
-      }
-    },
-    "invoicesHeader": {
-      "actions": {
-        "export": "Export",
-        "import": "Import",
-        "newInvoice": "New invoice",
-        "print": "Print"
-      },
-      "description": "Manage your receipts and track your spending habits",
-      "title": "Invoice management",
-      "tooltips": {
-        "export": "Export all invoices",
-        "import": "Import invoices from files",
-        "newInvoice": "Create a new invoice",
-        "print": "Print invoices"
-      }
-    },
-    "invoicesView": {
-      "categories": {
-        "all": "All categories",
-        "dining": "Dining",
-        "entertainment": "Entertainment",
-        "groceries": "Groceries",
-        "other": "Other",
-        "travel": "Travel",
-        "utilities": "Utilities"
       },
       "filters": {
         "activeCount": "{count} active",
         "amountMax": "Max amount",
         "amountMin": "Min amount",
         "amountPresets": {
-          "0to50": "0-50",
-          "100to500": "100-500",
-          "500plus": "500+",
-          "50to100": "50-100"
+          "value0to50": "0-50",
+          "value100to500": "100-500",
+          "value500plus": "500+",
+          "value50to100": "50-100"
         },
         "amountRange": "Amount Range",
         "anyValue": "any",
@@ -3328,10 +2250,10 @@
         "currencyAny": "any",
         "dateFrom": "From date",
         "datePresets": {
-          "30d": "30d",
-          "90d": "90d",
           "all": "All time",
           "custom": "Custom",
+          "value30d": "30d",
+          "value90d": "90d",
           "ytd": "YTD"
         },
         "dateRange": "Date Range",
@@ -3359,1960 +2281,3118 @@
         },
         "timeOfDay": "Time of day",
         "title": "Filters"
-      },
-      "placeholderPanel": "More filter controls coming soon.",
-      "searchPlaceholder": "Search invoices...",
-      "times": {
-        "all": "All times",
-        "day": "Daytime (6am-6pm)",
-        "night": "Nighttime (6pm-6am)"
-      },
-      "viewModes": {
-        "grid": "Grid view",
-        "table": "Table view"
-      }
-    },
-    "messageList": {
-      "aiAssistant": "AI Assistant",
-      "you": "You"
-    },
-    "metadata": {
-      "description": "List all invoices from the invoice management system.",
-      "title": "Invoice Management System - List Invoices"
-    },
-    "subtitle": "This is your digital receipts inventory. <br></br> Here you can find the receipts that you've uploaded so far. <br></br> By clicking on a receipt, you will be redirected to that specific receipt's page.",
-    "tableView": {
-      "aria": {
-        "rowsPerPage": "Rows per page",
-        "selectAllInvoices": "Select all invoices",
-        "selectInvoice": "Select invoice {name}",
-        "sortByAmount": "Sort by amount",
-        "sortByDate": "Sort by date"
-      },
-      "columns": {
-        "actions": "Actions",
-        "amount": "Amount",
-        "category": "Category",
-        "date": "Date",
-        "invoice": "Invoice"
-      },
-      "empty": {
-        "description": "Start by uploading your receipts to create your first invoice",
-        "title": "No Invoices Yet",
-        "uploadCta": "Upload Your First Receipt"
-      },
-      "nextPage": "Next Page",
-      "pageOf": "Page {current} of {total}",
-      "previousPage": "Previous Page",
-      "rowsPerPage": "Rows per page:",
-      "tooltips": {
-        "notAnalyzed": "This invoice has not been analyzed yet"
-      },
-      "viewInvoice": "View Invoice"
-    },
-    "tableViewActions": {
-      "actions": {
-        "delete": "Delete",
-        "edit": "Edit",
-        "share": "Share"
-      },
-      "tooltips": {
-        "delete": "Permanently delete this invoice",
-        "edit": "Edit invoice details",
-        "moreActions": "More actions",
-        "share": "Share invoice via link or email"
-      }
-    },
-    "title": "Welcome, {name}!",
-    "viewInvoicesIsland": {
-      "tabs": {
-        "invoices": "Invoices",
-        "liveAnalysis": "Live analysis",
-        "statistics": "Statistics"
-      }
-    },
-    "viewInvoicesPage": {
-      "guestName": "dear guest"
-    }
-  },
-  "IMS--Stats": {
-    "allergenSummary": {
-      "ariaLabel": "Allergen frequency summary",
-      "description": "Allergen exposure across products",
-      "empty": "No allergens detected in your purchases",
-      "stats": {
-        "ofTotal": "of total",
-        "products": "products"
-      },
-      "title": "Allergen Summary"
-    },
-    "calendarHeatmap": {
-      "aria": {
-        "calendarGrid": "Daily spending calendar"
-      },
-      "days": {
-        "fri": "Fri",
-        "mon": "Mon",
-        "sat": "Sat",
-        "sun": "Sun",
-        "thu": "Thu",
-        "tue": "Tue",
-        "wed": "Wed"
-      },
-      "description": "Daily spending intensity over time",
-      "legend": {
-        "less": "Less",
-        "more": "More"
-      },
-      "navigation": {
-        "next": "Next month",
-        "previous": "Previous month"
-      },
-      "title": "Spending Calendar",
-      "tooltip": {
-        "amount": "Spent",
-        "invoices": "{count} invoices",
-        "noSpending": "No spending"
-      }
-    },
-    "categoryBreakdown": {
-      "description": "Distribution across categories",
-      "title": "Spending by Category",
-      "tooltip": {
-        "invoiceCount": "{count} invoices"
-      },
-      "totalLabel": "Total Spending"
-    },
-    "comparison": {
-      "decrease": "decrease",
-      "description": "Comparison with previous month",
-      "discovered": "discovered",
-      "increase": "increase",
-      "invoiceCount": "Invoice Count",
-      "newMerchants": "New Merchants",
-      "none": "none",
-      "spendingDelta": "Spending Change",
-      "title": "Month-over-Month"
-    },
-    "currencyDistribution": {
-      "description": "Spending breakdown by currency with RON conversion",
-      "invoiceCount": "Invoices",
-      "originalAmount": "Original",
-      "ronEquivalent": "RON equivalent",
-      "showOriginal": "Show Original",
-      "showRON": "Show RON",
-      "singleCurrency": "All invoices in {currency} ({symbol})",
-      "title": "Currency Distribution",
-      "toggleLabel": "Toggle currency view",
-      "totalAmount": "Total Amount",
-      "totalCurrencies": "Total Currencies",
-      "totalSpending": "Total Spending"
-    },
-    "empty": {
-      "cta": "Upload Receipt",
-      "subtitle": "Upload receipts to see analytics",
-      "title": "No Statistics Yet"
-    },
-    "kpi": {
-      "acrossInvoices": "across {count} invoices",
-      "averageItems": "Avg. Items",
-      "avgPerInvoice": "avg {amount} per invoice",
-      "invoiceCount": "Invoice Count",
-      "noneYet": "No data yet",
-      "topMerchant": "Top Merchant",
-      "totalSpending": "Total Spending",
-      "visits": "{count} visits",
-      "vsLastMonth": "{delta}% vs last month"
-    },
-    "merchantLeaderboard": {
-      "description": "Where you spend most",
-      "empty": "No merchant data available yet",
-      "labels": {
-        "totalSpent": "Total Spent"
-      },
-      "title": "Top Merchants",
-      "tooltip": {
-        "invoiceCount": "{count} invoices"
-      },
-      "unknownMerchant": "Unknown Merchant"
-    },
-    "merchantTrends": {
-      "aria": {
-        "sparkline": "Spending trend for {merchant}"
-      },
-      "description": "Monthly spending patterns for top merchants",
-      "empty": "No merchant data available yet",
-      "labels": {
-        "merchant": "Merchant",
-        "totalSpend": "Total Spend",
-        "trend": "Trend (Last 6 Months)"
-      },
-      "title": "Merchant Spending Trends"
-    },
-    "merchantVisit": {
-      "description": "Shopping frequency and basket insights",
-      "empty": "No visit data available yet",
-      "metrics": {
-        "avgSpend": "Avg Spend/Visit",
-        "basketSize": "Avg Basket",
-        "preferredDay": "Preferred Day",
-        "totalVisits": "Total Visits",
-        "visitsPerMonth": "Visits/Month"
-      },
-      "title": "Merchant Visit Patterns"
-    },
-    "priceDistribution": {
-      "description": "Item price distribution",
-      "labels": {
-        "itemCount": "Item Count"
-      },
-      "title": "Price Distribution",
-      "tooltip": {
-        "itemCount": "{count} items"
-      }
-    },
-    "productAnalytics": {
-      "subtitle": "Insights into your purchased items",
-      "title": "Product-Level Analytics"
-    },
-    "productCategory": {
-      "description": "Spending breakdown by product type",
-      "empty": "No products to analyze yet",
-      "title": "Product Category Spending",
-      "tooltip": {
-        "productCount": "{count} products"
-      }
-    },
-    "spendingOverTime": {
-      "description": "Track your spending trends",
-      "labels": {
-        "amount": "Amount"
-      },
-      "title": "Spending Over Time",
-      "tooltip": {
-        "andMore": "and {count} more...",
-        "invoiceCount": "{count} invoices"
-      }
-    },
-    "subtitle": "Manage your receipts and track your spending habits",
-    "timeOfDay": {
-      "description": "When you shop",
-      "labels": {
-        "invoiceCount": "Invoice Count"
-      },
-      "title": "Shopping Patterns",
-      "tooltip": {
-        "invoiceCount": "{count} invoices"
-      }
-    },
-    "title": "Invoice Statistics",
-    "topProducts": {
-      "ariaLabel": "Top products leaderboard",
-      "description": "Most purchased items",
-      "empty": "No products purchased yet",
-      "headers": {
-        "avgPrice": "Avg Price",
-        "product": "Product",
-        "purchases": "Purchases",
-        "quantity": "Qty",
-        "rank": "#",
-        "totalSpent": "Total"
-      },
-      "title": "Top Products"
-    }
-  },
-  "IMS--UploadScans": {
-    "breadcrumb": "Back to Invoices",
-    "buttons": {
-      "myInvoices": "My Invoices",
-      "uploadFirst": "Upload Your First Scan",
-      "viewScans": "View Your Scans"
-    },
-    "errors": {
-      "tooLarge": "File too large: {name} (max 10MB)",
-      "unsupportedType": "Unsupported file type: {type}"
-    },
-    "header": {
-      "description": "Upload receipt images or PDFs. Create invoices from them later.",
-      "title": "Upload Scans",
-      "tooltip": "Upload your receipts, invoices, or bills here. You can select multiple files and organize them into invoices later from the View Scans page."
-    },
-    "metadata": {
-      "description": "Upload receipt scans to your account for later processing into invoices.",
-      "title": "Invoice Management System - Upload Scans"
-    },
-    "postUpload": {
-      "createInvoice": "Yes, start the analysis",
-      "dismiss": "Dismiss",
-      "subtitle": "{count, plural, one {Does this scan represent a single purchase?} other {Do these scans represent a single purchase?}}",
-      "title": "Upload Complete!",
-      "viewScans": "No, analyze separately"
-    },
-    "preview": {
-      "pagination": {
-        "next": "Next",
-        "pageInfo": "{current} / {total} ({count} scans)",
-        "previous": "Previous"
-      },
-      "pendingTooltip": "This scan will not be persisted until you click Upload",
-      "removeTooltip": "Remove this file",
-      "retryAttempt": "Retry attempt {attempt}",
-      "status": {
-        "completed": "Completed",
-        "failed": "Failed",
-        "pending": "Pending",
-        "retrying": "Retrying",
-        "uploading": "Uploading"
-      },
-      "title": "Pending uploads ({count})"
-    },
-    "sidebar": {
-      "formats": {
-        "documentExtensions": ".pdf",
-        "documents": "Documents",
-        "imageExtensions": ".jpg, .jpeg, .png",
-        "images": "Images",
-        "maxSize": "Maximum file size: 10MB per file",
-        "title": "Supported Formats"
-      },
-      "nextSteps": {
-        "button": "Continue to View Scans",
-        "description": "Your scans are ready. Head to View Scans to organize them into invoices.",
-        "title": "All uploads complete!"
-      },
-      "security": {
-        "description": "Your scans are encrypted and stored securely. Only you can access them.",
-        "title": "Secure Storage"
-      },
-      "tips": {
-        "tip1": "Use good lighting when photographing receipts",
-        "tip2": "Ensure text is clear and readable",
-        "tip3": "Avoid shadows and glare",
-        "tip4": "Capture the entire receipt in frame",
-        "tip5": "PDFs work best for digital receipts",
-        "title": "Tips for Best Results"
-      }
-    },
-    "stats": {
-      "added": "Added",
-      "completed": "Completed",
-      "failed": "Failed",
-      "pending": "Pending",
-      "uploading": "Uploading"
-    },
-    "subtitle": "Upload receipt images or PDFs. Create invoices from them later.",
-    "title": "Upload Scans",
-    "upload": {
-      "browse": "Browse files",
-      "dropzone": "Drag and drop your receipt images or PDFs here",
-      "or": "or"
-    },
-    "uploadArea": {
-      "actions": {
-        "clearAll": "Clear All",
-        "uploading": "Uploading...",
-        "uploadScans": "Upload Scans"
-      },
-      "aria": {
-        "uploadFiles": "Upload files"
-      },
-      "compact": {
-        "dropActive": "Drop files to add them",
-        "dropInactive": "Drag files here or click to browse",
-        "subtitle": "JPG, PNG, PDF up to 10MB"
-      },
-      "empty": {
-        "chooseFiles": "Choose Files",
-        "dropActive": "Drop files to upload",
-        "dropInactive": "Click or drag files to upload",
-        "formats": "Supported formats: JPG, PNG, PDF (max 10MB each)",
-        "note": "You can select multiple files.",
-        "pasteHint": "Tip: you can also paste an image from your clipboard (Ctrl+V).",
-        "title": "Drag and drop your files here"
-      },
-      "tooltips": {
-        "clearAll": "Remove all pending uploads",
-        "uploadScans": "Start uploading all pending scans"
       }
     }
   },
-  "IMS--View": {
-    "analysisPanel": {
-      "analyzing": {
-        "progress": "{progress}% complete",
-        "title": "Analyzing..."
-      },
-      "buttons": {
-        "reanalyze": "Re-Analyze Invoice"
-      },
-      "description": "Re-analyze this invoice with AI to extract or update data",
-      "labels": {
-        "analysisComplete": "Analysis Complete — All data has been extracted",
-        "granularOptions": "Or choose specific analysis",
-        "lastAnalyzed": "Last Analyzed",
-        "updates": "{count, plural, one {# update} other {# updates}}"
-      },
-      "options": {
-        "completeAnalysis": "Full Analysis",
-        "invoiceOnly": "Invoice Only",
-        "itemsOnly": "Items Only",
-        "merchantOnly": "Merchant Only"
-      },
-      "steps": {
-        "analyzing": "Analyzing with AI...",
-        "complete": "Analysis complete!",
-        "extracting": "Running OCR extraction...",
-        "finalizing": "Finalizing results...",
-        "preparing": "Preparing document...",
-        "processing": "Processing items..."
-      },
-      "tip": "Quick Tip: Full analysis takes 30-60 seconds but provides the most accurate results.",
-      "title": "AI Analysis",
-      "toasts": {
-        "error": {
-          "description": "Unable to analyze invoice. Please try again later.",
-          "title": "Analysis Failed"
-        },
-        "success": {
-          "description": "Invoice has been successfully re-analyzed with updated data.",
-          "title": "Analysis Complete"
+  "pages": {
+    "about": {
+      "author": {
+        "metadata": {
+          "description": "Learn more about the author, Alexandru-Razvan Olariu.",
+          "title": "Alexandru-Razvan Olariu"
         }
       },
-      "tooltips": {
-        "completeAnalysis": "Complete OCR extraction + AI processing of all invoice data",
-        "invoiceOnly": "Re-extract basic invoice information (date, total, payment)",
-        "itemsOnly": "Re-categorize and analyze line items only",
-        "merchantOnly": "Re-identify merchant and location data",
-        "reanalyze": "Trigger complete re-analysis with all AI features"
-      }
-    },
-    "categoryComparisonChart": {
-      "description": "This invoice vs your average",
-      "labels": {
-        "average": "Average",
-        "current": "Current"
-      },
-      "title": "Category Comparison"
-    },
-    "export": {
-      "copyError": "Failed to copy summary",
-      "copySuccess": "Summary copied to clipboard",
-      "copySummary": {
-        "description": "Copy text summary to clipboard",
-        "title": "Copy Summary"
-      },
-      "csv": {
-        "description": "Download items as spreadsheet",
-        "title": "Export as CSV"
-      },
-      "csvError": "Failed to export CSV",
-      "csvSuccess": "CSV file downloaded successfully",
-      "description": "Export your invoice data in various formats",
-      "json": {
-        "description": "Download complete invoice data",
-        "title": "Export as JSON"
-      },
-      "jsonError": "Failed to export JSON",
-      "jsonSuccess": "JSON file downloaded successfully",
-      "pdf": {
-        "description": "Download professional invoice document",
-        "title": "Export as PDF"
-      },
-      "pdfError": "Failed to generate PDF",
-      "pdfGenerating": "Generating PDF...",
-      "pdfSuccess": "PDF file downloaded successfully",
-      "print": {
-        "description": "Print invoice using browser",
-        "title": "Print"
-      },
-      "printError": "Failed to open print dialog",
-      "printSuccess": "Print dialog opened",
-      "title": "Export Invoice"
-    },
-    "healthScore": {
-      "cta": {
-        "analyze": "Run AI Analysis",
-        "edit": "Edit Invoice"
-      },
-      "dialogTitle": "Invoice Health Report",
-      "factors": {
-        "categoriesAssigned": "Categories assigned",
-        "merchantLinked": "Merchant linked",
-        "ocrConfidence": "OCR confidence",
-        "paymentInfo": "Payment information",
-        "productCompleteness": "Product completeness",
-        "productsPresent": "Products extracted",
-        "recipesGenerated": "Recipes generated"
-      },
-      "hideDetails": "Hide factor breakdown",
-      "points": "points",
-      "seeReport": "See detailed report",
-      "showDetails": "Show factor breakdown",
-      "status": {
-        "excellent": "Excellent",
-        "good": "Good",
-        "incomplete": "Incomplete",
-        "needsAttention": "Needs Attention"
-      },
-      "subtitle": "Comprehensive data quality assessment",
-      "suggestions": {
-        "fix": "Fix",
-        "incompletePayment": "Incomplete payment information — add transaction date, amount, and currency",
-        "incompleteProducts": "<strong>{count}</strong> products incomplete — review and complete missing fields",
-        "lowOcrConfidence": "Low OCR confidence on <strong>{count}</strong> products — review manually for accuracy",
-        "noMerchant": "No merchant linked — add merchant details for better insights",
-        "noProducts": "No products found — upload a receipt or add items manually",
-        "noRecipes": "No recipes generated — run AI analysis to discover meal ideas",
-        "title": "Suggested Improvements",
-        "uncategorizedProducts": "<strong>{count}</strong> products uncategorized — assign categories for spending analysis"
-      },
-      "title": "Invoice Health Score"
-    },
-    "invoiceAnalytics": {
-      "emptyState": {
-        "description": "Add more invoices to see spending trends, merchant breakdowns, and category comparisons.",
-        "title": "Not Enough Data for Comparisons"
-      },
-      "tabs": {
-        "compare": "Comparison",
-        "current": "This Invoice"
-      },
-      "title": "Analytics & Insights"
-    },
-    "invoiceGuestBanner": {
-      "description": "You are not currently the owner of this invoice. The view is limited to what the owner has specified in the share settings.",
-      "title": "Guest View"
-    },
-    "invoiceTabs": {
-      "actions": {
-        "generate": "Generate Recipes",
-        "regenerate": "Regenerate Recipes",
-        "regenerateTooltip": "Re-analyze the invoice to generate new recipe suggestions"
-      },
-      "empty": {
-        "additionalInfo": "No additional information available",
-        "recipes": "No recipe suggestions available"
-      },
-      "recipe": {
-        "duration": "{minutes} min",
-        "ingredients": "Ingredients",
-        "instructions": "Instructions",
-        "prepCook": "Prep: {prep}m • Cook: {cook}m",
-        "viewRecipe": "View Recipe"
-      },
-      "tabs": {
-        "additionalInfo": "Additional Info",
-        "possibleRecipes": "Possible Recipes"
-      }
-    },
-    "invoiceTimeline": {
-      "eventCount": "{count, plural, one {# event} other {# events}}",
-      "subtitle": "Complete history of actions and changes",
-      "title": "Invoice Timeline"
-    },
-    "itemAnalytics": {
-      "columns": {
-        "category": "Category",
-        "name": "Name",
-        "price": "Price",
-        "quantity": "Qty",
-        "total": "Total"
-      },
-      "confidence": {
-        "ariaLabel": "{level} confidence: {percent}%",
-        "high": "High",
-        "label": "OCR Confidence",
-        "low": "Low",
-        "lowWarning": "Low confidence — consider reviewing this item",
-        "medium": "Medium"
-      },
-      "empty": {
-        "subtitle": "Run AI analysis to extract items from your receipt",
-        "title": "No items"
-      },
-      "searchPlaceholder": "Search items...",
-      "summary": {
-        "allergens": "{count} allergens detected",
-        "categories": "{count} categories",
-        "cheapest": "Cheapest",
-        "mostExpensive": "Most expensive",
-        "title": "Summary"
-      },
-      "title": "Items",
-      "totalLabel": "TOTAL"
-    },
-    "itemsBreakdownChart": {
-      "description": "Highest spending items",
-      "labels": {
-        "price": "Price",
-        "quantity": "Qty"
-      },
-      "title": "Top Items by Cost"
-    },
-    "merchantBreakdownChart": {
-      "description": "All-time totals across merchants",
-      "labels": {
-        "averagePerVisit": "Avg/visit",
-        "total": "Total",
-        "totalSpent": "Total Spent",
-        "visits": "Visits"
-      },
-      "title": "Spending by Store",
-      "unknownMerchant": "Unknown Merchant"
-    },
-    "metadata": {
-      "description": "View your invoice details, items, and associated merchant information.",
-      "title": "Invoice Management System - View Invoice"
-    },
-    "priceDistributionChart": {
-      "description": "Items by price range ({currency})",
-      "labels": {
-        "items": "Items"
-      },
-      "title": "Price Distribution",
-      "tooltip": {
-        "itemCount": "{count, plural, one {# item} other {# items}}"
-      }
-    },
-    "print": {
-      "generatedOn": "Printed on {date}",
-      "labels": {
-        "date": "Date",
-        "items": "Items",
-        "merchant": "Merchant",
-        "total": "Total Amount"
-      },
-      "page": "Page"
-    },
-    "relatedInvoices": {
-      "noRelated": "No related invoices found",
-      "sameCategory": "Same Category",
-      "sameMerchant": "Same Merchant",
-      "similarAmount": "Similar Amount",
-      "subtitle": "Similar invoices based on merchant, category, or amount",
-      "title": "Related Invoices",
-      "viewInvoice": "View"
-    },
-    "shareCollaborate": {
-      "activity": {
-        "created": "Created {time}",
-        "daysAgo": "{count, plural, one {# day ago} other {# days ago}}",
-        "modified": "Last modified {time}",
-        "title": "Activity",
-        "today": "today"
-      },
-      "copied": "Link copied to clipboard!",
-      "copyError": "Failed to copy link",
-      "copyLink": "Copy Link",
-      "madePrivate": "Invoice is now private",
-      "madePublic": "Invoice is now public",
-      "manageSharing": "Manage Sharing",
-      "private": "Private",
-      "public": "Public",
-      "publicAccess": "Public Access",
-      "publicAccessDescription": "Anyone with the link can view this invoice",
-      "qrCode": "QR Code",
-      "qrCopied": "Link copied! QR code generation coming soon.",
-      "shared": "Shared",
-      "sharedWith": "Shared with",
-      "shareEmail": "Share via Email",
-      "title": "Sharing & Collaboration",
-      "toggleError": "Failed to update sharing settings"
-    },
-    "spendingByCategoryChart": {
-      "description": "Distribution of expenses",
-      "title": "Spending by Category",
-      "tooltip": {
-        "itemCount": "{count, plural, one {# item} other {# items}}"
-      },
-      "totalLabel": "Total Spending"
-    },
-    "spendingTrendChart": {
-      "description": "Your invoice history trend",
-      "labels": {
-        "amount": "Amount"
-      },
-      "title": "Spending Over Time",
-      "tooltip": {
-        "andMore": "and {count} more...",
-        "currentInvoice": "Current Invoice"
-      }
-    },
-    "timelineItem": {
-      "aria": {
-        "moreInfo": "More info about {title}"
-      },
-      "confidence": "Confidence: {value}%",
-      "events": {
-        "aiAnalysis": {
-          "description": "{count, plural, one {# item detected and categorized} other {# items detected and categorized}}",
-          "title": "AI Analysis Complete"
+      "hub": {
+        "cta": {
+          "footer": "Built with passion in Romania",
+          "primary": "View on GitHub",
+          "secondary": "Get in Touch",
+          "subtitle": "Start your journey through the platform or connect with the author.",
+          "title": "Ready to Explore?"
         },
-        "categorized": {
-          "description": "Auto-categorized based on items",
-          "title": "Category Assigned"
+        "faq": {
+          "questions": {
+            "q1": {
+              "answer": "arolariu.ro is a comprehensive full-stack platform that serves as both a personal portfolio and a technology showcase. It demonstrates modern web development practices using Next.js, .NET, and Azure cloud services.",
+              "question": "What is arolariu.ro?"
+            },
+            "q2": {
+              "answer": "Yes! The entire platform is open source and available on GitHub. You can explore the codebase, learn from it, or even contribute to its development.",
+              "question": "Is this platform open source?"
+            },
+            "q3": {
+              "answer": "The platform uses Next.js 16 with React 19 for the frontend, .NET 10 with ASP.NET Core for the backend, and Azure for cloud infrastructure. It also features a comprehensive component library and extensive testing.",
+              "question": "What technologies are used?"
+            },
+            "q4": {
+              "answer": "Absolutely! The platform is designed to showcase best practices in software engineering. Feel free to use it as a reference for architecture, patterns, and implementation details.",
+              "question": "Can I use this as a reference for my own projects?"
+            }
+          },
+          "subtitle": "Common questions about the platform and its purpose",
+          "title": "Frequently Asked Questions"
         },
-        "created": {
-          "description": "Scanned and digitized from receipt",
-          "title": "Invoice Created"
+        "hero": {
+          "badge": "About Us",
+          "ctaPrimary": "Explore the Platform",
+          "ctaSecondary": "Meet the Author",
+          "subtitle": "A modern full-stack platform built with passion, designed for innovation, and crafted with attention to detail.",
+          "title": "Discover arolariu.ro"
         },
-        "edited": {
-          "title": "Invoice Updated"
+        "mission": {
+          "description": "arolariu.ro is more than just a website - it's a playground for modern technologies, a showcase of best practices, and a platform that demonstrates what's possible when engineering excellence meets creative vision.",
+          "pillars": {
+            "innovation": {
+              "description": "Embracing cutting-edge technologies and architectural patterns",
+              "title": "Innovation"
+            },
+            "openness": {
+              "description": "Open source, transparent, and community-driven",
+              "title": "Openness"
+            },
+            "quality": {
+              "description": "Maintaining high standards with 90%+ test coverage",
+              "title": "Quality"
+            }
+          },
+          "statement": "To build software that makes a difference.",
+          "title": "Our Mission"
         },
-        "exported": {
-          "title": "Invoice Exported"
+        "navigation": {
+          "author": {
+            "cta": "Meet Alexandru",
+            "features": {
+              "item0": "Microsoft Engineer",
+              "item1": "Solution Architect",
+              "item2": "Tech Enthusiast"
+            },
+            "subtitle": "Meet Alexandru-Razvan Olariu, the software engineer behind this platform.",
+            "title": "The Author"
+          },
+          "platform": {
+            "cta": "Explore Platform",
+            "features": {
+              "item0": "Next.js 16 Frontend",
+              "item1": ".NET 10 Backend",
+              "item2": "Azure Cloud Infrastructure"
+            },
+            "subtitle": "Discover the architecture, technology stack, and features that power arolariu.ro.",
+            "title": "The Platform"
+          },
+          "subtitle": "Dive deeper into what makes arolariu.ro unique",
+          "title": "Explore Further"
         },
-        "markedImportant": {
-          "description": "Flagged for priority tracking",
-          "title": "Marked as Important"
+        "stats": {
+          "items": {
+            "linesOfCode": {
+              "description": "Across frontend and backend",
+              "label": "Lines of Code",
+              "value": "50K+"
+            },
+            "technologies": {
+              "description": "Modern tech stack",
+              "label": "Technologies",
+              "value": "25+"
+            },
+            "testCoverage": {
+              "description": "Quality assurance standard",
+              "label": "Test Coverage",
+              "value": "90%"
+            },
+            "yearsActive": {
+              "description": "Continuously evolving since 2022",
+              "label": "Years Active",
+              "value": "3+"
+            }
+          },
+          "subtitle": "Key metrics that showcase our commitment to quality",
+          "title": "By the Numbers"
         },
-        "recipesGenerated": {
-          "description": "{count, plural, one {# recipe suggested} other {# recipes suggested}}",
-          "title": "Recipes Generated"
-        },
-        "shared": {
-          "description": "Shared with {count, plural, one {# person} other {# people}}",
-          "title": "Shared with Others"
+        "values": {
+          "items": {
+            "accessibility": {
+              "description": "Built for everyone with keyboard navigation and screen reader support.",
+              "title": "Accessible Design"
+            },
+            "community": {
+              "description": "Open source at heart, contributing back to the developer community.",
+              "title": "Community First"
+            },
+            "engineering": {
+              "description": "Every feature is built with clean architecture, proper testing, and maintainability in mind.",
+              "title": "Engineering Excellence"
+            },
+            "learning": {
+              "description": "This platform serves as a testing ground for new technologies and approaches.",
+              "title": "Continuous Learning"
+            },
+            "performance": {
+              "description": "Optimized for speed with server-side rendering and edge deployments.",
+              "title": "Performance Driven"
+            },
+            "privacy": {
+              "description": "User data protection and privacy are fundamental, not afterthoughts.",
+              "title": "Privacy Focused"
+            }
+          },
+          "subtitle": "The principles that guide every line of code",
+          "title": "Core Values"
         }
       },
-      "fallbacks": {
-        "ocr": "OCR",
-        "pdf": "PDF"
-      },
-      "relativeTime": {
-        "now": "Just now"
-      },
-      "tooltips": {
-        "aiAnalysis": "AI processed this invoice in {duration} and analyzed {count, plural, one {# item} other {# items}}.",
-        "categorized": "Invoice was assigned a category for better organization.",
-        "created": "Invoice was scanned and digitized using {method}.",
-        "edited": "Manual changes were made to the invoice.",
-        "exported": "Invoice was exported in {format} format.",
-        "markedImportant": "Invoice was flagged as important for quick access.",
-        "recipesGenerated": "Based on purchased ingredients, {count, plural, one {# recipe was generated} other {# recipes were generated}}.",
-        "shared": "Invoice was shared with {count, plural, one {# user} other {# users}}.",
-        "unavailable": "Event details unavailable"
+      "platform": {
+        "metadata": {
+          "description": "Learn more about the platform, arolariu.ro.",
+          "title": "The platform"
+        }
       }
     },
-    "timelineSharedWithList": {
-      "actions": {
-        "manageSharing": "Manage Sharing",
-        "sendEmail": "Send email"
+    "auth": {
+      "button": {
+        "login": "Login",
+        "logout": "Logout"
       },
-      "aria": {
-        "sendEmail": "Send email to {user}"
+      "island": {
+        "callToAction": "Perform auth",
+        "description": "Sign in using our secure OAuth 2.0 auth server. Your profile will be kept in sync during this browser session. You can use your social media accounts to sign in.",
+        "footer": "You can switch providers at any time. Authentication is handled by our trusted identity provider.",
+        "hero": {
+          "badge": "Secure Authentication",
+          "subtitle": "Pick a path and continue with your preferred provider. Everything stays fast, secure, and localized.",
+          "title": "Welcome to the secure entry point"
+        },
+        "signIn": {
+          "bullets": {
+            "first": "Continue with the identity provider you already use.",
+            "second": "Resume where you left off on any device.",
+            "third": "Session stays in sync while you browse."
+          },
+          "cta": "Sign in",
+          "description": "Access your account and keep your session synchronized during this browser session.",
+          "illustrationAlt": "Illustration for signing in",
+          "secondaryAction": "Create one",
+          "secondaryPrompt": "Don’t have an account?",
+          "title": "Sign in"
+        },
+        "signUp": {
+          "bullets": {
+            "first": "Create an account in seconds with OAuth providers.",
+            "second": "No passwords to remember.",
+            "third": "Start using the platform right away."
+          },
+          "cta": "Create an account",
+          "description": "Join the platform and unlock member-only experiences across the domain space.",
+          "illustrationAlt": "Illustration for signing up",
+          "secondaryAction": "Sign in",
+          "secondaryPrompt": "Already have an account?",
+          "title": "Sign up"
+        },
+        "step1": "Step 1",
+        "step2": "Step 2",
+        "title": "Authenticate with our secure OAuth 2.0 auth server.",
+        "trust": {
+          "oauth": "OAuth 2.0",
+          "privacy": "Privacy-first",
+          "session": "Session sync"
+        }
       },
-      "header": {
-        "publicBadge": "Public",
-        "title": "Shared With"
-      },
-      "publicAccess": {
-        "description": "This invoice is publicly accessible. Anyone with the link can view it, including guests without an account.",
-        "title": "Public Access Enabled"
-      }
-    }
-  },
-  "IMS--ViewScans": {
-    "breadcrumb": "Back to Invoices",
-    "createFromAll": {
-      "button": "Create from All Scans",
-      "description": "Create invoices from all {count} scans at once",
-      "title": "All scans are ready!"
-    },
-    "emptyState": {
-      "description": "Start by uploading your receipts and invoices. Here's how it works:",
-      "learnMoreButton": "Learn More",
-      "step1Description": "Take photos of receipts or upload PDFs of digital invoices",
-      "step1Title": "Upload your scans",
-      "step2Description": "Choose which scans to convert into invoices",
-      "step2Title": "Select and organize",
-      "step3Description": "Our AI automatically extracts all the data for you",
-      "step3Title": "Create invoices",
-      "title": "No scans yet",
-      "uploadButton": "Upload Your First Scan"
-    },
-    "groupBanner": {
-      "createInvoice": "Create Invoice",
-      "dismiss": "Dismiss",
-      "subtitle": "Create an invoice from these scans?",
-      "title": "These {count} scans were uploaded together"
-    },
-    "header": {
-      "invoices": "Invoices",
-      "lastSynced": "Last synced: {time}",
-      "myInvoices": "My Invoices",
-      "myInvoicesTooltip": "View your created invoices",
-      "subtitle": "Select scans to create invoices from them",
-      "sync": "Sync",
-      "syncing": "Syncing...",
-      "syncTooltip": "Refresh scans from server",
-      "title": "Your Scans",
-      "titleWithCount": "Your Scans ({count})",
-      "tooltip": "Select scans to create invoices from them. You can create one invoice per scan or combine multiple scans into a single invoice.",
-      "upload": "Upload",
-      "uploadMore": "Upload More",
-      "uploadTooltip": "Upload more scans to your account"
-    },
-    "metadata": {
-      "description": "View and manage your uploaded scans. Create invoices from selected scans.",
-      "title": "Invoice Management System - View Scans"
-    },
-    "pagination": {
-      "next": "Next",
-      "pageInfo": "{current} / {total} ({count} scans)",
-      "previous": "Previous"
-    },
-    "scanCard": {
-      "actions": {
-        "delete": "Delete scan",
-        "rename": "Rename scan",
-        "rotateCCW": "Rotate 90° Counter-clockwise",
-        "rotateCW": "Rotate 90° Clockwise",
-        "rotateError": "Failed to rotate image",
-        "rotateSuccess": "Image rotated successfully",
-        "rotateUnsupported": "Cannot rotate PDF files",
-        "rotating": "Rotating..."
-      },
-      "delete": "Delete scan",
-      "deleteDialog": {
-        "cancel": "Cancel",
-        "delete": "Delete",
-        "deleting": "Deleting...",
-        "description": "Are you sure you want to delete \"{name}\"? This action cannot be undone and the scan will be permanently removed from storage.",
-        "error": "Failed to delete scan",
-        "linkedDescription": "Deleting it will remove the scan from storage, but the invoice will retain a copy of the image. This action cannot be undone.",
-        "linkedWarning": "This scan is linked to an invoice.",
-        "success": "Scan deleted successfully",
-        "title": "Delete scan?"
-      },
-      "linked": "Linked",
-      "loading": "Loading...",
-      "preview": "Preview scan",
-      "previewTitle": "Scan Preview",
-      "rename": "Rename scan",
-      "renamePlaceholder": "Enter new name"
-    },
-    "sidebar": {
-      "howTo": {
-        "step1Description": "Click on scans to select them",
-        "step1Title": "Select Scans",
-        "step2Description": "One invoice per scan or combine multiple",
-        "step2Title": "Choose Mode",
-        "step3Description": "AI extracts data automatically",
-        "step3Title": "Create Invoice",
-        "title": "How to Create Invoices"
-      },
-      "quickUpload": {
-        "button": "Upload",
-        "description": "Upload additional receipts",
-        "title": "Need more scans?"
-      },
-      "selectionStatus": {
-        "plural": "scans selected",
-        "readyPlural": "Create multiple invoices or combine into one",
-        "readySingular": "Ready to create an invoice",
-        "singular": "scan selected"
-      }
-    },
-    "stats": {
-      "ready": "Ready",
-      "selected": "Selected",
-      "selectHint": "Click on scans to select them for invoice creation",
-      "tapHint": "Tap to select",
-      "totalScans": "Total Scans"
-    },
-    "subtitle": "Select scans to create invoices from them.",
-    "title": "Your Scans",
-    "toolbar": {
-      "clearSelection": "Clear",
-      "createInvoice": "Create Invoice",
-      "createInvoices": "Create Invoices",
-      "delete": {
-        "button": "Delete ({count})",
-        "cancel": "Cancel",
-        "confirm": "Delete",
-        "confirmDescription": "This will permanently delete {count} scan(s) from storage. This action cannot be undone.",
-        "confirmTitle": "Delete selected scans?",
-        "error": "An error occurred while deleting scans",
-        "failed": "Failed to delete scans",
-        "partial": "{success} deleted, {failed} failed",
-        "success": "{count} scan(s) deleted successfully"
-      },
-      "selected": "selected"
-    }
-  },
-  "Legal": {
-    "PrivacyPolicy": {
-      "contactInformation": {
-        "content": "If you have any questions about our Privacy Policy, please contact us at admin@arolariu.ro",
-        "title": "Contact Information"
-      },
-      "last_updated": "Last updated: 2024-01-01",
       "metadata": {
-        "description": "The privacy policy page for the `arolariu.ro` platform.",
-        "title": "Privacy Policy"
+        "description": "The auth page for the arolariu.ro platform.",
+        "title": "Auth"
       },
-      "terms": {
-        "childrenPrivacy": {
-          "content": "Our website is not intended for children under the age of 13. We do not knowingly collect Personal Data from children under the age of 13. If you are a parent or guardian and you are aware that your child has provided us with Personal Data, please contact us. If we become aware that we have collected Personal Data from children without verification of parental consent, we will take steps to remove that information from our servers.",
-          "title": "Children's Privacy"
+      "signIn": {
+        "bullets": {
+          "first": "Fast sign-in with trusted providers.",
+          "second": "Your session stays consistent across the app.",
+          "third": "Designed to work well on mobile and desktop."
         },
-        "cookiesDefinition": {
-          "content": "Cookies are small pieces of data stored on your device (computer or mobile device). Cookies are used to improve your experience on our website and to provide you with relevant content. For more information on cookies, please visit https://www.allaboutcookies.org/ <br></br><br></br><br></br> We use cookies to collect information about your device and your use of our website. Our website analytics provider uses cookies to generate statistical and other information about website use by means of cookies. <br></br><br></br><br></br> You can opt-out of cookies by using the settings in your browser. Please note that if you disable cookies, you may not be able to use all the features of our website. <br></br><br></br><br></br> We will only retain your Personal Data for as long as necessary for the purpose for which that data was collected and to the extent required by applicable law. When we no longer need Personal Data, we will remove it from our systems and/or take steps to anonymize it.",
-          "title": "What are Cookies?"
+        "footer": "Protected by enterprise-grade security.",
+        "form": {
+          "kicker": "Sign in with your preferred provider",
+          "secondaryAction": "Create an account",
+          "secondaryPrompt": "New here?"
         },
-        "dataCollectionTerms": {
-          "content": "a) When you make a purchase or attempt to make a purchase, we collect the following types of Personal Data: <ul> <li> Payment Information such as your billing address, phone number, credit card, debit card and/or other payment method information; </li><li> Account Information such as your name, username, e-mail address; </li><li> Purchase Information specifically if personalized or unique;</li> <li>Demographic Data;</li> <li>Location Data.</li> </ul> <br></br><br></br> b) When you visit and use our website, we automatically collect the following types of Personal Data: <ul> <li> Payment Information such as your billing address, phone number, credit card, debit card and/or other payment method information; </li> <li>Device Data, such as your computer, phone, tablet or other device you use to access our website;</li> <li>Communication Data, such as your preferences for receiving communications from us;</li> <li>Feedback, such as customer support, product reviews, surveys and/or other feedback;</li> <li>Content Data, such as content you submit to us: posts, documents, audio, images, etc.;</li> <li>Usage Data, such as how you use our website, products and services;</li> <li>Account Information such as your name, username, e-mail address;</li> <li>Purchase Information specifically if personalized or unique;</li> <li>Demographic Data;</li> <li>Location Data;</li></ul>",
-          "title": "What Personal Data We Collect"
+        "hero": {
+          "subtitle": "Use the provider you trust and continue instantly.",
+          "title": "Welcome back"
         },
-        "dataTransferTerms": {
-          "content": "Where possible, we store and process data on servers within the general geographical region where you reside (note: this may not be within the country in which you reside). <span> Specifically, for European based users, companies and customers, we have servers in the European Economic Area (EEA). </span> Your Personal Data may also be transferred to, and maintained on, servers residing outside of your state, province, country or other governmental jurisdiction where the data laws may differ from those in your jurisdiction. We will take appropriate steps to ensure that your Personal Data is treated securely and in accordance with this Policy as well as applicable data protection law. Data may be kept in other countries that are considered adequate under your laws. <br></br><br></br><br></br><br></br> More information about these clauses can be found here: https://eur-lex.europa.eu/legal-content/en/TXT/?uri=CELEX:32021D0914",
-          "title": "International Data Transfer and Storage"
-        },
-        "deviceUsageTerms": {
-          "content": "When you visit a <code>AROLARIU.RO</code> website and/or mobile application, we automatically collect and store information about your visit using browser cookies (files which are sent by us to your computer), or similar technologies. You can instruct your browser to refuse all cookies or to indicate when a cookie is being sent. The `Help` feature on most browsers will provide information on how to accept cookies, disable cookies or to notify you when receiving a new cookie. If you do not accept cookies, you may not be able to use some features of our Service and we recommend that you leave them turned on. <br></br><br></br><br></br> We also process information when you use our services and products. This information may include: <ul> <li>   Information about your interactions with our services, including the time and date of your interactions,   and your interactions with our emails; </li> <li>   Information about your use of our services, including the type of browser you use, access times, pages   viewed, your IP address; </li> <li>   Information about your purchases, including the items you purchase, the date of purchase, and the payment   method you use; </li> <li>   Information about your device, including the type of device, its operating system, and mobile network   information; </li> <li>   Other information you provide to us, including your feedback, comments, and other information you provide   to us; </li> <li>Information about your location, including your general location based on your IP address;</li> <li>Other information we collect with your consent or as permitted or required by law;</li> <li>Information about your preferences, including your language preferences.</li> </ul>",
-          "title": "Device and Usage Data"
-        },
-        "exerciseRights": {
-          "content": "To exercise your rights, please contact us using the contact details provided under the “Contact Us” section below. We will respond to your request within a reasonable timeframe and in accordance with applicable law. <br></br><br></br> For your own safety and security, we may need to verify your identity before responding to your request. We will make reasonable efforts to verify your identity by asking for information that we have on file about you.",
-          "title": "How to Exercise Your Rights"
-        },
-        "howWeCollectDataTerms": {
-          "content": "We collect Personal Data in the following ways: <br></br><br></br> <span>1. From you.</span> <br></br> We collect Personal Data from you when you provide it to us directly or indirectly, by using our website, products or services. This includes: <br></br> <ul> <li>When you create an account or purchase products on our website;</li> <li>When you download software and/our our mobile application;</li> <li>When you participate in our surveys, contests or promotions;</li> <li>When you create content through our products and services;</li> <li>When you contact us with an inquiry or to report a problem;</li> <li>When you express interest(s) in our products and services;</li> <li>When you use our website, products or services;</li> <li>When you interact with us on social media;</li> <li>When you subscribe to our newsletter;</li> <li>When you provide it to us directly;</li> <li>When you communicate with us.</li> </ul> <br></br><br></br><br></br><br></br> <span>2. Automated technologies or interactions.</span> <br></br> <br></br> As you interact with our website, we may automatically collect the following types of data (all as described above): Device Data about your equipment, Usage Data about your browsing actions and patterns, and Contact Data where tasks carried out via our website remain uncompleted, such as incomplete orders or abandoned baskets. We collect this data by using cookies, server logs and other similar technologies. Please see our Cookie section (below) for further details. <br></br><br></br><br></br><br></br> <span>3. Third parties or publicly available sources.</span> <br></br><br></br> We may receive Personal Data about you from various third parties, including: <ul> <li>   Account Information and Payment Data from third parties, including organizations (such as law enforcement   agencies), associations and groups, who share data for the purposes of fraud prevention and detection and   credit risk reduction </li> <li>Contact, Financial and Transaction Data from providers of technical, payment and delivery services</li> <li>Technical Data from analytics providers such as Google Analytics</li> <li>Identity and Contact Data from data brokers or aggregators</li> <li>Identity and Contact Data from publicly available sources</li> </ul> <br></br><br></br><br></br><br></br><span> If you provide us, or our service providers, with any Personal Data relating to other individuals, you represent that you have the authority to do so and acknowledge that it will be used in accordance with this Policy. If you believe that your Personal Data has been provided to us improperly, or to otherwise exercise your rights relating to your Personal Data, please contact us by using the information set out in the “Contact Us” section below.</span>",
-          "title": "How We Collect Personal Data"
-        },
-        "legalTerms": {
-          "content": "We may use or disclose your Personal Data in order to comply with a legal obligation, in connection with a request from a public or government authority, or in connection with court or tribunal proceedings, to prevent loss of life or injury, or to protect our rights or property. Where possible and practical to do so, we will tell you in advance of such disclosure.",
-          "title": "Legal Requirements"
-        },
-        "personalDataRights": {
-          "content": "You have the right to access, correct, update or delete your Personal Data. You also have the right to object to the processing of your Personal Data, ask us to restrict the processing of your Personal Data or request portability of your Personal Data. You can exercise these rights by contacting us using the contact details provided under the “Contact us” section below. <br></br><br></br><br></br> Depending on your geographical location and citizenship, your rights are subject to local data privacy regulations. These rights may include: <ul> <li>   Right to be Forgotten (right to erasure) (GDPR Article 17, CCPA/CPRA, CPA, VCDPA, CTDPA, UCPA, LGPD,   POPIA) </li> <li>Right to Access (PIPEDA, GDPR Article 15, CCPA/CPRA, CPA, VCDPA, CTDPA, UCPA, LGPD, POPIA)</li> <li>Right to Rectification (PIPEDA, GDPR Article 16, CPRA, CPA, VCDPA, CTDPA, LGPD, POPIA)</li> <li>Nondiscrimination and nonretaliation (CCPA/CPRA, CPA, VCDPA, CTDPA, UCPA)</li> <li>Right to Restriction of Processing (GDPR Article 18, LGPD)</li> <li>Right to Opt Out (CPRA, CPA, VCDPA, CTDPA, UCPA)</li> <li>Right to Portability (PIPEDA, GDPR Article 20, LGPD)</li> <li>Right to Objection (GDPR Article 21, LGPD, POPIA)</li> </ul> <br></br><br></br><br></br> If you want to file an appeal or complaint about how we process your Personal Data, you can contact us using the contact details provided under the “Contact us” section below. You also have the right to file a complaint with the data protection authority in your jurisdiction. <br></br> In the case that you did contact us and you are not satisfied with our response, you have the right to file an appeal with the attorney general located here: <ul> <li>   If you are based in the EEA, please visit https://edpb.europa.eu/about-edpb/about-edpb/members_en website for a list of local data protection authorities. </li> <li>   If you are based in Connecticut, please visit https://portal.ct.gov/AG/Common/Complaint-Form-Landing-page website to file a complaint. </li> <li> If you are based in Colorado, please visit https://complaints.coag.gov/s/contact-us website to file a complaint. </li> <li> If you are based in Virginia, please visit https://www.oag.state.va.us/consumer-protection/index.php/file-a-complaint website to file a complaint. </li></ul>",
-          "title": "Your Rights for Your Personal Data"
-        },
-        "policyChanges": {
-          "content": "We may update this Policy from time to time. If we make significant changes, we will let you know, but please regularly check this Policy to ensure you are aware of the most updated version.",
-          "title": "Changes to this Policy"
-        },
-        "processingDataTerms": {
-          "content": "We collect and use your Personal Data with your consent to provide, maintain, and develop our products and services and understand how to further improve them. <br></br><br></br><br></br> These purposes include: <ul> <li>Building a safe and secure environment for our users and our community;</li> <li>Conducting research and analysis to improve our products and services;</li> <li>Communicating with you about your account, purchases, or inquiries;</li> <li>Investigate and prevent security incidents and other illegal activities;</li> <li>Personalizing your experience with our products and services;</li> <li>Deliver, maintain and improve our products and services;</li> <li>Providing you with the products and services you request;</li> <li>Providing you with marketing communications;</li> <li>Providing you with customer support;</li> <li>Protecting our products and services;</li> <li>Other purposes with your consent;</li> <li>Complying with legal obligations.</li> </ul> <br></br><br></br><br></br><br></br> Where we process your Personal Data to provide a product or service, we do so because it is necessary to perform contractual obligations. All of the above processing is necessary in our legitimate interests to provide products and services and to maintain our relationship with you and to protect our business for example against fraud. Consent will be required to initiate services with you. New consent will be required if any changes are made to the type of data collected. Within our contract, if you fail to provide consent, some services may not be available to you.",
-          "title": "Purpose and Legal Basis for the Processing of Personal Data"
-        },
-        "processingTerms": {
-          "content": "This policy applies when you visit our website, use our products or services, or interact with us. <br></br> Additionally, this policy applies when you: <ul> <li> Make use of our application and services as an authorized user;</li> <li>Visit any of our websites that link to this Privacy Policy;</li> <li>Receive any communication from us, including e-mails.</li></ul>",
-          "title": "Processing Activities"
-        },
-        "safeDataTerms": {
-          "content": "We have implemented appropriate technical and organizational security measures designed to protect the security of any Personal Data we process. However, please also remember that we cannot guarantee that the internet itself is 100% secure. Although we will do our best to protect your Personal Data, the transmission of Personal Data to and from our website is at your own risk. You should only access the services within a secure environment. <br></br><br></br><br></br> We have appropriate organizational safeguards and security measures in place to protect your Personal Data from being accidentally lost, used or accessed in an unauthorized way, altered or disclosed. <br></br><br></br><br></br> The communication between your browser and our website uses a secure encrypted connection wherever your Personal Data is involved. <br></br><br></br><br></br> We require any third party who is contracted to process your Personal Data on our behalf to have security measures in place to protect your data and to treat such data in accordance with the law. <br></br><br></br><br></br> In the unfortunate event of a Personal Data breach, we will notify you and any applicable regulator when we are legally required to do so.",
-          "title": "How We Keep Your Data Safe"
-        },
-        "scopeTerms": {
-          "content": "This policy applies to the <code> AROLARIU.RO </code> website, products, and services. It also applies to the use of our website, products, and services by our customers, partners, and visitors. <br></br><br></br> This Policy does not apply to third-party applications, websites, products, services or platforms that may be accessed through (non-<code>AROLARIU.RO</code>) links that we may provide to you. These sites are owned and operated independently from us, and they have their own separate privacy and data collection practices. Any Personal Data that you provide to these websites will be governed by the third-party's own privacy policy. We cannot accept liability for the actions or policies of these independent sites, and we are not responsible for the content or privacy practices of such sites.",
-          "title": "Scope of the Policy"
-        },
-        "serviceProviderTerms": {
-          "content": "We may use a third party service provider, independent contractors, agencies, or consultants to deliver and help us improve our products and services. We may share your Personal Data with marketing agencies, database service providers, backup and disaster recovery service providers, e-mail service providers and others but only to maintain and improve our products and services. <br></br><br></br> For further information on the recipients of your Personal Data, please contact us by using the information in the “Contact Us” section below.",
-          "title": "Service Providers and Other Third Parties"
-        },
-        "sharingAndDisclosureTerms": {
-          "content": "We will share your Personal Data with third parties only in the ways set out in this Policy or set out at the point when the Personal Data is collected. <br></br><br></br><br></br> We also use Google Analytics to help us understand how our customers use the site. You can read more about how Google uses your Personal Data here: https://www.google.com/intl/en/policies/privacy/ <br></br><br></br><br></br> You can also opt-out of Google Analytics here: https://tools.google.com/dlpage/gaoptout <br></br><br></br><br></br> We may also share your Personal Data with third parties where required by law, where it is necessary to administer the relationship between us or where we have another legitimate interest in doing so. We may also share your Personal Data with third parties to whom we may choose to sell, transfer, or merge parts of our business or our assets. Alternatively, we may seek to acquire other businesses or merge with them. <br></br><br></br><br></br> For more information about how targeted advertising works, you can visit the Network Advertising Initiative's (NAI) educational page at: https://www.networkadvertising.org/understanding-online-advertising/how-does-it-work <br></br><br></br><br></br> Additionally, you can opt out of some of these services by visiting the Digital Advertising Alliance's opt-out: https: //optout.aboutads.info/",
-          "title": "Sharing and Disclosure of Personal Data"
-        },
-        "thirdPartyData": {
-          "content": "We may receive your Personal Data from third parties such as companies subscribing to <code>AROLARIU.RO</code> services, partners and other sources. This Personal Data is not collected by us but by a third party and is subject to the relevant third party's own separate privacy and data collection policies. We do not have any control or input on how your Personal Data is handled by third parties. As always, you have the right to review and rectify this information. If you have any questions you should first contact the relevant third party for further information about your Personal Data. Where that third party is unresponsive to your rights, you may contact the Data Protection Officer at <code> AROLARIU.RO </code> (contact details below). <br></br><br></br><br></br>  Our websites and services may contain links to other websites, applications and services maintained by third parties. The information practices of such other services, or of social media networks that host our branded social media pages, are governed by third parties's privacy statements, which you should review to better understand those third parties's privacy practices.",
-          "title": "Data we collect from third parties"
-        },
-        "whatIsTerms": {
-          "content": "At <code> AROLARIU.RO </code> (“us”, “we”, “our” or the ”Company“) we value your privacy and the importance of safeguarding your data. This Privacy Policy (the “Policy”) describes our privacy practices for the activities set out below. <br></br> <br></br> As per your rights, we inform you how we collect, store, access, and otherwise process information relating to individuals. In this Policy, personal data (“Personal Data”) refers to any information that on its own, or in combination with other available information, can identify an individual. <br></br> <br></br> We are committed to protecting your privacy in accordance with the highest level of privacy regulation. As such, we follow the obligations under the below regulations: <ul> <li> California\"s Consumer Privacy Act (CCPA) / California Privacy Rights Act (CPRA) and California Online Privacy Protection Act (CalOPPA) </li> <li> Canada\"s Personal Information Protection and Electronic Documents Act (PIPEDA) and the applicable provincial legislations </li> <li> The European Union\"s General Data Protection Regulation (GDPR) </li> <li> South Africa\"s Protection of Personal Information Act (POPIA) </li> <li> Virginia Consumer Data Protection Act (VCDPA) </li> <li> Brazil\"s Data Protection Legislation (LGPD) </li> <li> Connecticut Data Privacy Act (CTDPA) </li> <li> Utah Consumer Privacy Act (UCPA) Colorado Privacy Act (CPA) </li> </ul>",
-          "title": "What is AROLARIU.RO?"
-        },
-        "withdrawingConsent": {
-          "content": "If you have given your consent to the processing of your Personal Data, you have the right to withdraw your consent at any time. To withdraw your consent, please contact us using the contact details provided under the “Contact Us” section below.",
-          "title": "Withdrawing Consent"
+        "illustrationAlt": "Illustration for the sign-in page",
+        "metadata": {
+          "description": "Sign in to continue your session on arolariu.ro.",
+          "title": "Sign In"
         }
       },
-      "title": "Privacy Policy"
+      "signUp": {
+        "bullets": {
+          "first": "Quick onboarding with OAuth providers.",
+          "second": "No credit card required.",
+          "third": "Start exploring the platform right away."
+        },
+        "footer": "Quick and secure registration.",
+        "form": {
+          "kicker": "Create your account with your preferred provider",
+          "secondaryAction": "Sign in",
+          "secondaryPrompt": "Already have an account?"
+        },
+        "hero": {
+          "subtitle": "Create your account in seconds and get started.",
+          "title": "Join us today"
+        },
+        "illustrationAlt": "Illustration for the sign-up page",
+        "metadata": {
+          "description": "Create an account and start using arolariu.ro.",
+          "title": "Sign Up"
+        }
+      }
     },
-    "TermsOfService": {
-      "contactInformation": {
-        "content": "If you have any questions about our Terms of Service, please contact us at admin@arolariu.ro",
-        "title": "Contact Information"
-      },
-      "last_updated": "Last updated: 2024-01-01",
+    "domains": {
       "metadata": {
-        "description": "The terms of service for arolariu.ro",
-        "title": "Terms of Service"
+        "description": "Domain Space Services are services that are offered to visitors and members of the `arolariu.ro` domain space",
+        "title": "Domain Space Services"
       },
-      "terms": {
-        "amendmentsTerms": {
-          "content": "We reserve the right to modify, supplement or replace the terms of the Agreement, effective upon posting at www.arolariu.ro or notifying you otherwise. If you do not want to agree to changes to the Agreement, you can terminate the Agreement at any time per the terms herein. If a revision is material we will provide at least 30 days' notice prior to any new terms taking effect. What constitutes a material change will be determined at our sole discretion. By continuing to access or use our service after any revisions become effective, you agree to be bound by the revised terms. If you do not agree to the new terms, you are no longer authorized to use our service.",
-          "title": "Amendments to Agreement"
-        },
-        "arbitrateTerms": {
-          "content": "This Agreement and any dispute or claim arising out of, or related to, it, its interpretation, or the breach, termination or validity thereof, the relationships which result from this Agreement, including the performance, breach, or validity of this Agreement, shall be governed by the laws of Romania. The exclusive jurisdiction and venue for any action under this Agreement shall be the courts located in Romania and you hereby submit to the personal jurisdiction of such courts. You hereby waive any right to a jury trial in any proceeding arising out of or related to this Agreement. The United Nations Convention on Contracts for the International Sale of Goods does not apply to this Agreement. The term “dispute” means any dispute, action, or other controversy between you and us concerning the Services or this agreement, whether in contract, warranty, tort, statute, regulation, ordinance, or any other legal or equitable basis. “Dispute” will be given the broadest possible meaning allowable under law.",
-          "title": "Arbitration"
-        },
-        "changesToTos": {
-          "content": "AROLARIU.RO reserves the right to change these Terms of Service at any time. We do, however, recommend that you read this page regularly to ensure that you are aware of any changes. Your continued use of the website following the posting of changes will mean that you accept and agree to the changes. You acknowledge and agree that we may stop (permanently or temporarily) providing the Service (or any features within the Service) to you or to users generally at our sole discretion, without prior notice to you. You may stop using the Service at any time. You do not need to specifically inform us when you stop using the Service. You acknowledge and agree that if we disable access to your account, you may be prevented from accessing the Service, your account details or any files or other materials which is contained in your account",
-          "title": "Changes to Terms of Service"
-        },
-        "consentTerms": {
-          "content": "We've updated our Terms & Conditions to provide you with complete transparency into what is being set when you visit our site and how it's being used. By using our website, you hereby consent to our Terms of Service and agree to the Terms & Conditions.",
-          "title": "Your Consent"
-        },
-        "cookiesTerms": {
-          "content": "We use 'Cookies' to identify the areas of our website that you have visited. A Cookie is a small piece of data stored on your computer or mobile device by your web browser. We use Cookies to enhance the performance and functionality of our service but are non-essential to their use. However, without these cookies, certain functionality like videos may become unavailable or you would be required to enter your login details every time you visit our platform as we would not be able to remember that you had logged in previously. Most web browsers can be set to disable the use of Cookies. However, if you disable Cookies, you may not be able to access functionality on our website correctly or at all. We never place Personally Identifiable Information in Cookies.",
-          "title": "Cookies"
-        },
-        "copyrightTerms": {
-          "content": "If you are a copyright owner or such owner’s agent and believe any material from us constitutes an infringement on your copyright, please contact us setting forth the following information: (a) a physical or electronic signature of the copyright owner or a person authorized to act on his behalf; (b) identification of the material that is claimed to be infringing; (c) your contact information, including your address, telephone number, and an email; (d) a statement by you that you have a good faith belief that use of the material is not authorized by the copyright owners; and (e) the a statement that the information in the notification is accurate, and, under penalty of perjury you are authorized to act on behalf of the owner.",
-          "title": "Copyright Protection"
-        },
-        "definitionTerms": {
-          "content": "The terms 'us' or 'we' or 'our' refers to AROLARIU.RO, the owner of the website. A customer is the person or organization that buys or agrees to buy the product. Our 'product' refers to the website, products, or services offered for sale on our website. A 'user' is a person who uses our website or services. The term 'you' refers to the user or viewer of our website.",
-          "title": "Definitions"
-        },
-        "disclaimerTerms": {
-          "content": "To the maximum extent permitted by applicable law, we exclude all representations, warranties, and conditions relating to our website and the use of this website. We shall not be liable for any damages arising out of the use or inability to use the materials on AROLARIU.RO's website, even if AROLARIU.RO or an authorized representative of AROLARIU.RO has been notified, orally or in writing, of the possibility of such damage. Because some jurisdictions do not allow limitations on implied warranties, or limitations of liability for consequential or incidental damages, these limitations may not apply to you. We are not responsible for any content, code or any other imprecision. We do not provide warranties or guarantees. In no event shall we be liable for any special, direct, indirect, consequential, or incidental damages or any damages whatsoever, whether in an action of contract, negligence or other tort, arising out of or in connection with the use of the Service or the contents of the Service. We reserve the right to make additions, deletions, or modifications to the contents on the Service at any time without prior notice. Our Service and its contents are provided 'AS IS' and 'AS AVAILABLE' without any warranty or representations of any kind, whether express or implied. We are a distributor and not a publisher of the content supplied by third parties; as such, our exercises no editorial control over such content and makes no warranty or representation as to the accuracy, reliability or currency of any information, content, service or merchandise provided through or accessible via our Service. Without limiting the foregoing, We specifically disclaim all warranties and representations in any content transmitted on or in connection with our Service or on sites that may appear as links on our Service, or in the products provided as a part of, or otherwise in connection with, our Service, including without limitation any warranties of merchantability, fitness for a particular purpose or non-infringement of third party rights. No oral advice or written information given by us or any of its affiliates, employees, officers, directors, agents, or the like will create a warranty. Price and availability information is subject to change without notice. Without limiting the foregoing, we do not warrant that our Service will be uninterrupted, uncorrupted, timely, or error-free.",
-          "title": "Disclaimer"
-        },
-        "disputeNoticeTerms": {
-          "content": "In the event of a dispute, you or AROLARIU.RO must give the other a Notice of Dispute, which is a written statement that sets forth the name, address, and contact information of the party giving it, the facts giving rise to the dispute, and the relief requested. You must send any Notice of Dispute by email to: admin@arolariu.ro. AROLARIU.RO will send any Notice of Dispute to you by mail to your address if we have it, or otherwise to your email address. You and AROLARIU.RO will attempt to resolve any dispute through informal negotiation within sixty (60) days from the date the Notice of Dispute is sent. After sixty (60) days, you or AROLARIU.RO may commence arbitration.",
-          "title": "Notice of Dispute"
-        },
-        "entireAgreementTerms": {
-          "content": "The Terms of Service constitute the entire agreement between you and AROLARIU.RO regarding your use of the service and supersede all prior and contemporaneous written or oral agreements between you and AROLARIU.RO. You may be subject to additional terms and conditions that apply when you use or purchase other AROLARIU.RO's services, which AROLARIU.RO will provide to you at the time of such use or purchase.",
-          "title": "Entire Agreement"
-        },
-        "generalTerms": {
-          "content": "By accessing and placing an order with AROLARIU.RO, you confirm that you are in agreement with and bound by the terms of service contained in the Terms & Conditions outlined below. These terms apply to the entire website and any email or other type of communication between you and AROLARIU.RO. Under no circumstances shall AROLARIU.RO team be liable for any direct, indirect, special, incidental or consequential damages, including, but not limited to, loss of data or profit, arising out of the use, or the inability to use, the materials on this site, even if AROLARIU.RO team or an authorized representative has been advised of the possibility of such damages. If your use of materials from this site results in the need for servicing, repair or correction of equipment or data, you assume any costs thereof. AROLARIU.RO will not be responsible for any outcome that may occur during the course of usage of our resources. We reserve the rights to change prices and revise the resources usage policy in any moment.",
-          "title": "General Terms"
-        },
-        "liabilityTerms": {
-          "content": "To the fullest extent permitted by applicable law, in no event will AROLARIU.RO be liable to you on any legal theory for any incidental, direct, indirect, punitive, actual, consequential, special, exemplary, or other damages, including without limitation, loss of revenue or income, lost profits, pain and suffering, emotional distress, cost of substitute goods or services, or similar damages suffered or incurred by you or any third party that arise in connection with the service (or the termination thereof for any reason), even if AROLARIU.RO has been advised of the possibility of such damages. AROLARIU.RO shall not be liable for any damages, liability or losses arising out of: (i) your use of or reliance on the service or your inability to access or use the service; or (ii) any transaction or relationship between you and any third party provider, even if AROLARIU.RO has been advised of the possibility of such damages. AROLARIU.RO shall not be liable for delay or failure in performance resulting from causes beyond AROLARIU.RO's reasonable control. You acknowledge that the service may be subject to limitations, delays, and other problems inherent in the use of the internet and electronic communications. AROLARIU.RO is not responsible for any delays, delivery failures, or other damage resulting from such problems. To the maximum extent permitted by applicable law, in no event shall we or our suppliers be liable for any special, incidental, indirect, or consequential damages whatsoever (including, but not limited to, damages for loss of profits, for loss of data or other information, for business interruption, for personal injury, for loss of privacy arising out of or in any way related to the use of or inability to use the service, third-party software and/or third-party hardware used with the service, or otherwise in connection with any provision of this Agreement), even if we or any supplier has been advised of the possibility of such damages and even if the remedy fails of its essential purpose. Some states/jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation or exclusion may not apply to you.",
-          "title": "Limitation of Liability"
-        },
-        "licenseTerms": {
-          "content": "By purchasing a product of AROLARIU.RO, you are granted a non-exclusive, non-transferable license to access the product. The product is for personal and commercial use. You are allowed to install the product on more than one computer or device, but you are not allowed to share the product with other individuals. You may not modify, adapt, translate, reverse engineer, decompile, disassemble or create derivative works based on the product without the prior written consent of AROLARIU.RO. You may not sell, rent, lease, or sublicense the product. You may not make the product available over a network where it could be used by multiple devices at the same time. You may not use the product to infringe on any copyright or trademark. You may not use the product to create any material that is unlawful, harmful, threatening, abusive, harassing, tortious, defamatory, vulgar, obscene, libelous, invasive of another's privacy, hateful, or racially, ethnically or otherwise objectionable.",
-          "title": "License Terms"
-        },
-        "linksToOtherSitesTerms": {
-          "content": "Our service may contain links to other websites that are not operated by Us. If you click on a third party link, you will be directed to that third party's site. We strongly advise you to review the Terms & Conditions of every site that you visit. We have no control over and assume no responsibility for the content, Terms & Conditions or practices of any third party sites or services.",
-          "title": "Links to Other Websites"
-        },
-        "miscellaneousTerms": {
-          "content": "If for any reason a court of competent jurisdiction finds any provision or portion of these Terms & Conditions to be unenforceable, the remainder of these Terms & Conditions will continue in full force and effect. Any waiver of any provision of these Terms & Conditions will be effective only if in writing and signed by an authorized representative of us. We will be entitled to injunctive or other equitable relief (without the obligations of posting any bond or surety) in the event of any breach or anticipatory breach by you. We operate and control our Service from our offices in Romania. The Service is not intended for distribution to or use by any person or entity in any jurisdiction or country where such distribution or use would be contrary to law or regulation. Accordingly, those persons who choose to access our Service from other locations do so on their own initiative and are solely responsible for compliance with local laws, if and to the extent local laws are applicable. These Terms & Conditions (which include and incorporate our Privacy Policy) contains the entire understanding, and supersedes all prior understandings, between you and us concerning its subject matter, and cannot be changed or modified by you. The section headings used in this Agreement are for convenience only and will not be given any legal import. The failure of either party to exercise in any respect any right provided for herein shall not be deemed a waiver of any further rights hereunder. AROLARIU.RO shall not be liable for any failure to perform its obligations hereunder where such failure results from any cause",
-          "title": "Miscellaneous"
-        },
-        "noWarrantiesTerms": {
-          "content": "This website is provided 'as is,' with all faults, and AROLARIU.RO makes no express or implied representations or warranties, of any kind related to this website or the materials contained on this website. Additionally, nothing contained on this website shall be construed as providing consult or advice to you. The service is provided to you 'AS IS' and 'AS AVAILABLE' and with all faults and defects without warranty of any kind. To the maximum extent permitted under applicable law, we, on our own behalf and on behalf of our affiliates and our respective licensors and service providers, expressly disclaims all warranties, whether express, implied, statutory or otherwise, with respect to the service, including all implied warranties of merchantability, fitness for a particular purpose, title and non-infringement, and warranties that may arise out of course of dealing, course of performance, usage or trade practice. Without limitation to the foregoing, we provide no warranty or undertaking, and make no representation of any kind that the service will meet your requirements, achieve any intended results, be compatible or work with any other software, websites, systems or services, operate without interruption, meet any performance or reliability standards or be error free or that any errors or defects can or will be corrected. Without limiting the foregoing, neither us nor any provider makes any representation or warranty of any kind, express or implied: (i) as to the operation or availability of the service, or the information, content, and materials or products included thereon; (ii) that the service will be uninterrupted or error-free; (iii) as to the accuracy, reliability, or currency of any information or content provided through the service; or (iv) that the service, its servers, the content, or e-mails sent from or on behalf of us are free of viruses, scripts, trojan horses, worms, malware, timebombs or other harmful components. Some jurisdictions do not allow the exclusion of or limitations on implied warranties or the limitations on the applicable statutory rights of a consumer, so some or all of the above exclusions and limitations may not apply to you.",
-          "title": "No Warranties"
-        },
-        "promotionTerms": {
-          "content": "We may, from time to time, include contests, promotions, sweepstakes, or other activities (“Promotions”) that require you to submit material or information concerning yourself. Please note that all Promotions may be governed by separate rules that may contain certain eligibility requirements, such as restrictions as to age and geographic location. You are responsible to read all Promotions rules to determine whether or not you are eligible to participate. If you enter any Promotion, you agree to abide by and to comply with all Promotions Rules. Additional terms and conditions may apply to purchases of goods or services on or through the Services, which terms and conditions are made a part of this Agreement by this reference. Any promotions made available through the service may be governed by rules that are separate from these Terms. If you participate in any promotions, please review the applicable rules as well as our Privacy Policy. If the rules for a promotion conflict with these Terms, the promotion rules will apply.",
-          "title": "Promotions"
-        },
-        "restrictionTerms": {
-          "content": "You are specifically restricted from publishing, selling, sublicensing, or otherwise commercializing any website material; using this website in any way that is or may be damaging to this website; using this website in any way that impacts user access to this website; using this website contrary to applicable laws and regulations, or in any way may cause harm to the website, or to any person or business entity; engaging in any data mining, data harvesting, data extracting or any other similar activity in relation to this website; using this website to engage in any advertising or marketing.",
-          "title": "Restrictions"
-        },
-        "severabilityTerms": {
-          "content": "If any provision of these Terms is held to be unenforceable or invalid, such provision will be changed and interpreted to accomplish the objectives of such provision to the greatest extent possible under applicable law and the remaining provisions will continue in full force and effect. This Agreement, together with the Privacy Policy and any other legal notices published by us on the Services, shall constitute the entire agreement between you and us concerning the Services. If any provision of this Agreement is deemed invalid by a court of competent jurisdiction, the invalidity of such provision shall not affect the validity of the remaining provisions of this Agreement, which shall remain in full force and effect. No waiver of any term of this Agreement shall be deemed a further or continuing waiver of such term or any other term, and our failure to assert any right or provision under this Agreement shall not constitute a waiver of such right or provision. YOU AND US AGREE THAT ANY CAUSE OF ACTION ARISING OUT OF OR RELATED TO THE SERVICES MUST COMMENCE WITHIN ONE (1) YEAR AFTER THE CAUSE OF ACTION ACCRUES. OTHERWISE, SUCH CAUSE OF ACTION IS PERMANENTLY BARRED.",
-          "title": "Severability"
-        },
-        "submissionsAndPrivacyTerms": {
-          "content": "When you visit the website or send emails to us, you are communicating with us electronically. You consent to receive communications from us electronically. We will communicate with you by email or by posting notices on the website. You agree that all agreements, notices, disclosures, and other communications that we provide electronically satisfy any legal requirement that such communications be in writing. AROLARIU.RO may, but shall not be obligated to, monitor, review, or edit User Content. In all cases, AROLARIU.RO reserves the right to remove or disable access to any User Content for any or no reason, including but not limited to, User Content that, in AROLARIU.RO's sole discretion, violates the Agreements. AROLARIU.RO may take these actions without prior notification to you or any third party. Removal or disabling of access to User Content shall be at our sole discretion, and we do not promise to remove or disable access to any specific User Content. In the event that you submit or post any ideas, creative suggestions, designs, photographs, information, advertisements, data or proposals, including ideas for new or improved products, services, features, technologies or promotions, you expressly agree that such submissions will automatically be treated as non-confidential and non-proprietary and will become the sole property of us without any compensation or credit to you whatsoever. We and our affiliates shall have no obligations with respect to such submissions or posts and may use the ideas contained in such submissions or posts for any purposes in any medium in perpetuity, including, but not limited to, developing, manufacturing, and marketing products and services using such ideas.",
-          "title": "Submissions and Privacy"
-        },
-        "terminationTerms": {
-          "content": "We may terminate or suspend your account and bar access to the service immediately, without prior notice or liability, under our sole discretion, for any reason whatsoever and without limitation, including but not limited to a breach of the Terms. If you wish to terminate your account, you may simply discontinue using the service. All provisions of the Terms which by their nature should survive termination shall survive termination, including, without limitation, ownership provisions, warranty disclaimers, indemnity and limitations of liability.",
-          "title": "Termination"
-        },
-        "thirdPartyTerms": {
-          "content": "In using the service, you may use third-party services, products, software, embeds, or applications developed by a third party ('Third Party Services'). Any use of a Third Party Service is at your own risk, and we shall not be responsible or liable to anyone for Third Party websites or Services. You acknowledge and agree that we shall not be responsible or liable for any damage or loss caused or alleged to be caused by or in connection with the use of any such content, goods or services available on or through any such websites or services. We do not assume and shall not have any liability or responsibility to you or any other person or entity for any Third-Party Services. Third-Party Services and links therefore are provided solely as a convenience to you and you access and use them entirely at your own risk and subject to such third parties' terms and conditions.",
-          "title": "Third Party Services"
-        },
-        "typographyErrorsTerms": {
-          "content": "In the event that a AROLARIU.RO product is mistakenly listed at an incorrect price, AROLARIU.RO reserves the right to refuse or cancel any orders placed for the product listed at the incorrect price. AROLARIU.RO reserves the right to refuse or cancel any such orders whether or not the order has been confirmed and your credit card charged. If your credit card has already been charged for the purchase and your order is cancelled, AROLARIU.RO shall issue a credit to your credit card account in the amount of the incorrect price.",
-          "title": "Typography Errors"
-        },
-        "updateOfServicesTerms": {
-          "content": "AROLARIU.RO is constantly updating its services, which means that we may add or remove features, products, or functionalities, and we may also suspend or stop the service altogether. We may take any of these actions at any time, and when we do, we may not provide you with any notice beforehand. You acknowledge that AROLARIU.RO may establish general practices and limits concerning use of the service, including without limitation the maximum period of time that data or other content will be retained by the service and the maximum storage space that will be allotted on AROLARIU.RO's servers on your behalf. You agree that AROLARIU.RO has no responsibility or liability for the deletion or failure to store any data or other content maintained or uploaded by the service. You acknowledge that AROLARIU.RO reserves the right to terminate accounts that are inactive for an extended period of time. You agree that we have no obligation to (i) provide any Updates, or (ii) continue to provide or enable any particular features and/or functionalities of the service to you. You further agree that all Updates will be (i) deemed to constitute an integral part of the service, and (ii) subject to the terms and conditions of this Agreement.",
-          "title": "Updates to the Service"
-        },
-        "waiverTerms": {
-          "content": "Except as provided herein, the failure to exercise a right or require performance of an obligation under this Agreement shall not affect a party's ability to exercise such right or require such performance at any time thereafter nor shall be the waiver of a breach constitute a waiver of any subsequent breach. No failure to exercise, and no delay in exercising, on the part of either party, any right or any power under this Agreement shall operate as a waiver of that right or power. Nor shall any single or partial exercise of any right or power under this Agreement preclude further exercise of that or any other right granted herein. In the event of a conflict between this Agreement and any applicable purchase or other terms, the terms of this Agreement shall govern.",
-          "title": "Waiver"
+      "services": {
+        "callToAction": "Visit this domain service",
+        "invoices": {
+          "card": {
+            "description": "This domain space service assists with the digital transformation of physical receipts. It allows users to upload receipts, and get carefully-crafted insights into their spending habits.",
+            "imageAlt": "Illustration of the Invoice Management System showing receipt digitization",
+            "title": "Invoice Management System"
+          }
         }
       },
-      "title": "Terms of Service"
-    }
-  },
-  "Navigation": {
-    "about": "About",
-    "domains": "Domains",
-    "invoices": "Invoices",
-    "mobile": {
-      "closeNavigation": "Close navigation",
-      "openNavigation": "Open navigation",
-      "title": "Navigation"
+      "subtitle": "The <code>arolariu.ro</code> platform offers a wide range of services under its umbrella. <br></br> Most of the services require that you have an account created on this platform, so that your data can be safely synchronized between all of the domain services. <br></br> <br></br> Here you can see a showcase of all domain services that are available for exploration.",
+      "title": "Domain Space Services"
     },
-    "myInvoices": "My Invoices",
-    "myProfile": "My Profile",
-    "theAuthor": "The Author",
-    "thePlatform": "The Platform",
-    "uploadScans": "Upload Scans",
-    "viewScans": "View Scans"
-  },
-  "Profile": {
-    "header": {
-      "completionHint": "Complete your profile to unlock all features",
-      "daysActive": "days active",
-      "editProfile": "Edit Profile",
-      "editProfileClerkNote": "Profile information is managed through Clerk. Click below to update your details.",
-      "editProfileDescription": "Update your profile information",
-      "editProfileTitle": "Edit Profile",
-      "manageOnClerk": "Manage on Clerk",
-      "memberSince": "Member since {date}",
-      "premium": "Premium",
-      "profileCompletion": "Profile Completion",
-      "userId": "User ID"
-    },
-    "island": {
-      "merchants": "{count} merchants",
-      "scans": "{count} scans",
-      "settingsNavigationAriaLabel": "Settings navigation",
-      "totalInvoices": "Total invoices"
-    },
-    "metadata": {
-      "description": "Manage your account settings and preferences",
-      "title": "My Profile"
-    },
-    "settings": {
-      "ai": {
-        "behavior": {
-          "description": "Choose how the AI responds",
-          "title": "Behavior Preset"
+    "home": {
+      "appreciation": "THANK YOU FOR THE TIME SPENT ON THE WEBSITE.",
+      "cta": "Start Exploring",
+      "featuresTab": {
+        "azure": {
+          "description": "The Microsoft Azure cloud is used to host the platform and all of its services. This ensures that the platform is always available and that it can scale on demand.",
+          "title": "Microsoft Azure"
         },
-        "description": "Configure your AI assistant behavior and preferences",
+        "csharp": {
+          "description": "The platform is built using .NET 8 LTS - the latest stable version of .NET. This ensures that the platform is fast, reliable, and easy to use. The platform is built using C# and F#.",
+          "title": ".NET 8 LTS"
+        },
+        "description": "The `arolariu.ro` platform is built using the latest stable technologies.",
+        "githubActions": {
+          "description": "The DevOps experience is powered by GitHub Actions. (CI/CD, Testing, etc.)",
+          "title": "GitHub Actions"
+        },
+        "learnMoreBtn": "Interesting? Click here to learn more...",
+        "nextJs": {
+          "description": "The platform is built using NextJS - the most popular React framework for production.  It is designed for production-grade React applications. NextJS is the most popular React framework for a reason: it is fast, reliable, and easy to use.",
+          "title": "Next.JS 15"
+        },
+        "otel": {
+          "description": "Complete observability with integrated metrics, traces, and logs. Everything is instrumented using OpenTelemetry. This allows for a unified telemetry experience across the board. (3PO: metrics, logs, traces)",
+          "title": "Open Telemetry"
+        },
+        "svelte": {
+          "description": "Utilizing Svelte for lightning-fast, reactive UI components. The `cv.arolariu.ro` platform is built exclusively using Svelte and SvelteKit (v5)",
+          "title": "Svelte"
+        },
+        "title": "Key Features"
+      },
+      "subtitle": "This platform was built by Alexandru-Razvan Olariu as a playground for new technologies. The platform is built using state-of-the-art, enterprise-grade technologies. <br> </br> <br> </br> You are welcome to explore all of the applications and services that are hosted on this domain space.",
+      "technologyTab": {
+        "badgeTitle": "Modern Architecture",
+        "description": "This platform leverages the latest in web technology, combining Next.js for the frontend with .NET for robust backend services, all deployed on Microsoft Azure.",
+        "learnMoreBtn": "Explore the Architecture",
+        "points": {
+          "point1": "Serverless architecture for optimal scaling and performance",
+          "point2": "Full-stack TypeScript for type safety across the entire application",
+          "point3": "Comprehensive telemetry and monitoring with OpenTelemetry"
+        },
+        "title": "Built for the Future."
+      },
+      "title": "Welcome to arolariu.ro"
+    },
+    "invoices": {
+      "editInvoice": {
+        "changeHistory": {
+          "changes": {
+            "categoryUpdated": "Category updated",
+            "descriptionChanged": "Description changed",
+            "importanceChanged": "Importance changed",
+            "markedImportant": "Marked as important",
+            "nameChanged": "Name changed",
+            "paymentTypeChanged": "Payment type changed",
+            "transactionDateChanged": "Transaction date changed",
+            "unmarkedImportant": "Unmarked as important"
+          },
+          "created": "Invoice created",
+          "modified": "Last modified",
+          "pending": "Pending",
+          "time": {
+            "daysAgo": "{days} days ago",
+            "hoursAgo": "{hours} hours ago",
+            "justNow": "Just now",
+            "minutesAgo": "{minutes} minutes ago",
+            "secondsAgo": "{seconds} seconds ago"
+          },
+          "title": "Change History",
+          "unsavedChanges": "Unsaved changes"
+        },
+        "editInvoiceContext": {
+          "console": {
+            "saveFailed": "Failed to save invoice:"
+          },
+          "toasts": {
+            "noChanges": "No changes to save",
+            "saveFailed": "Failed to save changes",
+            "updated": "Invoice updated successfully"
+          }
+        },
+        "guidedEditBanner": {
+          "actions": {
+            "dismiss": "Dismiss",
+            "reviewAll": "Review All"
+          },
+          "badges": {
+            "lowConfidence": "{count, plural, one {# low confidence} other {# low confidence}}",
+            "missingName": "{count, plural, one {# missing name} other {# missing name}}",
+            "uncategorized": "{count, plural, one {# uncategorized} other {# uncategorized}}"
+          },
+          "summary": {
+            "lowConfidence": "{count, plural, one {# low confidence} other {# low confidence}}",
+            "missingName": "{count, plural, one {# missing name} other {# missing name}}",
+            "uncategorized": "{count, plural, one {# uncategorized} other {# uncategorized}}"
+          },
+          "title": "{count, plural, one {# product needs review} other {# products need review}}"
+        },
+        "itemsTable": {
+          "actions": {
+            "editAllergens": "Edit allergens",
+            "remove": "Remove item",
+            "restore": "Restore item"
+          },
+          "bulkCategory": {
+            "noSelection": "Please select at least one product"
+          },
+          "bulkToolbar": {
+            "changeCategory": "Change Category",
+            "deleteSelected": "Delete Selected",
+            "noSelection": "No products selected",
+            "selectedCount": "{count, plural, one {# item selected} other {# items selected}}"
+          },
+          "buttons": {
+            "addItem": "Add Item",
+            "editItems": "Edit Items"
+          },
+          "columns": {
+            "actions": "Actions",
+            "name": "Name",
+            "price": "Price",
+            "quantity": "Quantity",
+            "selectAll": "Select all items",
+            "selectRow": "Select {name}",
+            "total": "Total",
+            "unit": "Unit"
+          },
+          "deleteConfirm": {
+            "cancel": "Cancel",
+            "confirm": "Delete",
+            "description": "{count, plural, one {Are you sure you want to delete this item?} other {Are you sure you want to delete # items?}}",
+            "success": "{count, plural, one {# item deleted} other {# items deleted}}",
+            "title": "Delete Items"
+          },
+          "editing": {
+            "cancel": "Edit canceled",
+            "fieldLabel": "Edit {field} for {name}",
+            "saved": "Item updated successfully"
+          },
+          "footer": {
+            "total": "Total"
+          },
+          "indicators": {
+            "allergens": "{count, plural, one {# allergen} other {# allergens}}",
+            "edited": "Edited",
+            "editedTooltip": "This product has been manually modified",
+            "lowConfidence": "Low confidence",
+            "lowConfidenceTooltip": "OCR confidence is {confidence}% - manual review recommended",
+            "missingName": "Missing name",
+            "missingNameTooltip": "Generic name translation is missing or identical to raw OCR text",
+            "uncategorized": "Uncategorized",
+            "uncategorizedTooltip": "This product needs a category assigned for better spending tracking"
+          },
+          "newItem": {
+            "added": "New item added",
+            "defaultName": "New Item"
+          },
+          "pagination": {
+            "next": "Next",
+            "pageOf": "Page {currentPage} of {totalPages}",
+            "previous": "Previous",
+            "totalItems": "{count, plural, one {# item in total} other {# items in total}}"
+          },
+          "restore": {
+            "error": "Failed to restore item",
+            "success": "Item {name} restored"
+          },
+          "search": {
+            "placeholder": "Search items..."
+          },
+          "softDelete": {
+            "error": "Failed to remove item",
+            "success": "Item {name} removed"
+          },
+          "tableHeaders": {
+            "item": "Item",
+            "price": "Price",
+            "quantity": "Qty",
+            "total": "Total"
+          },
+          "title": "Items",
+          "tooltips": {
+            "editInvoiceItemsAndQuantities": "Edit invoice items and quantities"
+          }
+        },
+        "metadata": {
+          "description": "View and edit your invoice details, items, recipes, and sharing settings.",
+          "title": "Invoice Management System - Edit Invoice"
+        },
+        "metadataTab": {
+          "badges": {
+            "readonly": "Readonly"
+          },
+          "buttons": {
+            "addField": "Add Field",
+            "addFirstMetadataField": "Add Your First Metadata Field"
+          },
+          "dropdown": {
+            "delete": "Delete",
+            "edit": "Edit"
+          },
+          "emptyState": {
+            "noMetadataFields": "No metadata fields added yet"
+          },
+          "header": {
+            "description": "Metadata associated with this invoice",
+            "title": "Additional Information"
+          },
+          "tooltips": {
+            "addCustomMetadata": "Add custom metadata to this invoice"
+          }
+        },
+        "recipesTab": {
+          "buttons": {
+            "addRecipe": "Add Recipe",
+            "createFirstRecipe": "Create Your First Recipe",
+            "generate": "Generate"
+          },
+          "emptyState": {
+            "noRecipesAvailable": "No recipes available yet"
+          },
+          "header": {
+            "description": "Based on items in this invoice",
+            "title": "Recipes You Can Make"
+          },
+          "pagination": {
+            "next": "Next",
+            "pageOf": "Page {currentPage} of {totalPages}",
+            "previous": "Previous"
+          },
+          "toasts": {
+            "aiGenerationComingSoon": {
+              "description": "This feature is currently under development.",
+              "title": "AI recipe generation coming soon"
+            }
+          },
+          "tooltips": {
+            "createRecipeWithIngredients": "Create a new recipe with these ingredients",
+            "generateRecipeUsingAi": "Generate a recipe using AI!"
+          }
+        },
+        "triviaTips": {
+          "banner": {
+            "hint": "Apply these tips to save on your next visit to {merchantName}",
+            "potentialSavingsLabel": "Potential Savings"
+          },
+          "buttons": {
+            "viewMoreSavingsTips": "View More Savings Tips"
+          },
+          "completeLabel": "Invoice is fully complete!",
+          "completeness": "Invoice is {percentage}% complete",
+          "contextActions": {
+            "addDescription": "Add Description",
+            "analyze": "Run Analysis",
+            "setCategory": "Set Category"
+          },
+          "contextTips": {
+            "defaultCategory": "Change the category from 'Uncategorized' to track better",
+            "noCategory": "Set a category to track spending patterns",
+            "noDescription": "Add a description to help you remember this purchase",
+            "noItems": "Run AI analysis to extract items from your receipt",
+            "noRecipes": "AI can suggest recipes based on your grocery items"
+          },
+          "difficulty": {
+            "easy": "Easy",
+            "medium": "Medium"
+          },
+          "disclaimer": "Savings are estimates based on average prices and promotions",
+          "tips": {
+            "bulkPurchase": {
+              "description": "Purchase non-perishable items in bulk to save on per-unit costs.",
+              "title": "Buy in Bulk"
+            },
+            "digitalCoupons": {
+              "description": "Check {merchantName}'s app for digital coupons before shopping.",
+              "title": "Use Digital Coupons"
+            },
+            "loyaltyProgram": {
+              "description": "Sign up for {merchantName}'s loyalty program to earn points on every purchase.",
+              "title": "Join Loyalty Program"
+            }
+          },
+          "title": "Savings Tips",
+          "tooltips": {
+            "estimatedSavings": "Estimated savings with this tip"
+          }
+        }
+      },
+      "landing": {
+        "bento": {
+          "ai": {
+            "description": "GPT-4 extraction",
+            "title": "AI-Powered"
+          },
+          "analyticsCard": {
+            "description": "Spending insights",
+            "title": "Analytics"
+          },
+          "cloud": {
+            "description": "Access anywhere",
+            "title": "Cloud Sync"
+          },
+          "description": "Powerful features designed to make invoice management effortless",
+          "mobile": "Works beautifully on mobile devices",
+          "ocr": {
+            "description": "Auto data capture",
+            "title": "Smart OCR"
+          },
+          "secure": {
+            "description": "Bank-grade encryption",
+            "title": "Secure"
+          },
+          "share": {
+            "description": "Collaborate easily",
+            "title": "Share"
+          },
+          "title": "Everything You Need"
+        },
+        "cta": {
+          "badges": {
+            "ai": "AI-Powered",
+            "cloud": "Cloud Synced",
+            "secure": "Secure & Private"
+          },
+          "description": "Upload your first scan and experience the magic of AI-powered invoice management.",
+          "learnMore": "Learn More",
+          "title": "Ready to Get Started?",
+          "uploadButton": "Upload Your First Scan"
+        },
         "features": {
-          "autoSuggest": "Auto-Suggest",
-          "autoSuggestHint": "Get automatic suggestions as you work",
-          "contextAwareness": "Context Awareness",
-          "contextAwarenessHint": "AI uses context from your invoices",
-          "description": "Enable or disable AI capabilities",
-          "memory": "Conversation Memory",
-          "memoryHint": "AI remembers previous conversations",
-          "title": "AI Features"
+          "analytics": {
+            "description": "Get detailed insights into your spending patterns with charts and reports.",
+            "title": "Spending Analytics"
+          },
+          "batch": {
+            "description": "Process multiple scans at once - create individual invoices or combine them into one.",
+            "title": "Batch Processing"
+          },
+          "description": "Everything you need to manage your invoices efficiently",
+          "imageAlt": "Invoice features illustration",
+          "ocr": {
+            "description": "Our AI automatically extracts merchant names, dates, amounts, and line items from your scans.",
+            "title": "Smart OCR Extraction"
+          },
+          "signIn": "Sign in",
+          "signInPrompt": "Sign in to save your invoices permanently and access them from any device.",
+          "title": "Powerful Features"
         },
-        "maxTokens": {
-          "description": "Maximum tokens per response",
-          "title": "Response Length"
+        "hero": {
+          "description": "Upload your receipts and bills, organize them into invoices, and gain insights into your spending habits. Our AI-powered system extracts data automatically.",
+          "getStarted": "Get Started",
+          "imageAlt": "Invoice management illustration",
+          "title": "Manage Your",
+          "titleHighlight": "Invoices",
+          "titleSuffix": "with Ease",
+          "viewMyInvoices": "View My Invoices"
         },
-        "model": {
-          "description": "Select the AI model for your assistant",
-          "title": "AI Model"
+        "metadata": {
+          "description": "Manage receipts, create invoices, and gain insights into your spending habits.",
+          "title": "Invoice Management System"
         },
-        "temperature": {
-          "creative": "Creative",
-          "description": "Balance between precision and creativity",
-          "precise": "Precise",
-          "title": "Response Style"
-        },
-        "title": "AI Assistant Settings",
-        "voice": {
-          "description": "Configure voice interaction",
-          "enabled": "Voice Input",
-          "enabledHint": "Use voice commands with the AI",
-          "title": "Voice Settings"
+        "workflow": {
+          "description": "Three simple steps to digitize and organize your financial documents",
+          "step1": {
+            "button": "Upload Now",
+            "description": "Drag and drop your receipts, invoices, or bills. We support JPG, PNG, and PDF files up to 10MB each.",
+            "title": "Upload Scans"
+          },
+          "step2": {
+            "button": "View Scans",
+            "description": "Review your uploaded scans, select the ones you want, and create invoices from them individually or in batches.",
+            "title": "View & Organize"
+          },
+          "step3": {
+            "button": "View Invoices",
+            "description": "View your invoices, analyze spending patterns, and get AI-powered insights into your financial habits.",
+            "title": "Manage Invoices"
+          },
+          "title": "How It Works"
         }
       },
-      "analytics": {
-        "advanced": {
-          "benchmarking": "Benchmarking",
-          "benchmarkingHint": "Compare with similar users",
-          "description": "Premium analytics features",
-          "predictive": "Predictive Analysis",
-          "predictiveHint": "AI-powered spending predictions",
-          "title": "Advanced Analytics"
+      "uploadScans": {
+        "breadcrumb": "Back to Invoices",
+        "buttons": {
+          "myInvoices": "My Invoices",
+          "uploadFirst": "Upload Your First Scan",
+          "viewScans": "View Your Scans"
         },
-        "dataUsage": {
-          "info": "Your analytics data is processed locally and never shared without your explicit consent.",
-          "title": "Data Usage"
+        "errors": {
+          "tooLarge": "File too large: {name} (max 10MB)",
+          "unsupportedType": "Unsupported file type: {type}"
         },
-        "description": "Configure how your data is analyzed and reported",
-        "enabled": {
-          "description": "Enable or disable analytics features",
-          "hint": "Track and analyze your spending patterns",
-          "label": "Enable Analytics",
-          "title": "Analytics"
+        "header": {
+          "description": "Upload receipt images or PDFs. Create invoices from them later.",
+          "title": "Upload Scans",
+          "tooltip": "Upload your receipts, invoices, or bills here. You can select multiple files and organize them into invoices later from the View Scans page."
         },
-        "export": {
-          "description": "Default format for data exports",
-          "title": "Export Format"
+        "metadata": {
+          "description": "Upload receipt scans to your account for later processing into invoices.",
+          "title": "Invoice Management System - Upload Scans"
         },
-        "granularity": {
-          "description": "How detailed should your analytics be",
-          "title": "Data Granularity"
+        "postUpload": {
+          "createInvoice": "Yes, start the analysis",
+          "dismiss": "Dismiss",
+          "subtitle": "{count, plural, one {Does this scan represent a single purchase?} other {Do these scans represent a single purchase?}}",
+          "title": "Upload Complete!",
+          "viewScans": "No, analyze separately"
         },
-        "title": "Analytics Settings",
-        "tracking": {
-          "categories": "Track Categories",
-          "categoriesHint": "Analyze spending by category",
-          "description": "Choose what to track",
-          "merchants": "Track Merchants",
-          "merchantsHint": "Monitor merchant-specific data",
-          "spending": "Track Spending",
-          "spendingHint": "Monitor your overall spending",
-          "title": "Tracking Options"
+        "preview": {
+          "pagination": {
+            "next": "Next",
+            "pageInfo": "{current} / {total} ({count} scans)",
+            "previous": "Previous"
+          },
+          "pendingTooltip": "This scan will not be persisted until you click Upload",
+          "removeTooltip": "Remove this file",
+          "retryAttempt": "Retry attempt {attempt}",
+          "status": {
+            "completed": "Completed",
+            "failed": "Failed",
+            "pending": "Pending",
+            "retrying": "Retrying",
+            "uploading": "Uploading"
+          },
+          "title": "Pending uploads ({count})"
+        },
+        "sidebar": {
+          "formats": {
+            "documentExtensions": ".pdf",
+            "documents": "Documents",
+            "imageExtensions": ".jpg, .jpeg, .png",
+            "images": "Images",
+            "maxSize": "Maximum file size: 10MB per file",
+            "title": "Supported Formats"
+          },
+          "nextSteps": {
+            "button": "Continue to View Scans",
+            "description": "Your scans are ready. Head to View Scans to organize them into invoices.",
+            "title": "All uploads complete!"
+          },
+          "security": {
+            "description": "Your scans are encrypted and stored securely. Only you can access them.",
+            "title": "Secure Storage"
+          },
+          "tips": {
+            "tip1": "Use good lighting when photographing receipts",
+            "tip2": "Ensure text is clear and readable",
+            "tip3": "Avoid shadows and glare",
+            "tip4": "Capture the entire receipt in frame",
+            "tip5": "PDFs work best for digital receipts",
+            "title": "Tips for Best Results"
+          }
+        },
+        "stats": {
+          "added": "Added",
+          "completed": "Completed",
+          "failed": "Failed",
+          "pending": "Pending",
+          "uploading": "Uploading"
+        },
+        "subtitle": "Upload receipt images or PDFs. Create invoices from them later.",
+        "title": "Upload Scans",
+        "upload": {
+          "browse": "Browse files",
+          "dropzone": "Drag and drop your receipt images or PDFs here",
+          "or": "or"
+        },
+        "uploadArea": {
+          "actions": {
+            "clearAll": "Clear All",
+            "uploading": "Uploading...",
+            "uploadScans": "Upload Scans"
+          },
+          "aria": {
+            "uploadFiles": "Upload files"
+          },
+          "compact": {
+            "dropActive": "Drop files to add them",
+            "dropInactive": "Drag files here or click to browse",
+            "subtitle": "JPG, PNG, PDF up to 10MB"
+          },
+          "empty": {
+            "chooseFiles": "Choose Files",
+            "dropActive": "Drop files to upload",
+            "dropInactive": "Click or drag files to upload",
+            "formats": "Supported formats: JPG, PNG, PDF (max 10MB each)",
+            "note": "You can select multiple files.",
+            "pasteHint": "Tip: you can also paste an image from your clipboard (Ctrl+V).",
+            "title": "Drag and drop your files here"
+          },
+          "tooltips": {
+            "clearAll": "Remove all pending uploads",
+            "uploadScans": "Start uploading all pending scans"
+          }
         }
       },
-      "appearance": {
-        "advanced": {
-          "animations": "Animations",
-          "animationsHint": "Enable interface animations",
-          "compactMode": "Compact Mode",
-          "compactModeHint": "Reduce spacing for more content",
-          "description": "Additional customization options",
-          "title": "Advanced Options"
+      "viewInvoice": {
+        "analysisPanel": {
+          "analyzing": {
+            "progress": "{progress}% complete",
+            "title": "Analyzing..."
+          },
+          "buttons": {
+            "reanalyze": "Re-Analyze Invoice"
+          },
+          "description": "Re-analyze this invoice with AI to extract or update data",
+          "labels": {
+            "analysisComplete": "Analysis Complete — All data has been extracted",
+            "granularOptions": "Or choose specific analysis",
+            "lastAnalyzed": "Last Analyzed",
+            "updates": "{count, plural, one {# update} other {# updates}}"
+          },
+          "options": {
+            "completeAnalysis": "Full Analysis",
+            "invoiceOnly": "Invoice Only",
+            "itemsOnly": "Items Only",
+            "merchantOnly": "Merchant Only"
+          },
+          "steps": {
+            "analyzing": "Analyzing with AI...",
+            "complete": "Analysis complete!",
+            "extracting": "Running OCR extraction...",
+            "finalizing": "Finalizing results...",
+            "preparing": "Preparing document...",
+            "processing": "Processing items..."
+          },
+          "tip": "Quick Tip: Full analysis takes 30-60 seconds but provides the most accurate results.",
+          "title": "AI Analysis",
+          "toasts": {
+            "error": {
+              "description": "Unable to analyze invoice. Please try again later.",
+              "title": "Analysis Failed"
+            },
+            "success": {
+              "description": "Invoice has been successfully re-analyzed with updated data.",
+              "title": "Analysis Complete"
+            }
+          },
+          "tooltips": {
+            "completeAnalysis": "Complete OCR extraction + AI processing of all invoice data",
+            "invoiceOnly": "Re-extract basic invoice information (date, total, payment)",
+            "itemsOnly": "Re-categorize and analyze line items only",
+            "merchantOnly": "Re-identify merchant and location data",
+            "reanalyze": "Trigger complete re-analysis with all AI features"
+          }
         },
-        "colors": {
-          "description": "Personalize your color scheme",
-          "preview": "Gradient Preview",
-          "previewText": "Sample Gradient Text",
-          "primary": "Primary Color",
-          "secondary": "Secondary Color",
-          "intermediary": "Intermediary Color",
-          "title": "Custom Colors"
+        "categoryComparisonChart": {
+          "description": "This invoice vs your average",
+          "labels": {
+            "average": "Average",
+            "current": "Current"
+          },
+          "title": "Category Comparison"
         },
-        "description": "Customize the look and feel of your experience",
-        "font": {
-          "description": "Select a comfortable font",
-          "dyslexic": "Dyslexic-friendly",
-          "dyslexicHint": "OpenDyslexic font for improved readability",
-          "normal": "Standard",
-          "title": "Font"
-        },
-        "locale": {
-          "description": "Set your preferred language",
-          "title": "Language"
-        },
-        "presets": {
-          "custom": "Custom",
-          "customDescription": "Create your own color scheme",
-          "description": "Choose a pre-designed color scheme or create your own",
-          "title": "Theme Preset"
-        },
-        "theme": {
-          "dark": "Dark",
-          "description": "Choose your preferred color scheme",
-          "hint": "Switch between light, dark, or your system preference",
-          "light": "Light",
-          "system": "System",
-          "title": "Theme"
-        },
-        "title": "Appearance Settings"
-      },
-      "data": {
-        "backup": {
-          "autoBackup": "Auto Backup",
-          "autoBackupHint": "Automatically backup your data",
-          "description": "Automatic data backup configuration",
-          "frequency": "Backup Frequency",
-          "title": "Backup Settings"
-        },
-        "danger": {
-          "deleteAccount": "Delete Account",
-          "deleteAccountHint": "Permanently delete your account",
-          "deleteButton": "Delete Data",
-          "deleteData": "Delete All Data",
-          "deleteDataHint": "Permanently remove all your invoices and scans",
-          "description": "Irreversible actions",
-          "manageAccount": "Manage on Clerk",
-          "title": "Danger Zone"
-        },
-        "description": "Control your data storage and privacy settings",
         "export": {
-          "description": "Download a copy of your data",
-          "downloadAll": "Download All Data",
-          "hint": "Export will include all invoices, scans, and settings",
-          "title": "Export Data"
+          "copyError": "Failed to copy summary",
+          "copySuccess": "Summary copied to clipboard",
+          "copySummary": {
+            "description": "Copy text summary to clipboard",
+            "title": "Copy Summary"
+          },
+          "csv": {
+            "description": "Download items as spreadsheet",
+            "title": "Export as CSV"
+          },
+          "csvError": "Failed to export CSV",
+          "csvSuccess": "CSV file downloaded successfully",
+          "description": "Export your invoice data in various formats",
+          "json": {
+            "description": "Download complete invoice data",
+            "title": "Export as JSON"
+          },
+          "jsonError": "Failed to export JSON",
+          "jsonSuccess": "JSON file downloaded successfully",
+          "pdf": {
+            "description": "Download professional invoice document",
+            "title": "Export as PDF"
+          },
+          "pdfError": "Failed to generate PDF",
+          "pdfGenerating": "Generating PDF...",
+          "pdfSuccess": "PDF file downloaded successfully",
+          "print": {
+            "description": "Print invoice using browser",
+            "title": "Print"
+          },
+          "printError": "Failed to open print dialog",
+          "printSuccess": "Print dialog opened",
+          "title": "Export Invoice"
         },
-        "privacy": {
-          "description": "Control how your data is used",
-          "shareAnonymous": "Share Anonymous Data",
-          "shareAnonymousHint": "Help improve the service with anonymized usage data",
-          "title": "Privacy Settings"
+        "healthScore": {
+          "cta": {
+            "analyze": "Run AI Analysis",
+            "edit": "Edit Invoice"
+          },
+          "dialogTitle": "Invoice Health Report",
+          "factors": {
+            "categoriesAssigned": "Categories assigned",
+            "merchantLinked": "Merchant linked",
+            "ocrConfidence": "OCR confidence",
+            "paymentInfo": "Payment information",
+            "productCompleteness": "Product completeness",
+            "productsPresent": "Products extracted",
+            "recipesGenerated": "Recipes generated"
+          },
+          "hideDetails": "Hide factor breakdown",
+          "points": "points",
+          "seeReport": "See detailed report",
+          "showDetails": "Show factor breakdown",
+          "status": {
+            "excellent": "Excellent",
+            "good": "Good",
+            "incomplete": "Incomplete",
+            "needsAttention": "Needs Attention"
+          },
+          "subtitle": "Comprehensive data quality assessment",
+          "suggestions": {
+            "fix": "Fix",
+            "incompletePayment": "Incomplete payment information — add transaction date, amount, and currency",
+            "incompleteProducts": "<strong>{count}</strong> products incomplete — review and complete missing fields",
+            "lowOcrConfidence": "Low OCR confidence on <strong>{count}</strong> products — review manually for accuracy",
+            "noMerchant": "No merchant linked — add merchant details for better insights",
+            "noProducts": "No products found — upload a receipt or add items manually",
+            "noRecipes": "No recipes generated — run AI analysis to discover meal ideas",
+            "title": "Suggested Improvements",
+            "uncategorizedProducts": "<strong>{count}</strong> products uncategorized — assign categories for spending analysis"
+          },
+          "title": "Invoice Health Score"
         },
-        "retention": {
-          "description": "How long to keep your data",
-          "hint": "Older data will be automatically archived",
-          "title": "Data Retention"
+        "invoiceAnalytics": {
+          "emptyState": {
+            "description": "Add more invoices to see spending trends, merchant breakdowns, and category comparisons.",
+            "title": "Not Enough Data for Comparisons"
+          },
+          "tabs": {
+            "compare": "Comparison",
+            "current": "This Invoice"
+          },
+          "title": "Analytics & Insights"
         },
-        "title": "Data Management"
+        "invoiceGuestBanner": {
+          "description": "You are not currently the owner of this invoice. The view is limited to what the owner has specified in the share settings.",
+          "title": "Guest View"
+        },
+        "invoiceTabs": {
+          "actions": {
+            "generate": "Generate Recipes",
+            "regenerate": "Regenerate Recipes",
+            "regenerateTooltip": "Re-analyze the invoice to generate new recipe suggestions"
+          },
+          "empty": {
+            "additionalInfo": "No additional information available",
+            "recipes": "No recipe suggestions available"
+          },
+          "recipe": {
+            "duration": "{minutes} min",
+            "ingredients": "Ingredients",
+            "instructions": "Instructions",
+            "prepCook": "Prep: {prep}m • Cook: {cook}m",
+            "viewRecipe": "View Recipe"
+          },
+          "tabs": {
+            "additionalInfo": "Additional Info",
+            "possibleRecipes": "Possible Recipes"
+          }
+        },
+        "invoiceTimeline": {
+          "eventCount": "{count, plural, one {# event} other {# events}}",
+          "subtitle": "Complete history of actions and changes",
+          "title": "Invoice Timeline"
+        },
+        "itemAnalytics": {
+          "columns": {
+            "category": "Category",
+            "name": "Name",
+            "price": "Price",
+            "quantity": "Qty",
+            "total": "Total"
+          },
+          "confidence": {
+            "ariaLabel": "{level} confidence: {percent}%",
+            "high": "High",
+            "label": "OCR Confidence",
+            "low": "Low",
+            "lowWarning": "Low confidence — consider reviewing this item",
+            "medium": "Medium"
+          },
+          "empty": {
+            "subtitle": "Run AI analysis to extract items from your receipt",
+            "title": "No items"
+          },
+          "searchPlaceholder": "Search items...",
+          "summary": {
+            "allergens": "{count} allergens detected",
+            "categories": "{count} categories",
+            "cheapest": "Cheapest",
+            "mostExpensive": "Most expensive",
+            "title": "Summary"
+          },
+          "title": "Items",
+          "totalLabel": "TOTAL"
+        },
+        "itemsBreakdownChart": {
+          "description": "Highest spending items",
+          "labels": {
+            "price": "Price",
+            "quantity": "Qty"
+          },
+          "title": "Top Items by Cost"
+        },
+        "merchantBreakdownChart": {
+          "description": "All-time totals across merchants",
+          "labels": {
+            "averagePerVisit": "Avg/visit",
+            "total": "Total",
+            "totalSpent": "Total Spent",
+            "visits": "Visits"
+          },
+          "title": "Spending by Store",
+          "unknownMerchant": "Unknown Merchant"
+        },
+        "metadata": {
+          "description": "View your invoice details, items, and associated merchant information.",
+          "title": "Invoice Management System - View Invoice"
+        },
+        "priceDistributionChart": {
+          "description": "Items by price range ({currency})",
+          "labels": {
+            "items": "Items"
+          },
+          "title": "Price Distribution",
+          "tooltip": {
+            "itemCount": "{count, plural, one {# item} other {# items}}"
+          }
+        },
+        "print": {
+          "generatedOn": "Printed on {date}",
+          "labels": {
+            "date": "Date",
+            "items": "Items",
+            "merchant": "Merchant",
+            "total": "Total Amount"
+          },
+          "page": "Page"
+        },
+        "relatedInvoices": {
+          "noRelated": "No related invoices found",
+          "sameCategory": "Same Category",
+          "sameMerchant": "Same Merchant",
+          "similarAmount": "Similar Amount",
+          "subtitle": "Similar invoices based on merchant, category, or amount",
+          "title": "Related Invoices",
+          "viewInvoice": "View"
+        },
+        "shareCollaborate": {
+          "activity": {
+            "created": "Created {time}",
+            "daysAgo": "{count, plural, one {# day ago} other {# days ago}}",
+            "modified": "Last modified {time}",
+            "title": "Activity",
+            "today": "today"
+          },
+          "copied": "Link copied to clipboard!",
+          "copyError": "Failed to copy link",
+          "copyLink": "Copy Link",
+          "madePrivate": "Invoice is now private",
+          "madePublic": "Invoice is now public",
+          "manageSharing": "Manage Sharing",
+          "private": "Private",
+          "public": "Public",
+          "publicAccess": "Public Access",
+          "publicAccessDescription": "Anyone with the link can view this invoice",
+          "qrCode": "QR Code",
+          "qrCopied": "Link copied! QR code generation coming soon.",
+          "shared": "Shared",
+          "sharedWith": "Shared with",
+          "shareEmail": "Share via Email",
+          "title": "Sharing & Collaboration",
+          "toggleError": "Failed to update sharing settings"
+        },
+        "spendingByCategoryChart": {
+          "description": "Distribution of expenses",
+          "title": "Spending by Category",
+          "tooltip": {
+            "itemCount": "{count, plural, one {# item} other {# items}}"
+          },
+          "totalLabel": "Total Spending"
+        },
+        "spendingTrendChart": {
+          "description": "Your invoice history trend",
+          "labels": {
+            "amount": "Amount"
+          },
+          "title": "Spending Over Time",
+          "tooltip": {
+            "andMore": "and {count} more...",
+            "currentInvoice": "Current Invoice"
+          }
+        },
+        "timelineSharedWithList": {
+          "actions": {
+            "manageSharing": "Manage Sharing",
+            "sendEmail": "Send email"
+          },
+          "aria": {
+            "sendEmail": "Send email to {user}"
+          },
+          "header": {
+            "publicBadge": "Public",
+            "title": "Shared With"
+          },
+          "publicAccess": {
+            "description": "This invoice is publicly accessible. Anyone with the link can view it, including guests without an account.",
+            "title": "Public Access Enabled"
+          }
+        }
       },
-      "notifications": {
-        "description": "Manage how and when you receive notifications",
-        "email": {
-          "description": "Configure email communication preferences",
-          "enabled": "Enable Email Notifications",
-          "enabledHint": "Receive updates via email",
-          "title": "Email Notifications"
+      "viewInvoices": {
+        "bulkActions": {
+          "categories": {
+            "carAuto": "Car & Auto",
+            "fastFood": "Fast Food",
+            "grocery": "Groceries",
+            "homeCleaning": "Home Cleaning",
+            "notDefined": "Not Defined",
+            "other": "Other"
+          },
+          "categoryChanged": "{count, plural, one {Invoice category updated successfully} other {# invoice categories updated successfully}}",
+          "categoryChangeError": "Failed to update invoice categories. Please try again.",
+          "categoryPartialSuccess": "{success} invoice(s) updated, {failed} failed",
+          "changeCategory": "Change Category",
+          "clearSelection": "Clear selection",
+          "delete": "Delete",
+          "deleteConfirm": {
+            "cancel": "Cancel",
+            "confirm": "Delete",
+            "description": "{count, plural, one {Are you sure you want to delete this invoice? This action cannot be undone.} other {Are you sure you want to delete these # invoices? This action cannot be undone.}}",
+            "title": "Delete Invoices"
+          },
+          "deleteError": "Failed to delete invoices. Please try again.",
+          "deletePartialSuccess": "{success} invoice(s) deleted, {failed} failed",
+          "deleteSuccess": "{count, plural, one {Invoice deleted successfully} other {# invoices deleted successfully}}",
+          "export": "Export",
+          "selected": "{count, plural, one {# invoice selected} other {# invoices selected}}"
         },
-        "financial": {
-          "budgetAlerts": "Budget Alerts",
-          "budgetAlertsHint": "Alert when approaching budget limits",
-          "description": "Get notified about spending",
-          "spendingAlerts": "Spending Alerts",
-          "spendingAlertsHint": "Notify when spending exceeds threshold",
-          "title": "Financial Alerts"
+        "generativeView": {
+          "chatDescription": "Chat with AI to analyze your invoices and get insights. Try commands like /find to search invoices.",
+          "help": "Help",
+          "settings": {
+            "allowInvoiceData": "Allow access to invoice data",
+            "allowMerchantData": "Allow access to merchant data",
+            "dataAccessTitle": "Data access",
+            "description": "Configure your AI assistant preferences",
+            "historyLabel": "Chat history",
+            "notificationPreferences": "Notification preferences",
+            "notifyInsights": "Notify me about new insights",
+            "retention": {
+              "item30": "Keep for 30 days",
+              "item60": "Keep for 60 days",
+              "item90": "Keep for 90 days",
+              "none": "Don't save history"
+            },
+            "retentionPlaceholder": "Select retention period",
+            "save": "Save settings",
+            "title": "Chat settings"
+          },
+          "subtitle": "Chat with AI to analyze your invoices and get insights",
+          "tabs": {
+            "chat": "Chat",
+            "settings": "Settings"
+          },
+          "title": "Live analysis",
+          "welcomeMessage": "Hello! I'm your invoice analysis assistant. How can I help you today? Try commands like /find to search invoices."
         },
-        "reports": {
-          "description": "Scheduled report delivery",
-          "monthlyReport": "Monthly Report",
-          "monthlyReportHint": "Detailed monthly spending analysis",
-          "title": "Reports",
-          "weeklyDigest": "Weekly Digest",
-          "weeklyDigestHint": "Summary of your weekly activity"
+        "gridView": {
+          "itemCount": "{count, plural, one {# item} other {# items}}",
+          "tooltips": {
+            "viewDetails": "View Details"
+          }
+        },
+        "invoicesHeader": {
+          "actions": {
+            "export": "Export",
+            "import": "Import",
+            "newInvoice": "New invoice",
+            "print": "Print"
+          },
+          "description": "Manage your receipts and track your spending habits",
+          "title": "Invoice management",
+          "tooltips": {
+            "export": "Export all invoices",
+            "import": "Import invoices from files",
+            "newInvoice": "Create a new invoice",
+            "print": "Print invoices"
+          }
+        },
+        "invoicesView": {
+          "categories": {
+            "all": "All categories",
+            "dining": "Dining",
+            "entertainment": "Entertainment",
+            "groceries": "Groceries",
+            "other": "Other",
+            "travel": "Travel",
+            "utilities": "Utilities"
+          },
+          "placeholderPanel": "More filter controls coming soon.",
+          "searchPlaceholder": "Search invoices...",
+          "times": {
+            "all": "All times",
+            "day": "Daytime (6am-6pm)",
+            "night": "Nighttime (6pm-6am)"
+          },
+          "viewModes": {
+            "grid": "Grid view",
+            "table": "Table view"
+          }
+        },
+        "messageList": {
+          "aiAssistant": "AI Assistant",
+          "you": "You"
+        },
+        "metadata": {
+          "description": "List all invoices from the invoice management system.",
+          "title": "Invoice Management System - List Invoices"
+        },
+        "subtitle": "This is your digital receipts inventory. <br></br> Here you can find the receipts that you've uploaded so far. <br></br> By clicking on a receipt, you will be redirected to that specific receipt's page.",
+        "tableView": {
+          "aria": {
+            "rowsPerPage": "Rows per page",
+            "selectAllInvoices": "Select all invoices",
+            "selectInvoice": "Select invoice {name}",
+            "sortByAmount": "Sort by amount",
+            "sortByDate": "Sort by date"
+          },
+          "columns": {
+            "actions": "Actions",
+            "amount": "Amount",
+            "category": "Category",
+            "date": "Date",
+            "invoice": "Invoice"
+          },
+          "empty": {
+            "description": "Start by uploading your receipts to create your first invoice",
+            "title": "No Invoices Yet",
+            "uploadCta": "Upload Your First Receipt"
+          },
+          "nextPage": "Next Page",
+          "pageOf": "Page {current} of {total}",
+          "previousPage": "Previous Page",
+          "rowsPerPage": "Rows per page:",
+          "tooltips": {
+            "notAnalyzed": "This invoice has not been analyzed yet"
+          },
+          "viewInvoice": "View Invoice"
+        },
+        "tableViewActions": {
+          "actions": {
+            "delete": "Delete",
+            "edit": "Edit",
+            "share": "Share"
+          },
+          "tooltips": {
+            "delete": "Permanently delete this invoice",
+            "edit": "Edit invoice details",
+            "moreActions": "More actions",
+            "share": "Share invoice via link or email"
+          }
+        },
+        "title": "Welcome, {name}!",
+        "viewInvoicesIsland": {
+          "tabs": {
+            "invoices": "Invoices",
+            "liveAnalysis": "Live analysis",
+            "statistics": "Statistics"
+          }
+        },
+        "viewInvoicesPage": {
+          "guestName": "dear guest"
+        }
+      },
+      "viewScans": {
+        "breadcrumb": "Back to Invoices",
+        "createFromAll": {
+          "button": "Create from All Scans",
+          "description": "Create invoices from all {count} scans at once",
+          "title": "All scans are ready!"
+        },
+        "emptyState": {
+          "description": "Start by uploading your receipts and invoices. Here's how it works:",
+          "learnMoreButton": "Learn More",
+          "step1Description": "Take photos of receipts or upload PDFs of digital invoices",
+          "step1Title": "Upload your scans",
+          "step2Description": "Choose which scans to convert into invoices",
+          "step2Title": "Select and organize",
+          "step3Description": "Our AI automatically extracts all the data for you",
+          "step3Title": "Create invoices",
+          "title": "No scans yet",
+          "uploadButton": "Upload Your First Scan"
+        },
+        "groupBanner": {
+          "createInvoice": "Create Invoice",
+          "dismiss": "Dismiss",
+          "subtitle": "Create an invoice from these scans?",
+          "title": "These {count} scans were uploaded together"
+        },
+        "header": {
+          "invoices": "Invoices",
+          "lastSynced": "Last synced: {time}",
+          "myInvoices": "My Invoices",
+          "myInvoicesTooltip": "View your created invoices",
+          "subtitle": "Select scans to create invoices from them",
+          "sync": "Sync",
+          "syncing": "Syncing...",
+          "syncTooltip": "Refresh scans from server",
+          "title": "Your Scans",
+          "titleWithCount": "Your Scans ({count})",
+          "tooltip": "Select scans to create invoices from them. You can create one invoice per scan or combine multiple scans into a single invoice.",
+          "upload": "Upload",
+          "uploadMore": "Upload More",
+          "uploadTooltip": "Upload more scans to your account"
+        },
+        "metadata": {
+          "description": "View and manage your uploaded scans. Create invoices from selected scans.",
+          "title": "Invoice Management System - View Scans"
+        },
+        "pagination": {
+          "next": "Next",
+          "pageInfo": "{current} / {total} ({count} scans)",
+          "previous": "Previous"
+        },
+        "scanCard": {
+          "actions": {
+            "delete": "Delete scan",
+            "rename": "Rename scan",
+            "rotateCCW": "Rotate 90° Counter-clockwise",
+            "rotateCW": "Rotate 90° Clockwise",
+            "rotateError": "Failed to rotate image",
+            "rotateSuccess": "Image rotated successfully",
+            "rotateUnsupported": "Cannot rotate PDF files",
+            "rotating": "Rotating..."
+          },
+          "delete": "Delete scan",
+          "deleteDialog": {
+            "cancel": "Cancel",
+            "delete": "Delete",
+            "deleting": "Deleting...",
+            "description": "Are you sure you want to delete \"{name}\"? This action cannot be undone and the scan will be permanently removed from storage.",
+            "error": "Failed to delete scan",
+            "linkedDescription": "Deleting it will remove the scan from storage, but the invoice will retain a copy of the image. This action cannot be undone.",
+            "linkedWarning": "This scan is linked to an invoice.",
+            "success": "Scan deleted successfully",
+            "title": "Delete scan?"
+          },
+          "linked": "Linked",
+          "loading": "Loading...",
+          "preview": "Preview scan",
+          "previewTitle": "Scan Preview",
+          "rename": "Rename scan",
+          "renamePlaceholder": "Enter new name"
+        },
+        "sidebar": {
+          "howTo": {
+            "step1Description": "Click on scans to select them",
+            "step1Title": "Select Scans",
+            "step2Description": "One invoice per scan or combine multiple",
+            "step2Title": "Choose Mode",
+            "step3Description": "AI extracts data automatically",
+            "step3Title": "Create Invoice",
+            "title": "How to Create Invoices"
+          },
+          "quickUpload": {
+            "button": "Upload",
+            "description": "Upload additional receipts",
+            "title": "Need more scans?"
+          },
+          "selectionStatus": {
+            "plural": "scans selected",
+            "readyPlural": "Create multiple invoices or combine into one",
+            "readySingular": "Ready to create an invoice",
+            "singular": "scan selected"
+          }
+        },
+        "stats": {
+          "ready": "Ready",
+          "selected": "Selected",
+          "selectHint": "Click on scans to select them for invoice creation",
+          "tapHint": "Tap to select",
+          "totalScans": "Total Scans"
+        },
+        "subtitle": "Select scans to create invoices from them.",
+        "title": "Your Scans",
+        "toolbar": {
+          "clearSelection": "Clear",
+          "createInvoice": "Create Invoice",
+          "createInvoices": "Create Invoices",
+          "delete": {
+            "button": "Delete ({count})",
+            "cancel": "Cancel",
+            "confirm": "Delete",
+            "confirmDescription": "This will permanently delete {count} scan(s) from storage. This action cannot be undone.",
+            "confirmTitle": "Delete selected scans?",
+            "error": "An error occurred while deleting scans",
+            "failed": "Failed to delete scans",
+            "partial": "{success} deleted, {failed} failed",
+            "success": "{count} scan(s) deleted successfully"
+          },
+          "selected": "selected"
+        }
+      }
+    },
+    "legal": {
+      "acknowledgements": {
+        "metadata": {
+          "description": "Acknowledgements page for the third-party packages used in this project and collaborators.",
+          "title": "Acknowledgements"
+        }
+      },
+      "eula": {
+        "accept": "Accept EULA",
+        "content": "By using this website, you agree to the terms and conditions and to the privacy policy of the End User License Agreement (EULA). Please read the following documents carefully before using the website:",
+        "cookiesPolicy": {
+          "cookies": {
+            "analytics": {
+              "checkbox": "Enabling the analytics cookies to helps us to improve our website.",
+              "description": "These cookies allow us to count visits and traffic sources, so we can measure and improve the performance of our site. They help us know which pages are the most and least popular and see how visitors move around the site. All information these cookies collect is aggregated and therefore can be considered anonymous.",
+              "title": "Analytics Cookies"
+            },
+            "cta": "Save cookies configuration",
+            "essential": {
+              "checkbox": "This option cannot be disabled. Essential cookies are always enabled.",
+              "description": "Essential cookies are necessary for the website to function properly. This category only includes cookies that ensures basic functionalities and security features of the website.",
+              "title": "Essential Cookies"
+            }
+          },
+          "subtitle": "Manage your cookie settings. You can enable or disable different types of cookies below.",
+          "title": "Cookies Preference"
+        },
+        "language": "Language",
+        "privacyPolicy": {
+          "cta": "View Policy",
+          "subtitle": "Our Privacy Policy explains how we collect, use, and protect your personal information when you use our services.",
+          "title": "Privacy Policy"
+        },
+        "subtitle": "Please review our terms and conditions before using the website.",
+        "termsOfService": {
+          "cta": "View Terms",
+          "subtitle": "Our Terms of Service outline the rules and guidelines for using our platform, including user responsibilities and our obligations.",
+          "title": "Terms of Service"
+        },
+        "title": "End User License Agreement (EULA)"
+      },
+      "privacyPolicy": {
+        "metadata": {
+          "description": "The privacy policy page for the `arolariu.ro` platform.",
+          "title": "Privacy Policy"
+        }
+      },
+      "termsOfService": {
+        "metadata": {
+          "description": "The terms of service for arolariu.ro",
+          "title": "Terms of Service"
+        }
+      }
+    },
+    "profile": {
+      "header": {
+        "completionHint": "Complete your profile to unlock all features",
+        "daysActive": "days active",
+        "editProfile": "Edit Profile",
+        "editProfileClerkNote": "Profile information is managed through Clerk. Click below to update your details.",
+        "editProfileDescription": "Update your profile information",
+        "editProfileTitle": "Edit Profile",
+        "manageOnClerk": "Manage on Clerk",
+        "memberSince": "Member since {date}",
+        "premium": "Premium",
+        "profileCompletion": "Profile Completion",
+        "userId": "User ID"
+      },
+      "island": {
+        "merchants": "{count} merchants",
+        "scans": "{count} scans",
+        "settingsNavigationAriaLabel": "Settings navigation",
+        "totalInvoices": "Total invoices"
+      },
+      "metadata": {
+        "description": "Manage your account settings and preferences",
+        "title": "My Profile"
+      },
+      "settings": {
+        "ai": {
+          "behavior": {
+            "description": "Choose how the AI responds",
+            "title": "Behavior Preset"
+          },
+          "description": "Configure your AI assistant behavior and preferences",
+          "features": {
+            "autoSuggest": "Auto-Suggest",
+            "autoSuggestHint": "Get automatic suggestions as you work",
+            "contextAwareness": "Context Awareness",
+            "contextAwarenessHint": "AI uses context from your invoices",
+            "description": "Enable or disable AI capabilities",
+            "memory": "Conversation Memory",
+            "memoryHint": "AI remembers previous conversations",
+            "title": "AI Features"
+          },
+          "maxTokens": {
+            "description": "Maximum tokens per response",
+            "title": "Response Length"
+          },
+          "model": {
+            "description": "Select the AI model for your assistant",
+            "title": "AI Model"
+          },
+          "temperature": {
+            "creative": "Creative",
+            "description": "Balance between precision and creativity",
+            "precise": "Precise",
+            "title": "Response Style"
+          },
+          "title": "AI Assistant Settings",
+          "voice": {
+            "description": "Configure voice interaction",
+            "enabled": "Voice Input",
+            "enabledHint": "Use voice commands with the AI",
+            "title": "Voice Settings"
+          }
+        },
+        "analytics": {
+          "advanced": {
+            "benchmarking": "Benchmarking",
+            "benchmarkingHint": "Compare with similar users",
+            "description": "Premium analytics features",
+            "predictive": "Predictive Analysis",
+            "predictiveHint": "AI-powered spending predictions",
+            "title": "Advanced Analytics"
+          },
+          "dataUsage": {
+            "info": "Your analytics data is processed locally and never shared without your explicit consent.",
+            "title": "Data Usage"
+          },
+          "description": "Configure how your data is analyzed and reported",
+          "enabled": {
+            "description": "Enable or disable analytics features",
+            "hint": "Track and analyze your spending patterns",
+            "label": "Enable Analytics",
+            "title": "Analytics"
+          },
+          "export": {
+            "description": "Default format for data exports",
+            "title": "Export Format"
+          },
+          "granularity": {
+            "description": "How detailed should your analytics be",
+            "title": "Data Granularity"
+          },
+          "title": "Analytics Settings",
+          "tracking": {
+            "categories": "Track Categories",
+            "categoriesHint": "Analyze spending by category",
+            "description": "Choose what to track",
+            "merchants": "Track Merchants",
+            "merchantsHint": "Monitor merchant-specific data",
+            "spending": "Track Spending",
+            "spendingHint": "Monitor your overall spending",
+            "title": "Tracking Options"
+          }
+        },
+        "appearance": {
+          "advanced": {
+            "animations": "Animations",
+            "animationsHint": "Enable interface animations",
+            "compactMode": "Compact Mode",
+            "compactModeHint": "Reduce spacing for more content",
+            "description": "Additional customization options",
+            "title": "Advanced Options"
+          },
+          "colors": {
+            "description": "Personalize your color scheme",
+            "intermediary": "Intermediary Color",
+            "preview": "Gradient Preview",
+            "previewText": "Sample Gradient Text",
+            "primary": "Primary Color",
+            "secondary": "Secondary Color",
+            "title": "Custom Colors"
+          },
+          "description": "Customize the look and feel of your experience",
+          "font": {
+            "description": "Select a comfortable font",
+            "dyslexic": "Dyslexic-friendly",
+            "dyslexicHint": "OpenDyslexic font for improved readability",
+            "normal": "Standard",
+            "title": "Font"
+          },
+          "locale": {
+            "description": "Set your preferred language",
+            "title": "Language"
+          },
+          "presets": {
+            "custom": "Custom",
+            "customDescription": "Create your own color scheme",
+            "description": "Choose a pre-designed color scheme or create your own",
+            "title": "Theme Preset"
+          },
+          "theme": {
+            "dark": "Dark",
+            "description": "Choose your preferred color scheme",
+            "hint": "Switch between light, dark, or your system preference",
+            "light": "Light",
+            "system": "System",
+            "title": "Theme"
+          },
+          "title": "Appearance Settings"
+        },
+        "data": {
+          "backup": {
+            "autoBackup": "Auto Backup",
+            "autoBackupHint": "Automatically backup your data",
+            "description": "Automatic data backup configuration",
+            "frequency": "Backup Frequency",
+            "title": "Backup Settings"
+          },
+          "danger": {
+            "deleteAccount": "Delete Account",
+            "deleteAccountHint": "Permanently delete your account",
+            "deleteButton": "Delete Data",
+            "deleteData": "Delete All Data",
+            "deleteDataHint": "Permanently remove all your invoices and scans",
+            "description": "Irreversible actions",
+            "manageAccount": "Manage on Clerk",
+            "title": "Danger Zone"
+          },
+          "description": "Control your data storage and privacy settings",
+          "export": {
+            "description": "Download a copy of your data",
+            "downloadAll": "Download All Data",
+            "hint": "Export will include all invoices, scans, and settings",
+            "title": "Export Data"
+          },
+          "privacy": {
+            "description": "Control how your data is used",
+            "shareAnonymous": "Share Anonymous Data",
+            "shareAnonymousHint": "Help improve the service with anonymized usage data",
+            "title": "Privacy Settings"
+          },
+          "retention": {
+            "description": "How long to keep your data",
+            "hint": "Older data will be automatically archived",
+            "title": "Data Retention"
+          },
+          "title": "Data Management"
+        },
+        "notifications": {
+          "description": "Manage how and when you receive notifications",
+          "email": {
+            "description": "Configure email communication preferences",
+            "enabled": "Enable Email Notifications",
+            "enabledHint": "Receive updates via email",
+            "title": "Email Notifications"
+          },
+          "financial": {
+            "budgetAlerts": "Budget Alerts",
+            "budgetAlertsHint": "Alert when approaching budget limits",
+            "description": "Get notified about spending",
+            "spendingAlerts": "Spending Alerts",
+            "spendingAlertsHint": "Notify when spending exceeds threshold",
+            "title": "Financial Alerts"
+          },
+          "reports": {
+            "description": "Scheduled report delivery",
+            "monthlyReport": "Monthly Report",
+            "monthlyReportHint": "Detailed monthly spending analysis",
+            "title": "Reports",
+            "weeklyDigest": "Weekly Digest",
+            "weeklyDigestHint": "Summary of your weekly activity"
+          },
+          "security": {
+            "alwaysOnNote": "Security alerts cannot be fully disabled for your protection",
+            "description": "Critical security alerts",
+            "securityAlerts": "Security Alerts",
+            "securityAlertsHint": "Important security notifications",
+            "title": "Security Notifications"
+          },
+          "title": "Notification Settings",
+          "updates": {
+            "description": "Stay informed about new features",
+            "marketing": "Marketing Emails",
+            "marketingHint": "Promotional content and offers",
+            "newFeatures": "New Features",
+            "newFeaturesHint": "Be notified about new functionality",
+            "title": "Product Updates"
+          }
         },
         "security": {
-          "alwaysOnNote": "Security alerts cannot be fully disabled for your protection",
-          "description": "Critical security alerts",
-          "securityAlerts": "Security Alerts",
-          "securityAlertsHint": "Important security notifications",
-          "title": "Security Notifications"
-        },
-        "title": "Notification Settings",
-        "updates": {
-          "description": "Stay informed about new features",
-          "marketing": "Marketing Emails",
-          "marketingHint": "Promotional content and offers",
-          "newFeatures": "New Features",
-          "newFeaturesHint": "Be notified about new functionality",
-          "title": "Product Updates"
+          "description": "Protect your account with enhanced security measures",
+          "devices": {
+            "current": "Current",
+            "description": "Manage devices that can access your account",
+            "empty": "No trusted devices configured",
+            "lastUsed": "Last used",
+            "title": "Trusted Devices"
+          },
+          "password": {
+            "changePassword": "Change Password",
+            "clerkNote": "Password management is handled through Clerk",
+            "description": "Manage your account credentials",
+            "title": "Password & Access"
+          },
+          "session": {
+            "description": "Manage your login sessions",
+            "hour": "hour",
+            "hours": "hours",
+            "loginNotifications": "Login Notifications",
+            "loginNotificationsHint": "Get notified of new sign-ins",
+            "minutes": "minutes",
+            "timeout": "Session Timeout",
+            "title": "Session Settings"
+          },
+          "title": "Security Settings",
+          "twoFactor": {
+            "activeMessage": "Two-factor authentication is active",
+            "description": "Add an extra layer of security to your account",
+            "enabled": "Enable 2FA",
+            "enabledHint": "Require a second factor when signing in",
+            "title": "Two-Factor Authentication"
+          }
         }
       },
-      "security": {
-        "description": "Protect your account with enhanced security measures",
-        "devices": {
-          "current": "Current",
-          "description": "Manage devices that can access your account",
-          "empty": "No trusted devices configured",
-          "lastUsed": "Last used",
-          "title": "Trusted Devices"
+      "sidebar": {
+        "account": "Account",
+        "daysActive": "days active",
+        "manageClerk": "Manage Account on Clerk",
+        "nav": {
+          "ai": "AI Assistant",
+          "analytics": "Analytics",
+          "appearance": "Appearance",
+          "data": "Data",
+          "notifications": "Notifications",
+          "profile": "Profile",
+          "security": "Security"
         },
-        "password": {
-          "changePassword": "Change Password",
-          "clerkNote": "Password management is handled through Clerk",
-          "description": "Manage your account credentials",
-          "title": "Password & Access"
+        "preferences": "Preferences",
+        "premium": "Premium",
+        "profileCompletion": "Profile Completion"
+      },
+      "stats": {
+        "aiQueries": {
+          "description": "AI assistant interactions",
+          "title": "AI Queries"
         },
-        "session": {
-          "description": "Manage your login sessions",
-          "hour": "hour",
-          "hours": "hours",
-          "loginNotifications": "Login Notifications",
-          "loginNotificationsHint": "Get notified of new sign-ins",
-          "minutes": "minutes",
-          "timeout": "Session Timeout",
-          "title": "Session Settings"
+        "description": "Overview of your account activity",
+        "invoices": {
+          "description": "Invoices processed and stored",
+          "title": "Total Invoices"
         },
-        "title": "Security Settings",
-        "twoFactor": {
-          "activeMessage": "Two-factor authentication is active",
-          "description": "Add an extra layer of security to your account",
-          "enabled": "Enable 2FA",
-          "enabledHint": "Require a second factor when signing in",
-          "title": "Two-Factor Authentication"
-        }
+        "merchants": {
+          "description": "Unique merchants tracked",
+          "title": "Merchants"
+        },
+        "monthly": {
+          "description": "Average monthly spending",
+          "title": "Monthly Average"
+        },
+        "saved": {
+          "description": "Estimated savings from tracking",
+          "title": "Total Saved"
+        },
+        "scans": {
+          "description": "Receipt scans uploaded",
+          "title": "Total Scans"
+        },
+        "storage": {
+          "description": "Your data storage allocation",
+          "title": "Storage Usage",
+          "used": "used"
+        },
+        "title": "Quick Statistics"
       }
-    },
-    "sidebar": {
-      "account": "Account",
-      "daysActive": "days active",
-      "manageClerk": "Manage Account on Clerk",
-      "nav": {
-        "ai": "AI Assistant",
-        "analytics": "Analytics",
-        "appearance": "Appearance",
-        "data": "Data",
-        "notifications": "Notifications",
-        "profile": "Profile",
-        "security": "Security"
-      },
-      "preferences": "Preferences",
-      "premium": "Premium",
-      "profileCompletion": "Profile Completion"
-    },
-    "stats": {
-      "aiQueries": {
-        "description": "AI assistant interactions",
-        "title": "AI Queries"
-      },
-      "description": "Overview of your account activity",
-      "invoices": {
-        "description": "Invoices processed and stored",
-        "title": "Total Invoices"
-      },
-      "merchants": {
-        "description": "Unique merchants tracked",
-        "title": "Merchants"
-      },
-      "monthly": {
-        "description": "Average monthly spending",
-        "title": "Monthly Average"
-      },
-      "saved": {
-        "description": "Estimated savings from tracking",
-        "title": "Total Saved"
-      },
-      "scans": {
-        "description": "Receipt scans uploaded",
-        "title": "Total Scans"
-      },
-      "storage": {
-        "description": "Your data storage allocation",
-        "title": "Storage Usage",
-        "used": "used"
-      },
-      "title": "Quick Statistics"
     }
   },
-  "email": {
-    "layout": {
-      "tagline": "Practical tools. Clean insights. Built for everyday spending.",
-      "managePreferences": "Manage email preferences",
-      "unsubscribe": "Unsubscribe",
-      "buttonFallback": "If the button doesn't work, open this link:",
-      "secondaryFallback": "Or:",
-      "allRightsReserved": "© 2022-{year} {brand}. All rights reserved."
-    },
-    "welcome": {
-      "subject": "Welcome to {brand}",
-      "badge": "Welcome",
-      "heading": "Welcome to {brand}",
-      "preview": "Welcome to {brand}, {name}! Let's get started.",
-      "greeting": "Hi {name},",
-      "intro": "Thanks for joining {brand}. We're glad you're here. Our platform helps you turn everyday receipts into organized financial insights — powered by AI analysis.",
-      "howItWorksTitle": "How it works",
-      "howItWorks": {
-        "0": "Upload — snap a photo or upload a PDF of any receipt",
-        "1": "Analyze — our AI extracts items, prices, merchants, and even suggests recipes from grocery receipts",
-        "2": "Track — view spending dashboards by merchant, category, month, or year"
+  "sections": {
+    "about": {
+      "author": {
+        "biography": {
+          "fifthPoint": "Alexandru is open for collaboration in projects that involve any of the Internet of Things, Software Engineering and Network Engineering fields. He has a proven track record of providing high-quality solutions to complex problems and is always looking for new challenges.",
+          "firstPoint": "Alexandru is a {age} years old software engineer and solution architect. He currently works at Microsoft as a software engineer in the E+D MSAI FAST organization, building solutions that are used by millions of users worldwide.",
+          "fourthPoint": "Alexandru enjoys reading technical books and playing with new technologies. He has built this platform as a \"test-bench\" for new technologies and as a way to learn new things. He is also a big fan of the \"open-source\" movement and has contributed to Microsoft's OSS repositories (dotnet/core, dotnet/docs, azure/docs).",
+          "secondPoint": "Alexandru was born on the 8th of January, year 2000 in a small city called Curtea de Argeș in Romania. He got his first computer when he was just 5 years old - a Pentium 4 E2200 2.2Ghz Dual-Core  with 512 MB of RAM. Since then, he's been running different versions of Windows (started with Windows 98!), tinkering with his personal computer and developing his computer skills by playing video games. He also learnt a good amount of English and was able to fluently read, write and speak in English by the age of 12!",
+          "thirdPoint": "Alexandru is a video game enthusiast. He used to be a professional player, ranking at #70 in Romania for the video game called \"DotA 2\". He enjoys playing strategy games that have a focus on mechanics and a technical setting like Age of Empires, Age of Mythology, etc. He also enjoys playing games such as Red Alert, StarCraft, and other RTS games.",
+          "title": "About Alexandru"
+        },
+        "certifications": {
+          "certificates": {
+            "ab730": {
+              "code": "AB-730",
+              "coreSkills": "# AI Strategy # AI Adoption # Responsible AI # Business Value of AI # Identifying AI Use Cases",
+              "description": "Validates business-focused AI knowledge for professionals leading or influencing AI initiatives within their organization. Targeted at decision-makers, product owners and consultants who shape AI strategy rather than implement it.",
+              "issuer": "Microsoft",
+              "issuerDate": "2026",
+              "link": "https://learn.microsoft.com/en-us/credentials/certifications/ai-business-professional/",
+              "name": "Microsoft Certified: AI Business Professional"
+            },
+            "ab731": {
+              "code": "AB-731",
+              "coreSkills": "# Enterprise AI Transformation # AI Strategy # Change Management # AI Governance # Executive Leadership",
+              "description": "Validates the ability to lead enterprise-scale AI transformation initiatives — defining the strategy, driving organizational change, and establishing governance to operationalize AI across the business.",
+              "issuer": "Microsoft",
+              "issuerDate": "2026",
+              "link": "https://learn.microsoft.com/en-us/credentials/certifications/ai-transformation-leader/",
+              "name": "Microsoft Certified: AI Transformation Leader"
+            },
+            "ai900": {
+              "code": "AI-900",
+              "coreSkills": "# Machine Learning # Computer Vision # Natural Language Processing # Conversational AI # Responsible AI",
+              "description": "Demonstrates knowledge of common AI and machine learning workloads and how to implement them on Azure. This certification is intended for candidates with both technical and non-technical backgrounds.",
+              "issuer": "Microsoft",
+              "issuerDate": "2023",
+              "link": "https://learn.microsoft.com/en-us/certifications/azure-ai-fundamentals/",
+              "name": "Microsoft Certified: Azure AI Fundamentals"
+            },
+            "az900": {
+              "code": "AZ-900",
+              "coreSkills": "# Cloud Concepts # Core Azure Services # Security, Privacy, Compliance, and Trust # Azure Pricing, SLA, and Lifecycle",
+              "description": "Validates foundational knowledge of cloud services and how those services are provided with Microsoft Azure. The certification is intended for candidates who are just beginning to work with cloud-based solutions and services.",
+              "issuer": "Microsoft",
+              "issuerDate": "2023",
+              "link": "https://learn.microsoft.com/en-us/certifications/azure-fundamentals/",
+              "name": "Microsoft Certified: Azure Fundamentals"
+            },
+            "gh100": {
+              "code": "GH-100",
+              "coreSkills": "# Authentication # User & Team Management # Repository Policies # Enterprise Configuration # Security & Compliance",
+              "description": "Validates the skills required to administer GitHub Enterprise organizations — managing users, teams, repositories, policies, and integrations at scale.",
+              "issuer": "GitHub",
+              "issuerDate": "2026",
+              "link": "https://learn.microsoft.com/en-us/credentials/certifications/github-administration/",
+              "name": "GitHub Certified: Administration"
+            },
+            "gh200": {
+              "code": "GH-200",
+              "coreSkills": "# Workflow Authoring # Self-Hosted Runners # Workflow Security # Reusable Workflows # CI/CD Pipelines",
+              "description": "Validates expertise in authoring, configuring, and maintaining GitHub Actions workflows for build, test, and deployment automation across the entire software lifecycle.",
+              "issuer": "GitHub",
+              "issuerDate": "2026",
+              "link": "https://learn.microsoft.com/en-us/credentials/certifications/github-actions/",
+              "name": "GitHub Certified: Actions"
+            },
+            "gh300": {
+              "code": "GH-300",
+              "coreSkills": "# Copilot Plans & Features # Code Suggestions # Prompt Engineering # Responsible AI Use # Copilot Chat",
+              "description": "Validates the skills required to leverage GitHub Copilot effectively for AI-assisted software development — covering features, customization, prompt engineering, and responsible use.",
+              "issuer": "GitHub",
+              "issuerDate": "2026",
+              "link": "https://learn.microsoft.com/en-us/credentials/certifications/github-copilot/",
+              "name": "GitHub Certified: Copilot"
+            },
+            "gh900": {
+              "code": "GH-900",
+              "coreSkills": "# GitHub Basics # Repositories # Collaboration # GitHub Products # Issues, Pull Requests & Workflows",
+              "description": "Validates foundational knowledge of GitHub — covering repositories, collaboration features, the GitHub product family, and core developer workflows.",
+              "issuer": "GitHub",
+              "issuerDate": "2026",
+              "link": "https://learn.microsoft.com/en-us/credentials/certifications/github-foundations/",
+              "name": "GitHub Certified: Foundations"
+            },
+            "sc900": {
+              "code": "SC-900",
+              "coreSkills": "# Security Concepts # Identity Principles # Microsoft Entra # Compliance Solutions # Privacy & Information Protection",
+              "description": "Validates foundational knowledge of security, compliance, and identity concepts, alongside related Microsoft cloud-based solutions covering Entra, Defender, and Purview.",
+              "issuer": "Microsoft",
+              "issuerDate": "2023",
+              "link": "https://learn.microsoft.com/en-us/credentials/certifications/security-compliance-and-identity-fundamentals/",
+              "name": "Microsoft Certified: Security, Compliance & Identity Fundamentals"
+            }
+          },
+          "coreSkillsLabel": "Core Skills Demonstrated:",
+          "subtitle": "Professional certifications and credentials that Alexandru has earned throughout his career.",
+          "title": "Certifications",
+          "viewCertification": "View certification"
+        },
+        "competencies": {
+          "competences": {
+            "agileMethodologies": {
+              "description": "Alexandru has learned about agile working and agile methodologies since he was a student in his BSc degree. He follows the agile manifesto and is a big fan of the Kanban technique of planning.",
+              "title": "Agile Methodologies"
+            },
+            "algorithmicSkills": {
+              "description": "Alexandru has completed many Hacker Rank, Hacker Earth and Leet Code challenges published from 2019 until 2021. He has a strong algorithmic thinking and is able to construct complex algorithms with ease.",
+              "title": "Algorithmic Skills"
+            },
+            "customerCentric": {
+              "description": "Alexandru has been working with customers for many years, in his tenure at Microsoft. He has gained a lot of knowledge and is able to put himself in the shoes of the customer. He is able to understand the customer's needs and to deliver solutions that are exactly tailored to their needs.",
+              "title": "Customer Centric"
+            },
+            "domainDrivenDesign": {
+              "description": "Alexandru follows domain-driven design principles strongly. He is able to combine DDD with TDD to create complex solutions that are easy to maintain and extend. He is also a big fan of the \"onion architecture\" and \"clean architecture\" approaches.",
+              "title": "Domain-Driven Design (DDD)"
+            },
+            "engineeringExcellence": {
+              "description": "Alexandru is passionate about delivering the best solutions for the problem and for the customer. He is always striving to deliver the best software and to follow understood engineering excellence practices. A perfect solution is a solution that is easy to maintain, extend and understand, not the one that is the most complex.",
+              "title": "Engineering Excellence"
+            },
+            "testDrivenDevelopment": {
+              "description": "Alexandru is a firm believer of test-driven development. He constantly applies this approach to his projects and he is always trying to improve his testing skills. He is also a big fan of the \"red-green-refactor\" approach.",
+              "title": "Test-Driven Development (TDD)"
+            }
+          },
+          "subtitle": "A showcase of Alexandru's technical skills and professional competencies.",
+          "title": "Alexandru's Competences"
+        },
+        "contact": {
+          "collaborate": {
+            "discipline1": "Software Engineering",
+            "discipline2": "Internet of Things",
+            "discipline3": "Cloud Native Applications",
+            "discipline4": "Network Engineering",
+            "footer": " If you have an interesting project or opportunity that aligns with Alexandru's expertise, don't hesitate to reach out. He's always eager to explore new challenges and collaborations.",
+            "subtitle": "Alexandru is open for collaboration in projects that involve any of the following fields:",
+            "title": "Let's collaborate!"
+          },
+          "footer": "Thank you.",
+          "socials": {
+            "footer": "To reach out to him, use one of the above contact methods.",
+            "subtitle": "Feel free to reach out for collaborations, questions, or just to say hello!",
+            "title": "Get in touch"
+          },
+          "subtitle": "If you would like to get in touch with Alexandru, please use the below ways of contact.",
+          "title": "Connect with Alexandru"
+        },
+        "education": {
+          "subtitle": "Alexandru's academic background and learning journey.",
+          "title": "Education",
+          "university": {
+            "aseBucharest": {
+              "aboutTheProgramCta": "See more details",
+              "aboutTheProgramDescription": "The BSc in Computer Science at the University of Bucharest is a rigorous program that provides students with a strong foundation in theoretical computer science and practical software development. The curriculum emphasizes problem-solving skills, algorithmic thinking, and software engineering principles.",
+              "aboutTheProgramLearnings": "# Design and analyze algorithms and data structures # Develop software using various programming paradigms # Implement database systems and manage data # Understand computer networks and distributed systems # Apply software engineering principles to real-world problems",
+              "aboutTheProgramLearningsTitle": "Key Learning Outcomes",
+              "aboutTheProgramTitle": "About the program",
+              "degree": "BSc. Computer Science & Economy",
+              "description": "Bachelor's degree in Computer Science and Economy from the Bucharest University of Economic Studies in Bucharest, Romania. Finished in top 1% according to thesis rating statistics.",
+              "institution": "Academia de Studii Economice",
+              "keyCourses": "# Software Engineering # Computer Networks # Operating Systems # Algorithms & Data Structures # Database Management Systems # Web Development # Mobile Development",
+              "keyCoursesTitle": "Key courses",
+              "location": "Bucharest, Romania",
+              "period": "2019 - 2022",
+              "status": "Completed"
+            },
+            "malmoSweden": {
+              "aboutTheProgramCta": "See more details",
+              "aboutTheProgramDescription": "The MSc in Internet of Things at Malmö University is a cutting-edge program that prepares students for the challenges and opportunities of the IoT revolution. The curriculum emphasizes hands-on learning, interdisciplinary collaboration, and real-world applications.",
+              "aboutTheProgramLearnings": "# Design and implement IoT systems using various hardware and software platforms # Analyze and manage data generated by IoT devices # Apply machine learning and artificial intelligence techniques to IoT applications # Understand the security and privacy implications of IoT systems # Collaborate with industry partners on real-world projects",
+              "aboutTheProgramLearningsTitle": "Key Learning Outcomes",
+              "aboutTheProgramTitle": "About the program",
+              "degree": "MSc. Internet of Things",
+              "description": "Previously enrolled in the MSc. Internet of Things program at Malmö University, Sweden. Interrupted due to personal and unforeseen circumstances in 2024.",
+              "institution": "Malmö University",
+              "keyCourses": "# Internet of Things # Cloud Computing # Data Science # Machine Learning # Artificial Intelligence # Computer Vision # Robotics",
+              "keyCoursesTitle": "Key courses",
+              "location": "Malmö, Sweden",
+              "period": "2023 - 2024",
+              "status": "Interrupted"
+            }
+          }
+        },
+        "experiences": {
+          "achievementsLabel": "Achievements",
+          "intel": {
+            "achievements": "# Developed color space converters (CSC) in C and Assembly x8086 (YUV->RGB, Grayscale).# Created 10+ types of image filters such as Fish Eye, Sobel, Edge Detection, Box Blur, etc.# Refactored .ASM code to better perform on IoT & Embedded Systems devices.",
+            "company": "Intel",
+            "description": "The Timisoara site addresses several focus areas where software for various hardware components, image processing algorithms, and low-level and high-level implementations of component parts of neural networks are actively being developed.",
+            "location": "Remote (Romania - Timisoara)",
+            "period": "2021 (6 Months)",
+            "responsibilites": "#Mastering skills in the world of image processing. #Gaining a grasp of the domain of Machine Learning (ML). #Practicing the achieved knowledge by developing different color space converters.",
+            "techAndSkills": "# C # C++ #Intel x8086 Assembly # Color Space Converters # Python # Embedded Compute # Internet of Things",
+            "title": "Embedded Engineer"
+          },
+          "microsoft1": {
+            "achievements": "# (Engineering Excellence) Constantly pushed myself to achieve the best customer feedback. (Current score: 4.94 / 5.00) # (Proactive interactions) Provided continuous feedback to the Product Group for the Azure Virtual Desktop (AVD) product, regarding the implementation of specific features and services. # (Customer Experience) Developed the existing documentation about the features of Azure Core services such as Azure Virtual Desktop, Azure Virtual Machines, Azure Networks. # Worked exclusively with TOP 100 & Fortune 500 clients and industry leading professionals.",
+            "company": "Microsoft",
+            "description": "With over 12,000 employees worldwide, the Microsoft Customer Experience & Success (CE&S) organization is responsible for the strategy, design, and implementation of the Microsoft end-to-end customer experience.",
+            "location": "Romania",
+            "period": "03/2021 – 03/2023",
+            "responsibilites": "# Provide knowledge sharing, technical coaching and mentoring to fellow colleagues; # Problem solving through deep troubleshooting, debugging, log analysis, A/B testing; # Identify and respond to business critical customer issues specific to Azure services such as Azure Virtual Desktop; # Work exclusively with Fortune 500 customers to understand their technical needs, and define an action plan to meet them, collaborating with peers or other teams regularly.",
+            "techAndSkills": "# Network Traffic Analysis # Azure # Customer-centric Approach # Business Relationships # Incident Manager",
+            "title": "Azure Technical Engineer"
+          },
+          "microsoft2": {
+            "achievements": "# (Observability-as-a-Service) Fully orchestrated and implemented the three pillars of observability in our microservices architecture using Open Telemetry standards; I've also built automated monitoring and alerting triggers based on p95/p99 statistics for real-time and synthetic traffic. # (Research & Development) Assisted with major contributions to the development of an in-house .NET library that implements the ODataV4 data consumption protocol for NoSQL database engines such as Azure Data Explorer (ADX), using Domain-Driven Design (DDD) practices (e.g. aggregator roots) (patent in progress). # (Development Experience) Took leadership of two key areas for DX: documentation & consumption layers. Built outstanding documentation and leveraged static site generator tools (DocFX) to automatically generate API documentation from code; offered API consumption layers in form of frontend UIs, CLI tooling and OpenAPI spec files. # (Growth) Shadowed and attended hiring interviews for SWE II and Senior SWE positions.",
+            "company": "Microsoft",
+            "description": "As governments today look at technology innovation, there is a need to address the rapidly evolving demands of their citizens while protecting the most sensitive data and delivering on promises of trust and security.",
+            "location": "EMEA",
+            "period": "03/2023 – 12/2024",
+            "responsibilites": "# Deliver one E+C Data Platform that is capable of running cross-clouds and cross-tenant in sovereign environments and air-gapped scenarios. # Manage and assure the wellbeing of the Runtime in Sovereign Environments (RISE) Data Platform operations. # Build a novel data mesh enterprise architecture using data engineering concepts, tools like Azure Data Factory and other data warehouse notions.",
+            "techAndSkills": "# .NET # Azure # Microservices # Cloud-Native Applications # Agile Methodologies # DevOps # Domain-Driven Design # Test-Driven Development # Project Management",
+            "title": "E + D Sovereign Clouds Software Engineer II"
+          },
+          "microsoft3": {
+            "achievements": "Current role achievements are being actively collected.",
+            "company": "Microsoft",
+            "description": "Alexandru is currently working at Microsoft as a software engineer in the E+D MSAI (M365 AI Experiences) organization.",
+            "location": "Remote (Norway)",
+            "period": "11/2024 - Present",
+            "responsibilites": "Current role responsibilities are being actively refined.",
+            "techAndSkills": "# React # GraphQL # Large-Scale Development # Cloud-Native Applications # Agile Methodologies # Engineering Excellence # Leadership",
+            "title": "E + D M365 AI Fullstack Software Engineer II"
+          },
+          "responsibilitiesLabel": "Responsibilities",
+          "subtitle": "A journey through Alexandru's professional career and the companies he's worked with.",
+          "techSkillsLabel": "Technologies & Skills",
+          "title": "Professional Experience",
+          "ubisoft": {
+            "achievements": "#  I've consistently over-exceeded the quota of reported bugs, glitches and artefacts, ranking as the #1 reporter for a solid 5 months out of the 6 worked. #  Found and reported major code defects that ranged from race conditions to memory resource allocation defects. #  Increased the daily report efficiency by leveraging SQL and JQL filtering capabilities.",
+            "company": "Ubisoft",
+            "description": "I've worked on the Avatar: Frontiers of Pandora™ first person, action-adventure game built using the latest iteration of the Snowdrop engine (C++) by Massive Entertainment - a UBISOFT studio, and tested by UBISOFT Romania.",
+            "location": "Hybrid (Bucharest, Romania)",
+            "period": "2020 - 2021",
+            "responsibilites": "# Managed regression, integration and unit testing with software such as XRAY, TestRail, Bugzilla. # Create high quality test suites and test plans using Atlassian (JIRA / Confluence) products. # Assure communications are stable and clear between production and testing teams.",
+            "techAndSkills": "# Unit Testing # Integration Testing # A/B Testing # Performance Testing # Automatic Testing # E2E Testing",
+            "title": "QA/QC Engineer"
+          }
+        },
+        "perspectives": {
+          "perspectiveFromX": {
+            "author": "Anonymous",
+            "avatar": "Anonymous avatar",
+            "company": "Microsoft",
+            "position": "Senior Software Engineer",
+            "quote": "The thing that I appreciate a lot about you is your relentless pursuit of improvement and your willingness to challenge the status quo. Your commitment to continuous self-development is evident in the way you approach every task with a mindset geared towards innovation and excellence. Your ability to question existing methods and propose better alternatives has been instrumental in driving our projects forward. This proactive attitude not only enhances the quality of our work but also inspires the team to strive for higher standards. I am happy to have worked with you and hope our paths will cross again in the future."
+          },
+          "perspectiveFromXX": {
+            "author": "Anonymous",
+            "avatar": "Anonymous avatar",
+            "company": "Microsoft",
+            "position": "Senior Software Engineering Manager",
+            "quote": "Alex is an intelligent engineer whose capabilities shone brightly during our collaboration on our projects. He consistently demonstrates eagerness to assist the team with any request, showcasing his dedication to collective success. His proactive approach to problem-solving and dedication to system stability greatly benefit our team's workflow. Additionally, Alex's availability and willingness to support others during our release flow highlight his value as a colleague who prioritizes teamwork and collaboration."
+          },
+          "perspectiveFromXY": {
+            "author": "Anonymous",
+            "avatar": "Anonymous avatar",
+            "company": "Microsoft",
+            "position": "Senior Escalation Engineer",
+            "quote": "Alex, if I am to choose one thing, I value the most about working with you, it has to be your mindset - as it includes multiple aspects. Working with you is genuine, funny, wise and relevant at the same time. It is easy to notice that your daily drivers are commitment, reasoning and continuous learning. I admire your approach, your genuine desire to help, to build on the success of others and to support everyone in their growth which is such a rare value. On top of that I value your patience, as well as the great amount of knowledge you bring into our interactions. The way you manage stressful situations and your overall approach have the power to shape a positive outcome for any matter or topic."
+          },
+          "perspectiveFromXZ": {
+            "author": "Anonymous",
+            "avatar": "Anonymous avatar",
+            "company": "Microsoft",
+            "position": "Senior Software Engineer",
+            "quote": "I've been consistently impressed with your work output. You always deliver high-quality work, paying close attention to details and ensuring that everything is done to the best of your abilities, Additionally, you have a deep understanding of the technical aspects of our work, which has been a valuable asset for the team. Your willingness to share your knowledge and experience with others has been invaluable and it's clear that you take pride in mentoring others and helping them grow."
+          },
+          "perspectiveFromY": {
+            "author": "Anonymous",
+            "avatar": "Anonymous avatar",
+            "company": "Microsoft",
+            "position": "Software Engineer II",
+            "quote": "I really appreciate your proactive approach and collaborative spirit, and your support and friendly communication style have been very positive to my onboarding experience and to learning the ins and outs of our project. Your ability to communicate effectively and keep everyone in the loop is something I'm looking up to, you are experienced with dealing with cross-functional teams, especially with our partner teams, with learning their needs and solving their problems. Your technical skills are impressive and your attention to detail is commendable."
+          },
+          "perspectiveFromYX": {
+            "author": "Anonymous",
+            "avatar": "Anonymous avatar",
+            "company": "Microsoft",
+            "position": "Senior Product Manager",
+            "quote": "Alexandru's depth of character is evident in his passion and commitment towards helping others succeed and nowhere is that clearer that in his mentorship of. I hold Alexandru in high regard - I may have a few years on him, but he should not hesitate to challenge me if he believes there's a better way to approach a problem."
+          },
+          "perspectiveFromYY": {
+            "author": "Anonymous",
+            "avatar": "Anonymous avatar",
+            "company": "Microsoft",
+            "position": "Staff Software Engineer",
+            "quote": "I love your attitude and open mindset, I find it easy to work and talk with you. I don't have much for you to leverage these strength further: keep being yourself and you are already doing great work!"
+          },
+          "perspectiveFromYZ": {
+            "author": "Anonymous",
+            "avatar": "Anonymous avatar",
+            "company": "Microsoft",
+            "position": "Staff Software Engineer",
+            "quote": "Alexandru is a great software engineer. He's incredibly sharp and I would rate him in the top 1% for his age - at 25 most people struggle to find a job, while Alexandru is delivering impact that translates into millions of dollars. He's extremely talented."
+          },
+          "perspectiveFromZ": {
+            "author": "Anonymous",
+            "avatar": "Anonymous avatar",
+            "company": "Microsoft",
+            "position": "Senior Software Engineer",
+            "quote": "You always step up to help, sharing your time generously, even when you have your own pressing tasks. Your quick and helpful replies to any questions are greatly appreciated. You take a prioritized and meticulous approach, providing instant solutions that not only unblock us in the short term but also outline long-term fixes and their implementation timelines. Your solution-oriented mindset is a true asset for our team. Your expertise, willingness to assist, and pleasant personality make you a great colleague. Keep up the great work!"
+          },
+          "subtitle": "Perspectives from colleagues who have worked with or alongside Alexandru.",
+          "title": "Perspectives"
+        },
+        "subtitle": "Alexandru-Razvan Olariu is the author of the platform that you are currently browsing.",
+        "title": "Meet the author."
       },
-      "whatYouCanDoTitle": "What you can do",
-      "whatYouCanDo": {
-        "0": "Get allergen alerts on food products",
-        "1": "Share invoices with family members or colleagues",
-        "2": "Export statistics and spending reports",
-        "3": "Access your data from any device"
-      },
-      "body": "Ready to get started? Upload your first receipt and watch the magic happen. The whole process takes less than a minute.",
-      "feedbackPrompt": "Questions or feedback? We'd love to hear from you at <email></email>.",
-      "signOff": {
-        "line1": "Cheers,",
-        "line2": "The {brand} Team"
-      },
-      "ctaPrimary": "Upload your first receipt",
-      "ctaSecondary": "Explore the dashboard"
-    },
-    "firstInvoiceUploaded": {
-      "subject": "Your first invoice is in!",
-      "badge": "Milestone",
-      "heading": "Your first invoice is in!",
-      "preview": "Congratulations, {name}! Your first invoice is in.",
-      "greeting": "Hi {name},",
-      "intro": "Congratulations on uploading your first invoice! You've taken the first step toward organized, insightful spending tracking. Here's what we've got so far:",
-      "invoiceSummaryTitle": "Your First Invoice",
-      "invoiceSummary": {
-        "invoiceName": "Invoice name",
-        "uploaded": "Uploaded",
-        "status": "Status"
-      },
-      "statusValue": "Ready for analysis",
-      "untitledFallback": "Untitled",
-      "whatHappensNextTitle": "What happens next",
-      "whatHappensNext": {
-        "0": "We analyze your receipt — our AI extracts items, prices, and merchant info",
-        "1": "You review the results — check the analysis and correct anything that looks off",
-        "2": "Your dashboard updates — spending charts, category breakdowns, and trends start building"
-      },
-      "featuresToExploreTitle": "Features to explore",
-      "featuresToExplore": {
-        "0": "Share invoices with family or colleagues for joint expense tracking",
-        "1": "View AI-generated recipe suggestions from your grocery items",
-        "2": "Check allergen warnings on detected food products",
-        "3": "Track spending patterns across merchants, categories, and time periods"
-      },
-      "body": "The more invoices you upload, the richer your spending insights become. Try uploading a few more receipts this week to see your dashboard come to life.",
-      "feedbackPrompt": "Need help or have feedback? Reach us at <email></email>.",
-      "signOff": {
-        "line1": "Cheers,",
-        "line2": "The {brand} Team"
-      },
-      "ctaPrimary": "View your invoice",
-      "ctaSecondary": "Upload another receipt"
-    },
-    "invoiceAnalyzed": {
-      "subject": "Your invoice has been analyzed",
-      "badge": "Invoices • Analysis Complete",
-      "heading": "Your invoice analysis is ready",
-      "preview": "Your invoice is ready, {name}. Analysis complete!",
-      "greeting": "Hi {name},",
-      "intro": "Great news! Our AI has finished analyzing your invoice. We've extracted all the key information, categorized your items, and generated spending insights to help you track your finances.",
-      "summaryTitle": "Invoice Summary",
-      "summary": {
-        "invoiceName": "Invoice name",
-        "merchantId": "Merchant ID",
-        "itemsDetected": "Items detected",
-        "totalAmount": "Total amount",
-        "notIdentified": "Not identified yet"
-      },
-      "whatWasAnalyzedTitle": "What was analyzed",
-      "whatWasAnalyzed": {
-        "0": "Merchant identification and categorization",
-        "1": "Line-by-line item extraction with pricing",
-        "2": "Automatic product categorization (groceries, beverages, household, etc.)",
-        "3": "Currency detection and amount validation",
-        "4": "Date and time extraction when available"
-      },
-      "body": "Click the button above to view the complete analysis. If anything looks off—perhaps a product was miscategorized or a price wasn't detected correctly—you can edit the invoice directly in your dashboard and the insights will update automatically.",
-      "feedbackPrompt": "Have questions about your analysis, or need help? Contact us at <email></email>.",
-      "signOff": {
-        "line1": "Cheers,",
-        "line2": "The {brand} Team"
-      },
-      "ctaPrimary": "View full analysis"
-    },
-    "invoiceDeleted": {
-      "subject": "Your invoice was deleted",
-      "badge": "Invoices • Deleted",
-      "heading": "Invoice removed from your account",
-      "preview": "Invoice {invoiceLabel} has been removed from your account.",
-      "greeting": "Hi {name},",
-      "intro": "This email confirms that an invoice has been removed from your {brand} account. The deletion was processed successfully.",
-      "detailsTitle": "Deletion Details",
-      "details": {
-        "invoice": "Invoice",
-        "invoiceId": "Invoice ID",
-        "status": "Status"
-      },
-      "statusValue": "Deleted (soft delete)",
-      "placeholder": "—",
-      "whatYouShouldKnowTitle": "What you should know",
-      "whatYouShouldKnow": {
-        "0": "This is a soft delete—the invoice data may be retained for 30 days for recovery purposes.",
-        "1": "Any shared access to this invoice has been automatically revoked.",
-        "2": "Statistics and insights will be recalculated to exclude this invoice.",
-        "3": "If you need to recover this invoice, contact support within 30 days."
-      },
-      "body": "If you didn't initiate this deletion, or if you need to recover the invoice, please contact us immediately at <email></email>. We're here to help.",
-      "signOff": {
-        "line1": "Cheers,",
-        "line2": "The {brand} Team"
-      },
-      "ctaPrimary": "View your invoices"
-    },
-    "invoiceMadePublic": {
-      "subject": "Your invoice is now public",
-      "badge": "Invoices • Public Link",
-      "heading": "Your invoice is now public",
-      "preview": "Your invoice \"{invoiceName}\" is now public and shareable.",
-      "greeting": "Hi {name},",
-      "intro": "You've successfully made your invoice public. Anyone with the link or QR code below can now view this invoice—no login required. This is perfect for sharing receipts with colleagues, accountants, or for expense reporting.",
-      "detailsTitle": "Invoice details",
-      "details": {
-        "invoiceName": "Invoice name",
-        "invoiceId": "Invoice ID",
-        "merchant": "Merchant",
-        "total": "Total",
-        "created": "Created",
-        "access": "Access"
-      },
-      "accessValue": "Public (anyone with link)",
-      "qrTitle": "Quick Access QR Code",
-      "qrSubText": "Scan with your phone camera for instant access.",
-      "qrAlt": "QR Code for invoice access",
-      "howToShareTitle": "How to share",
-      "howToShare": {
-        "0": "Copy the direct link below and send via email or message",
-        "1": "Print or screenshot the QR code for in-person sharing",
-        "2": "Include in expense reports or reimbursement requests"
-      },
-      "privacyNoticeTitle": "Privacy Notice",
-      "privacyNoticeBody": "Public invoices can be accessed by anyone who has the URL or QR code. To make this invoice private again, update the sharing settings from your invoice page at any time.",
-      "directLinkLabel": "Direct link:",
-      "feedbackPrompt": "Questions about sharing or privacy settings? Contact us at <email></email>.",
-      "signOff": {
-        "line1": "Cheers,",
-        "line2": "The {brand} Team"
-      },
-      "ctaPrimary": "Open public invoice"
-    },
-    "invoiceShared": {
-      "subject": "{fromName} shared an invoice with you",
-      "badge": "Invoices • Shared",
-      "heading": "An invoice was shared with you",
-      "preview": "{fromName} shared an invoice with you.",
-      "greeting": "Hi {toName},",
-      "intro": "Great news! <from></from> has shared an invoice with you on {brand}. This gives you access to view all the invoice details, including itemized products, merchant information, and analysis insights.",
-      "detailsTitle": "Share details",
-      "details": {
-        "sharedBy": "Shared by",
-        "invoiceId": "Invoice ID"
-      },
-      "whatYouCanDoTitle": "What you can do",
-      "whatYouCanDo": {
-        "0": "View the complete invoice details and itemized breakdown",
-        "1": "See analysis insights and spending categories",
-        "2": "Download or print the invoice for your records"
-      },
-      "body": "Click the button above to access the shared invoice. This link will remain active as long as the sharing permissions are in place.",
-      "feedbackPrompt": "Have questions about this share, or need help? Contact us at <email></email>.",
-      "signOff": {
-        "line1": "Cheers,",
-        "line2": "The {brand} Team"
-      },
-      "ctaPrimary": "View shared invoice"
-    },
-    "invoiceUnshared": {
-      "subject": "Access to a shared invoice was revoked",
-      "badge": "Invoices • Access Revoked",
-      "heading": "Your access to an invoice was revoked",
-      "preview": "{fromName} revoked your access to a shared invoice.",
-      "greeting": "Hi {toName},",
-      "intro": "We're writing to let you know that <from></from> has revoked your access to an invoice that was previously shared with you. This means you will no longer be able to view this invoice.",
-      "detailsTitle": "Revocation Details",
-      "details": {
-        "revokedBy": "Revoked by",
-        "invoiceId": "Invoice ID",
-        "revokedAt": "Revoked at",
-        "yourAccess": "Your access",
-        "accessRevoked": "Revoked",
-        "notProvided": "—"
-      },
-      "whatThisMeansTitle": "What this means",
-      "whatThisMeans": {
-        "0": "Any bookmarked links to this invoice will no longer work for you.",
-        "1": "This invoice will not appear in your shared invoices list.",
-        "2": "If you need access again, contact the invoice owner directly."
-      },
-      "body": "If you believe this change was made in error, please reach out to <from></from> or contact our support team. Access revocations are sometimes accidental, and we're happy to help facilitate communication if needed.",
-      "feedbackPrompt": "Need assistance? Email us at <email></email>.",
-      "signOff": {
-        "line1": "Cheers,",
-        "line2": "The {brand} Team"
-      },
-      "ctaPrimary": "View your invoices",
-      "ctaSecondary": "Contact support"
-    },
-    "spendingAlert": {
-      "subject": "Spending threshold alert",
-      "badge": "Spending Alert • {percent}%",
-      "heading": "{percent, select, 80 {Heads up: approaching your budget limit} 90 {Almost there: 90% of your budget used} 100 {Budget reached: you've hit your spending limit} other {Spending alert}}",
-      "preview": "{name}, you've used {percent}% of your {category} budget for {period}.",
-      "greeting": "Hi {name},",
-      "intro": "{state, select, over {You've reached your spending limit for {category} in {period}. Here's a summary of where you stand.} other {You've used {percent}% of your {category} budget for {period}. Here's a quick summary to help you plan the rest of the period.}}",
-      "overBudgetWarning": "Your spending has reached or exceeded the budget you set. Review your recent purchases to stay on track.",
-      "metricsLabels": {
-        "budgetLimit": "Budget limit",
-        "currentSpending": "Current spending",
-        "remaining": "Remaining",
-        "threshold": "Threshold"
-      },
-      "overBudgetValue": "Over budget",
-      "detailsTitle": "Budget Details",
-      "detailsLabels": {
-        "category": "Category",
-        "period": "Period",
-        "budget": "Budget",
-        "spent": "Spent"
-      },
-      "chartTitle": "Spending by category",
-      "chartAlt": "Spending breakdown by category for {period}",
-      "tipsTitle": "{state, select, over {What you can do} other {Tips to stay on track}}",
-      "tipsOverBudget": {
-        "0": "Review recent purchases to identify non-essential spending",
-        "1": "Consider adjusting your budget if it no longer reflects reality",
-        "2": "Set a stricter threshold (e.g., 80%) for earlier warnings"
-      },
-      "tipsOnTrack": {
-        "0": "Check your recent purchases to see where the bulk is going",
-        "1": "Prioritize essential spending for the rest of the period",
-        "2": "Consider cooking at home more if dining is driving costs up"
-      },
-      "notificationsParagraph": "You can adjust your budget thresholds and notification preferences in your <settings></settings>.",
-      "notificationsLink": "notification settings",
-      "feedbackPrompt": "Questions? Reach us at <email></email>.",
-      "ctaPrimary": "View dashboard",
-      "signOff": {
-        "line1": "Best regards",
-        "line2": "The {brand} Team"
+      "platform": {
+        "architecture": {
+          "badge": "Technical Architecture",
+          "description": "A modern cloud-native architecture following domain-driven design principles, The Standard methodology, and industry best practices.",
+          "layers": {
+            "ai": {
+              "description": "Intelligent document processing and natural language understanding",
+              "name": "AI Services",
+              "technologies": "Azure OpenAI,Document Intelligence,Computer Vision"
+            },
+            "api": {
+              "description": "RESTful APIs with OpenAPI documentation and rate limiting",
+              "name": "API Gateway",
+              "technologies": ".NET 10,Minimal APIs,OpenAPI,GraphQL"
+            },
+            "auth": {
+              "description": "Enterprise-grade authentication with multiple providers",
+              "name": "Identity & Security",
+              "technologies": "Azure AD B2C,OAuth 2.0,OIDC,MFA"
+            },
+            "cdn": {
+              "description": "Global content delivery with edge caching and optimization",
+              "name": "Edge & CDN",
+              "technologies": "Azure CDN,Vercel Edge,Static Assets"
+            },
+            "client": {
+              "description": "Modern React-based frontends with SSR and SSG capabilities",
+              "name": "Client Layer",
+              "technologies": "Next.js 16,React 19,TypeScript,SCSS Modules"
+            },
+            "data": {
+              "description": "Multi-model database strategy for optimal performance",
+              "name": "Data Layer",
+              "technologies": "CosmosDB,Azure SQL,Redis Cache,Blob Storage"
+            },
+            "infra": {
+              "description": "Fully managed Azure infrastructure with IaC deployment",
+              "name": "Cloud Infrastructure",
+              "technologies": "Azure,Bicep IaC,Container Apps,Key Vault"
+            },
+            "services": {
+              "description": "Domain-driven design with bounded contexts and clean architecture",
+              "name": "Microservices",
+              "technologies": "DDD,CQRS,Event Sourcing,The Standard"
+            }
+          },
+          "principles": {
+            "appRouter": {
+              "description": "File-based routing with layouts, loading states, and error boundaries",
+              "title": "App Router Architecture"
+            },
+            "cloudNative": {
+              "description": "Containerized microservices with auto-scaling and self-healing capabilities",
+              "title": "Cloud Native Design"
+            },
+            "rsc": {
+              "description": "Leveraging RSC for optimal performance with server-side rendering and streaming",
+              "title": "React Server Components"
+            }
+          },
+          "title": "Built for",
+          "titleHighlight": "scale and reliability"
+        },
+        "callToAction": {
+          "cta": {
+            "createAccount": "Create Account",
+            "exploreApplications": "Explore Applications"
+          },
+          "description": "Explore the platform, try out the features, and join the community. Whether you're here to manage invoices, discover recipes, or just explore, there's something for everyone.",
+          "footer": "Built with passion by",
+          "footerRole": ", a software engineer at Microsoft.",
+          "links": {
+            "getInTouch": "Get in Touch",
+            "meetAuthor": "Meet the Author",
+            "viewSource": "View Source Code"
+          },
+          "title": "Ready to",
+          "titleHighlight": "get started",
+          "trust": {
+            "freeToUse": {
+              "description": "No hidden fees or subscriptions",
+              "title": "Free to Use"
+            },
+            "openSource": {
+              "description": "100% open source with MIT license",
+              "title": "Open Source"
+            },
+            "privacyFirst": {
+              "description": "Your data stays yours, always",
+              "title": "Privacy First"
+            }
+          }
+        },
+        "features": {
+          "badge": "Platform Features",
+          "description": "A comprehensive suite of tools designed for modern personal finance management, recipe organization, and more. Built with cutting-edge technologies and a focus on user experience.",
+          "items": {
+            "ai": {
+              "description": "Intelligent automation at your fingertips",
+              "longDescription": "Powered by Azure OpenAI, our AI assistant helps with document understanding, data extraction, smart categorization, and natural language queries about your data.",
+              "tags": "GPT-4,Azure AI,NLP",
+              "title": "AI Assistant"
+            },
+            "analytics": {
+              "description": "Deep insights into your spending",
+              "longDescription": "Comprehensive analytics dashboard with spending trends, category breakdowns, monthly comparisons, and predictive insights powered by machine learning algorithms.",
+              "tags": "Charts,Trends,Reports",
+              "title": "Expense Analytics"
+            },
+            "auth": {
+              "description": "Flexible and secure sign-in options",
+              "longDescription": "Sign in with Microsoft, Google, GitHub, or email. Azure AD B2C provides enterprise-grade identity management with MFA support and seamless SSO experience.",
+              "tags": "OAuth,MFA,SSO",
+              "title": "Secure Authentication"
+            },
+            "budgets": {
+              "description": "Smart budget tracking and alerts",
+              "longDescription": "Set budgets by category and receive intelligent alerts when approaching limits. Visualize your spending with interactive charts and identify areas for optimization.",
+              "tags": "Budgets,Alerts,Planning",
+              "title": "Budget Management"
+            },
+            "i18n": {
+              "description": "Fully internationalized experience",
+              "longDescription": "The platform supports multiple languages with full RTL support. Currently available in English and Romanian, with more languages planned for future releases.",
+              "tags": "i18n,English,Romanian",
+              "title": "Multi-Language"
+            },
+            "invoices": {
+              "description": "AI-powered invoice analysis and management",
+              "longDescription": "Upload receipt photos and let AI extract merchant details, items, prices, and more. Automatic categorization, expense tracking, and detailed analytics help you understand your spending patterns.",
+              "tags": "AI,OCR,Analytics",
+              "title": "Invoice Processing"
+            },
+            "merchants": {
+              "description": "Automatic merchant detection and insights",
+              "longDescription": "Our AI identifies merchants from receipt data, building a comprehensive database of your shopping patterns. Get insights into where you shop, spending trends, and merchant comparisons.",
+              "tags": "ML,Insights,Tracking",
+              "title": "Merchant Intelligence"
+            },
+            "recipes": {
+              "description": "Organize and discover culinary creations",
+              "longDescription": "Store your favorite recipes, discover new ones, and plan meals efficiently. AI-powered suggestions based on ingredients, dietary preferences, and past cooking history.",
+              "tags": "Cooking,Meal Planning,AI",
+              "title": "Recipe Management"
+            },
+            "security": {
+              "description": "Bank-grade security for your data",
+              "longDescription": "Your data is protected with enterprise-grade encryption, secure authentication via Azure AD B2C, and compliance with GDPR. We never sell or share your personal information.",
+              "tags": "Encryption,GDPR,SSO",
+              "title": "Enterprise Security"
+            }
+          },
+          "modal": {
+            "close": "Close",
+            "exploreFeature": "Explore Feature"
+          },
+          "title": "Everything you need,",
+          "titleHighlight": "beautifully crafted"
+        },
+        "hero": {
+          "cta": {
+            "exploreFeatures": "Explore Features",
+            "viewSource": "View Source"
+          },
+          "description": "A comprehensive full-stack platform combining Next.js, .NET, and Azure cloud services. Built with enterprise-grade architecture, domain-driven design, and a focus on developer experience.",
+          "scrollIndicator": "Scroll to explore",
+          "stats": {
+            "countries": "Countries",
+            "linesOfCode": "Lines of Code",
+            "projects": "Projects",
+            "techStack": "Tech Stack"
+          },
+          "statusBadge": "Open Source Technology Platform",
+          "subtitle": "Modern • Scalable • Open Source",
+          "title": "Welcome to",
+          "trust": {
+            "freeForever": "Free Forever",
+            "openSource": "Open Source",
+            "privacyFirst": "Privacy First"
+          }
+        },
+        "statistics": {
+          "badge": "Platform Statistics",
+          "description": "A glimpse into the scale and impact of the arolariu.ro platform, from lines of code to global reach.",
+          "items": {
+            "apis": {
+              "description": "Microservices",
+              "label": "APIs",
+              "suffix": "+",
+              "value": "8"
+            },
+            "commits": {
+              "description": "Code contributions",
+              "label": "Commits",
+              "suffix": "+",
+              "value": "2500"
+            },
+            "contributors": {
+              "description": "Open source",
+              "label": "Contributors",
+              "suffix": "+",
+              "value": "5"
+            },
+            "countries": {
+              "description": "Global reach",
+              "label": "Countries",
+              "suffix": "+",
+              "value": "25"
+            },
+            "linesOfCode": {
+              "description": "Across all projects",
+              "label": "Lines of Code",
+              "suffix": "K+",
+              "value": "150"
+            },
+            "projects": {
+              "description": "Active repositories",
+              "label": "Projects",
+              "suffix": "+",
+              "value": "15"
+            },
+            "stars": {
+              "description": "GitHub stars",
+              "label": "Stars",
+              "suffix": "+",
+              "value": "50"
+            },
+            "users": {
+              "description": "Active monthly",
+              "label": "Users",
+              "suffix": "+",
+              "value": "1000"
+            }
+          },
+          "title": "Numbers that",
+          "titleHighlight": "speak for themselves"
+        },
+        "techStack": {
+          "badge": "Technology Stack",
+          "categories": {
+            "backend": {
+              "description": "Scalable server-side technologies and APIs",
+              "name": "Backend"
+            },
+            "cloud": {
+              "description": "Infrastructure and deployment automation",
+              "name": "Cloud & DevOps"
+            },
+            "frontend": {
+              "description": "Modern web technologies for blazing-fast user experiences",
+              "name": "Frontend"
+            },
+            "tooling": {
+              "description": "Tools and frameworks for development excellence",
+              "name": "Developer Tools"
+            }
+          },
+          "description": "A carefully curated technology stack chosen for performance, developer experience, and long-term maintainability.",
+          "stats": {
+            "coverage": {
+              "description": "Unit & E2E tests",
+              "label": "Test Coverage",
+              "value": "90%+"
+            },
+            "security": {
+              "description": "Best practices",
+              "label": "Security Grade",
+              "value": "A+"
+            },
+            "technologies": {
+              "description": "In our stack",
+              "label": "Technologies",
+              "value": "24+"
+            },
+            "typescript": {
+              "description": "Full type safety",
+              "label": "TypeScript",
+              "value": "100%"
+            }
+          },
+          "technologies": {
+            "aspnet": {
+              "description": "High-performance web APIs",
+              "name": "ASP.NET Core"
+            },
+            "azure": {
+              "description": "Primary cloud provider",
+              "name": "Azure"
+            },
+            "azureDevops": {
+              "description": "Project management & pipelines",
+              "name": "Azure DevOps"
+            },
+            "azuresql": {
+              "description": "Managed relational database",
+              "name": "Azure SQL"
+            },
+            "bicep": {
+              "description": "Infrastructure as Code",
+              "name": "Bicep"
+            },
+            "cosmosdb": {
+              "description": "Globally distributed NoSQL database",
+              "name": "CosmosDB"
+            },
+            "docker": {
+              "description": "Containerization platform",
+              "name": "Docker"
+            },
+            "dotnet": {
+              "description": "Primary backend framework",
+              "name": ".NET"
+            },
+            "eslint": {
+              "description": "JavaScript linting with 20+ plugins",
+              "name": "ESLint"
+            },
+            "git": {
+              "description": "Version control system",
+              "name": "Git"
+            },
+            "githubActions": {
+              "description": "CI/CD automation",
+              "name": "GitHub Actions"
+            },
+            "motion": {
+              "description": "Production-ready animations",
+              "name": "Motion"
+            },
+            "nextjs": {
+              "description": "Full-stack React framework with SSR/SSG",
+              "name": "Next.js"
+            },
+            "nodejs": {
+              "description": "BFF and serverless functions",
+              "name": "Node.js"
+            },
+            "playwright": {
+              "description": "E2E testing framework",
+              "name": "Playwright"
+            },
+            "pnpm": {
+              "description": "Package management",
+              "name": "pnpm/npm"
+            },
+            "prettier": {
+              "description": "Code formatting",
+              "name": "Prettier"
+            },
+            "react": {
+              "description": "UI library for building interactive interfaces",
+              "name": "React"
+            },
+            "redis": {
+              "description": "In-memory cache for performance",
+              "name": "Redis"
+            },
+            "scss": {
+              "description": "Component-scoped stylesheets with CSS Modules",
+              "name": "SCSS Modules"
+            },
+            "typescript": {
+              "description": "Type-safe JavaScript for robust code",
+              "name": "TypeScript"
+            },
+            "vercel": {
+              "description": "Frontend deployment platform",
+              "name": "Vercel"
+            },
+            "vitest": {
+              "description": "Unit testing framework",
+              "name": "Vitest"
+            },
+            "zustand": {
+              "description": "Lightweight state management",
+              "name": "Zustand"
+            }
+          },
+          "title": "Powered by",
+          "titleHighlight": "modern technologies"
+        },
+        "timeline": {
+          "badge": "Development Journey",
+          "collapseHint": "Click to collapse",
+          "description": "The journey of arolariu.ro from a simple idea to a full-featured platform, with key milestones along the way.",
+          "events": {
+            "ai": {
+              "date": "June 2024",
+              "description": "Deep integration with Azure OpenAI for intelligent document processing and natural language queries.",
+              "details": "Azure OpenAI GPT-4 integration,Natural language invoice queries,Smart categorization algorithms,Predictive analytics features",
+              "tags": "GPT-4,Azure AI,NLP",
+              "title": "AI Integration"
+            },
+            "backend": {
+              "date": "September 2022",
+              "description": "Complete backend overhaul with .NET and cloud-native architecture implementation.",
+              "details": ".NET 6 API development,Azure cloud infrastructure setup,Database design with CosmosDB,CI/CD pipeline implementation",
+              "tags": ".NET,Azure,API",
+              "title": "Backend Infrastructure"
+            },
+            "expansion": {
+              "date": "January 2023",
+              "description": "Major feature additions including invoice processing and AI-powered analysis capabilities.",
+              "details": "Invoice upload and OCR integration,Azure Document Intelligence integration,Merchant detection algorithms,Budget tracking features",
+              "tags": "AI,OCR,Invoices",
+              "title": "Platform Expansion"
+            },
+            "inception": {
+              "date": "March 2022",
+              "description": "The arolariu.ro platform was conceived as a personal learning project to explore modern web development.",
+              "details": "Initial concept and planning phase,Research into modern web technologies,First repository created on GitHub,Basic HTML/CSS prototype developed",
+              "tags": "Planning,Research",
+              "title": "Project Inception"
+            },
+            "launch": {
+              "date": "June 2023",
+              "description": "Official public launch with a complete set of features and production-ready infrastructure.",
+              "details": "Production deployment to Azure,Custom domain configuration,SSL/TLS security implementation,Performance optimization",
+              "tags": "Launch,Production",
+              "title": "Public Launch"
+            },
+            "nextjs": {
+              "date": "December 2023",
+              "description": "Complete frontend rewrite to Next.js App Router with React Server Components.",
+              "details": "Migration to Next.js 14+,React Server Components adoption,Improved SEO with static generation,Enhanced performance metrics",
+              "tags": "Next.js,RSC,Migration",
+              "title": "Next.js Migration"
+            },
+            "present": {
+              "date": "Present",
+              "description": "Ongoing development with new features, optimizations, and community contributions.",
+              "details": "Regular feature updates,Performance improvements,Community feedback integration,Future roadmap planning",
+              "tags": "Active,Growing",
+              "title": "Continuous Evolution"
+            },
+            "prototype": {
+              "date": "June 2022",
+              "description": "The first working prototype of the platform was developed using React and basic backend services.",
+              "details": "React frontend implementation,Basic authentication flow,Initial UI/UX design,Local development environment setup",
+              "tags": "React,Frontend",
+              "title": "First Prototype"
+            }
+          },
+          "expandHint": "Click to expand",
+          "futureIndicator": "The journey continues...",
+          "keyAchievements": "Key Achievements:",
+          "title": "From idea to",
+          "titleHighlight": "reality"
+        }
       }
     },
-    "newsletterSubscribed": {
-      "subject": "You're subscribed!",
-      "badge": "Newsletter",
-      "heading": "You're in — welcome aboard",
-      "preview": "Welcome, {name} — you're subscribed.",
-      "greeting": "Hi {name},",
-      "intro": "Thanks for subscribing to the <brand>{brandName}</brand> newsletter. I'm genuinely excited to have you here. I'll keep communications lightweight, meaningful, and worth your time.",
-      "whatToExpectTitle": "What to expect",
-      "whatToExpect": {
-        "0": "Product updates & new features as they launch",
-        "1": "New articles & write-ups about technology, productivity, and personal finance",
-        "2": "Occasional highlights and curated resources (1–2 emails per quarter)"
-      },
-      "body": "Your inbox is sacred—I respect that. Every email is crafted to provide genuine value, whether it's a tip that saves you hours or an insight that shifts your perspective on personal finance.",
-      "feedbackPrompt": "Questions, feedback, or just want to say hello? Reply to this email or reach me directly at <email></email>.",
-      "ctaPrimary": "Visit arolariu.ro",
-      "signOff": {
-        "line1": "Best regards",
-        "line2": "The {brand} Team"
-      }
-    },
-    "newsletterUnsubscribed": {
-      "subject": "You've been unsubscribed",
-      "badge": "Newsletter",
-      "heading": "You've been unsubscribed",
-      "preview": "Hi {name} — you've been unsubscribed.",
-      "greeting": "Hi {name},",
-      "intro": "This email confirms you've been removed from the <brand>{brandName}</brand> newsletter list. I'm sorry to see you go.",
-      "whatHappensNextTitle": "What happens next",
-      "whatHappensNext": {
-        "0": "You won't receive newsletter updates from us going forward.",
-        "1": "You may still receive essential account and service emails if you use the product.",
-        "2": "Changed your mind? You can resubscribe at any time using the button above."
-      },
-      "body": "I appreciate the time you spent with us. If you have feedback about why you left or how I can improve, I'd genuinely love to hear it—just reply to this email.",
-      "feedbackPrompt": "If you didn't request this unsubscription, or you need help with anything, please contact <email></email>.",
-      "ctaPrimary": "Review preferences",
-      "ctaSecondary": "Resubscribe",
-      "signOff": {
-        "line1": "Best regards",
-        "line2": "The {brand} Team"
-      }
-    },
-    "accountInactivity": {
-      "subject": "We miss you at {brand}",
-      "badge": "Account",
-      "heading": "Account inactivity notice",
-      "preview": "Hi {name} — your account has been inactive for {inactiveDays} days.",
-      "greeting": "Hi {name},",
-      "intro": "This is a heads-up that your account has been inactive for <count>{inactiveDays}</count> days.",
-      "whatThisMeans": {
-        "title": "What this means",
-        "bullet1": "Signing in will keep your account active.",
-        "bullet2": "If there's no activity for the next {daysUntilClosure} days, the account may be scheduled for closure.",
-        "bullet3": "If you want to keep your data, please take action before the deadline."
-      },
+    "invoices": {
       "timeline": {
-        "title": "Timeline",
-        "inactiveFor": "Inactive for",
-        "timeRemaining": "Time remaining",
-        "daysValue": "{days} days"
-      },
-      "supportPrompt": "If you believe you received this message in error, or you need assistance, please contact <link>{supportEmail}</link>.",
-      "signOff": {
-        "line1": "Best regards,",
-        "line2": "The {brand} Team"
-      },
-      "footnote": "Note: This notice is informational and intended to help you avoid losing access. Actual account retention policies may vary by region and product.",
-      "cta": {
-        "primary": "Sign in",
-        "secondary": "Contact support"
+        "item": {
+          "aria": {
+            "moreInfo": "More info about {title}"
+          },
+          "confidence": "Confidence: {value}%",
+          "events": {
+            "aiAnalysis": {
+              "description": "{count, plural, one {# item detected and categorized} other {# items detected and categorized}}",
+              "title": "AI Analysis Complete"
+            },
+            "categorized": {
+              "description": "Auto-categorized based on items",
+              "title": "Category Assigned"
+            },
+            "created": {
+              "description": "Scanned and digitized from receipt",
+              "title": "Invoice Created"
+            },
+            "edited": {
+              "title": "Invoice Updated"
+            },
+            "exported": {
+              "title": "Invoice Exported"
+            },
+            "markedImportant": {
+              "description": "Flagged for priority tracking",
+              "title": "Marked as Important"
+            },
+            "recipesGenerated": {
+              "description": "{count, plural, one {# recipe suggested} other {# recipes suggested}}",
+              "title": "Recipes Generated"
+            },
+            "shared": {
+              "description": "Shared with {count, plural, one {# person} other {# people}}",
+              "title": "Shared with Others"
+            }
+          },
+          "fallbacks": {
+            "ocr": "OCR",
+            "pdf": "PDF"
+          },
+          "relativeTime": {
+            "now": "Just now"
+          },
+          "tooltips": {
+            "aiAnalysis": "AI processed this invoice in {duration} and analyzed {count, plural, one {# item} other {# items}}.",
+            "categorized": "Invoice was assigned a category for better organization.",
+            "created": "Invoice was scanned and digitized using {method}.",
+            "edited": "Manual changes were made to the invoice.",
+            "exported": "Invoice was exported in {format} format.",
+            "markedImportant": "Invoice was flagged as important for quick access.",
+            "recipesGenerated": "Based on purchased ingredients, {count, plural, one {# recipe was generated} other {# recipes were generated}}.",
+            "shared": "Invoice was shared with {count, plural, one {# user} other {# users}}.",
+            "unavailable": "Event details unavailable"
+          }
+        }
       }
     },
-    "invoiceInactivity": {
-      "subject": "It's been {daysWithoutUpload} days since your last invoice",
-      "badge": {
-        "3": "Inactivity • 3 days",
-        "7": "Inactivity • 7 days",
-        "14": "Inactivity • 14 days",
-        "30": "Inactivity • 30 days"
+    "legal": {
+      "acknowledgements": {
+        "contributors": {
+          "items": {
+            "c1": {
+              "description": "Observability instrumentation",
+              "name": "OpenTelemetry Authors",
+              "packages": "12"
+            },
+            "c2": {
+              "description": "Azure SDKs and tooling",
+              "name": "Microsoft Corporation",
+              "packages": "5"
+            },
+            "c3": {
+              "description": "Authentication solutions",
+              "name": "Clerk",
+              "packages": "2"
+            },
+            "c4": {
+              "description": "Testing utilities",
+              "name": "Kent C. Dodds",
+              "packages": "3"
+            }
+          },
+          "packages": "{count, plural, one {# package} other {# packages}}",
+          "subtitle": "Organizations and individuals whose packages we rely on most",
+          "title": "Top Contributors"
+        },
+        "hero": {
+          "badge": "Open Source",
+          "lastUpdate": "Last updated: {date}",
+          "subtitle": "This platform is built on the shoulders of incredible open-source projects. We're grateful to the maintainers and contributors who make their work freely available.",
+          "title": "Acknowledgements"
+        },
+        "lastUpdate": "Last updated on: {date}",
+        "licenses": {
+          "apache": "Apache 2.0",
+          "apacheDescription": "Enterprise-friendly open-source license",
+          "gpl": "GPL License",
+          "gplDescription": "Copyleft license ensuring code remains free",
+          "mit": "MIT License",
+          "mitDescription": "Permissive license allowing broad use",
+          "other": "Other Licenses",
+          "otherDescription": "Custom or miscellaneous open-source licenses",
+          "packages": "{count, plural, one {# package} other {# packages}}",
+          "title": "License Distribution"
+        },
+        "packages": {
+          "subtitle": "This website could not have been possible without the following third-party packages. I would like to thank the authors of these packages for their hard work and dedication to the open-source community.",
+          "title": "Third-party packages"
+        },
+        "packagesScreen": {
+          "badge": {
+            "development": "Development",
+            "production": "Production"
+          },
+          "card": {
+            "dependencies": "Dependencies:",
+            "license": "License:",
+            "viewDependencies": "View Dependencies",
+            "website": "Website"
+          },
+          "dialog": {
+            "dependencies": "{name} Dependencies",
+            "dependenciesCount": "This package has {count} dependencies."
+          },
+          "emptyState": {
+            "subtitle": "Try adjusting the filters above.",
+            "title": "No packages found."
+          },
+          "filters": {
+            "allPackages": "All Packages",
+            "ascending": "Ascending",
+            "dependenciesCount": "Dependencies Count",
+            "descending": "Descending",
+            "developmentOnly": "Development Only",
+            "filterByType": "Filter by type",
+            "name": "Name",
+            "packageType": "Package Type",
+            "productionOnly": "Production Only",
+            "sortBy": "Sort by",
+            "sortDirection": "Sort direction"
+          },
+          "openSource": {
+            "description": "This project stands on the shoulders of giants. We're grateful for the open-source community and all the developers who have contributed to these packages.",
+            "title": "Open Source Matters"
+          },
+          "search": {
+            "placeholder": "Search..."
+          },
+          "table": {
+            "dependencies": "Dependencies",
+            "description": "Description",
+            "license": "License",
+            "package": "Package",
+            "type": "Type",
+            "version": "Version",
+            "website": "Website"
+          },
+          "views": {
+            "gridView": "Grid View",
+            "tableView": "Table View"
+          }
+        },
+        "stats": {
+          "development": {
+            "description": "Build-time tools",
+            "label": "Development",
+            "value": "{count}"
+          },
+          "mitLicense": {
+            "description": "Most common license",
+            "label": "MIT Licensed",
+            "value": "{count}"
+          },
+          "production": {
+            "description": "Runtime dependencies",
+            "label": "Production",
+            "value": "{count}"
+          },
+          "subtitle": "A snapshot of the open-source ecosystem powering this platform",
+          "title": "Dependency Overview",
+          "total": {
+            "description": "Dependencies used",
+            "label": "Total Packages",
+            "value": "{count}"
+          }
+        },
+        "title": "Acknowledgements"
       },
-      "heading": {
-        "3": "Quick check-in",
-        "7": "A gentle reminder",
-        "14": "Let's get you back on track",
-        "30": "It's been a while"
+      "privacyPolicy": {
+        "contactInformation": {
+          "content": "If you have any questions about our Privacy Policy, please contact us at admin@arolariu.ro",
+          "title": "Contact Information"
+        },
+        "lastUpdated": "Last updated: 2024-01-01",
+        "terms": {
+          "childrenPrivacy": {
+            "content": "Our website is not intended for children under the age of 13. We do not knowingly collect Personal Data from children under the age of 13. If you are a parent or guardian and you are aware that your child has provided us with Personal Data, please contact us. If we become aware that we have collected Personal Data from children without verification of parental consent, we will take steps to remove that information from our servers.",
+            "title": "Children's Privacy"
+          },
+          "cookiesDefinition": {
+            "content": "Cookies are small pieces of data stored on your device (computer or mobile device). Cookies are used to improve your experience on our website and to provide you with relevant content. For more information on cookies, please visit https://www.allaboutcookies.org/ <br></br><br></br><br></br> We use cookies to collect information about your device and your use of our website. Our website analytics provider uses cookies to generate statistical and other information about website use by means of cookies. <br></br><br></br><br></br> You can opt-out of cookies by using the settings in your browser. Please note that if you disable cookies, you may not be able to use all the features of our website. <br></br><br></br><br></br> We will only retain your Personal Data for as long as necessary for the purpose for which that data was collected and to the extent required by applicable law. When we no longer need Personal Data, we will remove it from our systems and/or take steps to anonymize it.",
+            "title": "What are Cookies?"
+          },
+          "dataCollectionTerms": {
+            "content": "a) When you make a purchase or attempt to make a purchase, we collect the following types of Personal Data: <ul> <li> Payment Information such as your billing address, phone number, credit card, debit card and/or other payment method information; </li><li> Account Information such as your name, username, e-mail address; </li><li> Purchase Information specifically if personalized or unique;</li> <li>Demographic Data;</li> <li>Location Data.</li> </ul> <br></br><br></br> b) When you visit and use our website, we automatically collect the following types of Personal Data: <ul> <li> Payment Information such as your billing address, phone number, credit card, debit card and/or other payment method information; </li> <li>Device Data, such as your computer, phone, tablet or other device you use to access our website;</li> <li>Communication Data, such as your preferences for receiving communications from us;</li> <li>Feedback, such as customer support, product reviews, surveys and/or other feedback;</li> <li>Content Data, such as content you submit to us: posts, documents, audio, images, etc.;</li> <li>Usage Data, such as how you use our website, products and services;</li> <li>Account Information such as your name, username, e-mail address;</li> <li>Purchase Information specifically if personalized or unique;</li> <li>Demographic Data;</li> <li>Location Data;</li></ul>",
+            "title": "What Personal Data We Collect"
+          },
+          "dataTransferTerms": {
+            "content": "Where possible, we store and process data on servers within the general geographical region where you reside (note: this may not be within the country in which you reside). <span> Specifically, for European based users, companies and customers, we have servers in the European Economic Area (EEA). </span> Your Personal Data may also be transferred to, and maintained on, servers residing outside of your state, province, country or other governmental jurisdiction where the data laws may differ from those in your jurisdiction. We will take appropriate steps to ensure that your Personal Data is treated securely and in accordance with this Policy as well as applicable data protection law. Data may be kept in other countries that are considered adequate under your laws. <br></br><br></br><br></br><br></br> More information about these clauses can be found here: https://eur-lex.europa.eu/legal-content/en/TXT/?uri=CELEX:32021D0914",
+            "title": "International Data Transfer and Storage"
+          },
+          "deviceUsageTerms": {
+            "content": "When you visit a <code>AROLARIU.RO</code> website and/or mobile application, we automatically collect and store information about your visit using browser cookies (files which are sent by us to your computer), or similar technologies. You can instruct your browser to refuse all cookies or to indicate when a cookie is being sent. The `Help` feature on most browsers will provide information on how to accept cookies, disable cookies or to notify you when receiving a new cookie. If you do not accept cookies, you may not be able to use some features of our Service and we recommend that you leave them turned on. <br></br><br></br><br></br> We also process information when you use our services and products. This information may include: <ul> <li>   Information about your interactions with our services, including the time and date of your interactions,   and your interactions with our emails; </li> <li>   Information about your use of our services, including the type of browser you use, access times, pages   viewed, your IP address; </li> <li>   Information about your purchases, including the items you purchase, the date of purchase, and the payment   method you use; </li> <li>   Information about your device, including the type of device, its operating system, and mobile network   information; </li> <li>   Other information you provide to us, including your feedback, comments, and other information you provide   to us; </li> <li>Information about your location, including your general location based on your IP address;</li> <li>Other information we collect with your consent or as permitted or required by law;</li> <li>Information about your preferences, including your language preferences.</li> </ul>",
+            "title": "Device and Usage Data"
+          },
+          "exerciseRights": {
+            "content": "To exercise your rights, please contact us using the contact details provided under the “Contact Us” section below. We will respond to your request within a reasonable timeframe and in accordance with applicable law. <br></br><br></br> For your own safety and security, we may need to verify your identity before responding to your request. We will make reasonable efforts to verify your identity by asking for information that we have on file about you.",
+            "title": "How to Exercise Your Rights"
+          },
+          "howWeCollectDataTerms": {
+            "content": "We collect Personal Data in the following ways: <br></br><br></br> <span>1. From you.</span> <br></br> We collect Personal Data from you when you provide it to us directly or indirectly, by using our website, products or services. This includes: <br></br> <ul> <li>When you create an account or purchase products on our website;</li> <li>When you download software and/our our mobile application;</li> <li>When you participate in our surveys, contests or promotions;</li> <li>When you create content through our products and services;</li> <li>When you contact us with an inquiry or to report a problem;</li> <li>When you express interest(s) in our products and services;</li> <li>When you use our website, products or services;</li> <li>When you interact with us on social media;</li> <li>When you subscribe to our newsletter;</li> <li>When you provide it to us directly;</li> <li>When you communicate with us.</li> </ul> <br></br><br></br><br></br><br></br> <span>2. Automated technologies or interactions.</span> <br></br> <br></br> As you interact with our website, we may automatically collect the following types of data (all as described above): Device Data about your equipment, Usage Data about your browsing actions and patterns, and Contact Data where tasks carried out via our website remain uncompleted, such as incomplete orders or abandoned baskets. We collect this data by using cookies, server logs and other similar technologies. Please see our Cookie section (below) for further details. <br></br><br></br><br></br><br></br> <span>3. Third parties or publicly available sources.</span> <br></br><br></br> We may receive Personal Data about you from various third parties, including: <ul> <li>   Account Information and Payment Data from third parties, including organizations (such as law enforcement   agencies), associations and groups, who share data for the purposes of fraud prevention and detection and   credit risk reduction </li> <li>Contact, Financial and Transaction Data from providers of technical, payment and delivery services</li> <li>Technical Data from analytics providers such as Google Analytics</li> <li>Identity and Contact Data from data brokers or aggregators</li> <li>Identity and Contact Data from publicly available sources</li> </ul> <br></br><br></br><br></br><br></br><span> If you provide us, or our service providers, with any Personal Data relating to other individuals, you represent that you have the authority to do so and acknowledge that it will be used in accordance with this Policy. If you believe that your Personal Data has been provided to us improperly, or to otherwise exercise your rights relating to your Personal Data, please contact us by using the information set out in the “Contact Us” section below.</span>",
+            "title": "How We Collect Personal Data"
+          },
+          "legalTerms": {
+            "content": "We may use or disclose your Personal Data in order to comply with a legal obligation, in connection with a request from a public or government authority, or in connection with court or tribunal proceedings, to prevent loss of life or injury, or to protect our rights or property. Where possible and practical to do so, we will tell you in advance of such disclosure.",
+            "title": "Legal Requirements"
+          },
+          "personalDataRights": {
+            "content": "You have the right to access, correct, update or delete your Personal Data. You also have the right to object to the processing of your Personal Data, ask us to restrict the processing of your Personal Data or request portability of your Personal Data. You can exercise these rights by contacting us using the contact details provided under the “Contact us” section below. <br></br><br></br><br></br> Depending on your geographical location and citizenship, your rights are subject to local data privacy regulations. These rights may include: <ul> <li>   Right to be Forgotten (right to erasure) (GDPR Article 17, CCPA/CPRA, CPA, VCDPA, CTDPA, UCPA, LGPD,   POPIA) </li> <li>Right to Access (PIPEDA, GDPR Article 15, CCPA/CPRA, CPA, VCDPA, CTDPA, UCPA, LGPD, POPIA)</li> <li>Right to Rectification (PIPEDA, GDPR Article 16, CPRA, CPA, VCDPA, CTDPA, LGPD, POPIA)</li> <li>Nondiscrimination and nonretaliation (CCPA/CPRA, CPA, VCDPA, CTDPA, UCPA)</li> <li>Right to Restriction of Processing (GDPR Article 18, LGPD)</li> <li>Right to Opt Out (CPRA, CPA, VCDPA, CTDPA, UCPA)</li> <li>Right to Portability (PIPEDA, GDPR Article 20, LGPD)</li> <li>Right to Objection (GDPR Article 21, LGPD, POPIA)</li> </ul> <br></br><br></br><br></br> If you want to file an appeal or complaint about how we process your Personal Data, you can contact us using the contact details provided under the “Contact us” section below. You also have the right to file a complaint with the data protection authority in your jurisdiction. <br></br> In the case that you did contact us and you are not satisfied with our response, you have the right to file an appeal with the attorney general located here: <ul> <li>   If you are based in the EEA, please visit https://edpb.europa.eu/about-edpb/about-edpb/members_en website for a list of local data protection authorities. </li> <li>   If you are based in Connecticut, please visit https://portal.ct.gov/AG/Common/Complaint-Form-Landing-page website to file a complaint. </li> <li> If you are based in Colorado, please visit https://complaints.coag.gov/s/contact-us website to file a complaint. </li> <li> If you are based in Virginia, please visit https://www.oag.state.va.us/consumer-protection/index.php/file-a-complaint website to file a complaint. </li></ul>",
+            "title": "Your Rights for Your Personal Data"
+          },
+          "policyChanges": {
+            "content": "We may update this Policy from time to time. If we make significant changes, we will let you know, but please regularly check this Policy to ensure you are aware of the most updated version.",
+            "title": "Changes to this Policy"
+          },
+          "processingDataTerms": {
+            "content": "We collect and use your Personal Data with your consent to provide, maintain, and develop our products and services and understand how to further improve them. <br></br><br></br><br></br> These purposes include: <ul> <li>Building a safe and secure environment for our users and our community;</li> <li>Conducting research and analysis to improve our products and services;</li> <li>Communicating with you about your account, purchases, or inquiries;</li> <li>Investigate and prevent security incidents and other illegal activities;</li> <li>Personalizing your experience with our products and services;</li> <li>Deliver, maintain and improve our products and services;</li> <li>Providing you with the products and services you request;</li> <li>Providing you with marketing communications;</li> <li>Providing you with customer support;</li> <li>Protecting our products and services;</li> <li>Other purposes with your consent;</li> <li>Complying with legal obligations.</li> </ul> <br></br><br></br><br></br><br></br> Where we process your Personal Data to provide a product or service, we do so because it is necessary to perform contractual obligations. All of the above processing is necessary in our legitimate interests to provide products and services and to maintain our relationship with you and to protect our business for example against fraud. Consent will be required to initiate services with you. New consent will be required if any changes are made to the type of data collected. Within our contract, if you fail to provide consent, some services may not be available to you.",
+            "title": "Purpose and Legal Basis for the Processing of Personal Data"
+          },
+          "processingTerms": {
+            "content": "This policy applies when you visit our website, use our products or services, or interact with us. <br></br> Additionally, this policy applies when you: <ul> <li> Make use of our application and services as an authorized user;</li> <li>Visit any of our websites that link to this Privacy Policy;</li> <li>Receive any communication from us, including e-mails.</li></ul>",
+            "title": "Processing Activities"
+          },
+          "safeDataTerms": {
+            "content": "We have implemented appropriate technical and organizational security measures designed to protect the security of any Personal Data we process. However, please also remember that we cannot guarantee that the internet itself is 100% secure. Although we will do our best to protect your Personal Data, the transmission of Personal Data to and from our website is at your own risk. You should only access the services within a secure environment. <br></br><br></br><br></br> We have appropriate organizational safeguards and security measures in place to protect your Personal Data from being accidentally lost, used or accessed in an unauthorized way, altered or disclosed. <br></br><br></br><br></br> The communication between your browser and our website uses a secure encrypted connection wherever your Personal Data is involved. <br></br><br></br><br></br> We require any third party who is contracted to process your Personal Data on our behalf to have security measures in place to protect your data and to treat such data in accordance with the law. <br></br><br></br><br></br> In the unfortunate event of a Personal Data breach, we will notify you and any applicable regulator when we are legally required to do so.",
+            "title": "How We Keep Your Data Safe"
+          },
+          "scopeTerms": {
+            "content": "This policy applies to the <code> AROLARIU.RO </code> website, products, and services. It also applies to the use of our website, products, and services by our customers, partners, and visitors. <br></br><br></br> This Policy does not apply to third-party applications, websites, products, services or platforms that may be accessed through (non-<code>AROLARIU.RO</code>) links that we may provide to you. These sites are owned and operated independently from us, and they have their own separate privacy and data collection practices. Any Personal Data that you provide to these websites will be governed by the third-party's own privacy policy. We cannot accept liability for the actions or policies of these independent sites, and we are not responsible for the content or privacy practices of such sites.",
+            "title": "Scope of the Policy"
+          },
+          "serviceProviderTerms": {
+            "content": "We may use a third party service provider, independent contractors, agencies, or consultants to deliver and help us improve our products and services. We may share your Personal Data with marketing agencies, database service providers, backup and disaster recovery service providers, e-mail service providers and others but only to maintain and improve our products and services. <br></br><br></br> For further information on the recipients of your Personal Data, please contact us by using the information in the “Contact Us” section below.",
+            "title": "Service Providers and Other Third Parties"
+          },
+          "sharingAndDisclosureTerms": {
+            "content": "We will share your Personal Data with third parties only in the ways set out in this Policy or set out at the point when the Personal Data is collected. <br></br><br></br><br></br> We also use Google Analytics to help us understand how our customers use the site. You can read more about how Google uses your Personal Data here: https://www.google.com/intl/en/policies/privacy/ <br></br><br></br><br></br> You can also opt-out of Google Analytics here: https://tools.google.com/dlpage/gaoptout <br></br><br></br><br></br> We may also share your Personal Data with third parties where required by law, where it is necessary to administer the relationship between us or where we have another legitimate interest in doing so. We may also share your Personal Data with third parties to whom we may choose to sell, transfer, or merge parts of our business or our assets. Alternatively, we may seek to acquire other businesses or merge with them. <br></br><br></br><br></br> For more information about how targeted advertising works, you can visit the Network Advertising Initiative's (NAI) educational page at: https://www.networkadvertising.org/understanding-online-advertising/how-does-it-work <br></br><br></br><br></br> Additionally, you can opt out of some of these services by visiting the Digital Advertising Alliance's opt-out: https: //optout.aboutads.info/",
+            "title": "Sharing and Disclosure of Personal Data"
+          },
+          "thirdPartyData": {
+            "content": "We may receive your Personal Data from third parties such as companies subscribing to <code>AROLARIU.RO</code> services, partners and other sources. This Personal Data is not collected by us but by a third party and is subject to the relevant third party's own separate privacy and data collection policies. We do not have any control or input on how your Personal Data is handled by third parties. As always, you have the right to review and rectify this information. If you have any questions you should first contact the relevant third party for further information about your Personal Data. Where that third party is unresponsive to your rights, you may contact the Data Protection Officer at <code> AROLARIU.RO </code> (contact details below). <br></br><br></br><br></br>  Our websites and services may contain links to other websites, applications and services maintained by third parties. The information practices of such other services, or of social media networks that host our branded social media pages, are governed by third parties's privacy statements, which you should review to better understand those third parties's privacy practices.",
+            "title": "Data we collect from third parties"
+          },
+          "whatIsTerms": {
+            "content": "At <code> AROLARIU.RO </code> (“us”, “we”, “our” or the ”Company“) we value your privacy and the importance of safeguarding your data. This Privacy Policy (the “Policy”) describes our privacy practices for the activities set out below. <br></br> <br></br> As per your rights, we inform you how we collect, store, access, and otherwise process information relating to individuals. In this Policy, personal data (“Personal Data”) refers to any information that on its own, or in combination with other available information, can identify an individual. <br></br> <br></br> We are committed to protecting your privacy in accordance with the highest level of privacy regulation. As such, we follow the obligations under the below regulations: <ul> <li> California\"s Consumer Privacy Act (CCPA) / California Privacy Rights Act (CPRA) and California Online Privacy Protection Act (CalOPPA) </li> <li> Canada\"s Personal Information Protection and Electronic Documents Act (PIPEDA) and the applicable provincial legislations </li> <li> The European Union\"s General Data Protection Regulation (GDPR) </li> <li> South Africa\"s Protection of Personal Information Act (POPIA) </li> <li> Virginia Consumer Data Protection Act (VCDPA) </li> <li> Brazil\"s Data Protection Legislation (LGPD) </li> <li> Connecticut Data Privacy Act (CTDPA) </li> <li> Utah Consumer Privacy Act (UCPA) Colorado Privacy Act (CPA) </li> </ul>",
+            "title": "What is AROLARIU.RO?"
+          },
+          "withdrawingConsent": {
+            "content": "If you have given your consent to the processing of your Personal Data, you have the right to withdraw your consent at any time. To withdraw your consent, please contact us using the contact details provided under the “Contact Us” section below.",
+            "title": "Withdrawing Consent"
+          }
+        },
+        "title": "Privacy Policy"
       },
-      "preview": "Hi {name} — {days} days since your last upload.",
-      "greeting": "Hi {name},",
-      "intro": {
-        "3": "We noticed you haven't uploaded any invoices recently.",
-        "7": "Looks like it's been a week since your last invoice upload.",
-        "14": "Two weeks without uploads — want a quick nudge to restart the habit?",
-        "30": "It's been about a month since your last upload — we can help you pick up where you left off."
-      },
-      "whyWorthIt": {
-        "title": "Why it's worth it",
-        "bullet1": "Keep your spending timeline accurate.",
-        "bullet2": "Get cleaner totals by merchant and category.",
-        "bullet3": "Find receipts faster when you need them."
-      },
-      "status": {
-        "title": "Status",
-        "daysWithoutUpload": "Days without upload",
-        "lastUpload": "Last upload"
-      },
-      "tip": {
-        "title": "Tip (30 seconds)",
-        "message": "Upload one recent invoice today — small consistency beats big catch-up."
-      },
-      "important": {
-        "title": "Important",
-        "message": "If you're stuck or something isn't working, reply to this email or contact support — we'll help."
-      },
-      "helpPrompt": "Need help or have questions? Email <link>{supportEmail}</link>.",
-      "signOff": {
-        "line1": "Best regards",
-        "line2": "The {brand} Team"
-      },
-      "cta": {
-        "primary": "Upload an invoice",
-        "secondary": "View invoices"
+      "termsOfService": {
+        "contactInformation": {
+          "content": "If you have any questions about our Terms of Service, please contact us at admin@arolariu.ro",
+          "title": "Contact Information"
+        },
+        "lastUpdated": "Last updated: 2024-01-01",
+        "terms": {
+          "amendmentsTerms": {
+            "content": "We reserve the right to modify, supplement or replace the terms of the Agreement, effective upon posting at www.arolariu.ro or notifying you otherwise. If you do not want to agree to changes to the Agreement, you can terminate the Agreement at any time per the terms herein. If a revision is material we will provide at least 30 days' notice prior to any new terms taking effect. What constitutes a material change will be determined at our sole discretion. By continuing to access or use our service after any revisions become effective, you agree to be bound by the revised terms. If you do not agree to the new terms, you are no longer authorized to use our service.",
+            "title": "Amendments to Agreement"
+          },
+          "arbitrateTerms": {
+            "content": "This Agreement and any dispute or claim arising out of, or related to, it, its interpretation, or the breach, termination or validity thereof, the relationships which result from this Agreement, including the performance, breach, or validity of this Agreement, shall be governed by the laws of Romania. The exclusive jurisdiction and venue for any action under this Agreement shall be the courts located in Romania and you hereby submit to the personal jurisdiction of such courts. You hereby waive any right to a jury trial in any proceeding arising out of or related to this Agreement. The United Nations Convention on Contracts for the International Sale of Goods does not apply to this Agreement. The term “dispute” means any dispute, action, or other controversy between you and us concerning the Services or this agreement, whether in contract, warranty, tort, statute, regulation, ordinance, or any other legal or equitable basis. “Dispute” will be given the broadest possible meaning allowable under law.",
+            "title": "Arbitration"
+          },
+          "changesToTos": {
+            "content": "AROLARIU.RO reserves the right to change these Terms of Service at any time. We do, however, recommend that you read this page regularly to ensure that you are aware of any changes. Your continued use of the website following the posting of changes will mean that you accept and agree to the changes. You acknowledge and agree that we may stop (permanently or temporarily) providing the Service (or any features within the Service) to you or to users generally at our sole discretion, without prior notice to you. You may stop using the Service at any time. You do not need to specifically inform us when you stop using the Service. You acknowledge and agree that if we disable access to your account, you may be prevented from accessing the Service, your account details or any files or other materials which is contained in your account",
+            "title": "Changes to Terms of Service"
+          },
+          "consentTerms": {
+            "content": "We've updated our Terms & Conditions to provide you with complete transparency into what is being set when you visit our site and how it's being used. By using our website, you hereby consent to our Terms of Service and agree to the Terms & Conditions.",
+            "title": "Your Consent"
+          },
+          "cookiesTerms": {
+            "content": "We use 'Cookies' to identify the areas of our website that you have visited. A Cookie is a small piece of data stored on your computer or mobile device by your web browser. We use Cookies to enhance the performance and functionality of our service but are non-essential to their use. However, without these cookies, certain functionality like videos may become unavailable or you would be required to enter your login details every time you visit our platform as we would not be able to remember that you had logged in previously. Most web browsers can be set to disable the use of Cookies. However, if you disable Cookies, you may not be able to access functionality on our website correctly or at all. We never place Personally Identifiable Information in Cookies.",
+            "title": "Cookies"
+          },
+          "copyrightTerms": {
+            "content": "If you are a copyright owner or such owner’s agent and believe any material from us constitutes an infringement on your copyright, please contact us setting forth the following information: (a) a physical or electronic signature of the copyright owner or a person authorized to act on his behalf; (b) identification of the material that is claimed to be infringing; (c) your contact information, including your address, telephone number, and an email; (d) a statement by you that you have a good faith belief that use of the material is not authorized by the copyright owners; and (e) the a statement that the information in the notification is accurate, and, under penalty of perjury you are authorized to act on behalf of the owner.",
+            "title": "Copyright Protection"
+          },
+          "definitionTerms": {
+            "content": "The terms 'us' or 'we' or 'our' refers to AROLARIU.RO, the owner of the website. A customer is the person or organization that buys or agrees to buy the product. Our 'product' refers to the website, products, or services offered for sale on our website. A 'user' is a person who uses our website or services. The term 'you' refers to the user or viewer of our website.",
+            "title": "Definitions"
+          },
+          "disclaimerTerms": {
+            "content": "To the maximum extent permitted by applicable law, we exclude all representations, warranties, and conditions relating to our website and the use of this website. We shall not be liable for any damages arising out of the use or inability to use the materials on AROLARIU.RO's website, even if AROLARIU.RO or an authorized representative of AROLARIU.RO has been notified, orally or in writing, of the possibility of such damage. Because some jurisdictions do not allow limitations on implied warranties, or limitations of liability for consequential or incidental damages, these limitations may not apply to you. We are not responsible for any content, code or any other imprecision. We do not provide warranties or guarantees. In no event shall we be liable for any special, direct, indirect, consequential, or incidental damages or any damages whatsoever, whether in an action of contract, negligence or other tort, arising out of or in connection with the use of the Service or the contents of the Service. We reserve the right to make additions, deletions, or modifications to the contents on the Service at any time without prior notice. Our Service and its contents are provided 'AS IS' and 'AS AVAILABLE' without any warranty or representations of any kind, whether express or implied. We are a distributor and not a publisher of the content supplied by third parties; as such, our exercises no editorial control over such content and makes no warranty or representation as to the accuracy, reliability or currency of any information, content, service or merchandise provided through or accessible via our Service. Without limiting the foregoing, We specifically disclaim all warranties and representations in any content transmitted on or in connection with our Service or on sites that may appear as links on our Service, or in the products provided as a part of, or otherwise in connection with, our Service, including without limitation any warranties of merchantability, fitness for a particular purpose or non-infringement of third party rights. No oral advice or written information given by us or any of its affiliates, employees, officers, directors, agents, or the like will create a warranty. Price and availability information is subject to change without notice. Without limiting the foregoing, we do not warrant that our Service will be uninterrupted, uncorrupted, timely, or error-free.",
+            "title": "Disclaimer"
+          },
+          "disputeNoticeTerms": {
+            "content": "In the event of a dispute, you or AROLARIU.RO must give the other a Notice of Dispute, which is a written statement that sets forth the name, address, and contact information of the party giving it, the facts giving rise to the dispute, and the relief requested. You must send any Notice of Dispute by email to: admin@arolariu.ro. AROLARIU.RO will send any Notice of Dispute to you by mail to your address if we have it, or otherwise to your email address. You and AROLARIU.RO will attempt to resolve any dispute through informal negotiation within sixty (60) days from the date the Notice of Dispute is sent. After sixty (60) days, you or AROLARIU.RO may commence arbitration.",
+            "title": "Notice of Dispute"
+          },
+          "entireAgreementTerms": {
+            "content": "The Terms of Service constitute the entire agreement between you and AROLARIU.RO regarding your use of the service and supersede all prior and contemporaneous written or oral agreements between you and AROLARIU.RO. You may be subject to additional terms and conditions that apply when you use or purchase other AROLARIU.RO's services, which AROLARIU.RO will provide to you at the time of such use or purchase.",
+            "title": "Entire Agreement"
+          },
+          "generalTerms": {
+            "content": "By accessing and placing an order with AROLARIU.RO, you confirm that you are in agreement with and bound by the terms of service contained in the Terms & Conditions outlined below. These terms apply to the entire website and any email or other type of communication between you and AROLARIU.RO. Under no circumstances shall AROLARIU.RO team be liable for any direct, indirect, special, incidental or consequential damages, including, but not limited to, loss of data or profit, arising out of the use, or the inability to use, the materials on this site, even if AROLARIU.RO team or an authorized representative has been advised of the possibility of such damages. If your use of materials from this site results in the need for servicing, repair or correction of equipment or data, you assume any costs thereof. AROLARIU.RO will not be responsible for any outcome that may occur during the course of usage of our resources. We reserve the rights to change prices and revise the resources usage policy in any moment.",
+            "title": "General Terms"
+          },
+          "liabilityTerms": {
+            "content": "To the fullest extent permitted by applicable law, in no event will AROLARIU.RO be liable to you on any legal theory for any incidental, direct, indirect, punitive, actual, consequential, special, exemplary, or other damages, including without limitation, loss of revenue or income, lost profits, pain and suffering, emotional distress, cost of substitute goods or services, or similar damages suffered or incurred by you or any third party that arise in connection with the service (or the termination thereof for any reason), even if AROLARIU.RO has been advised of the possibility of such damages. AROLARIU.RO shall not be liable for any damages, liability or losses arising out of: (i) your use of or reliance on the service or your inability to access or use the service; or (ii) any transaction or relationship between you and any third party provider, even if AROLARIU.RO has been advised of the possibility of such damages. AROLARIU.RO shall not be liable for delay or failure in performance resulting from causes beyond AROLARIU.RO's reasonable control. You acknowledge that the service may be subject to limitations, delays, and other problems inherent in the use of the internet and electronic communications. AROLARIU.RO is not responsible for any delays, delivery failures, or other damage resulting from such problems. To the maximum extent permitted by applicable law, in no event shall we or our suppliers be liable for any special, incidental, indirect, or consequential damages whatsoever (including, but not limited to, damages for loss of profits, for loss of data or other information, for business interruption, for personal injury, for loss of privacy arising out of or in any way related to the use of or inability to use the service, third-party software and/or third-party hardware used with the service, or otherwise in connection with any provision of this Agreement), even if we or any supplier has been advised of the possibility of such damages and even if the remedy fails of its essential purpose. Some states/jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation or exclusion may not apply to you.",
+            "title": "Limitation of Liability"
+          },
+          "licenseTerms": {
+            "content": "By purchasing a product of AROLARIU.RO, you are granted a non-exclusive, non-transferable license to access the product. The product is for personal and commercial use. You are allowed to install the product on more than one computer or device, but you are not allowed to share the product with other individuals. You may not modify, adapt, translate, reverse engineer, decompile, disassemble or create derivative works based on the product without the prior written consent of AROLARIU.RO. You may not sell, rent, lease, or sublicense the product. You may not make the product available over a network where it could be used by multiple devices at the same time. You may not use the product to infringe on any copyright or trademark. You may not use the product to create any material that is unlawful, harmful, threatening, abusive, harassing, tortious, defamatory, vulgar, obscene, libelous, invasive of another's privacy, hateful, or racially, ethnically or otherwise objectionable.",
+            "title": "License Terms"
+          },
+          "linksToOtherSitesTerms": {
+            "content": "Our service may contain links to other websites that are not operated by Us. If you click on a third party link, you will be directed to that third party's site. We strongly advise you to review the Terms & Conditions of every site that you visit. We have no control over and assume no responsibility for the content, Terms & Conditions or practices of any third party sites or services.",
+            "title": "Links to Other Websites"
+          },
+          "miscellaneousTerms": {
+            "content": "If for any reason a court of competent jurisdiction finds any provision or portion of these Terms & Conditions to be unenforceable, the remainder of these Terms & Conditions will continue in full force and effect. Any waiver of any provision of these Terms & Conditions will be effective only if in writing and signed by an authorized representative of us. We will be entitled to injunctive or other equitable relief (without the obligations of posting any bond or surety) in the event of any breach or anticipatory breach by you. We operate and control our Service from our offices in Romania. The Service is not intended for distribution to or use by any person or entity in any jurisdiction or country where such distribution or use would be contrary to law or regulation. Accordingly, those persons who choose to access our Service from other locations do so on their own initiative and are solely responsible for compliance with local laws, if and to the extent local laws are applicable. These Terms & Conditions (which include and incorporate our Privacy Policy) contains the entire understanding, and supersedes all prior understandings, between you and us concerning its subject matter, and cannot be changed or modified by you. The section headings used in this Agreement are for convenience only and will not be given any legal import. The failure of either party to exercise in any respect any right provided for herein shall not be deemed a waiver of any further rights hereunder. AROLARIU.RO shall not be liable for any failure to perform its obligations hereunder where such failure results from any cause",
+            "title": "Miscellaneous"
+          },
+          "noWarrantiesTerms": {
+            "content": "This website is provided 'as is,' with all faults, and AROLARIU.RO makes no express or implied representations or warranties, of any kind related to this website or the materials contained on this website. Additionally, nothing contained on this website shall be construed as providing consult or advice to you. The service is provided to you 'AS IS' and 'AS AVAILABLE' and with all faults and defects without warranty of any kind. To the maximum extent permitted under applicable law, we, on our own behalf and on behalf of our affiliates and our respective licensors and service providers, expressly disclaims all warranties, whether express, implied, statutory or otherwise, with respect to the service, including all implied warranties of merchantability, fitness for a particular purpose, title and non-infringement, and warranties that may arise out of course of dealing, course of performance, usage or trade practice. Without limitation to the foregoing, we provide no warranty or undertaking, and make no representation of any kind that the service will meet your requirements, achieve any intended results, be compatible or work with any other software, websites, systems or services, operate without interruption, meet any performance or reliability standards or be error free or that any errors or defects can or will be corrected. Without limiting the foregoing, neither us nor any provider makes any representation or warranty of any kind, express or implied: (i) as to the operation or availability of the service, or the information, content, and materials or products included thereon; (ii) that the service will be uninterrupted or error-free; (iii) as to the accuracy, reliability, or currency of any information or content provided through the service; or (iv) that the service, its servers, the content, or e-mails sent from or on behalf of us are free of viruses, scripts, trojan horses, worms, malware, timebombs or other harmful components. Some jurisdictions do not allow the exclusion of or limitations on implied warranties or the limitations on the applicable statutory rights of a consumer, so some or all of the above exclusions and limitations may not apply to you.",
+            "title": "No Warranties"
+          },
+          "promotionTerms": {
+            "content": "We may, from time to time, include contests, promotions, sweepstakes, or other activities (“Promotions”) that require you to submit material or information concerning yourself. Please note that all Promotions may be governed by separate rules that may contain certain eligibility requirements, such as restrictions as to age and geographic location. You are responsible to read all Promotions rules to determine whether or not you are eligible to participate. If you enter any Promotion, you agree to abide by and to comply with all Promotions Rules. Additional terms and conditions may apply to purchases of goods or services on or through the Services, which terms and conditions are made a part of this Agreement by this reference. Any promotions made available through the service may be governed by rules that are separate from these Terms. If you participate in any promotions, please review the applicable rules as well as our Privacy Policy. If the rules for a promotion conflict with these Terms, the promotion rules will apply.",
+            "title": "Promotions"
+          },
+          "restrictionTerms": {
+            "content": "You are specifically restricted from publishing, selling, sublicensing, or otherwise commercializing any website material; using this website in any way that is or may be damaging to this website; using this website in any way that impacts user access to this website; using this website contrary to applicable laws and regulations, or in any way may cause harm to the website, or to any person or business entity; engaging in any data mining, data harvesting, data extracting or any other similar activity in relation to this website; using this website to engage in any advertising or marketing.",
+            "title": "Restrictions"
+          },
+          "severabilityTerms": {
+            "content": "If any provision of these Terms is held to be unenforceable or invalid, such provision will be changed and interpreted to accomplish the objectives of such provision to the greatest extent possible under applicable law and the remaining provisions will continue in full force and effect. This Agreement, together with the Privacy Policy and any other legal notices published by us on the Services, shall constitute the entire agreement between you and us concerning the Services. If any provision of this Agreement is deemed invalid by a court of competent jurisdiction, the invalidity of such provision shall not affect the validity of the remaining provisions of this Agreement, which shall remain in full force and effect. No waiver of any term of this Agreement shall be deemed a further or continuing waiver of such term or any other term, and our failure to assert any right or provision under this Agreement shall not constitute a waiver of such right or provision. YOU AND US AGREE THAT ANY CAUSE OF ACTION ARISING OUT OF OR RELATED TO THE SERVICES MUST COMMENCE WITHIN ONE (1) YEAR AFTER THE CAUSE OF ACTION ACCRUES. OTHERWISE, SUCH CAUSE OF ACTION IS PERMANENTLY BARRED.",
+            "title": "Severability"
+          },
+          "submissionsAndPrivacyTerms": {
+            "content": "When you visit the website or send emails to us, you are communicating with us electronically. You consent to receive communications from us electronically. We will communicate with you by email or by posting notices on the website. You agree that all agreements, notices, disclosures, and other communications that we provide electronically satisfy any legal requirement that such communications be in writing. AROLARIU.RO may, but shall not be obligated to, monitor, review, or edit User Content. In all cases, AROLARIU.RO reserves the right to remove or disable access to any User Content for any or no reason, including but not limited to, User Content that, in AROLARIU.RO's sole discretion, violates the Agreements. AROLARIU.RO may take these actions without prior notification to you or any third party. Removal or disabling of access to User Content shall be at our sole discretion, and we do not promise to remove or disable access to any specific User Content. In the event that you submit or post any ideas, creative suggestions, designs, photographs, information, advertisements, data or proposals, including ideas for new or improved products, services, features, technologies or promotions, you expressly agree that such submissions will automatically be treated as non-confidential and non-proprietary and will become the sole property of us without any compensation or credit to you whatsoever. We and our affiliates shall have no obligations with respect to such submissions or posts and may use the ideas contained in such submissions or posts for any purposes in any medium in perpetuity, including, but not limited to, developing, manufacturing, and marketing products and services using such ideas.",
+            "title": "Submissions and Privacy"
+          },
+          "terminationTerms": {
+            "content": "We may terminate or suspend your account and bar access to the service immediately, without prior notice or liability, under our sole discretion, for any reason whatsoever and without limitation, including but not limited to a breach of the Terms. If you wish to terminate your account, you may simply discontinue using the service. All provisions of the Terms which by their nature should survive termination shall survive termination, including, without limitation, ownership provisions, warranty disclaimers, indemnity and limitations of liability.",
+            "title": "Termination"
+          },
+          "thirdPartyTerms": {
+            "content": "In using the service, you may use third-party services, products, software, embeds, or applications developed by a third party ('Third Party Services'). Any use of a Third Party Service is at your own risk, and we shall not be responsible or liable to anyone for Third Party websites or Services. You acknowledge and agree that we shall not be responsible or liable for any damage or loss caused or alleged to be caused by or in connection with the use of any such content, goods or services available on or through any such websites or services. We do not assume and shall not have any liability or responsibility to you or any other person or entity for any Third-Party Services. Third-Party Services and links therefore are provided solely as a convenience to you and you access and use them entirely at your own risk and subject to such third parties' terms and conditions.",
+            "title": "Third Party Services"
+          },
+          "typographyErrorsTerms": {
+            "content": "In the event that a AROLARIU.RO product is mistakenly listed at an incorrect price, AROLARIU.RO reserves the right to refuse or cancel any orders placed for the product listed at the incorrect price. AROLARIU.RO reserves the right to refuse or cancel any such orders whether or not the order has been confirmed and your credit card charged. If your credit card has already been charged for the purchase and your order is cancelled, AROLARIU.RO shall issue a credit to your credit card account in the amount of the incorrect price.",
+            "title": "Typography Errors"
+          },
+          "updateOfServicesTerms": {
+            "content": "AROLARIU.RO is constantly updating its services, which means that we may add or remove features, products, or functionalities, and we may also suspend or stop the service altogether. We may take any of these actions at any time, and when we do, we may not provide you with any notice beforehand. You acknowledge that AROLARIU.RO may establish general practices and limits concerning use of the service, including without limitation the maximum period of time that data or other content will be retained by the service and the maximum storage space that will be allotted on AROLARIU.RO's servers on your behalf. You agree that AROLARIU.RO has no responsibility or liability for the deletion or failure to store any data or other content maintained or uploaded by the service. You acknowledge that AROLARIU.RO reserves the right to terminate accounts that are inactive for an extended period of time. You agree that we have no obligation to (i) provide any Updates, or (ii) continue to provide or enable any particular features and/or functionalities of the service to you. You further agree that all Updates will be (i) deemed to constitute an integral part of the service, and (ii) subject to the terms and conditions of this Agreement.",
+            "title": "Updates to the Service"
+          },
+          "waiverTerms": {
+            "content": "Except as provided herein, the failure to exercise a right or require performance of an obligation under this Agreement shall not affect a party's ability to exercise such right or require such performance at any time thereafter nor shall be the waiver of a breach constitute a waiver of any subsequent breach. No failure to exercise, and no delay in exercising, on the part of either party, any right or any power under this Agreement shall operate as a waiver of that right or power. Nor shall any single or partial exercise of any right or power under this Agreement preclude further exercise of that or any other right granted herein. In the event of a conflict between this Agreement and any applicable purchase or other terms, the terms of this Agreement shall govern.",
+            "title": "Waiver"
+          }
+        },
+        "title": "Terms of Service"
       }
+    }
+  },
+  "shared": {
+    "accessibility": {
+      "logoAlt": "arolariu.ro logo",
+      "toggleTheme": "Toggle theme"
     },
-    "incompleteInvoice": {
-      "subject": "You have incomplete invoices",
-      "badge": "Reminder",
-      "heading": "Your invoice needs a quick update",
-      "preview": "{name}, your invoice \"{invoiceName}\" needs some attention.",
-      "greeting": "Hi {name},",
-      "intro": "We analyzed your invoice {invoiceName} but couldn't extract everything. A few details are missing, and completing them will give you better spending insights and more accurate dashboards.",
-      "invoiceDetailsTitle": "Invoice Details",
-      "invoiceLabel": "Invoice",
-      "analyzedOnLabel": "Analyzed on",
-      "missingFieldsLabel": "Missing fields",
-      "whatsMissingTitle": "What's missing",
-      "missingFields": {
-        "merchant": {
-          "label": "Merchant",
-          "suggestion": "Add the store name manually in the edit view"
+    "invoices": {
+      "commandPalette": {
+        "actions": {
+          "createInvoice": "Create Invoice",
+          "uploadScans": "Upload Scans",
+          "viewAll": "View All Invoices",
+          "viewStatistics": "View Statistics"
         },
-        "items": {
-          "label": "Line items",
-          "suggestion": "Try re-uploading a clearer photo, or add items manually"
+        "groups": {
+          "quickActions": "Quick Actions",
+          "recentInvoices": "Recent Invoices",
+          "searchResults": "Search Results"
         },
-        "payment": {
-          "label": "Payment info",
-          "suggestion": "Enter the total amount and payment method in the edit view"
+        "noResults": "No results found",
+        "placeholder": "Search invoices, merchants, items..."
+      },
+      "invoiceHeader": {
+        "buttons": {
+          "analyzeWithAi": "Analyze with AI",
+          "delete": "Delete",
+          "discard": "Discard",
+          "edit": "Edit",
+          "export": "Export",
+          "print": "Print",
+          "save": "Save",
+          "saving": "Saving..."
         },
-        "category": {
-          "label": "Invoice category",
-          "suggestion": "Select a category (groceries, fast food, household, etc.)"
-        },
-        "unknown": {
-          "label": "{field}",
-          "suggestion": "Please review and update this information"
+        "id": "ID: {id}",
+        "tooltips": {
+          "analyzeSpendingPatterns": "Analyze spending patterns for this invoice",
+          "delete": "Delete this invoice permanently",
+          "deleteInvoicePermanently": "Delete this invoice permanently",
+          "discardAllPendingChanges": "Discard all pending changes",
+          "edit": "Edit this invoice",
+          "export": "Export invoice data in various formats",
+          "importantInvoice": "Important Invoice",
+          "print": "Print this invoice",
+          "printInvoiceWithAllDetails": "Print this invoice with all details",
+          "saveAllPendingChanges": "Save all pending changes"
         }
       },
-      "tipsTitle": "Tips for better analysis",
-      "tips": {
-        "0": "Use a well-lit, flat surface when photographing receipts",
-        "1": "Ensure the entire receipt is visible and in focus",
-        "2": "PDF receipts from online orders tend to analyze best",
-        "3": "You can always add or correct details manually after analysis"
+      "invoicesNotFound": {
+        "cta": "Upload an invoice here.",
+        "description": "It seems that you do not have any invoices associated with your account. Please upload some invoices and come back later.",
+        "title": "Something is missing here..."
       },
-      "bodyText": "Completing these details takes less than a minute and ensures your spending reports stay accurate.",
-      "feedback": "Stuck or need help? Reach out at <link>{supportEmail}</link>.",
-      "signOff": {
-        "line1": "Best regards,",
-        "line2": "The {brand} Team"
+      "loadingInvoices": {
+        "description": "Loading invoices...",
+        "title": "Loading invoices"
       },
-      "primaryCta": "Complete your invoice",
-      "secondaryCta": "Re-run analysis"
-    },
-    "unanalyzedInvoices": {
-      "subject": "You have unanalyzed invoices",
-      "badge": "Reminder",
-      "heading": "{count, plural, =1 {1 invoice waiting for analysis} other {# invoices waiting for analysis}}",
-      "preview": "{name}, you have {count, plural, =1 {1 invoice} other {# invoices}} waiting for AI analysis.",
-      "greeting": "Hi {name},",
-      "intro": "{count, plural, =1 {You have 1 invoice that hasn't been analyzed yet. Running our AI analysis unlocks the full value of your uploaded receipts.} other {You have # invoices that haven't been analyzed yet. Running our AI analysis unlocks the full value of your uploaded receipts.}}",
-      "invoicesAwaitingTitle": "Invoices awaiting analysis",
-      "uploadedDate": "Uploaded {date}",
-      "andMore": "…and {remaining} more. View all in your <dashboard></dashboard>.",
-      "analysisProvidedTitle": "What analysis provides",
-      "analysisProvides": {
-        "0": "Line-by-line item extraction with prices and categories",
-        "1": "Merchant identification and categorization",
-        "2": "Allergen detection on food products",
-        "3": "Recipe suggestions based on your grocery items",
-        "4": "Automatic spending categorization for dashboard insights"
-      },
-      "bodyText": "Analysis typically takes under a minute per invoice. Once complete, you'll receive a notification with the results.",
-      "feedback": "Need help? Contact us at <link>{supportEmail}</link>.",
-      "signOff": {
-        "line1": "Best regards,",
-        "line2": "The {brand} Team"
-      },
-      "primaryCta": "View invoices"
-    },
-    "weeklyUploadReminder": {
-      "subject": "Your weekly upload reminder",
-      "badge": "Weekly Reminder",
-      "heading": "Your weekly receipt check-in",
-      "preview": "Hi {name} — here's your weekly receipt check-in.",
-      "greeting": "Hi {name},",
-      "intro": "Here's a quick look at your receipt tracking activity. Consistent uploading gives you the most accurate spending insights.",
-      "metricsLabels": {
-        "thisWeek": "This week",
-        "lastWeek": "Last week",
-        "totalInvoices": "Total invoices",
-        "totalTracked": "Total tracked"
-      },
-      "quickTipsTitle": "Quick tips",
-      "quickTips": {
-        "0": "Upload receipts right after shopping — it takes under 30 seconds",
-        "1": "Batch upload at the end of the day if you prefer",
-        "2": "Even small purchases help build a complete spending picture"
-      },
-      "bodyText": "Every receipt you track makes your spending insights more accurate and your dashboards more useful.",
-      "feedback": "Questions or feedback? Reach us at <link>{supportEmail}</link>.",
-      "signOff": {
-        "line1": "Best regards,",
-        "line2": "The {brand} Team"
-      },
-      "primaryCta": "Upload this week's receipts",
-      "secondaryCta": "View dashboard"
-    },
-    "invoiceStats": {
-      "subject": "Your {frequency, select, daily {daily} weekly {weekly} monthly {monthly} yearly {yearly} other {periodic}} invoice statistics",
-      "frequencyLabel": "{frequency, select, daily {Daily} weekly {Weekly} monthly {Monthly} yearly {Yearly} other {Periodic}}",
-      "title": "{frequencyLabel} invoice stats",
-      "badge": "Invoices",
-      "heading": "{frequencyLabel} invoice statistics",
-      "preview": "{frequencyLabel} stats for {name} — {totalSpend} total.",
-      "greeting": "Hi {name},",
-      "intro": "This is your invoice activity and spending summary for <start></start> → <end></end>.",
-      "metrics": {
+      "mobileNav": {
+        "ariaLabel": "Mobile navigation",
+        "home": "Home",
         "invoices": "Invoices",
-        "scans": "Scans",
-        "totalSpend": "Total spend",
-        "averagePerInvoice": "Avg / invoice"
+        "profile": "Profile",
+        "scan": "Scan"
       },
-      "reportDetailsTitle": "Report details",
-      "reportDetails": {
-        "period": "Period",
-        "currency": "Currency"
+      "notifications": {
+        "markAllRead": "Mark all as read",
+        "noNotifications": "No notifications yet",
+        "timeAgo": {
+          "days": "{count, plural, one {# day ago} other {# days ago}}",
+          "hours": "{count, plural, one {# hour ago} other {# hours ago}}",
+          "minutes": "{count, plural, one {# minute ago} other {# minutes ago}}",
+          "now": "Just now"
+        },
+        "title": "Notifications",
+        "types": {
+          "analysisComplete": "AI analysis complete",
+          "invoiceCreated": "Invoice created",
+          "monthlyReport": "Monthly report ready"
+        }
       },
-      "topMerchantsTitle": "Top merchants",
-      "topCategoriesTitle": "Top categories",
-      "noDataFallback": "No data yet — upload a couple of invoices to unlock insights.",
-      "breakdownCardTitle": "Spending breakdown (by category)",
-      "donutChartTitle": "Category spend distribution",
-      "donutChartAlt": "Donut chart showing spending distribution by category.",
-      "breakdownTableTitle": "Breakdown",
-      "breakdownNote": "Note: This chart uses the available category ranking data for the period.",
-      "body": "For a complete breakdown of your spending, visit your invoices list to review trends, merchants, categories, and totals over time. These insights can help you identify spending patterns and make more informed financial decisions.",
-      "feedbackPrompt": "Questions or something looks off? Email <email></email>.",
-      "signOff": {
-        "line1": "Cheers,",
-        "line2": "The {brand} Team"
+      "onboarding": {
+        "back": "Back",
+        "dontShowAgain": "Don't show this again",
+        "getStarted": "Get Started",
+        "next": "Next",
+        "skip": "Skip",
+        "stepOf": "Step {current} of {total}",
+        "steps": {
+          "analyze": {
+            "description": "Our AI-powered system automatically extracts merchant names, dates, amounts, and line items from your receipts with high accuracy.",
+            "title": "AI Extracts the Details"
+          },
+          "track": {
+            "description": "View detailed analytics and insights into your spending patterns. Understand where your money goes with interactive charts and reports.",
+            "title": "Track Your Spending"
+          },
+          "upload": {
+            "description": "Take a photo or upload a PDF of your receipt. Our system supports multiple formats and can process batches of receipts at once.",
+            "title": "Upload Your Receipts"
+          }
+        }
       },
-      "ctaPrimary": "View invoices",
-      "ctaSecondary": "Upload a new invoice"
+      "preferences": {
+        "currency": "Currency",
+        "defaultView": "Default View",
+        "pageSize": "Items per Page",
+        "save": "Save Preferences",
+        "saved": "Preferences saved successfully",
+        "showStats": "Show statistics on home",
+        "sortBy": "Sort By",
+        "sortOptions": {
+          "amountAsc": "Amount (Low to High)",
+          "amountDesc": "Amount (High to Low)",
+          "dateAsc": "Date (Oldest First)",
+          "dateDesc": "Date (Newest First)",
+          "nameAsc": "Name (A to Z)"
+        },
+        "title": "Invoice Preferences",
+        "views": {
+          "grid": "Grid View",
+          "table": "Table View"
+        }
+      },
+      "shortcuts": {
+        "close": "Close",
+        "closeDialog": "Close dialog",
+        "description": "Quick access to common actions using your keyboard",
+        "newInvoice": "New invoice",
+        "openSearch": "Open search",
+        "showHelp": "Show this help",
+        "title": "Keyboard Shortcuts",
+        "uploadScan": "Upload scan"
+      },
+      "statesLoading": {
+        "description": "Loading the invoice with the identifier {invoiceIdentifier}.",
+        "title": "Loading Invoice"
+      },
+      "statesNotFound": {
+        "description": "The invoice with the identifier {invoiceIdentifier} was not found.",
+        "title": "Invoice Not Found"
+      },
+      "unknownMerchant": "Unknown Merchant",
+      "workflowProgress": {
+        "create": "Create",
+        "review": "Review",
+        "upload": "Upload"
+      }
+    },
+    "legacy": {
+      "about": {
+        "cards": {
+          "author": {
+            "cta": "Learn more about the author...",
+            "subtitle": "arolariu is the alias/nickname of the author: Alexandru-Razvan Olariu. Alexandru is a well-tenured software engineer, solution architect and lifelong learner. To learn more about Alexandru, click the button below.",
+            "title": "Who is arolariu?"
+          },
+          "platform": {
+            "cta": "Learn more about the platform...",
+            "subtitle": "The arolariu.ro platform is a collection of applications that are hosted under the arolariu.ro domain. The platform was built with the purpose of providing a unified experience for all of the applications and OSS projects that the author (Alexandru-Razvan Olariu) is working on. To learn more about the technologies that are used in the process and how they interact with each other, click the button below.",
+            "title": "What is arolariu.ro?"
+          }
+        },
+        "footer": "Thank you!",
+        "metadata": {
+          "description": "Learn more about the author and the platform.",
+          "title": "About Us"
+        },
+        "subtitle": " The arolariu.ro story began in 2022, when the author - Alexandru-Razvan Olariu, wanted to understand how websites work. The whole platform and underlying integrations have been developed solely by the author, from what he has learnt along the years. Alexandru currently works as a software engineer at Microsoft. To learn more about him, check the right section of this page. The platform is built using the latest state-of-the-art technologies. To learn more about it, check the left section of this page.",
+        "title": "About Us"
+      },
+      "common": {
+        "states": {
+          "forbidden": {
+            "callToAction": "Join the arolariu.ro domain.",
+            "description": "Unfortunately, this functionality requires you to have an account on our domain. By creating an account on our platform or signing in with an existing account, you will be able to access our whole arsenal of services, including this one.",
+            "title": "You're missing out on the fun!"
+          }
+        }
+      }
+    }
+  },
+  "toasts": {
+    "invoices": {
+      "useInvoiceDelete": {
+        "bulkDeleteError": "Failed to delete {count} invoices.",
+        "bulkDeletePartial": "Deleted {successCount}; failed {failureCount}.",
+        "bulkDeleteSuccess": "{count} invoices deleted.",
+        "deleteError": "Could not delete invoice: {error}",
+        "deleteSuccess": "Invoice deleted."
+      },
+      "useInvoiceShare": {
+        "emailError": "Could not send email to {email}: {error}",
+        "emailSending": "Sending email to {email}…",
+        "emailSuccess": "Email sent to {email}.",
+        "revokeError": "Could not revoke access.",
+        "toggleError": "Could not toggle invoice visibility."
+      },
+      "useRecipeAdd": {
+        "error": "Could not add recipe."
+      },
+      "useRecipeDelete": {
+        "error": "Could not delete recipe."
+      },
+      "useRecipeUpdate": {
+        "error": "Could not update recipe."
+      },
+      "useScanAdd": {
+        "addError": "Failed to add scan",
+        "addSuccess": "Scan added",
+        "uploadFailed": "Upload failed (status {status})"
+      }
     }
   }
 }

--- a/sites/arolariu.ro/messages/en.json
+++ b/sites/arolariu.ro/messages/en.json
@@ -826,12 +826,19 @@
           "upload": "Upload scan",
           "uploading": "Uploading..."
         },
+        "console": {
+          "uploadError": "Error uploading scan:"
+        },
         "description": "Upload a new receipt image or document to attach to this invoice.",
         "dropzone": {
           "dragAndDrop": "Drag & drop a file here",
           "dropHere": "Drop the file here...",
           "formats": "JPEG, PNG, PDF (max 10MB)",
           "orClickBrowse": "or click to browse"
+        },
+        "errors": {
+          "unknown": "Unknown error occurred",
+          "uploadStorageFailed": "Failed to upload scan to storage"
         },
         "scanType": {
           "jpeg": "JPEG image",
@@ -844,7 +851,10 @@
         "title": "Add new scan",
         "toasts": {
           "fileTooLargeDescription": "Maximum file size is 10MB",
-          "fileTooLargeTitle": "File too large"
+          "fileTooLargeTitle": "File too large",
+          "scanAddedDescription": "The scan has been attached to the invoice",
+          "scanAddedTitle": "Scan added successfully",
+          "scanFailedTitle": "Failed to add scan"
         }
       },
       "allergenDialog": {

--- a/sites/arolariu.ro/messages/fr.json
+++ b/sites/arolariu.ro/messages/fr.json
@@ -1,2033 +1,2183 @@
 {
-  "About": {
-    "Author": {
-      "Biography": {
-        "FifthPoint": "Alexandru est ouvert à la collaboration dans des projets impliquant l'Internet des objets, l'ingénierie logicielle et l'ingénierie réseau. Il a fait ses preuves en fournissant des solutions de haute qualité à des problèmes complexes et est toujours à la recherche de nouveaux défis.",
-        "FirstPoint": "Alexandru est un ingénieur logiciel et architecte de solutions de {age} ans. Il travaille actuellement chez Microsoft en tant qu'ingénieur logiciel dans l'organisation E+D MSAI FAST, développant des solutions utilisées par des millions d'utilisateurs dans le monde entier.",
-        "FourthPoint": "Alexandru aime lire des livres techniques et expérimenter de nouvelles technologies. Il a construit cette plateforme comme un \"banc d'essai\" pour les nouvelles technologies et comme un moyen d'apprendre de nouvelles choses. Il est également un grand partisan du mouvement \"open-source\" et a contribué aux dépôts OSS de Microsoft (dotnet/core, dotnet/docs, azure/docs).",
-        "SecondPoint": "Alexandru est né le 8 janvier 2000 dans une petite ville appelée Curtea de Argeș en Roumanie. Il a eu son premier ordinateur à l'âge de 5 ans - un Pentium 4 E2200 2,2 GHz Dual-Core avec 512 Mo de RAM. Depuis lors, il a utilisé différentes versions de Windows (en commençant par Windows 98 !), bricolant son ordinateur personnel et développant ses compétences informatiques en jouant à des jeux vidéo. Il a également appris beaucoup d'anglais et était capable de lire, écrire et parler couramment l'anglais à l'âge de 12 ans !",
-        "ThirdPoint": "Alexandru est un passionné de jeux vidéo. Il était autrefois joueur professionnel, classé n°70 en Roumanie pour le jeu vidéo \"DotA 2\". Il aime les jeux de stratégie axés sur la mécanique et l'aspect technique comme Age of Empires, Age of Mythology, etc. Il apprécie également les jeux tels que Red Alert, StarCraft et d'autres jeux RTS.",
-        "title": "À propos d'Alexandru"
+  "app": {
+    "commander": {
+      "groups": {
+        "accessibility": "Accessibilité",
+        "fun": "Amusement",
+        "language": "Langue",
+        "links": "Liens",
+        "navigation": "Navigation",
+        "theme": "Thème"
       },
-      "Certifications": {
-        "certificates": {
-          "ab730": {
-            "code": "AB-730",
-            "coreSkills": "# Stratégie IA # Adoption de l'IA # IA responsable # Valeur métier de l'IA # Identification des cas d'usage IA",
-            "description": "Valide les connaissances orientées métier en IA pour les professionnels qui dirigent ou influencent les initiatives IA au sein de leur organisation. Destinée aux décideurs, product owners et consultants qui définissent la stratégie IA plutôt que sa mise en œuvre.",
-            "issuer": "Microsoft",
-            "issuerDate": "2026",
-            "link": "https://learn.microsoft.com/en-us/credentials/certifications/ai-business-professional/",
-            "name": "Microsoft Certified: AI Business Professional"
-          },
-          "ab731": {
-            "code": "AB-731",
-            "coreSkills": "# Transformation IA d'entreprise # Stratégie IA # Conduite du changement # Gouvernance IA # Leadership exécutif",
-            "description": "Valide la capacité à diriger des initiatives de transformation IA à l'échelle de l'entreprise — définition de la stratégie, conduite du changement organisationnel et mise en place de la gouvernance pour opérationnaliser l'IA dans toute l'organisation.",
-            "issuer": "Microsoft",
-            "issuerDate": "2026",
-            "link": "https://learn.microsoft.com/en-us/credentials/certifications/ai-transformation-leader/",
-            "name": "Microsoft Certified: AI Transformation Leader"
-          },
-          "ai900": {
-            "code": "AI-900",
-            "coreSkills": "# Machine Learning # Vision par ordinateur # Traitement du langage naturel # IA conversationnelle # IA responsable",
-            "description": "Démontre la connaissance des charges de travail courantes en IA et en apprentissage automatique et comment les implémenter sur Azure. Cette certification est destinée aux candidats ayant des antécédents techniques et non techniques.",
-            "issuer": "Microsoft",
-            "issuerDate": "2023",
-            "link": "https://learn.microsoft.com/en-us/certifications/azure-ai-fundamentals/",
-            "name": "Microsoft Certified: Azure AI Fundamentals"
-          },
-          "az900": {
-            "code": "AZ-900",
-            "coreSkills": "# Concepts Cloud # Services Azure principaux # Sécurité, confidentialité, conformité et confiance # Tarification Azure, SLA et cycle de vie",
-            "description": "Valide les connaissances fondamentales des services cloud et la manière dont ces services sont fournis avec Microsoft Azure. Cette certification est destinée aux candidats qui commencent à travailler avec des solutions et services basés sur le cloud.",
-            "issuer": "Microsoft",
-            "issuerDate": "2023",
-            "link": "https://learn.microsoft.com/en-us/certifications/azure-fundamentals/",
-            "name": "Microsoft Certified: Azure Fundamentals"
-          },
-          "gh100": {
-            "code": "GH-100",
-            "coreSkills": "# Authentification # Gestion des utilisateurs et équipes # Politiques de référentiel # Configuration Enterprise # Sécurité et conformité",
-            "description": "Valide les compétences nécessaires pour administrer les organisations GitHub Enterprise — gestion des utilisateurs, équipes, dépôts, politiques et intégrations à grande échelle.",
-            "issuer": "GitHub",
-            "issuerDate": "2026",
-            "link": "https://learn.microsoft.com/en-us/credentials/certifications/github-administration/",
-            "name": "GitHub Certified: Administration"
-          },
-          "gh200": {
-            "code": "GH-200",
-            "coreSkills": "# Création de workflows # Runners auto-hébergés # Sécurité des workflows # Workflows réutilisables # Pipelines CI/CD",
-            "description": "Valide l'expertise dans la création, la configuration et la maintenance des workflows GitHub Actions pour l'automatisation du build, des tests et du déploiement tout au long du cycle de vie logiciel.",
-            "issuer": "GitHub",
-            "issuerDate": "2026",
-            "link": "https://learn.microsoft.com/en-us/credentials/certifications/github-actions/",
-            "name": "GitHub Certified: Actions"
-          },
-          "gh300": {
-            "code": "GH-300",
-            "coreSkills": "# Plans et fonctionnalités Copilot # Suggestions de code # Prompt engineering # Utilisation responsable de l'IA # Copilot Chat",
-            "description": "Valide les compétences nécessaires pour exploiter efficacement GitHub Copilot dans le développement logiciel assisté par IA — couvrant les fonctionnalités, la personnalisation, le prompt engineering et l'utilisation responsable.",
-            "issuer": "GitHub",
-            "issuerDate": "2026",
-            "link": "https://learn.microsoft.com/en-us/credentials/certifications/github-copilot/",
-            "name": "GitHub Certified: Copilot"
-          },
-          "gh900": {
-            "code": "GH-900",
-            "coreSkills": "# Bases de GitHub # Dépôts # Collaboration # Produits GitHub # Issues, pull requests et workflows",
-            "description": "Valide les connaissances fondamentales sur GitHub — couvrant les dépôts, les fonctionnalités de collaboration, la famille de produits GitHub et les workflows essentiels du développeur.",
-            "issuer": "GitHub",
-            "issuerDate": "2026",
-            "link": "https://learn.microsoft.com/en-us/credentials/certifications/github-foundations/",
-            "name": "GitHub Certified: Foundations"
-          },
-          "sc900": {
-            "code": "SC-900",
-            "coreSkills": "# Concepts de sécurité # Principes d'identité # Microsoft Entra # Solutions de conformité # Confidentialité et protection des informations",
-            "description": "Valide les connaissances fondamentales en matière de sécurité, conformité et identité, ainsi que les solutions Microsoft cloud associées — Entra, Defender et Purview.",
-            "issuer": "Microsoft",
-            "issuerDate": "2023",
-            "link": "https://learn.microsoft.com/en-us/credentials/certifications/security-compliance-and-identity-fundamentals/",
-            "name": "Microsoft Certified: Security, Compliance & Identity Fundamentals"
-          }
-        },
-        "coreSkillsLabel": "Compétences clés démontrées :",
-        "subtitle": "Certifications professionnelles et accréditations qu'Alexandru a obtenues tout au long de sa carrière.",
-        "title": "Certifications",
-        "viewCertification": "Voir la certification"
-      },
-      "Competencies": {
-        "competences": {
-          "agileMethodologies": {
-            "description": "Alexandru a appris le travail agile et les méthodologies agiles depuis qu'il était étudiant en licence. Il suit le manifeste agile et est un grand adepte de la technique Kanban pour la planification.",
-            "title": "Méthodologies Agiles"
-          },
-          "algorithmicSkills": {
-            "description": "Alexandru a complété de nombreux défis Hacker Rank, Hacker Earth et Leet Code publiés de 2019 à 2021. Il possède une forte pensée algorithmique et est capable de construire des algorithmes complexes avec facilité.",
-            "title": "Compétences Algorithmiques"
-          },
-          "customerCentric": {
-            "description": "Alexandru travaille avec des clients depuis de nombreuses années chez Microsoft. Il a acquis beaucoup de connaissances et est capable de se mettre à la place du client. Il est capable de comprendre les besoins du client et de fournir des solutions exactement adaptées à leurs besoins.",
-            "title": "Orienté Client"
-          },
-          "domainDrivenDesign": {
-            "description": "Alexandru suit fortement les principes de conception pilotée par le domaine. Il est capable de combiner DDD avec TDD pour créer des solutions complexes faciles à maintenir et à étendre. Il est également un grand adepte des approches \"architecture en oignon\" et \"architecture propre\".",
-            "title": "Domain-Driven Design (DDD)"
-          },
-          "engineeringExcellence": {
-            "description": "Alexandru est passionné par la fourniture des meilleures solutions pour le problème et pour le client. Il s'efforce toujours de livrer le meilleur logiciel et de suivre les pratiques d'excellence en ingénierie reconnues. Une solution parfaite est une solution facile à maintenir, étendre et comprendre, pas celle qui est la plus complexe.",
-            "title": "Excellence en Ingénierie"
-          },
-          "testDrivenDevelopment": {
-            "description": "Alexandru croit fermement au développement piloté par les tests. Il applique constamment cette approche à ses projets et essaie toujours d'améliorer ses compétences en test. Il est également un grand adepte de l'approche \"red-green-refactor\".",
-            "title": "Test-Driven Development (TDD)"
-          }
-        },
-        "subtitle": "Une vitrine des compétences techniques et professionnelles d'Alexandru.",
-        "title": "Les Compétences d'Alexandru"
-      },
-      "Contact": {
-        "collaborate": {
-          "discipline1": "Ingénierie Logicielle",
-          "discipline2": "Internet des Objets",
-          "discipline3": "Applications Cloud Native",
-          "discipline4": "Ingénierie Réseau",
-          "footer": " Si vous avez un projet ou une opportunité intéressante qui correspond à l'expertise d'Alexandru, n'hésitez pas à le contacter. Il est toujours désireux d'explorer de nouveaux défis et collaborations.",
-          "subtitle": "Alexandru est ouvert à la collaboration dans des projets impliquant l'un des domaines suivants :",
-          "title": "Collaborons ensemble !"
-        },
-        "footer": "Merci.",
-        "socials": {
-          "footer": "Pour le contacter, utilisez l'une des méthodes de contact ci-dessus.",
-          "subtitle": "N'hésitez pas à nous contacter pour des collaborations, des questions, ou simplement pour dire bonjour !",
-          "title": "Entrer en contact"
-        },
-        "subtitle": "Si vous souhaitez contacter Alexandru, veuillez utiliser les moyens de contact ci-dessous.",
-        "title": "Contactez Alexandru"
-      },
-      "Education": {
-        "subtitle": "Le parcours académique et d'apprentissage d'Alexandru.",
-        "title": "Formation",
-        "university": {
-          "aseBucharest": {
-            "aboutTheProgram_cta": "Voir plus de détails",
-            "aboutTheProgram_description": "La licence en informatique à l'Université de Bucarest est un programme rigoureux qui fournit aux étudiants une base solide en informatique théorique et en développement logiciel pratique. Le programme met l'accent sur les compétences en résolution de problèmes, la pensée algorithmique et les principes d'ingénierie logicielle.",
-            "aboutTheProgram_learnings": "# Concevoir et analyser des algorithmes et des structures de données # Développer des logiciels utilisant différents paradigmes de programmation # Implémenter des systèmes de bases de données et gérer les données # Comprendre les réseaux informatiques et les systèmes distribués # Appliquer les principes d'ingénierie logicielle aux problèmes du monde réel",
-            "aboutTheProgram_learnings_title": "Résultats d'apprentissage clés",
-            "aboutTheProgram_title": "À propos du programme",
-            "degree": "Licence en Informatique et Économie",
-            "description": "Licence en informatique et économie de l'Université des Études Économiques de Bucarest, Roumanie. Diplômé dans le top 1% selon les statistiques de notation des thèses.",
-            "institution": "Academia de Studii Economice",
-            "keyCourses": "# Ingénierie Logicielle # Réseaux Informatiques # Systèmes d'Exploitation # Algorithmes et Structures de Données # Systèmes de Gestion de Bases de Données # Développement Web # Développement Mobile",
-            "keyCourses_title": "Cours principaux",
-            "location": "Bucarest, Roumanie",
-            "period": "2019 - 2022",
-            "status": "Terminé"
-          },
-          "malmoSweden": {
-            "aboutTheProgram_cta": "Voir plus de détails",
-            "aboutTheProgram_description": "Le Master en Internet des Objets à l'Université de Malmö est un programme de pointe qui prépare les étudiants aux défis et opportunités de la révolution IoT. Le programme met l'accent sur l'apprentissage pratique, la collaboration interdisciplinaire et les applications du monde réel.",
-            "aboutTheProgram_learnings": "# Concevoir et implémenter des systèmes IoT utilisant diverses plateformes matérielles et logicielles # Analyser et gérer les données générées par les appareils IoT # Appliquer les techniques d'apprentissage automatique et d'intelligence artificielle aux applications IoT # Comprendre les implications de sécurité et de confidentialité des systèmes IoT # Collaborer avec des partenaires industriels sur des projets réels",
-            "aboutTheProgram_learnings_title": "Résultats d'apprentissage clés",
-            "aboutTheProgram_title": "À propos du programme",
-            "degree": "Master en Internet des Objets",
-            "description": "Précédemment inscrit au programme de Master Internet des Objets à l'Université de Malmö, Suède. Interrompu en raison de circonstances personnelles et imprévues en 2024.",
-            "institution": "Malmö University",
-            "keyCourses": "# Internet des Objets # Cloud Computing # Science des Données # Apprentissage Automatique # Intelligence Artificielle # Vision par Ordinateur # Robotique",
-            "keyCourses_title": "Cours principaux",
-            "location": "Malmö, Suède",
-            "period": "2023 - 2024",
-            "status": "Interrompu"
-          }
-        }
-      },
-      "Experiences": {
-        "achievementsLabel": "Réalisations",
-        "intel": {
-          "achievements": "# Développement de convertisseurs d'espace colorimétrique (CSC) en C et Assembly x8086 (YUV->RGB, Niveaux de gris).# Création de plus de 10 types de filtres d'image tels que Fish Eye, Sobel, Détection de contours, Flou de boîte, etc.# Refactorisation du code .ASM pour de meilleures performances sur les appareils IoT et Systèmes Embarqués.",
-          "company": "Intel",
-          "description": "Le site de Timisoara aborde plusieurs domaines où des logiciels pour divers composants matériels, des algorithmes de traitement d'image et des implémentations de bas niveau et de haut niveau de parties de réseaux neuronaux sont activement développés.",
-          "location": "Télétravail (Roumanie - Timisoara)",
-          "period": "2021 (6 Mois)",
-          "responsibilites": "#Maîtriser les compétences dans le monde du traitement d'image. #Acquérir une compréhension du domaine de l'apprentissage automatique (ML). #Mettre en pratique les connaissances acquises en développant différents convertisseurs d'espace colorimétrique.",
-          "techAndSkills": "# C # C++ #Intel x8086 Assembly # Convertisseurs d'espace colorimétrique # Python # Calcul embarqué # Internet des Objets",
-          "title": "Ingénieur Systèmes Embarqués"
-        },
-        "microsoft1": {
-          "achievements": "# (Excellence en Ingénierie) Je me suis constamment poussé pour obtenir les meilleurs retours clients. (Score actuel : 4,94 / 5,00) # (Interactions Proactives) Fourniture de retours continus au Product Group concernant le produit Azure Virtual Desktop (AVD), au sujet de l'implémentation de fonctionnalités et services spécifiques. # (Expérience Client) Développement de la documentation existante sur les fonctionnalités des services Azure Core tels qu'Azure Virtual Desktop, Azure Virtual Machines, Azure Networks. # Travail exclusif avec des clients TOP 100 et Fortune 500 et des professionnels leaders du secteur.",
-          "company": "Microsoft",
-          "description": "Avec plus de 12 000 employés dans le monde, l'organisation Microsoft Customer Experience & Success (CE&S) est responsable de la stratégie, de la conception et de la mise en œuvre de l'expérience client de bout en bout de Microsoft.",
-          "location": "Roumanie",
-          "period": "03/2021 – 03/2023",
-          "responsibilites": "# Fournir le partage de connaissances, le coaching technique et le mentorat aux collègues ; # Résolution de problèmes par un dépannage approfondi, débogage, analyse de logs, tests A/B ; # Identifier et répondre aux problèmes critiques des clients spécifiques aux services Azure tels qu'Azure Virtual Desktop ; # Travailler exclusivement avec des clients Fortune 500 pour comprendre leurs besoins techniques et définir un plan d'action pour y répondre, en collaborant régulièrement avec des pairs ou d'autres équipes.",
-          "techAndSkills": "# Analyse du trafic réseau # Azure # Approche centrée client # Relations commerciales # Gestionnaire d'incidents",
-          "title": "Ingénieur Technique Azure"
-        },
-        "microsoft2": {
-          "achievements": "# (Observabilité-as-a-Service) Orchestration et implémentation complète des trois piliers de l'observabilité dans notre architecture microservices utilisant les standards Open Telemetry ; j'ai également construit des déclencheurs automatisés de surveillance et d'alerte basés sur les statistiques p95/p99 pour le trafic réel et synthétique. # (Recherche & Développement) Contributions majeures au développement d'une bibliothèque .NET interne implémentant le protocole de consommation de données ODataV4 pour les moteurs de bases de données NoSQL tels qu'Azure Data Explorer (ADX), en utilisant les pratiques Domain-Driven Design (DDD) (par ex. aggregator roots) (brevet en cours). # (Expérience de Développement) Prise de leadership sur deux domaines clés pour la DX : documentation et couches de consommation. Construction d'une documentation exceptionnelle et utilisation d'outils de génération de sites statiques (DocFX) pour générer automatiquement la documentation API à partir du code ; offre de couches de consommation API sous forme d'UI frontend, outillage CLI et fichiers de spécification OpenAPI. # (Croissance) J'ai assisté et participé à des entretiens d'embauche pour les postes SWE II et Senior SWE.",
-          "company": "Microsoft",
-          "description": "Alors que les gouvernements d'aujourd'hui envisagent l'innovation technologique, il est nécessaire de répondre aux demandes en rapide évolution de leurs citoyens tout en protégeant les données les plus sensibles et en tenant les promesses de confiance et de sécurité.",
-          "location": "EMEA",
-          "period": "03/2023 – 12/2024",
-          "responsibilites": "# Livrer une plateforme de données E+C capable de fonctionner multi-cloud et multi-tenant dans des environnements souverains et des scénarios air-gap. # Gérer et assurer le bon fonctionnement des opérations de la plateforme de données Runtime in Sovereign Environments (RISE). # Construire une architecture d'entreprise data mesh innovante utilisant des concepts d'ingénierie de données, des outils comme Azure Data Factory et d'autres notions d'entrepôt de données.",
-          "techAndSkills": "# .NET # Azure # Microservices # Applications Cloud-Native # Méthodologies Agiles # DevOps # Domain-Driven Design # Test-Driven Development # Gestion de Projet",
-          "title": "E + D Ingénieur Logiciel II - Clouds Souverains"
-        },
-        "microsoft3": {
-          "achievements": " ",
-          "company": "Microsoft",
-          "description": "Alexandru travaille actuellement chez Microsoft en tant qu'ingénieur logiciel dans l'organisation E+D MSAI (M365 AI Experiences).",
-          "location": "Télétravail (Norvège)",
-          "period": "11/2024 - Présent",
-          "responsibilites": " ",
-          "techAndSkills": "# React # GraphQL # Développement à grande échelle # Applications Cloud-Native # Méthodologies Agiles # Excellence en Ingénierie # Leadership",
-          "title": "E + D Ingénieur Logiciel Fullstack II - M365 AI"
-        },
-        "responsibilitiesLabel": "Responsabilités",
-        "subtitle": "Un parcours à travers la carrière professionnelle d'Alexandru et les entreprises avec lesquelles il a travaillé.",
-        "techSkillsLabel": "Technologies et Compétences",
-        "title": "Expérience Professionnelle",
-        "ubisoft": {
-          "achievements": "# J'ai constamment dépassé le quota de bugs, glitches et artefacts signalés, me classant n°1 des rapporteurs pendant 5 mois solides sur les 6 travaillés. # Découverte et signalement de défauts de code majeurs allant des conditions de concurrence aux défauts d'allocation de ressources mémoire. # Augmentation de l'efficacité des rapports quotidiens en exploitant les capacités de filtrage SQL et JQL.",
-          "company": "Ubisoft",
-          "description": "J'ai travaillé sur Avatar: Frontiers of Pandora™, un jeu d'action-aventure à la première personne construit avec la dernière version du moteur Snowdrop (C++) par Massive Entertainment - un studio UBISOFT, et testé par UBISOFT Roumanie.",
-          "location": "Hybride (Bucarest, Roumanie)",
-          "period": "2020 - 2021",
-          "responsibilites": "# Gestion des tests de régression, d'intégration et unitaires avec des logiciels tels que XRAY, TestRail, Bugzilla. # Création de suites de tests et de plans de tests de haute qualité utilisant les produits Atlassian (JIRA / Confluence). # Assurer des communications stables et claires entre les équipes de production et de test.",
-          "techAndSkills": "# Tests Unitaires # Tests d'Intégration # Tests A/B # Tests de Performance # Tests Automatiques # Tests E2E",
-          "title": "Ingénieur QA/QC"
-        }
-      },
-      "metadata": {
-        "description": "En savoir plus sur l'auteur, Alexandru-Razvan Olariu.",
-        "title": "Alexandru-Razvan Olariu"
-      },
-      "Perspectives": {
-        "perspectiveFromX": {
-          "author": "Anonyme",
-          "avatar": " ",
-          "company": "Microsoft",
-          "position": "Ingénieur Logiciel Senior",
-          "quote": "Ce que j'apprécie beaucoup chez vous, c'est votre recherche incessante de l'amélioration et votre volonté de remettre en question le statu quo. Votre engagement envers le développement personnel continu est évident dans la façon dont vous abordez chaque tâche avec un état d'esprit orienté vers l'innovation et l'excellence. Votre capacité à questionner les méthodes existantes et à proposer de meilleures alternatives a été déterminante pour faire avancer nos projets. Cette attitude proactive améliore non seulement la qualité de notre travail mais inspire également l'équipe à viser des standards plus élevés. Je suis heureux d'avoir travaillé avec vous et j'espère que nos chemins se croiseront à nouveau à l'avenir."
-        },
-        "perspectiveFromXX": {
-          "author": "Anonyme",
-          "avatar": " ",
-          "company": "Microsoft",
-          "position": "Senior Software Engineering Manager",
-          "quote": "Alex est un ingénieur intelligent dont les capacités ont brillé durant notre collaboration sur nos projets. Il démontre constamment son empressement à aider l'équipe avec toute demande, montrant son dévouement au succès collectif. Son approche proactive de la résolution de problèmes et son dévouement à la stabilité du système bénéficient grandement au flux de travail de notre équipe. De plus, la disponibilité d'Alex et sa volonté de soutenir les autres pendant notre flux de release soulignent sa valeur en tant que collègue qui priorise le travail d'équipe et la collaboration."
-        },
-        "perspectiveFromXY": {
-          "author": "Anonyme",
-          "avatar": " ",
-          "company": "Microsoft",
-          "position": "Ingénieur d'Escalade Senior",
-          "quote": "Alex, si je devais choisir une chose que j'apprécie le plus dans le travail avec vous, ce serait votre état d'esprit - car il englobe plusieurs aspects. Travailler avec vous est authentique, amusant, sage et pertinent en même temps. Il est facile de remarquer que vos moteurs quotidiens sont l'engagement, le raisonnement et l'apprentissage continu. J'admire votre approche, votre désir sincère d'aider, de construire sur le succès des autres et de soutenir chacun dans sa croissance, ce qui est une valeur si rare. En plus de cela, j'apprécie votre patience, ainsi que la grande quantité de connaissances que vous apportez dans nos interactions. La façon dont vous gérez les situations stressantes et votre approche globale ont le pouvoir de façonner un résultat positif pour toute question ou sujet."
-        },
-        "perspectiveFromXZ": {
-          "author": "Anonyme",
-          "avatar": " ",
-          "company": "Microsoft",
-          "position": "Ingénieur Logiciel Senior",
-          "quote": "J'ai été constamment impressionné par votre production de travail. Vous livrez toujours un travail de haute qualité, en accordant une attention particulière aux détails et en vous assurant que tout est fait au mieux de vos capacités. De plus, vous avez une compréhension approfondie des aspects techniques de notre travail, ce qui a été un atout précieux pour l'équipe. Votre volonté de partager vos connaissances et votre expérience avec les autres a été inestimable et il est clair que vous êtes fier de mentorer les autres et de les aider à grandir."
-        },
-        "perspectiveFromY": {
-          "author": "Anonyme",
-          "avatar": " ",
-          "company": "Microsoft",
-          "position": "Ingénieur Logiciel II",
-          "quote": "J'apprécie vraiment votre approche proactive et votre esprit collaboratif, et votre soutien et style de communication amical ont été très positifs pour mon expérience d'intégration et pour apprendre les tenants et aboutissants de notre projet. Votre capacité à communiquer efficacement et à tenir tout le monde informé est quelque chose que j'admire, vous avez de l'expérience dans les relations avec les équipes transversales, en particulier avec nos équipes partenaires, en apprenant leurs besoins et en résolvant leurs problèmes. Vos compétences techniques sont impressionnantes et votre attention aux détails est louable."
-        },
-        "perspectiveFromYX": {
-          "author": "Anonyme",
-          "avatar": " ",
-          "company": "Microsoft",
-          "position": "Chef de Produit Senior",
-          "quote": "La profondeur de caractère d'Alexandru est évidente dans sa passion et son engagement à aider les autres à réussir et nulle part cela n'est plus clair que dans son mentorat. Je tiens Alexandru en haute estime - j'ai peut-être quelques années de plus que lui, mais il ne devrait pas hésiter à me défier s'il croit qu'il y a une meilleure façon d'aborder un problème."
-        },
-        "perspectiveFromYY": {
-          "author": "Anonyme",
-          "avatar": " ",
-          "company": "Microsoft",
-          "position": "Ingénieur Logiciel Staff",
-          "quote": "J'aime votre attitude et votre ouverture d'esprit, je trouve facile de travailler et de parler avec vous. Je n'ai pas grand-chose à vous dire pour exploiter davantage ces forces : restez vous-même et vous faites déjà un excellent travail !"
-        },
-        "perspectiveFromYZ": {
-          "author": "Anonyme",
-          "avatar": " ",
-          "company": "Microsoft",
-          "position": "Ingénieur Logiciel Staff",
-          "quote": "Alexandru est un excellent ingénieur logiciel. Il est incroyablement vif et je le classerais dans le top 1% pour son âge - à 25 ans, la plupart des gens ont du mal à trouver un emploi, tandis qu'Alexandru délivre un impact qui se traduit en millions de dollars. Il est extrêmement talentueux."
-        },
-        "perspectiveFromZ": {
-          "author": "Anonyme",
-          "avatar": " ",
-          "company": "Microsoft",
-          "position": "Ingénieur Logiciel Senior",
-          "quote": "Vous êtes toujours prêt à aider, partageant généreusement votre temps, même lorsque vous avez vos propres tâches urgentes. Vos réponses rapides et utiles à toutes les questions sont grandement appréciées. Vous adoptez une approche priorisée et méticuleuse, fournissant des solutions instantanées qui non seulement nous débloquent à court terme mais décrivent également les corrections à long terme et leurs calendriers de mise en œuvre. Votre état d'esprit orienté solutions est un véritable atout pour notre équipe. Votre expertise, votre volonté d'aider et votre personnalité agréable font de vous un excellent collègue. Continuez votre excellent travail !"
-        },
-        "subtitle": "Perspectives de collègues qui ont travaillé avec ou aux côtés d'Alexandru.",
-        "title": "Perspectives"
-      },
-      "subtitle": "Alexandru-Razvan Olariu est l'auteur de la plateforme que vous consultez actuellement.",
-      "title": "Rencontrez l'auteur."
-    },
-    "cards": {
-      "author": {
-        "cta": "En savoir plus sur l'auteur...",
-        "subtitle": "arolariu est l'alias/pseudo de l'auteur : Alexandru-Razvan Olariu. Alexandru est un ingénieur logiciel expérimenté, architecte de solutions et apprenant perpétuel. Pour en savoir plus sur Alexandru, cliquez sur le bouton ci-dessous.",
-        "title": "Qui est arolariu ?"
-      },
-      "platform": {
-        "cta": "En savoir plus sur la plateforme...",
-        "subtitle": "La plateforme arolariu.ro est une collection d'applications hébergées sous le domaine arolariu.ro. La plateforme a été construite dans le but de fournir une expérience unifiée pour toutes les applications et projets OSS sur lesquels l'auteur (Alexandru-Razvan Olariu) travaille. Pour en savoir plus sur les technologies utilisées et comment elles interagissent entre elles, cliquez sur le bouton ci-dessous.",
-        "title": "Qu'est-ce que arolariu.ro ?"
-      }
-    },
-    "footer": "Merci !",
-    "Hub": {
-      "cta": {
-        "footer": "Construit avec passion en Roumanie",
-        "primary": "Voir sur GitHub",
-        "secondary": "Prendre contact",
-        "subtitle": "Commencez votre voyage à travers la plateforme ou connectez-vous avec l'auteur.",
-        "title": "Prêt à explorer ?"
-      },
-      "faq": {
-        "questions": {
-          "q1": {
-            "answer": "arolariu.ro est une plateforme full-stack complète qui sert à la fois de portfolio personnel et de vitrine technologique. Elle démontre les pratiques modernes de développement web utilisant Next.js, .NET et les services cloud Azure.",
-            "question": "Qu'est-ce que arolariu.ro ?"
-          },
-          "q2": {
-            "answer": "Oui ! Toute la plateforme est open source et disponible sur GitHub. Vous pouvez explorer le code, en apprendre et même contribuer à son développement.",
-            "question": "Cette plateforme est-elle open source ?"
-          },
-          "q3": {
-            "answer": "La plateforme utilise Next.js 16 avec React 19 pour le frontend, .NET 10 avec ASP.NET Core pour le backend et Azure pour l'infrastructure cloud. Elle comprend également une bibliothèque de composants complète et des tests extensifs.",
-            "question": "Quelles technologies sont utilisées ?"
-          },
-          "q4": {
-            "answer": "Absolument ! La plateforme est conçue pour présenter les meilleures pratiques en ingénierie logicielle. N'hésitez pas à l'utiliser comme référence pour l'architecture, les modèles et les détails d'implémentation.",
-            "question": "Puis-je utiliser ceci comme référence pour mes propres projets ?"
-          }
-        },
-        "subtitle": "Questions courantes sur la plateforme et son objectif",
-        "title": "Questions fréquentes"
-      },
-      "hero": {
-        "badge": "À propos",
-        "ctaPrimary": "Explorer la plateforme",
-        "ctaSecondary": "Rencontrer l'auteur",
-        "subtitle": "Une plateforme full-stack moderne construite avec passion, conçue pour l'innovation et créée avec attention aux détails.",
-        "title": "Découvrez arolariu.ro"
-      },
-      "mission": {
-        "description": "arolariu.ro est plus qu'un simple site web - c'est un terrain de jeu pour les technologies modernes, une vitrine des meilleures pratiques et une plateforme qui démontre ce qui est possible quand l'excellence en ingénierie rencontre la vision créative.",
-        "pillars": {
-          "innovation": {
-            "description": "Adopter les technologies de pointe et les modèles architecturaux modernes",
-            "title": "Innovation"
-          },
-          "openness": {
-            "description": "Open source, transparent et orienté communauté",
-            "title": "Ouverture"
-          },
-          "quality": {
-            "description": "Maintenir des standards élevés avec plus de 90% de couverture de tests",
-            "title": "Qualité"
-          }
-        },
-        "statement": "Construire des logiciels qui font la différence.",
-        "title": "Notre mission"
-      },
-      "navigation": {
-        "author": {
-          "cta": "Rencontrer Alexandru",
-          "features": {
-            "0": "Ingénieur Microsoft",
-            "1": "Architecte de solutions",
-            "2": "Passionné de technologie"
-          },
-          "subtitle": "Rencontrez Alexandru-Razvan Olariu, l'ingénieur logiciel derrière cette plateforme.",
-          "title": "L'auteur"
-        },
-        "platform": {
-          "cta": "Explorer la plateforme",
-          "features": {
-            "0": "Frontend Next.js 16",
-            "1": "Backend .NET 10",
-            "2": "Infrastructure Azure Cloud"
-          },
-          "subtitle": "Découvrez l'architecture, le stack technologique et les fonctionnalités qui alimentent arolariu.ro.",
-          "title": "La plateforme"
-        },
-        "subtitle": "Plongez plus profondément dans ce qui rend arolariu.ro unique",
-        "title": "Explorer davantage"
-      },
-      "stats": {
-        "items": {
-          "linesOfCode": {
-            "description": "Entre frontend et backend",
-            "label": "Lignes de code",
-            "value": "50K+"
-          },
-          "technologies": {
-            "description": "Stack technologique moderne",
-            "label": "Technologies",
-            "value": "25+"
-          },
-          "testCoverage": {
-            "description": "Standard d'assurance qualité",
-            "label": "Couverture tests",
-            "value": "90%"
-          },
-          "yearsActive": {
-            "description": "En évolution continue depuis 2022",
-            "label": "Années actives",
-            "value": "3+"
-          }
-        },
-        "subtitle": "Métriques clés qui démontrent notre engagement envers la qualité",
-        "title": "En chiffres"
-      },
-      "values": {
-        "items": {
-          "accessibility": {
-            "description": "Conçu pour tous avec navigation clavier et support lecteur d'écran.",
-            "title": "Design accessible"
-          },
-          "community": {
-            "description": "Open source dans l'âme, contribuant à la communauté des développeurs.",
-            "title": "Communauté d'abord"
-          },
-          "engineering": {
-            "description": "Chaque fonctionnalité est construite avec une architecture propre, des tests appropriés et la maintenabilité à l'esprit.",
-            "title": "Excellence en ingénierie"
-          },
-          "learning": {
-            "description": "Cette plateforme sert de terrain d'essai pour les nouvelles technologies et approches.",
-            "title": "Apprentissage continu"
-          },
-          "performance": {
-            "description": "Optimisé pour la vitesse avec rendu côté serveur et déploiements edge.",
-            "title": "Orienté performance"
-          },
-          "privacy": {
-            "description": "La protection des données et la vie privée sont fondamentales, pas des réflexions après coup.",
-            "title": "Axé sur la confidentialité"
-          }
-        },
-        "subtitle": "Les principes qui guident chaque ligne de code",
-        "title": "Valeurs fondamentales"
-      }
-    },
-    "metadata": {
-      "description": "En savoir plus sur l'auteur et la plateforme.",
-      "title": "À propos de nous"
-    },
-    "Platform": {
-      "architecture": {
-        "badge": "Architecture Technique",
-        "description": "Une architecture cloud-native moderne suivant les principes de conception pilotée par le domaine, la méthodologie The Standard et les meilleures pratiques de l'industrie.",
-        "layers": {
-          "ai": {
-            "description": "Traitement intelligent de documents et compréhension du langage naturel",
-            "name": "Services IA",
-            "technologies": "Azure OpenAI,Document Intelligence,Computer Vision"
-          },
-          "api": {
-            "description": "APIs RESTful avec documentation OpenAPI et limitation de débit",
-            "name": "Passerelle API",
-            "technologies": ".NET 10,Minimal APIs,OpenAPI,GraphQL"
-          },
-          "auth": {
-            "description": "Authentification de niveau entreprise avec plusieurs fournisseurs",
-            "name": "Identité et Sécurité",
-            "technologies": "Azure AD B2C,OAuth 2.0,OIDC,MFA"
-          },
-          "cdn": {
-            "description": "Distribution de contenu mondiale avec mise en cache edge et optimisation",
-            "name": "Edge et CDN",
-            "technologies": "Azure CDN,Vercel Edge,Static Assets"
-          },
-          "client": {
-            "description": "Frontends modernes basés sur React avec capacités SSR et SSG",
-            "name": "Couche Client",
-            "technologies": "Next.js 16,React 19,TypeScript,Modules SCSS"
-          },
-          "data": {
-            "description": "Stratégie de base de données multi-modèle pour des performances optimales",
-            "name": "Couche Données",
-            "technologies": "CosmosDB,Azure SQL,Redis Cache,Blob Storage"
-          },
-          "infra": {
-            "description": "Infrastructure Azure entièrement gérée avec déploiement IaC",
-            "name": "Infrastructure Cloud",
-            "technologies": "Azure,Bicep IaC,Container Apps,Key Vault"
-          },
-          "services": {
-            "description": "Conception pilotée par le domaine avec contextes délimités et architecture propre",
-            "name": "Microservices",
-            "technologies": "DDD,CQRS,Event Sourcing,The Standard"
-          }
-        },
-        "principles": {
-          "appRouter": {
-            "description": "Routage basé sur les fichiers avec layouts, états de chargement et limites d'erreur",
-            "title": "Architecture App Router"
-          },
-          "cloudNative": {
-            "description": "Microservices conteneurisés avec auto-scaling et capacités d'auto-réparation",
-            "title": "Conception Cloud Native"
-          },
-          "rsc": {
-            "description": "Exploitation des RSC pour des performances optimales avec rendu côté serveur et streaming",
-            "title": "React Server Components"
-          }
-        },
-        "title": "Conçue pour",
-        "titleHighlight": "l'évolutivité et la fiabilité"
-      },
-      "callToAction": {
-        "cta": {
-          "createAccount": "Créer un Compte",
-          "exploreApplications": "Explorer les Applications"
-        },
-        "description": "Explorez la plateforme, essayez les fonctionnalités et rejoignez la communauté. Que vous soyez ici pour gérer des factures, découvrir des recettes ou simplement explorer, il y a quelque chose pour tout le monde.",
-        "footer": "Construit avec passion par",
-        "footerRole": ", un ingénieur logiciel chez Microsoft.",
-        "links": {
-          "getInTouch": "Nous Contacter",
-          "meetAuthor": "Rencontrer l'Auteur",
-          "viewSource": "Voir le Code Source"
-        },
-        "title": "Prêt à",
-        "titleHighlight": "commencer",
-        "trust": {
-          "freeToUse": {
-            "description": "Pas de frais cachés ni d'abonnements",
-            "title": "Gratuit"
-          },
-          "openSource": {
-            "description": "100% open source avec licence MIT",
-            "title": "Open Source"
-          },
-          "privacyFirst": {
-            "description": "Vos données restent les vôtres, toujours",
-            "title": "Confidentialité d'Abord"
-          }
-        }
-      },
-      "features": {
-        "badge": "Fonctionnalités de la Plateforme",
-        "description": "Une suite complète d'outils conçus pour la gestion moderne des finances personnelles, l'organisation des recettes et plus encore. Construite avec des technologies de pointe et un accent sur l'expérience utilisateur.",
-        "items": {
-          "ai": {
-            "description": "Automatisation intelligente à portée de main",
-            "longDescription": "Alimenté par Azure OpenAI, notre assistant IA aide à la compréhension de documents, l'extraction de données, la catégorisation intelligente et les requêtes en langage naturel sur vos données.",
-            "tags": "GPT-4,Azure AI,NLP",
-            "title": "Assistant IA"
-          },
-          "analytics": {
-            "description": "Aperçus approfondis de vos dépenses",
-            "longDescription": "Tableau de bord analytique complet avec les tendances de dépenses, les répartitions par catégorie, les comparaisons mensuelles et les aperçus prédictifs alimentés par des algorithmes d'apprentissage automatique.",
-            "tags": "Graphiques,Tendances,Rapports",
-            "title": "Analytique des Dépenses"
-          },
-          "auth": {
-            "description": "Options de connexion flexibles et sécurisées",
-            "longDescription": "Connectez-vous avec Microsoft, Google, GitHub ou email. Azure AD B2C fournit une gestion d'identité de niveau entreprise avec support MFA et une expérience SSO transparente.",
-            "tags": "OAuth,MFA,SSO",
-            "title": "Authentification Sécurisée"
-          },
-          "budgets": {
-            "description": "Suivi intelligent du budget et alertes",
-            "longDescription": "Définissez des budgets par catégorie et recevez des alertes intelligentes à l'approche des limites. Visualisez vos dépenses avec des graphiques interactifs et identifiez les domaines à optimiser.",
-            "tags": "Budgets,Alertes,Planification",
-            "title": "Gestion du Budget"
-          },
-          "i18n": {
-            "description": "Expérience entièrement internationalisée",
-            "longDescription": "La plateforme prend en charge plusieurs langues avec un support RTL complet. Actuellement disponible en anglais et en roumain, avec d'autres langues prévues pour les versions futures.",
-            "tags": "i18n,Anglais,Roumain",
-            "title": "Multi-Langue"
-          },
-          "invoices": {
-            "description": "Analyse et gestion des factures alimentées par l'IA",
-            "longDescription": "Téléchargez des photos de reçus et laissez l'IA extraire les détails du commerçant, les articles, les prix et plus encore. La catégorisation automatique, le suivi des dépenses et les analyses détaillées vous aident à comprendre vos habitudes de consommation.",
-            "tags": "IA,OCR,Analytique",
-            "title": "Traitement des Factures"
-          },
-          "merchants": {
-            "description": "Détection automatique des commerçants et aperçus",
-            "longDescription": "Notre IA identifie les commerçants à partir des données de reçus, construisant une base de données complète de vos habitudes d'achat. Obtenez des aperçus sur vos lieux d'achat, les tendances de dépenses et les comparaisons de commerçants.",
-            "tags": "ML,Aperçus,Suivi",
-            "title": "Intelligence Commerçants"
-          },
-          "recipes": {
-            "description": "Organisez et découvrez des créations culinaires",
-            "longDescription": "Stockez vos recettes préférées, découvrez-en de nouvelles et planifiez vos repas efficacement. Suggestions alimentées par l'IA basées sur les ingrédients, les préférences alimentaires et l'historique de cuisine.",
-            "tags": "Cuisine,Planification Repas,IA",
-            "title": "Gestion des Recettes"
-          },
-          "security": {
-            "description": "Sécurité de niveau bancaire pour vos données",
-            "longDescription": "Vos données sont protégées par un chiffrement de niveau entreprise, une authentification sécurisée via Azure AD B2C et la conformité au RGPD. Nous ne vendons ni ne partageons jamais vos informations personnelles.",
-            "tags": "Chiffrement,RGPD,SSO",
-            "title": "Sécurité Entreprise"
-          }
-        },
-        "modal": {
-          "close": "Fermer",
-          "exploreFeature": "Explorer la Fonctionnalité"
-        },
-        "title": "Tout ce dont vous avez besoin,",
-        "titleHighlight": "magnifiquement conçu"
-      },
-      "hero": {
-        "cta": {
-          "exploreFeatures": "Explorer les Fonctionnalités",
-          "viewSource": "Voir le Code Source"
-        },
-        "description": "Une plateforme full-stack complète combinant Next.js, .NET et les services cloud Azure. Construite avec une architecture de niveau entreprise, une conception pilotée par le domaine et un accent sur l'expérience développeur.",
-        "scrollIndicator": "Faites défiler pour explorer",
-        "stats": {
-          "countries": "Pays",
-          "linesOfCode": "Lignes de Code",
-          "projects": "Projets",
-          "techStack": "Stack Technologique"
-        },
-        "statusBadge": "Plateforme Technologique Open Source",
-        "subtitle": "Moderne • Évolutive • Open Source",
-        "title": "Bienvenue sur",
-        "trust": {
-          "freeForever": "Gratuit pour Toujours",
-          "openSource": "Open Source",
-          "privacyFirst": "Confidentialité d'Abord"
-        }
-      },
-      "metadata": {
-        "description": "En savoir plus sur la plateforme, arolariu.ro.",
-        "title": "La plateforme"
-      },
-      "statistics": {
-        "badge": "Statistiques de la Plateforme",
-        "description": "Un aperçu de l'échelle et de l'impact de la plateforme arolariu.ro, des lignes de code à la portée mondiale.",
-        "items": {
-          "apis": {
-            "description": "Microservices",
-            "label": "APIs",
-            "suffix": "+",
-            "value": "8"
-          },
-          "commits": {
-            "description": "Contributions de code",
-            "label": "Commits",
-            "suffix": "+",
-            "value": "2500"
-          },
-          "contributors": {
-            "description": "Open source",
-            "label": "Contributeurs",
-            "suffix": "+",
-            "value": "5"
-          },
-          "countries": {
-            "description": "Portée mondiale",
-            "label": "Pays",
-            "suffix": "+",
-            "value": "25"
-          },
-          "linesOfCode": {
-            "description": "Sur tous les projets",
-            "label": "Lignes de Code",
-            "suffix": "K+",
-            "value": "150"
-          },
-          "projects": {
-            "description": "Dépôts actifs",
-            "label": "Projets",
-            "suffix": "+",
-            "value": "15"
-          },
-          "stars": {
-            "description": "Étoiles GitHub",
-            "label": "Étoiles",
-            "suffix": "+",
-            "value": "50"
-          },
-          "users": {
-            "description": "Actifs mensuellement",
-            "label": "Utilisateurs",
-            "suffix": "+",
-            "value": "1000"
-          }
-        },
-        "title": "Des chiffres qui",
-        "titleHighlight": "parlent d'eux-mêmes"
-      },
-      "techStack": {
-        "badge": "Stack Technologique",
-        "categories": {
-          "backend": {
-            "description": "Technologies côté serveur évolutives et APIs",
-            "name": "Backend"
-          },
-          "cloud": {
-            "description": "Infrastructure et automatisation du déploiement",
-            "name": "Cloud et DevOps"
-          },
-          "frontend": {
-            "description": "Technologies web modernes pour des expériences utilisateur ultra-rapides",
-            "name": "Frontend"
-          },
-          "tooling": {
-            "description": "Outils et frameworks pour l'excellence en développement",
-            "name": "Outils de Développement"
-          }
-        },
-        "description": "Un stack technologique soigneusement sélectionné pour la performance, l'expérience développeur et la maintenabilité à long terme.",
-        "stats": {
-          "coverage": {
-            "description": "Tests unitaires et E2E",
-            "label": "Couverture de Tests",
-            "value": "90%+"
-          },
-          "security": {
-            "description": "Meilleures pratiques",
-            "label": "Note de Sécurité",
-            "value": "A+"
-          },
-          "technologies": {
-            "description": "Dans notre stack",
-            "label": "Technologies",
-            "value": "24+"
-          },
-          "typescript": {
-            "description": "Typage complet",
-            "label": "TypeScript",
-            "value": "100%"
-          }
-        },
-        "technologies": {
-          "aspnet": {
-            "description": "APIs web haute performance",
-            "name": "ASP.NET Core"
-          },
-          "azure": {
-            "description": "Fournisseur cloud principal",
-            "name": "Azure"
-          },
-          "azureDevops": {
-            "description": "Gestion de projet et pipelines",
-            "name": "Azure DevOps"
-          },
-          "azuresql": {
-            "description": "Base de données relationnelle gérée",
-            "name": "Azure SQL"
-          },
-          "bicep": {
-            "description": "Infrastructure as Code",
-            "name": "Bicep"
-          },
-          "cosmosdb": {
-            "description": "Base de données NoSQL distribuée globalement",
-            "name": "CosmosDB"
-          },
-          "docker": {
-            "description": "Plateforme de conteneurisation",
-            "name": "Docker"
-          },
-          "dotnet": {
-            "description": "Framework backend principal",
-            "name": ".NET"
-          },
-          "eslint": {
-            "description": "Linting JavaScript avec plus de 20 plugins",
-            "name": "ESLint"
-          },
-          "git": {
-            "description": "Système de contrôle de version",
-            "name": "Git"
-          },
-          "githubActions": {
-            "description": "Automatisation CI/CD",
-            "name": "GitHub Actions"
-          },
-          "motion": {
-            "description": "Animations prêtes pour la production",
-            "name": "Motion"
-          },
-          "nextjs": {
-            "description": "Framework React full-stack avec SSR/SSG",
-            "name": "Next.js"
-          },
-          "nodejs": {
-            "description": "BFF et fonctions serverless",
-            "name": "Node.js"
-          },
-          "playwright": {
-            "description": "Framework de tests E2E",
-            "name": "Playwright"
-          },
-          "pnpm": {
-            "description": "Gestion des paquets",
-            "name": "pnpm/npm"
-          },
-          "prettier": {
-            "description": "Formatage de code",
-            "name": "Prettier"
-          },
-          "react": {
-            "description": "Bibliothèque UI pour construire des interfaces interactives",
-            "name": "React"
-          },
-          "redis": {
-            "description": "Cache en mémoire pour la performance",
-            "name": "Redis"
-          },
-          "scss": {
-            "description": "Feuilles de style à portée de composant avec CSS Modules",
-            "name": "Modules SCSS"
-          },
-          "typescript": {
-            "description": "JavaScript typé pour un code robuste",
-            "name": "TypeScript"
-          },
-          "vercel": {
-            "description": "Plateforme de déploiement frontend",
-            "name": "Vercel"
-          },
-          "vitest": {
-            "description": "Framework de tests unitaires",
-            "name": "Vitest"
-          },
-          "zustand": {
-            "description": "Gestion d'état légère",
-            "name": "Zustand"
-          }
-        },
-        "title": "Alimentée par",
-        "titleHighlight": "des technologies modernes"
-      },
-      "timeline": {
-        "badge": "Parcours de Développement",
-        "collapseHint": "Cliquez pour réduire",
-        "description": "Le parcours d'arolariu.ro d'une simple idée à une plateforme complète, avec les jalons clés en chemin.",
-        "events": {
-          "ai": {
-            "date": "Juin 2024",
-            "description": "Intégration profonde avec Azure OpenAI pour le traitement intelligent de documents et les requêtes en langage naturel.",
-            "details": "Intégration Azure OpenAI GPT-4,Requêtes de factures en langage naturel,Algorithmes de catégorisation intelligente,Fonctionnalités d'analytique prédictive",
-            "tags": "GPT-4,Azure AI,NLP",
-            "title": "Intégration IA"
-          },
-          "backend": {
-            "date": "Septembre 2022",
-            "description": "Refonte complète du backend avec implémentation de .NET et architecture cloud-native.",
-            "details": "Développement API .NET 6,Configuration de l'infrastructure cloud Azure,Conception de base de données avec CosmosDB,Implémentation du pipeline CI/CD",
-            "tags": ".NET,Azure,API",
-            "title": "Infrastructure Backend"
-          },
-          "expansion": {
-            "date": "Janvier 2023",
-            "description": "Ajouts majeurs de fonctionnalités incluant le traitement des factures et les capacités d'analyse alimentées par l'IA.",
-            "details": "Téléchargement de factures et intégration OCR,Intégration Azure Document Intelligence,Algorithmes de détection de commerçants,Fonctionnalités de suivi de budget",
-            "tags": "IA,OCR,Factures",
-            "title": "Expansion de la Plateforme"
-          },
-          "inception": {
-            "date": "Mars 2022",
-            "description": "La plateforme arolariu.ro a été conçue comme un projet d'apprentissage personnel pour explorer le développement web moderne.",
-            "details": "Phase initiale de concept et planification,Recherche sur les technologies web modernes,Premier dépôt créé sur GitHub,Prototype HTML/CSS de base développé",
-            "tags": "Planification,Recherche",
-            "title": "Lancement du Projet"
-          },
-          "launch": {
-            "date": "Juin 2023",
-            "description": "Lancement public officiel avec un ensemble complet de fonctionnalités et une infrastructure prête pour la production.",
-            "details": "Déploiement en production sur Azure,Configuration de domaine personnalisé,Implémentation de la sécurité SSL/TLS,Optimisation des performances",
-            "tags": "Lancement,Production",
-            "title": "Lancement Public"
-          },
-          "nextjs": {
-            "date": "Décembre 2023",
-            "description": "Réécriture complète du frontend vers Next.js App Router avec React Server Components.",
-            "details": "Migration vers Next.js 14+,Adoption des React Server Components,SEO amélioré avec génération statique,Métriques de performance améliorées",
-            "tags": "Next.js,RSC,Migration",
-            "title": "Migration Next.js"
-          },
-          "present": {
-            "date": "Présent",
-            "description": "Développement en cours avec de nouvelles fonctionnalités, optimisations et contributions de la communauté.",
-            "details": "Mises à jour régulières des fonctionnalités,Améliorations de performance,Intégration des retours de la communauté,Planification de la feuille de route future",
-            "tags": "Actif,En croissance",
-            "title": "Évolution Continue"
-          },
-          "prototype": {
-            "date": "Juin 2022",
-            "description": "Le premier prototype fonctionnel de la plateforme a été développé en utilisant React et des services backend de base.",
-            "details": "Implémentation du frontend React,Flux d'authentification de base,Design UI/UX initial,Configuration de l'environnement de développement local",
-            "tags": "React,Frontend",
-            "title": "Premier Prototype"
-          }
-        },
-        "expandHint": "Cliquez pour développer",
-        "futureIndicator": "Le voyage continue...",
-        "keyAchievements": "Réalisations clés :",
-        "title": "De l'idée à",
-        "titleHighlight": "la réalité"
-      }
-    },
-    "subtitle": " L'histoire d'arolariu.ro a commencé en 2022, lorsque l'auteur - Alexandru-Razvan Olariu, voulait comprendre comment fonctionnent les sites web. Toute la plateforme et les intégrations sous-jacentes ont été développées uniquement par l'auteur, à partir de ce qu'il a appris au fil des années. Alexandru travaille actuellement comme ingénieur logiciel chez Microsoft. Pour en savoir plus sur lui, consultez la section de droite de cette page. La plateforme est construite en utilisant les dernières technologies de pointe. Pour en savoir plus, consultez la section de gauche de cette page.",
-    "title": "À propos de nous"
-  },
-  "Acknowledgements": {
-    "contributors": {
       "items": {
-        "c1": {
-          "description": "Instrumentation d'observabilité",
-          "name": "OpenTelemetry Authors",
-          "packages": "12"
+        "dark": "Sombre",
+        "disco": "Mode disco",
+        "english": "English",
+        "fontDyslexic": "Police adaptée à la dyslexie",
+        "fontNormal": "Police standard",
+        "french": "Français",
+        "github": "GitHub",
+        "homepage": "Page d'accueil",
+        "light": "Clair",
+        "matrix": "Mode Matrix",
+        "rainbow": "Mode arc-en-ciel",
+        "romanian": "Română",
+        "system": "Système"
+      },
+      "noResults": "Aucun résultat trouvé.",
+      "placeholder": "Tapez une commande ou recherchez..."
+    },
+    "errors": {
+      "globalError": {
+        "actions": {
+          "step1": "Essayez de rafraîchir la page en utilisant le bouton ci-dessous.",
+          "step2": "Retournez à la page d'accueil et recommencez.",
+          "step3": "Contactez le support si le problème persiste.",
+          "whatCanYouDoTitle": "Que pouvez-vous faire ?"
         },
-        "c2": {
-          "description": "SDKs Azure et outils",
-          "name": "Microsoft Corporation",
-          "packages": "5"
+        "buttons": {
+          "copied": "Copié !",
+          "copyErrorId": "Copier l’ID d’erreur",
+          "copyErrorIdTitle": "Copier l’ID d’erreur",
+          "returnHome": "Retour à l’accueil",
+          "tryAgain": "Réessayer"
         },
-        "c3": {
-          "description": "Solutions d'authentification",
-          "name": "Clerk",
-          "packages": "2"
+        "copyErrorConsoleMessage": "Échec de la copie de l’ID d’erreur :",
+        "details": {
+          "errorIdLabel": "ID d’erreur :",
+          "genericDescription": "Une erreur est survenue lors du traitement de votre demande.",
+          "title": "Détails de l’erreur",
+          "unknownError": "Une erreur inconnue est survenue.",
+          "whatHappenedTitle": "Que s’est-il passé ?"
         },
-        "c4": {
-          "description": "Utilitaires de test",
-          "name": "Kent C. Dodds",
-          "packages": "3"
+        "diagnostics": {
+          "loading": "Chargement des informations de diagnostic...",
+          "scanLabel": "Analyser pour obtenir des informations de diagnostic :",
+          "stackTraceLabel": "Trace de pile :",
+          "technicalSummary": "Informations techniques (pour les développeurs)"
+        },
+        "hero": {
+          "subtitle": "Une erreur inattendue est survenue. Notre équipe a été automatiquement informée.",
+          "title": "Un problème est survenu"
+        },
+        "metadata": {
+          "title": "Erreur d'application - AROLARIU.RO"
+        },
+        "support": {
+          "contactPrefix": "Si ce problème persiste, veuillez nous contacter à",
+          "includeErrorId": "et incluez l’ID d’erreur :"
         }
       },
-      "packages": "{count, plural, one {# paquet} other {# paquets}}",
-      "subtitle": "Organisations et individus dont nous dépendons le plus",
-      "title": "Principaux Contributeurs"
-    },
-    "hero": {
-      "badge": "Open Source",
-      "lastUpdate": "Dernière mise à jour : {date}",
-      "subtitle": "Cette plateforme est construite sur les épaules de projets open-source incroyables. Nous sommes reconnaissants envers les mainteneurs et contributeurs qui rendent leur travail librement disponible.",
-      "title": "Remerciements"
-    },
-    "lastUpdate": "Dernière mise à jour le : {date}",
-    "licenses": {
-      "apache": "Apache 2.0",
-      "apacheDescription": "Licence open-source adaptée aux entreprises",
-      "gpl": "Licence GPL",
-      "gplDescription": "Licence copyleft garantissant que le code reste libre",
-      "mit": "Licence MIT",
-      "mitDescription": "Licence permissive permettant une utilisation large",
-      "other": "Autres Licences",
-      "otherDescription": "Licences personnalisées ou diverses licences open-source",
-      "packages": "{count, plural, one {# paquet} other {# paquets}}",
-      "title": "Distribution des Licences"
-    },
-    "metadata": {
-      "description": "Page de remerciements pour les packages tiers utilisés dans ce projet et les collaborateurs.",
-      "title": "Remerciements"
-    },
-    "packages": {
-      "subtitle": "Ce site web n'aurait pas été possible sans les packages tiers suivants. Je tiens à remercier les auteurs de ces packages pour leur travail acharné et leur dévouement à la communauté open-source.",
-      "title": "Packages tiers"
-    },
-    "packagesScreen": {
-      "badge": {
-        "development": "Développement",
-        "production": "Production"
-      },
-      "card": {
-        "dependencies": "Dépendances :",
-        "license": "Licence :",
-        "viewDependencies": "Voir les Dépendances",
-        "website": "Site Web"
-      },
-      "dialog": {
-        "dependencies": "Dépendances de {name}",
-        "dependenciesCount": "Ce package a {count} dépendances."
-      },
-      "emptyState": {
-        "subtitle": "Essayez d'ajuster les filtres ci-dessus.",
-        "title": "Aucun package trouvé."
-      },
-      "filters": {
-        "allPackages": "Tous les Packages",
-        "ascending": "Croissant",
-        "dependenciesCount": "Nombre de Dépendances",
-        "descending": "Décroissant",
-        "developmentOnly": "Développement Uniquement",
-        "filterByType": "Filtrer par type",
-        "name": "Nom",
-        "packageType": "Type de Package",
-        "productionOnly": "Production Uniquement",
-        "sortBy": "Trier par",
-        "sortDirection": "Direction du tri"
-      },
-      "openSource": {
-        "description": "Ce projet repose sur les épaules de géants. Nous sommes reconnaissants envers la communauté open-source et tous les développeurs qui ont contribué à ces packages.",
-        "title": "L'Open Source Compte"
-      },
-      "search": {
-        "placeholder": "Rechercher..."
-      },
-      "table": {
-        "dependencies": "Dépendances",
-        "description": "Description",
-        "license": "Licence",
-        "package": "Paquet",
-        "type": "Type",
-        "version": "Version",
-        "website": "Site Web"
-      },
-      "views": {
-        "gridView": "Vue Grille",
-        "tableView": "Vue Tableau"
-      }
-    },
-    "stats": {
-      "development": {
-        "description": "Outils de build",
-        "label": "Développement",
-        "value": "{count}"
-      },
-      "mitLicense": {
-        "description": "Licence la plus courante",
-        "label": "Licence MIT",
-        "value": "{count}"
-      },
-      "production": {
-        "description": "Dépendances d'exécution",
-        "label": "Production",
-        "value": "{count}"
-      },
-      "subtitle": "Un aperçu de l'écosystème open-source qui alimente cette plateforme",
-      "title": "Aperçu des Dépendances",
-      "total": {
-        "description": "Dépendances utilisées",
-        "label": "Total des Packages",
-        "value": "{count}"
-      }
-    },
-    "title": "Remerciements"
-  },
-  "Auth": {
-    "Button": {
-      "login": "Connexion",
-      "logout": "Déconnexion"
-    },
-    "Island": {
-      "callToAction": "S'authentifier",
-      "description": "Connectez-vous en utilisant notre serveur d'authentification OAuth 2.0 sécurisé. Votre profil sera synchronisé pendant cette session de navigation. Vous pouvez utiliser vos comptes de réseaux sociaux pour vous connecter.",
-      "footer": "Vous pouvez changer de fournisseur à tout moment. L'authentification est gérée par notre fournisseur d'identité de confiance.",
-      "hero": {
-        "badge": "Authentification Sécurisée",
-        "subtitle": "Choisissez un chemin et continuez avec votre fournisseur préféré. Tout reste rapide, sécurisé et localisé.",
-        "title": "Bienvenue au point d'entrée sécurisé"
-      },
-      "signIn": {
-        "bullets": {
-          "first": "Continuez avec le fournisseur d'identité que vous utilisez déjà.",
-          "second": "Reprenez là où vous vous êtes arrêté sur n'importe quel appareil.",
-          "third": "La session reste synchronisée pendant votre navigation."
+      "notFound": {
+        "additionalInfo": "Informations supplémentaires :",
+        "buttons": {
+          "returnButton": "Retourner à la page d'accueil.",
+          "submitErrorButton": "Signaler une fausse erreur."
         },
-        "cta": "Se connecter",
-        "description": "Accédez à votre compte et gardez votre session synchronisée pendant cette session de navigation.",
-        "illustrationAlt": "Illustration pour la connexion",
-        "secondaryAction": "En créer un",
-        "secondaryPrompt": "Vous n'avez pas de compte ?",
-        "title": "Se connecter"
-      },
-      "signUp": {
-        "bullets": {
-          "first": "Créez un compte en quelques secondes avec les fournisseurs OAuth.",
-          "second": "Pas de mots de passe à retenir.",
-          "third": "Commencez à utiliser la plateforme immédiatement."
-        },
-        "cta": "Créer un compte",
-        "description": "Rejoignez la plateforme et débloquez les expériences réservées aux membres dans l'espace du domaine.",
-        "illustrationAlt": "Illustration pour l'inscription",
-        "secondaryAction": "Se connecter",
-        "secondaryPrompt": "Vous avez déjà un compte ?",
-        "title": "S'inscrire"
-      },
-      "step1": "Étape 1",
-      "step2": "Étape 2",
-      "title": "Authentifiez-vous avec notre serveur d'authentification OAuth 2.0 sécurisé.",
-      "trust": {
-        "oauth": "OAuth 2.0",
-        "privacy": "Confidentialité d'abord",
-        "session": "Synchronisation de session"
+        "falsePositive": "Si vous pensez que cette page devrait exister et que vous rencontrez une erreur, veuillez le signaler à l'administrateur du site.",
+        "subtitle": "Il semble que la page sur laquelle vous avez atterri n'est pas présente sur le site web. Si cette page devrait exister, veuillez le signaler à l'administrateur du site.",
+        "title": "404 - Page non trouvée."
       }
     },
-    "metadata": {
-      "description": "La page d'authentification pour la plateforme arolariu.ro.",
-      "title": "Authentification"
+    "footer": {
+      "accessibility": {
+        "brandTitle": "AROLARIU.RO",
+        "goHome": "Aller à l'accueil",
+        "logoAlt": "Le logo d'arolariu.ro."
+      },
+      "builtOn": "Construit le ",
+      "commitSha": "SHA du Commit :",
+      "copyright": "Droits d'auteur",
+      "navigation": {
+        "about": "À propos",
+        "acknowledgements": "Remerciements",
+        "privacyPolicy": "Politique de Confidentialité",
+        "subdomains": "Sous-domaines",
+        "termsOfService": "Conditions de Service",
+        "what": "Qu'est-ce que c'est ?"
+      },
+      "socialLinks": {
+        "github": "Sélectionnez ce lien pour accéder à la page GitHub de l'auteur.",
+        "linkedin": "Sélectionnez ce lien pour accéder à la page LinkedIn de l'auteur."
+      },
+      "sourceCode": "Le code source est disponible ",
+      "sourceCodeAnchor": "ici (dépôt GitHub)",
+      "subtitle": "La plateforme est construite en utilisant les dernières technologies stables et de pointe avec une expérience de niveau entreprise. <br></br> <br></br> Nous espérons que vous aurez une excellente expérience en explorant cette plateforme."
     },
-    "SignIn": {
-      "bullets": {
-        "first": "Connexion rapide avec des fournisseurs de confiance.",
-        "second": "Votre session reste cohérente dans toute l'application.",
-        "third": "Conçu pour fonctionner parfaitement sur mobile et ordinateur."
-      },
-      "footer": "Protégé par une sécurité de niveau entreprise.",
-      "form": {
-        "kicker": "Connectez-vous avec votre fournisseur préféré",
-        "secondaryAction": "Créer un compte",
-        "secondaryPrompt": "Nouveau ici ?"
-      },
-      "hero": {
-        "subtitle": "Utilisez le fournisseur en qui vous avez confiance et continuez instantanément.",
-        "title": "Bon retour"
-      },
-      "illustrationAlt": "Illustration pour la page de connexion",
-      "metadata": {
-        "description": "Connectez-vous pour continuer votre session sur arolariu.ro.",
-        "title": "Connexion"
-      }
-    },
-    "SignUp": {
-      "bullets": {
-        "first": "Intégration rapide avec les fournisseurs OAuth.",
-        "second": "Pas de carte de crédit requise.",
-        "third": "Commencez à explorer la plateforme immédiatement."
-      },
-      "footer": "Inscription rapide et sécurisée.",
-      "form": {
-        "kicker": "Créez votre compte avec votre fournisseur préféré",
-        "secondaryAction": "Se connecter",
-        "secondaryPrompt": "Vous avez déjà un compte ?"
-      },
-      "hero": {
-        "subtitle": "Créez votre compte en quelques secondes et commencez.",
-        "title": "Rejoignez-nous aujourd'hui"
-      },
-      "illustrationAlt": "Illustration pour la page d'inscription",
-      "metadata": {
-        "description": "Créez un compte et commencez à utiliser arolariu.ro.",
-        "title": "Inscription"
-      }
-    }
-  },
-  "Commander": {
-    "groups": {
-      "accessibility": "Accessibilité",
-      "fun": "Amusement",
-      "language": "Langue",
-      "links": "Liens",
-      "navigation": "Navigation",
-      "theme": "Thème"
-    },
-    "items": {
-      "dark": "Sombre",
-      "disco": "Mode disco",
-      "english": "English",
-      "fontDyslexic": "Police adaptée à la dyslexie",
-      "fontNormal": "Police standard",
-      "french": "Français",
-      "github": "GitHub",
-      "homepage": "Page d'accueil",
-      "light": "Clair",
-      "matrix": "Mode Matrix",
-      "rainbow": "Mode arc-en-ciel",
-      "romanian": "Română",
-      "system": "Système"
-    },
-    "noResults": "Aucun résultat trouvé.",
-    "placeholder": "Tapez une commande ou recherchez..."
-  },
-  "Common": {
-    "accessibility": {
-      "logoAlt": "logo arolariu.ro",
-      "toggleTheme": "Basculer le thème"
-    },
-    "states": {
-      "forbidden": {
-        "callToAction": "Rejoignez le domaine arolariu.ro.",
-        "description": "Malheureusement, cette fonctionnalité nécessite que vous ayez un compte sur notre domaine. En créant un compte sur notre plateforme ou en vous connectant avec un compte existant, vous pourrez accéder à tout notre arsenal de services, y compris celui-ci.",
-        "title": "Vous manquez quelque chose d'amusant !"
-      }
-    }
-  },
-  "Domains": {
-    "metadata": {
-      "description": "Les services de l'espace de domaine sont des services offerts aux visiteurs et membres de l'espace de domaine `arolariu.ro`",
-      "title": "Services de l'Espace de Domaine"
-    },
-    "services": {
-      "callToAction": "Visiter ce service de domaine",
-      "invoices": {
-        "card": {
-          "description": "Ce service de l'espace de domaine aide à la transformation numérique des reçus physiques. Il permet aux utilisateurs de télécharger des reçus et d'obtenir des informations soigneusement élaborées sur leurs habitudes de dépenses.",
-          "imageAlt": "Illustration du système de gestion des factures montrant la numérisation des reçus",
-          "title": "Système de Gestion des Factures"
-        }
-      }
-    },
-    "subtitle": "La plateforme <code>arolariu.ro</code> offre une large gamme de services sous son parapluie. <br></br> La plupart des services nécessitent que vous ayez un compte créé sur cette plateforme, afin que vos données puissent être synchronisées en toute sécurité entre tous les services du domaine. <br></br> <br></br> Ici vous pouvez voir une vitrine de tous les services de domaine disponibles pour l'exploration.",
-    "title": "Services de l'Espace de Domaine"
-  },
-  "Errors": {
-    "globalError": {
-      "actions": {
-        "step1": "Essayez de rafraîchir la page en utilisant le bouton ci-dessous.",
-        "step2": "Retournez à la page d'accueil et recommencez.",
-        "step3": "Contactez le support si le problème persiste.",
-        "whatCanYouDoTitle": "Que pouvez-vous faire ?"
-      },
-      "buttons": {
-        "copied": "Copié !",
-        "copyErrorId": "Copier l’ID d’erreur",
-        "copyErrorIdTitle": "Copier l’ID d’erreur",
-        "returnHome": "Retour à l’accueil",
-        "tryAgain": "Réessayer"
-      },
-      "copyErrorConsoleMessage": "Échec de la copie de l’ID d’erreur :",
-      "details": {
-        "errorIdLabel": "ID d’erreur :",
-        "genericDescription": "Une erreur est survenue lors du traitement de votre demande.",
-        "title": "Détails de l’erreur",
-        "unknownError": "Une erreur inconnue est survenue.",
-        "whatHappenedTitle": "Que s’est-il passé ?"
-      },
-      "diagnostics": {
-        "loading": "Chargement des informations de diagnostic...",
-        "scanLabel": "Analyser pour obtenir des informations de diagnostic :",
-        "stackTraceLabel": "Trace de pile :",
-        "technicalSummary": "Informations techniques (pour les développeurs)"
-      },
-      "hero": {
-        "subtitle": "Une erreur inattendue est survenue. Notre équipe a été automatiquement informée.",
-        "title": "Un problème est survenu"
-      },
-      "metadata": {
-        "title": "Erreur d'application - AROLARIU.RO"
-      },
-      "support": {
-        "contactPrefix": "Si ce problème persiste, veuillez nous contacter à",
-        "includeErrorId": "et incluez l’ID d’erreur :"
-      }
-    },
-    "notFound": {
-      "additionalInfo": "Informations supplémentaires :",
-      "buttons": {
-        "returnButton": "Retourner à la page d'accueil.",
-        "submitErrorButton": "Signaler une fausse erreur."
-      },
-      "falsePositive": "Si vous pensez que cette page devrait exister et que vous rencontrez une erreur, veuillez le signaler à l'administrateur du site.",
-      "subtitle": "Il semble que la page sur laquelle vous avez atterri n'est pas présente sur le site web. Si cette page devrait exister, veuillez le signaler à l'administrateur du site.",
-      "title": "404 - Page non trouvée."
-    }
-  },
-  "EULA": {
-    "accept": "Accepter le CLUF",
-    "content": "En utilisant ce site web, vous acceptez les termes et conditions et la politique de confidentialité du Contrat de Licence Utilisateur Final (CLUF). Veuillez lire attentivement les documents suivants avant d'utiliser le site web :",
-    "cookiesPolicy": {
-      "cookies": {
-        "analytics": {
-          "checkbox": "Activer les cookies analytiques nous aide à améliorer notre site web.",
-          "description": "Ces cookies nous permettent de compter les visites et les sources de trafic, afin que nous puissions mesurer et améliorer les performances de notre site. Ils nous aident à savoir quelles pages sont les plus et les moins populaires et à voir comment les visiteurs naviguent sur le site. Toutes les informations que ces cookies collectent sont agrégées et peuvent donc être considérées comme anonymes.",
-          "title": "Cookies Analytiques"
-        },
-        "cta": "Enregistrer la configuration des cookies",
-        "essential": {
-          "checkbox": "Cette option ne peut pas être désactivée. Les cookies essentiels sont toujours activés.",
-          "description": "Les cookies essentiels sont nécessaires au bon fonctionnement du site web. Cette catégorie n'inclut que les cookies qui assurent les fonctionnalités de base et les caractéristiques de sécurité du site web.",
-          "title": "Cookies Essentiels"
-        }
-      },
-      "subtitle": "Gérez vos paramètres de cookies. Vous pouvez activer ou désactiver différents types de cookies ci-dessous.",
-      "title": "Préférences de Cookies"
-    },
-    "language": "Langue",
-    "privacyPolicy": {
-      "cta": "Voir la Politique",
-      "subtitle": "Notre Politique de Confidentialité explique comment nous collectons, utilisons et protégeons vos informations personnelles lorsque vous utilisez nos services.",
-      "title": "Politique de Confidentialité"
-    },
-    "subtitle": "Veuillez consulter nos termes et conditions avant d'utiliser le site web.",
-    "termsOfService": {
-      "cta": "Voir les Conditions",
-      "subtitle": "Nos Conditions de Service décrivent les règles et directives pour l'utilisation de notre plateforme, y compris les responsabilités de l'utilisateur et nos obligations.",
-      "title": "Conditions de Service"
-    },
-    "title": "Contrat de Licence Utilisateur Final (CLUF)"
-  },
-  "Footer": {
-    "accessibility": {
-      "brandTitle": "AROLARIU.RO",
-      "goHome": "Aller à l'accueil",
-      "logoAlt": "Le logo d'arolariu.ro."
-    },
-    "builtOn": "Construit le ",
-    "commitSha": "SHA du Commit :",
-    "copyright": "Droits d'auteur",
     "navigation": {
       "about": "À propos",
-      "acknowledgements": "Remerciements",
-      "privacyPolicy": "Politique de Confidentialité",
-      "subdomains": "Sous-domaines",
-      "termsOfService": "Conditions de Service",
-      "what": "Qu'est-ce que c'est ?"
-    },
-    "socialLinks": {
-      "github": "Sélectionnez ce lien pour accéder à la page GitHub de l'auteur.",
-      "linkedin": "Sélectionnez ce lien pour accéder à la page LinkedIn de l'auteur."
-    },
-    "sourceCode": "Le code source est disponible ",
-    "sourceCodeAnchor": "ici (dépôt GitHub)",
-    "subtitle": "La plateforme est construite en utilisant les dernières technologies stables et de pointe avec une expérience de niveau entreprise. <br></br> <br></br> Nous espérons que vous aurez une excellente expérience en explorant cette plateforme."
+      "domains": "Domaines",
+      "invoices": "Factures",
+      "mobile": {
+        "closeNavigation": "Fermer la navigation",
+        "openNavigation": "Ouvrir la navigation",
+        "title": "Navigation"
+      },
+      "myInvoices": "Mes Factures",
+      "myProfile": "Mon Profil",
+      "theAuthor": "L'Auteur",
+      "thePlatform": "La Plateforme",
+      "uploadScans": "Télécharger des Scans",
+      "viewScans": "Voir les Scans"
+    }
   },
-  "Home": {
-    "appreciation": "MERCI POUR LE TEMPS PASSÉ SUR LE SITE WEB.",
-    "cta": "Commencer l'Exploration",
-    "featuresTab": {
-      "azure": {
-        "description": "Le cloud Microsoft Azure est utilisé pour héberger la plateforme et tous ses services. Cela garantit que la plateforme est toujours disponible et qu'elle peut évoluer à la demande.",
-        "title": "Microsoft Azure"
+  "cards": {
+    "invoices": {
+      "budgetImpactCard": {
+        "dailyAllowance": "Budget quotidien",
+        "dailyAllowanceValue": "{amount} / jour",
+        "daysLeft": "Jours restants",
+        "inMonth": "en {month}",
+        "invoiceUsed": "Cette facture a utilisé",
+        "monthlyBudget": "Budget mensuel",
+        "ofMonthlyBudget": "de votre budget mensuel",
+        "overBudget": "Dépassement de budget",
+        "remaining": "Restant",
+        "spent": "{amount} dépensés",
+        "title": "Impact budgétaire de {month}"
       },
-      "csharp": {
-        "description": "La plateforme est construite avec .NET 8 LTS - la dernière version stable de .NET. Cela garantit que la plateforme est rapide, fiable et facile à utiliser. La plateforme est construite avec C# et F#.",
-        "title": ".NET 8 LTS"
+      "categorySuggestionCard": {
+        "description": "Nous n’avons pas pu catégoriser automatiquement cette facture. Sélectionnez la bonne catégorie pour débloquer des analyses :",
+        "gamification": "Catégorisez {goal} factures pour débloquer des analyses détaillées !",
+        "moreCategories": "Plus de catégories :",
+        "title": "Aidez-nous à catégoriser cette facture"
       },
-      "description": "La plateforme `arolariu.ro` est construite avec les dernières technologies stables.",
-      "githubActions": {
-        "description": "L'expérience DevOps est alimentée par GitHub Actions. (CI/CD, Tests, etc.)",
-        "title": "GitHub Actions"
+      "comparisonStatsCard": {
+        "avgValue": "Moy. : {amount} {currency}",
+        "itemCount": "Article Count",
+        "itemCountComparison": "{current} vs moy {average}",
+        "maxValue": "Max. : {amount}",
+        "minValue": "Min. : {amount}",
+        "positionInRange": "Votre position dans la plage de dépenses",
+        "sameStore": "Même magasin",
+        "sameStoreComparison": "vs moy {average} {currency}",
+        "subtitle": "Par rapport à vos {count} dernières factures",
+        "thisValue": "Cette facture : {amount} {currency}",
+        "title": "Comment vous vous situez",
+        "vsAverage": "vs moyenne"
       },
-      "learnMoreBtn": "Intéressant ? Cliquez ici pour en savoir plus...",
-      "nextJs": {
-        "description": "La plateforme est construite avec NextJS - le framework React le plus populaire pour la production. Il est conçu pour des applications React de niveau production. NextJS est le framework React le plus populaire pour une bonne raison : il est rapide, fiable et facile à utiliser.",
-        "title": "Next.JS 15"
+      "diningCard": {
+        "challenge": {
+          "descriptionPrefix": "Évitez la restauration rapide pendant 7 jours et enregistrez",
+          "descriptionSuffix": "",
+          "title": "Défi hebdomadaire"
+        },
+        "estimatedNutrition": {
+          "calories": "Énergie",
+          "caloriesValue": "~{value} kcal",
+          "carbs": "Glucides",
+          "carbsValue": "~{value}g",
+          "protein": "Protéines",
+          "proteinValue": "~{value}g",
+          "sodium": "Sel (sodium)",
+          "title": "Valeurs nutritionnelles estimées"
+        },
+        "habits": {
+          "avgSpend": "Dépense moyenne",
+          "favorite": "Préféré",
+          "frequency": "Fréquence",
+          "frequencyDiff": "+1 vs moyenne",
+          "frequencyValue": "{count}x/mois",
+          "title": "Vos habitudes de restauration rapide",
+          "visits": "{count} visites"
+        },
+        "sodium": {
+          "high": "Élevé",
+          "low": "Faible",
+          "medium": "Moyen"
+        },
+        "swaps": {
+          "caloriesSaved": "-{count} kcal",
+          "grilled": "Grillé au lieu de frit",
+          "moneySaved": ", économise {amount}",
+          "salad": "Salade d’accompagnement au lieu de frites",
+          "title": "Alternatives plus saines",
+          "water": "Eau au lieu de soda"
+        },
+        "title": "Informations restauration"
       },
-      "otel": {
-        "description": "Observabilité complète avec métriques, traces et logs intégrés. Tout est instrumenté avec OpenTelemetry. Cela permet une expérience de télémétrie unifiée sur toute la ligne. (3PO : métriques, logs, traces)",
-        "title": "Open Telemetry"
+      "generalExpenseCard": {
+        "aria": {
+          "changeCategory": "Change detected catégorie",
+          "confirmCategory": "Confirmer que la catégorie détectée est correcte",
+          "export": "Exporter les données de dépense",
+          "organize": "Organiser cette dépense en catégories"
+        },
+        "budgetCategories": {
+          "electronics": "Électronique",
+          "entertainment": "Divertissement",
+          "shopping": "Achats"
+        },
+        "buttons": {
+          "change": "Modifier",
+          "correct": "Valider",
+          "export": "Exporter",
+          "organize": "Organiser"
+        },
+        "confidence": "Confiance : {value}%",
+        "detectedCategory": "Électronique / Technologie",
+        "nearLimitAlert": "{name} : {percent}% utilisé (10 jours restants ce mois)",
+        "options": {
+          "businessExpense": "Marquer comme dépense professionnelle",
+          "insuranceInventory": "Ajouter à l’inventaire d’assurance",
+          "trackWarranty": "Suivre la garantie (24 mois standard)"
+        },
+        "sections": {
+          "autoDetectedCategory": "Auto-detected catégorie",
+          "budgetImpact": "Impact sur le budget",
+          "similarPurchases": "Achats similaires passés",
+          "taxBusiness": "Options fiscales et professionnelles"
+        },
+        "title": "Analyse des dépenses",
+        "vatReclaimable": "TVA récupérable"
       },
-      "svelte": {
-        "description": "Utilisation de Svelte pour des composants UI réactifs ultra-rapides. La plateforme `cv.arolariu.ro` est construite exclusivement avec Svelte et SvelteKit (v5)",
-        "title": "Svelte"
+      "homeInventoryCard": {
+        "bulk": {
+          "description": "Un bidon de 5L vs 2L permet d’économiser 18% ({amount}/an)",
+          "title": "Économies sur achats en gros"
+        },
+        "eco": {
+          "productsWithEcoLabels": "{count} produits avec des écolabels",
+          "recyclablePackaging": "{count} produit avec emballage recyclable",
+          "tip": "Tip: Eco alternatives enregistrer 2kg plastic/year",
+          "title": "Score écoresponsable"
+        },
+        "stockLevels": {
+          "daysRemaining": "~{count} jours",
+          "title": "Niveaux de stock des fournitures (estimés)"
+        },
+        "supplyNames": {
+          "dishSoap": "Liquide vaisselle",
+          "floorCleaner": "Nettoyant pour sols",
+          "laundryDetergent": "Lessive",
+          "paperProducts": "Produits en papier"
+        },
+        "title": "Inventaire du domicile et fournitures"
       },
-      "title": "Fonctionnalités Clés"
-    },
-    "subtitle": "Cette plateforme a été construite par Alexandru-Razvan Olariu comme terrain de jeu pour les nouvelles technologies. La plateforme est construite avec des technologies de pointe et de niveau entreprise. <br> </br> <br> </br> Vous êtes invité à explorer toutes les applications et services hébergés sur cet espace de domaine.",
-    "technologyTab": {
-      "badgeTitle": "Architecture Moderne",
-      "description": "Cette plateforme exploite les dernières technologies web, combinant Next.js pour le frontend avec .NET pour des services backend robustes, le tout déployé sur Microsoft Azure.",
-      "learnMoreBtn": "Explorer l'Architecture",
-      "points": {
-        "point1": "Architecture serverless pour une mise à l'échelle et des performances optimales",
-        "point2": "TypeScript full-stack pour la sécurité des types dans toute l'application",
-        "point3": "Télémétrie et surveillance complètes avec OpenTelemetry"
+      "imageCard": {
+        "aria": {
+          "expandImage": "Cliquer pour agrandir l’image"
+        },
+        "buttons": {
+          "addScan": "Ajouter un scan",
+          "expand": "Agrandir l’image",
+          "next": "Suivant",
+          "previous": "Précédent",
+          "remove": "Supprimer"
+        },
+        "dialogTitle": "Image du reçu",
+        "dialogTitleWithIndex": "Image du reçu ({current}/{total})",
+        "scanAlt": "Scan du reçu {index}",
+        "scanAltFullSize": "Scan du reçu {index} - taille réelle",
+        "title": "Scan du reçu",
+        "titleWithIndex": "Scan du reçu ({current}/{total})",
+        "tooltips": {
+          "addScan": "Téléverser et joindre un nouveau scan du reçu",
+          "expand": "Voir l’image du reçu en taille réelle",
+          "next": "Voir le scan suivant du reçu",
+          "previous": "Voir le scan précédent du reçu",
+          "remove": "Supprimer le scan actuel du reçu"
+        }
       },
-      "title": "Construit pour l'Avenir."
-    },
-    "title": "Bienvenue sur arolariu.ro"
+      "invoiceCard": {
+        "descriptionPlaceholder": "Saisissez la description de la facture...",
+        "fromMerchant": "De {merchant}",
+        "importantBadge": "IMPORTANT",
+        "labels": {
+          "category": "Catégorie",
+          "dateUtc": "Date et heure (UTC)",
+          "hours": "Heures",
+          "minutes": "Min",
+          "paymentMethod": "Mode de paiement",
+          "totalAmount": "Montant total",
+          "utc": "UTC"
+        },
+        "markImportant": "Marquer comme important",
+        "placeholders": {
+          "selectCategory": "Sélectionner catégorie",
+          "selectPaymentType": "Sélectionner le type de paiement"
+        },
+        "title": "Détails de la facture",
+        "tooltips": {
+          "markFavorite": "Cliquer pour ajouter aux favoris",
+          "unmarkFavorite": "Cliquer pour retirer des favoris"
+        }
+      },
+      "invoiceDetailsCard": {
+        "itemsTitle": "Articles ({count})",
+        "labels": {
+          "category": "Catégorie",
+          "countryRegion": "Pays/Région",
+          "dateUtc": "Date et heure (UTC)",
+          "payment": "Paiement",
+          "receiptType": "Type de reçu",
+          "ronEquivalent": "Équivalent RON",
+          "subtotal": "Sous-total",
+          "tip": "Pourboire",
+          "totalAmount": "Montant total"
+        },
+        "pagination": {
+          "next": "Suivant",
+          "pageOf": "Page {current} sur {total}",
+          "previous": "Précédent"
+        },
+        "sections": {
+          "paymentMethods": "Modes de paiement",
+          "taxBreakdown": "Détail des taxes"
+        },
+        "table": {
+          "grandTotal": "Total général",
+          "item": "Article",
+          "price": "Prix",
+          "qty": "Qté",
+          "total": "Somme",
+          "unit": "Unité"
+        },
+        "taxLabels": {
+          "net": "Net",
+          "tax": "Taxe"
+        },
+        "title": "Détails de la facture",
+        "tooltips": {
+          "exchangeRate": "1 {fromCurrency} = {rate} RON (moy. {year})"
+        }
+      },
+      "merchantCard": {
+        "addressLabel": "Adresse : {address}",
+        "buttons": {
+          "viewAllReceipts": "Voir tous les reçus",
+          "viewMerchantDetails": "Voir les détails du commerçant"
+        },
+        "noMerchantLinked": "Aucun commerçant lié à cette facture",
+        "title": "Commerçant",
+        "tooltips": {
+          "viewAllReceipts": "Voir tous les reçus de ce commerçant",
+          "viewMerchantDetails": "Voir des informations détaillées sur ce commerçant"
+        }
+      },
+      "merchantInfoCard": {
+        "categoryDistribution": "Répartition par catégorie",
+        "noMerchantLinked": "Aucun commerçant lié à cette facture",
+        "spendingHistory": "Historique des dépenses",
+        "stats": {
+          "avgSpend": "Dépense moyenne",
+          "daysAgo": "il y a quelques jours",
+          "visits": "visites"
+        },
+        "title": "Informations sur le commerçant",
+        "viewAllInvoices": "Voir toutes les factures",
+        "viewAllReceipts": "Voir tous les reçus",
+        "viewOnMap": "Voir sur la carte"
+      },
+      "nutritionCard": {
+        "allergens": {
+          "foundInItems": "Trouvé dans {count} article(s)",
+          "title": "Allergènes détectés"
+        },
+        "composition": {
+          "dairyOther": "Produits laitiers/Autre",
+          "processed": "Transformés",
+          "title": "Composition de votre panier",
+          "wholeFoods": "Aliments complets"
+        },
+        "foodGroups": {
+          "fruits": "Fruits frais",
+          "grains": "Céréales",
+          "itemsCount": "{count} article(s)",
+          "protein": "Protéines",
+          "vegetables": "Légumes"
+        },
+        "score": {
+          "excellent": "Très bon",
+          "fair": "Moyen",
+          "good": "Bon",
+          "needsWork": "À améliorer",
+          "title": "Score d’équilibre alimentaire"
+        },
+        "suggestions": {
+          "addFruits": "Ajouter des fruits améliorerait l’équilibre nutritionnel",
+          "addFruitsAndVegetables": "Ajoutez davantage de fruits et légumes pour équilibrer votre panier",
+          "addVegetables": "Pensez à ajouter des légumes pour une alimentation plus équilibrée",
+          "greatBalance": "Excellent équilibre d’achats !",
+          "swapProcessed": "Essayez de remplacer certains produits transformés par des aliments complets"
+        },
+        "title": "Vue d’ensemble nutritionnelle"
+      },
+      "receiptScanCard": {
+        "buttons": {
+          "expand": "Agrandir l’image",
+          "nextScan": "Scan suivant",
+          "previousScan": "Scan précédent"
+        },
+        "controls": {
+          "download": "Télécharger",
+          "fullScreen": "Plein écran",
+          "reset": "Réinitialiser le zoom",
+          "rotate": "Pivoter",
+          "toggleZoom": "Basculer le zoom",
+          "zoomIn": "Zoom avant",
+          "zoomOut": "Zoom arrière"
+        },
+        "dialogTitle": "Image du reçu",
+        "dialogTitleWithIndex": "Image du reçu ({current}/{total})",
+        "navigation": {
+          "next": "Suivant",
+          "of": "sur",
+          "previous": "Précédent"
+        },
+        "scanAlt": "Scan du reçu {index}",
+        "scanAltFullSize": "Scan du reçu {index} - taille réelle",
+        "title": "Scan du reçu",
+        "titleWithIndex": "Scan du reçu ({current}/{total})",
+        "tooltips": {
+          "expand": "Voir l’image du reçu en taille réelle",
+          "nextScan": "Voir le scan suivant du reçu",
+          "previousScan": "Voir le scan précédent du reçu"
+        }
+      },
+      "recipeCard": {
+        "buttons": {
+          "viewRecipe": "Voir la recette",
+          "visitReference": "Visiter la référence"
+        },
+        "complexity": {
+          "easy": "Facile",
+          "hard": "Difficile",
+          "normal": "Normal",
+          "unknown": "Inconnu"
+        },
+        "dropdown": {
+          "delete": "Supprimer",
+          "edit": "Modifier",
+          "markAsFavorite": "Marquer comme favori",
+          "share": "Partager",
+          "view": "Voir"
+        },
+        "ingredients": {
+          "additionalLabel": "Ingrédients supplémentaires :",
+          "label": "Ingrédients :",
+          "more": "+{count} de plus"
+        },
+        "timing": {
+          "cookLabel": "Cuisson : {minutes}′",
+          "cookTooltip": "Le temps de cuisson est de {minutes} minutes.",
+          "prepLabel": "Prépa : {minutes}′",
+          "prepTooltip": "Le temps de préparation est de {minutes} minutes."
+        }
+      },
+      "seasonalInsightsCard": {
+        "insights": {
+          "holidaySeason": {
+            "description": "Les dépenses de décembre sont généralement 35% plus élevées",
+            "title": "Saison des fêtes"
+          },
+          "insufficientData": {
+            "description": "Il n’y a pas encore assez de données pour afficher des tendances saisonnières fiables.",
+            "title": "Données insuffisantes"
+          },
+          "normalPattern": {
+            "description": "Vos dépenses sont dans la plage habituelle",
+            "title": "Habitude d’achat normale"
+          },
+          "spike": {
+            "description": "+{percent}% vs votre moyenne",
+            "title": "Pic de {category}"
+          },
+          "stockUpTip": {
+            "description": "Les prix augmentent d’environ 15% après le 15 décembre",
+            "title": "Conseil de stock"
+          }
+        },
+        "month": {
+          "spendingSoFar": "{month} jusqu’à présent",
+          "vsAverage": "vs moyenne de {month} : {amount}"
+        },
+        "title": "Insight saisonnier"
+      },
+      "sharingCard": {
+        "buttons": {
+          "manageSharing": "Gérer Partage",
+          "markAsPrivate": "Marquer comme privée",
+          "revokingAccess": "Révocation de l’accès...",
+          "shareInvoice": "Partager Facture"
+        },
+        "emptyShared": {
+          "private": "Non partagée",
+          "public": "Aucun utilisateur supplémentaire n’a d’accès direct"
+        },
+        "owner": "Propriétaire",
+        "ownerAvatarAlt": "Utilisateur",
+        "publicInvoice": {
+          "description": "Cette facture est accessible publiquement. Toute personne disposant du lien peut la consulter.",
+          "title": "Facture publique"
+        },
+        "sharedWith": "Partagée avec",
+        "title": "Partage",
+        "toasts": {
+          "removeAccessComingSoon": {
+            "description": "Cette fonctionnalité est en cours de développement.",
+            "title": "La suppression d’accès sera bientôt disponible"
+          },
+          "revoke": {
+            "error": "Échec du passage en privé : {message}",
+            "loading": "Révocation de l’accès public...",
+            "success": "La facture est maintenant privée. Les liens existants ne fonctionneront plus."
+          }
+        },
+        "tooltips": {
+          "manageSharing": "Gérer les paramètres de partage de cette facture",
+          "markAsPrivate": "Marquer la facture comme privée",
+          "removeAccess": "Supprimer l’accès",
+          "shareInvoice": "Partager cette facture avec d’autres utilisateurs"
+        },
+        "userWithId": "Utilisateur {id}"
+      },
+      "shoppingCalendarCard": {
+        "insights": {
+          "days": "{count} jours",
+          "mostActiveOn": "Plus actif le",
+          "onAverage": "en moyenne",
+          "perTrip": " par achat",
+          "shopEveryPrefix": "Vous faites vos achats tous les",
+          "spendingPrefix": ", dépensant",
+          "weekdayLabel": "{weekday}"
+        },
+        "legend": {
+          "less": "Moins",
+          "more": "Plus"
+        },
+        "stats": {
+          "monthTotal": "Total du mois",
+          "shoppingDays": "Jours d’achats"
+        },
+        "title": "Calendrier d’achats",
+        "tooltip": {
+          "basedOnCachedInvoices": "Basé sur {count} factures en cache",
+          "currentInvoice": "Facture actuelle",
+          "currentInvoiceOnly": "Affichage de la facture actuelle uniquement",
+          "invoiceCount": "{count} facture(s)",
+          "more": "+{count} de plus",
+          "vsAverage": "vs moy ({years} ans de données)"
+        }
+      },
+      "statistics": {
+        "allergenSummary": {
+          "ariaLabel": "Résumé de la fréquence des allergènes",
+          "description": "Exposition aux allergènes dans vos produits",
+          "empty": "Aucun allergène détecté dans vos achats",
+          "stats": {
+            "ofTotal": "du total",
+            "products": "produits"
+          },
+          "title": "Résumé des allergènes"
+        },
+        "calendarHeatmap": {
+          "aria": {
+            "calendarGrid": "Calendrier des dépenses quotidiennes"
+          },
+          "days": {
+            "fri": "Ven",
+            "mon": "Lun",
+            "sat": "Sam",
+            "sun": "Dim",
+            "thu": "Jeu",
+            "tue": "Mar",
+            "wed": "Mer"
+          },
+          "description": "Intensité des dépenses quotidiennes au fil du temps",
+          "legend": {
+            "less": "Moins",
+            "more": "Plus"
+          },
+          "navigation": {
+            "next": "Mois suivant",
+            "previous": "Mois précédent"
+          },
+          "title": "Calendrier des dépenses",
+          "tooltip": {
+            "amount": "Dépensé",
+            "invoices": "{count} factures",
+            "noSpending": "Aucune dépense"
+          }
+        },
+        "categoryBreakdown": {
+          "description": "Répartition par catégories",
+          "title": "Dépenses par catégorie",
+          "tooltip": {
+            "invoiceCount": "{count} factures"
+          },
+          "totalLabel": "Dépenses totales"
+        },
+        "comparison": {
+          "decrease": "diminution",
+          "description": "Comparaison avec le mois précédent",
+          "discovered": "découverts",
+          "increase": "augmentation",
+          "invoiceCount": "Nombre de factures",
+          "newMerchants": "Nouveaux commerçants",
+          "none": "aucun",
+          "spendingDelta": "Variation des dépenses",
+          "title": "Mois par mois"
+        },
+        "currencyDistribution": {
+          "description": "Répartition des dépenses par devise avec conversion en RON",
+          "invoiceCount": "Factures",
+          "originalAmount": "Original",
+          "ronEquivalent": "Équivalent RON",
+          "showOriginal": "Afficher l''original",
+          "showRON": "Afficher en RON",
+          "singleCurrency": "Toutes les factures en {currency} ({symbol})",
+          "title": "Répartition par devise",
+          "toggleLabel": "Basculer la vue des devises",
+          "totalAmount": "Montant total",
+          "totalCurrencies": "Total des devises",
+          "totalSpending": "Dépenses totales"
+        },
+        "empty": {
+          "cta": "Télécharger un reçu",
+          "subtitle": "Téléchargez des reçus pour voir les analyses",
+          "title": "Pas encore de statistiques"
+        },
+        "kpi": {
+          "acrossInvoices": "sur {count} factures",
+          "averageItems": "Articles moy.",
+          "avgPerInvoice": "moy. {amount} par facture",
+          "invoiceCount": "Nombre de factures",
+          "noneYet": "Pas encore de données",
+          "topMerchant": "Commerçant principal",
+          "totalSpending": "Dépenses totales",
+          "visits": "{count} visites",
+          "vsLastMonth": "{delta}% par rapport au mois dernier"
+        },
+        "merchantLeaderboard": {
+          "description": "Où vous dépensez le plus",
+          "empty": "Aucune donnée de marchand disponible",
+          "labels": {
+            "totalSpent": "Total dépensé"
+          },
+          "title": "Principaux commerçants",
+          "tooltip": {
+            "invoiceCount": "{count} factures"
+          },
+          "unknownMerchant": "Commerçant inconnu"
+        },
+        "merchantTrends": {
+          "aria": {
+            "sparkline": "Tendance des dépenses pour {merchant}"
+          },
+          "description": "Évolution mensuelle des dépenses chez les principaux commerçants",
+          "empty": "Aucune donnée de commerçant disponible",
+          "labels": {
+            "merchant": "Commerçant",
+            "totalSpend": "Total dépensé",
+            "trend": "Tendance (6 derniers mois)"
+          },
+          "title": "Tendances de dépenses par commerçant"
+        },
+        "merchantVisit": {
+          "description": "Fréquence d'achat et aperçu du panier",
+          "empty": "Aucune donnée de visite disponible",
+          "metrics": {
+            "avgSpend": "Dépense moy./visite",
+            "basketSize": "Panier moyen",
+            "preferredDay": "Jour préféré",
+            "totalVisits": "Visites totales",
+            "visitsPerMonth": "Visites/mois"
+          },
+          "title": "Fréquentation des commerçants"
+        },
+        "priceDistribution": {
+          "description": "Distribution des prix des articles",
+          "labels": {
+            "itemCount": "Nombre d'articles"
+          },
+          "title": "Distribution des prix",
+          "tooltip": {
+            "itemCount": "{count} articles"
+          }
+        },
+        "productAnalytics": {
+          "subtitle": "Aperçu de vos articles achetés",
+          "title": "Analyse des produits"
+        },
+        "productCategory": {
+          "description": "Répartition des dépenses par type de produit",
+          "empty": "Aucun produit à analyser pour le moment",
+          "title": "Dépenses par catégorie de produit",
+          "tooltip": {
+            "productCount": "{count} produits"
+          }
+        },
+        "spendingOverTime": {
+          "description": "",
+          "labels": {
+            "amount": ""
+          },
+          "title": "",
+          "tooltip": {
+            "andMore": "et {count} de plus...",
+            "invoiceCount": ""
+          }
+        },
+        "subtitle": "Gérez vos reçus et suivez vos habitudes de dépenses",
+        "timeOfDay": {
+          "description": "Quand vous faites vos achats",
+          "labels": {
+            "invoiceCount": "Nombre de factures"
+          },
+          "title": "Habitudes d'achat",
+          "tooltip": {
+            "invoiceCount": "{count} factures"
+          }
+        },
+        "title": "Statistiques des factures",
+        "topProducts": {
+          "ariaLabel": "Classement des produits les plus achetés",
+          "description": "Articles les plus achetés",
+          "empty": "Aucun produit acheté pour le moment",
+          "headers": {
+            "avgPrice": "Prix moyen",
+            "product": "Produit",
+            "purchases": "Achats",
+            "quantity": "Qté",
+            "rank": "#",
+            "totalSpent": "Total"
+          },
+          "title": "Produits principaux"
+        }
+      },
+      "summaryStatsCard": {
+        "description": "Statistiques clés en un coup d’œil",
+        "extremes": {
+          "highest": "Le plus élevé",
+          "lowest": "Le plus bas"
+        },
+        "stats": {
+          "averagePrice": {
+            "description": "{currency} par article",
+            "label": "Prix moyen"
+          },
+          "categories": {
+            "description": "Catégories uniques",
+            "label": "Catégories"
+          },
+          "taxRate": {
+            "description": "{amount} {currency}",
+            "label": "Taux de taxe"
+          },
+          "totalItems": {
+            "description": "Produits achetés",
+            "label": "Articles totaux"
+          }
+        },
+        "title": "Résumé de la facture"
+      },
+      "vehicleCard": {
+        "buttons": {
+          "addVehicle": "Ajouter Véhicule",
+          "fullReport": "Rapport complet"
+        },
+        "chart": {
+          "amount": "Montant",
+          "title": "Dépenses mensuelles en carburant"
+        },
+        "details": {
+          "liters": "Litres",
+          "notSet": "Non défini",
+          "pricePerLiter": "Prix/L",
+          "station": "Station-service",
+          "vehicle": "Véhicule"
+        },
+        "expenseType": "Type de dépense : Carburant",
+        "maintenance": {
+          "title": "Rappels d’entretien"
+        },
+        "months": {
+          "dec": "déc.",
+          "nov": "nov.",
+          "oct": "oct.",
+          "sep": "sept."
+        },
+        "reminders": {
+          "oilChange": "Vidange à prévoir dans ~1 200 km",
+          "tireRotation": "Rotation des pneus recommandée"
+        },
+        "stats": {
+          "costPerKm": "Coût/km",
+          "estimated": "estimé",
+          "fillUps": "{count} pleins",
+          "fuelPrice": "Fuel Prix",
+          "thisMonth": "Ce mois-ci",
+          "thisMonthSuffix": "ce mois-ci"
+        },
+        "tip": {
+          "perLiter": "L",
+          "title": "Le moins cher à proximité"
+        },
+        "title": "Analyse des dépenses du véhicule"
+      }
+    }
   },
-  "IMS--Cards": {
-    "budgetImpactCard": {
-      "dailyAllowance": "Budget quotidien",
-      "dailyAllowanceValue": "{amount} / jour",
-      "daysLeft": "Jours restants",
-      "inMonth": "en {month}",
-      "invoiceUsed": "Cette facture a utilisé",
-      "monthlyBudget": "Budget mensuel",
-      "ofMonthlyBudget": "de votre budget mensuel",
-      "overBudget": "Dépassement de budget",
-      "remaining": "Restant",
-      "spent": "{amount} dépensés",
-      "title": "Impact budgétaire de {month}"
-    },
-    "categorySuggestionCard": {
-      "description": "Nous n’avons pas pu catégoriser automatiquement cette facture. Sélectionnez la bonne catégorie pour débloquer des analyses :",
-      "gamification": "Catégorisez {goal} factures pour débloquer des analyses détaillées !",
-      "moreCategories": "Plus de catégories :",
-      "title": "Aidez-nous à catégoriser cette facture"
-    },
-    "comparisonStatsCard": {
-      "avgValue": "Moy. : {amount} {currency}",
-      "itemCount": "Article Count",
-      "itemCountComparison": "{current} vs moy {average}",
-      "maxValue": "Max. : {amount}",
-      "minValue": "Min. : {amount}",
-      "positionInRange": "Votre position dans la plage de dépenses",
-      "sameStore": "Même magasin",
-      "sameStoreComparison": "vs moy {average} {currency}",
-      "subtitle": "Par rapport à vos {count} dernières factures",
-      "thisValue": "Cette facture : {amount} {currency}",
-      "title": "Comment vous vous situez",
-      "vsAverage": "vs moyenne"
-    },
-    "diningCard": {
-      "challenge": {
-        "descriptionPrefix": "Évitez la restauration rapide pendant 7 jours et enregistrez",
-        "descriptionSuffix": "",
-        "title": "Défi hebdomadaire"
+  "dialogs": {
+    "invoices": {
+      "addScanDialog": {
+        "buttons": {
+          "cancel": "Annuler",
+          "upload": "Téléverser le scan",
+          "uploading": "Téléversement..."
+        },
+        "description": "Téléversez une nouvelle image ou un nouveau document de reçu à joindre à cette facture.",
+        "dropzone": {
+          "dragAndDrop": "Glissez-déposez un fichier ici",
+          "dropHere": "Déposez le fichier ici...",
+          "formats": "JPEG, PNG, PDF (max 10 Mo)",
+          "orClickBrowse": "ou cliquez pour parcourir"
+        },
+        "scanType": {
+          "jpeg": "Image JPEG",
+          "label": "Type de scan",
+          "other": "Autre",
+          "pdf": "Document PDF",
+          "placeholder": "Sélectionnez le type de scan",
+          "png": "Image PNG"
+        },
+        "title": "Ajouter un nouveau scan",
+        "toasts": {
+          "fileTooLargeDescription": "La taille maximale du fichier est de 10 Mo",
+          "fileTooLargeTitle": "Fichier trop volumineux"
+        }
       },
-      "estimatedNutrition": {
-        "calories": "Énergie",
-        "caloriesValue": "~{value} kcal",
-        "carbs": "Glucides",
-        "carbsValue": "~{value}g",
-        "protein": "Protéines",
-        "proteinValue": "~{value}g",
-        "sodium": "Sel (sodium)",
-        "title": "Valeurs nutritionnelles estimées"
+      "allergenDialog": {
+        "aria": {
+          "removeAllergen": "Retirer l'allergène {name}"
+        },
+        "buttons": {
+          "add": "Ajouter",
+          "cancel": "Annuler",
+          "save": "Enregistrer les modifications",
+          "saving": "Enregistrement..."
+        },
+        "defaultDescription": "Contient {name}",
+        "description": "Gérer les allergènes pour {productName}",
+        "empty": {
+          "noAllergens": "Aucun allergène détecté"
+        },
+        "errors": {
+          "duplicate": "L''allergène {name} a déjà été ajouté",
+          "emptyName": "Le nom de l'allergène ne peut pas être vide",
+          "missingData": "Données de produit manquantes",
+          "saveFailed": "Échec de l'enregistrement des allergènes"
+        },
+        "labels": {
+          "currentAllergens": "Allergènes actuels",
+          "customAllergen": "Ajouter un allergène personnalisé",
+          "quickAdd": "Ajout rapide d'allergènes courants"
+        },
+        "placeholders": {
+          "customAllergen": "Entrez le nom de l'allergène..."
+        },
+        "success": {
+          "added": "Allergène ajouté : {name}",
+          "removed": "Allergène retiré : {name}",
+          "saved": "Allergènes mis à jour avec succès"
+        },
+        "title": "Modifier les allergènes"
       },
-      "habits": {
-        "avgSpend": "Dépense moyenne",
-        "favorite": "Préféré",
-        "frequency": "Fréquence",
-        "frequencyDiff": "+1 vs moyenne",
-        "frequencyValue": "{count}x/mois",
-        "title": "Vos habitudes de restauration rapide",
-        "visits": "{count} visites"
+      "analyzeDialog": {
+        "analysisSteps": {
+          "analyzingWithAi": "Analyse avec l'IA...",
+          "categorizingItems": "Catégorisation des articles...",
+          "finalizingResults": "Finalisation des résultats...",
+          "preparingDocument": "Préparation du document...",
+          "processing": "Traitement...",
+          "runningOcrExtraction": "Exécution de l'extraction OCR..."
+        },
+        "analyzing": {
+          "progressComplete": "{progress}% terminé",
+          "title": "Analyse de la facture"
+        },
+        "badges": {
+          "recommended": "Recommandé"
+        },
+        "buttons": {
+          "analyzing": "Analyse en cours...",
+          "cancel": "Annuler",
+          "startAnalysis": "Démarrer l'analyse"
+        },
+        "enhancements": {
+          "priceComparison": {
+            "description": "Comparer les prix avec les données historiques",
+            "label": "Comparaison des prix"
+          },
+          "quickExtract": {
+            "description": "Prioriser la vitesse plutôt que la précision",
+            "label": "Mode extraction rapide"
+          },
+          "savingsTips": {
+            "description": "Obtenir des recommandations d'économies par IA",
+            "label": "Suggestions d'économies"
+          }
+        },
+        "header": {
+          "description": "Configurer une analyse alimentée par IA pour la facture",
+          "title": "Analyser la facture"
+        },
+        "options": {
+          "completeAnalysis": {
+            "description": "Analyse IA complète incluant toutes les données de la facture, les articles et les informations du commerçant.",
+            "estimatedTime": "2-3 min",
+            "features": {
+              "itemCategorization": "Catégorisation des articles",
+              "merchantIdentification": "Identification du commerçant",
+              "ocrExtraction": "Extraction OCR",
+              "priceAnalysis": "Analyse des prix",
+              "receiptValidation": "Validation du reçu"
+            },
+            "title": "Analyse complète"
+          },
+          "invoiceOnly": {
+            "description": "Analyser les informations de base de la facture comme les totaux, dates et détails de paiement.",
+            "estimatedTime": "30-60 s",
+            "features": {
+              "dateParsing": "Analyse des dates",
+              "paymentMethodDetection": "Détection du mode de paiement",
+              "totalExtraction": "Extraction du total"
+            },
+            "title": "Données de facture uniquement"
+          },
+          "itemsOnly": {
+            "description": "Se concentrer sur l'extraction et la catégorisation des lignes d'articles de la facture.",
+            "estimatedTime": "1-2 min",
+            "features": {
+              "categoryAssignment": "Attribution des catégories",
+              "itemExtraction": "Extraction des articles",
+              "pricePerItem": "Prix par article",
+              "quantityDetection": "Détection des quantités"
+            },
+            "title": "Analyse des articles"
+          },
+          "merchantOnly": {
+            "description": "Identifier et analyser les informations du commerçant, y compris localisation et catégorie.",
+            "estimatedTime": "30-45 s",
+            "features": {
+              "businessCategory": "Catégorie commerciale",
+              "contactInfo": "Coordonnées",
+              "locationExtraction": "Extraction de la localisation",
+              "merchantIdentification": "Identification du commerçant"
+            },
+            "title": "Analyse du commerçant"
+          }
+        },
+        "sections": {
+          "analysisType": "Type d'analyse",
+          "enhancementsOptional": "Améliorations (optionnel)",
+          "includedFeatures": "Fonctionnalités incluses"
+        },
+        "summary": {
+          "enhancementsSelected": "+ {count} amélioration(s)",
+          "estimatedTime": "Durée estimée",
+          "noEnhancementsSelected": "Aucune amélioration sélectionnée"
+        },
+        "toasts": {
+          "analysisComplete": {
+            "description": "Votre facture a été analysée avec succès.",
+            "title": "Analyse terminée"
+          },
+          "analysisFailed": {
+            "description": "Nous n'avons pas pu analyser votre facture. Veuillez réessayer.",
+            "title": "Échec de l'analyse"
+          }
+        }
       },
-      "sodium": {
-        "high": "Élevé",
-        "low": "Faible",
-        "medium": "Moyen"
+      "bulkCategoryDialog": {
+        "buttons": {
+          "cancel": "Annuler",
+          "save": "Appliquer à tous",
+          "saving": "Enregistrement..."
+        },
+        "description": "{count, plural, one {Changer la catégorie pour # produit} other {Changer la catégorie pour # produits}}",
+        "errors": {
+          "allFailed": "Echec de la mise a jour de tous les produits",
+          "missingData": "Données manquantes",
+          "noProducts": "Aucun produit sélectionné",
+          "saveFailed": "Échec de la mise à jour des catégories"
+        },
+        "labels": {
+          "andMore": "...et {count} de plus",
+          "newCategory": "Nouvelle catégorie",
+          "progress": "Progression",
+          "selectedProducts": "Produits sélectionnés"
+        },
+        "placeholders": {
+          "selectCategory": "Sélectionner une catégorie"
+        },
+        "progress": {
+          "updating": "Mise a jour {current} sur {total}..."
+        },
+        "success": {
+          "partialSuccess": "{success} produits mis a jour, {failed} echoues",
+          "saved": "{count, plural, one {Catégorie mise à jour pour # produit} other {Catégorie mise à jour pour # produits}}"
+        },
+        "title": "Changer de catégorie"
       },
-      "swaps": {
-        "caloriesSaved": "-{count} kcal",
-        "grilled": "Grillé au lieu de frit",
-        "moneySaved": ", économise {amount}",
-        "salad": "Salade d’accompagnement au lieu de frites",
-        "title": "Alternatives plus saines",
-        "water": "Eau au lieu de soda"
+      "createInvoiceDialog": {
+        "batchMode": {
+          "description": "Crée 1 facture avec les {count} scans attachés. Idéal pour les reçus multi-pages.",
+          "title": "Combiner en une seule facture"
+        },
+        "buttons": {
+          "cancel": "Annuler",
+          "close": "Fermer",
+          "createMultiple": "Lancer l'analyse sur {count} scans",
+          "createSingle": "Lancer l'analyse"
+        },
+        "chooseMode": "Choisir le Mode de Création",
+        "complete": {
+          "description": "Votre facture est prête à être consultée et modifiée.",
+          "descriptionPlural": "Vos factures sont prêtes à être consultées et modifiées.",
+          "errorsLabel": "Scans échoués :",
+          "failureDescription": "Nous n'avons pas pu créer de factures. Veuillez vérifier les erreurs ci-dessous et réessayer.",
+          "failureTitle": "Échec de la création",
+          "nextSteps": "Prochaines étapes :",
+          "nextStepsDescription": "Examinez votre facture, vérifiez les données extraites et effectuez les modifications nécessaires. Vous pouvez également demander une analyse IA pour des informations sur vos dépenses.",
+          "nextStepsDescriptionPlural": "Examinez vos factures, vérifiez les données extraites et effectuez les modifications nécessaires. Vous pouvez également demander une analyse IA pour des informations sur vos dépenses.",
+          "partialDescription": "Certains scans n'ont pas pu être traités. Les factures créées avec succès sont prêtes à être consultées.",
+          "partialTitle": "{created} factures créées sur {total}",
+          "retryButton": "Réessayer",
+          "title": "{count} Facture Créée !",
+          "titlePlural": "{count} Factures Créées !",
+          "viewButton": "Voir la Facture",
+          "viewButtonPlural": "Voir les Factures"
+        },
+        "creating": {
+          "processing": "Traitement de {count} scan...",
+          "processingPlural": "Traitement de {count} scans...",
+          "step1Description": "Envoi de vos scans vers nos serveurs",
+          "step1Title": "Téléchargement des scans",
+          "step2Description": "Configuration des structures de données de factures",
+          "step2Title": "Création des enregistrements de factures",
+          "step3Description": "Préparation des factures pour la visualisation",
+          "step3Title": "Finalisation",
+          "title": "Création de Votre Facture",
+          "titlePlural": "Création de Vos Factures"
+        },
+        "description": "Transformez vos scans en données de facture structurées.",
+        "errors": {
+          "createFailed": "Échec de la création des factures : {message}",
+          "partialFail": "Échec de la création de {count} facture(s)",
+          "unknown": "Erreur inconnue"
+        },
+        "selectedScans": "Scans Sélectionnés",
+        "singleMode": {
+          "description": "Crée {count} factures séparées. Idéal lorsque chaque scan est un reçu différent.",
+          "title": "Une facture par scan"
+        },
+        "singleScanInfo": {
+          "description": "Notre IA analysera votre scan et extraira automatiquement les détails du commerçant, les articles, les prix et les totaux. Vous pourrez examiner et modifier les résultats par la suite.",
+          "title": "Que se passe-t-il ensuite ?"
+        },
+        "title": "Lancer l'analyse IA",
+        "titlePlural": "Lancer l'analyse IA",
+        "totalSize": "total"
       },
-      "title": "Informations restauration"
-    },
-    "generalExpenseCard": {
-      "aria": {
-        "changeCategory": "Change detected catégorie",
-        "confirmCategory": "Confirmer que la catégorie détectée est correcte",
-        "export": "Exporter les données de dépense",
-        "organize": "Organiser cette dépense en catégories"
+      "deleteInvoiceDialog": {
+        "buttons": {
+          "cancel": "Annuler",
+          "deletePermanently": "Supprimer définitivement",
+          "deleting": "Suppression..."
+        },
+        "confirmation": {
+          "typeToConfirm": "Tapez <highlight>{name}</highlight> pour confirmer :",
+          "understoodDescription": "Cette facture et toutes ses données seront définitivement supprimées et ne pourront pas être récupérées.",
+          "understoodLabel": "Je comprends que cette action est définitive"
+        },
+        "console": {
+          "deleteError": "Erreur suppression de facture:"
+        },
+        "deleting": {
+          "description": "Veuillez patienter pendant que nous supprimons toutes les données associées.",
+          "title": "Suppression de facture..."
+        },
+        "description": "Cette action est irréversible. Veuillez vérifier attentivement avant de continuer.",
+        "impact": {
+          "intro": "Les données suivantes seront supprimées définitivement :",
+          "invoiceRecord": "Enregistrement de facture et métadonnées",
+          "lineItems": "{count} line article(s)",
+          "sharedAccess": "Accès partagé pour {count} utilisateur(s)",
+          "title": "Suppression définitive",
+          "uploadedScans": "{count} scan(s) téléversé(s)"
+        },
+        "title": "Supprimer facture",
+        "toasts": {
+          "deletedDescription": "La facture a été supprimée avec succès.",
+          "deletedTitle": "Facture supprimée",
+          "deleteFailedDescription": "Nous n’avons pas pu supprimer cette facture. Veuillez réessayer.",
+          "deleteFailedTitle": "Supprimer échoué"
+        }
       },
-      "budgetCategories": {
-        "electronics": "Électronique",
-        "entertainment": "Divertissement",
-        "shopping": "Achats"
+      "exportDialog": {
+        "buttons": {
+          "cancel": "Annuler",
+          "copied": "Copié !",
+          "copy": "Copier dans le presse-papiers",
+          "export": "Exporter"
+        },
+        "description": "Exporter {count} factures dans le format de votre choix.",
+        "estimate": {
+          "label": "Taille estimée du fichier :"
+        },
+        "filename": {
+          "hint": "Le fichier sera enregistré avec l'extension basée sur le format",
+          "label": "Nom du fichier"
+        },
+        "format": {
+          "descriptions": {
+            "csv": "Format tableur, compatible avec Excel",
+            "json": "Format de données structurées",
+            "pdf": "Format de document imprimable"
+          },
+          "labels": {
+            "csv": "CSV",
+            "json": "JSON",
+            "pdf": "PDF"
+          },
+          "title": "Format d’export"
+        },
+        "options": {
+          "csv": {
+            "delimiterLabel": "Séparateur CSV personnalisé (facultatif) :",
+            "delimiterPlaceholder": ",",
+            "includeHeaders": "Inclure les en-têtes CSV"
+          },
+          "includeMerchant": "Inclure le commerçant",
+          "includeMetadata": "Inclure les métadonnées",
+          "includeProducts": "Inclure les produits",
+          "json": {
+            "prettyPrint": "Formatage lisible (2 espaces)"
+          },
+          "title": "Paramètres"
+        },
+        "title": "Exporter des factures"
       },
-      "buttons": {
-        "change": "Modifier",
-        "correct": "Valider",
-        "export": "Exporter",
-        "organize": "Organiser"
+      "feedbackDialog": {
+        "buttons": {
+          "cancel": "Annuler",
+          "submit": "Envoyer le retour"
+        },
+        "commentsPlaceholder": "Partagez vos impressions sur les analyses...",
+        "description": "Aidez-nous à améliorer les analyses pour {merchant} en partageant votre avis",
+        "features": {
+          "categoryBreakdown": "Catégorie Breakdown",
+          "merchantAnalysis": "Merchant Analyse",
+          "priceComparisons": "Prix Comparisons",
+          "savingsTips": "Conseils d’économie",
+          "spendingTrends": "Tendances de dépenses",
+          "visualCharts": "Graphiques visuels"
+        },
+        "sections": {
+          "comments": "Commentaires supplémentaires (facultatifs)",
+          "features": "Quelles fonctionnalités ont été les plus utiles ? (Sélectionnez toutes les réponses pertinentes)",
+          "rating": "Comment évalueriez-vous les analyses ?"
+        },
+        "title": "Donner un retour",
+        "toasts": {
+          "error": {
+            "description": "Veuillez réessayer plus tard.",
+            "title": "Une erreur est survenue lors de l’envoi du retour"
+          },
+          "ratingRequired": {
+            "description": "Veuillez attribuer une note en étoiles avant l’envoi",
+            "title": "Note requise"
+          },
+          "sending": {
+            "description": "Veuillez patienter pendant l’envoi de votre retour.",
+            "title": "Envoi du retour..."
+          },
+          "success": {
+            "description": "Retour envoyé avec succès",
+            "title": "Retour envoyé !"
+          }
+        }
       },
-      "confidence": "Confiance : {value}%",
-      "detectedCategory": "Électronique / Technologie",
-      "nearLimitAlert": "{name} : {percent}% utilisé (10 jours restants ce mois)",
-      "options": {
-        "businessExpense": "Marquer comme dépense professionnelle",
-        "insuranceInventory": "Ajouter à l’inventaire d’assurance",
-        "trackWarranty": "Suivre la garantie (24 mois standard)"
+      "imageDialog": {
+        "imageAlt": "Photo du reçu",
+        "title": "Aperçu ({image})"
       },
-      "sections": {
-        "autoDetectedCategory": "Auto-detected catégorie",
-        "budgetImpact": "Impact sur le budget",
-        "similarPurchases": "Achats similaires passés",
-        "taxBusiness": "Options fiscales et professionnelles"
+      "importDialog": {
+        "buttons": {
+          "cancel": "Annuler",
+          "import": "Importer",
+          "importWithCount": "Importer ({count})"
+        },
+        "description": "Téléversez vos fichiers de factures pour les importer dans le système.",
+        "dropzone": {
+          "acceptsCsv": "Accepte les fichiers .csv (max 10 Mo)",
+          "acceptsPdf": "Accepte les fichiers .pdf (max 10 Mo)",
+          "acceptsXlsx": "Accepte les fichiers .xlsx et .xls (max. 10 Mo)",
+          "dragAndDrop": "Glissez-déposez les fichiers ici",
+          "dropHere": "Déposez les fichiers ici...",
+          "orClickBrowse": "ou cliquez pour parcourir les fichiers"
+        },
+        "remove": "Supprimer",
+        "selectedFiles": "Fichiers sélectionnés",
+        "status": {
+          "error": "Erreur lors de l’import des fichiers. Veuillez réessayer.",
+          "success": "Fichiers importés avec succès !"
+        },
+        "tabs": {
+          "csv": "CSV",
+          "pdf": "PDF",
+          "xlsx": "Excel"
+        },
+        "title": "Importer des factures"
       },
-      "title": "Analyse des dépenses",
-      "vatReclaimable": "TVA récupérable"
-    },
-    "homeInventoryCard": {
-      "bulk": {
-        "description": "Un bidon de 5L vs 2L permet d’économiser 18% ({amount}/an)",
-        "title": "Économies sur achats en gros"
+      "itemsDialog": {
+        "aria": {
+          "addItem": "Ajouter un nouvel article à la facture",
+          "cancel": "Annuler la modification et fermer la boîte de dialogue",
+          "deleteItem": "Supprimer article: {name}",
+          "nextPage": "Aller à la page suivante (page {page})",
+          "previousPage": "Aller à la page précédente (page {page})",
+          "save": "Enregistrer les modifications des articles de la facture",
+          "unnamedItem": "unnamed article"
+        },
+        "buttons": {
+          "addItem": "Ajouter article",
+          "cancel": "Annuler",
+          "next": "Suivant",
+          "previous": "Précédent",
+          "saveChanges": "Enregistrer changes"
+        },
+        "description": "Mettez à jour les quantités, les prix ou ajoutez de nouveaux articles à cette facture",
+        "footer": {
+          "itemsFound": "{total} articles trouvés (affichage de {shown})",
+          "itemsTotal": "{count, plural, one {# article au total} other {# articles au total}}",
+          "page": "Page {current} sur {total}"
+        },
+        "table": {
+          "actions": "Opérations",
+          "item": "Article",
+          "price": "Prix",
+          "quantity": "Quantité",
+          "total": "Somme",
+          "unit": "Unité"
+        },
+        "title": "Modifier facture articles"
       },
-      "eco": {
-        "productsWithEcoLabels": "{count} produits avec des écolabels",
-        "recyclablePackaging": "{count} produit avec emballage recyclable",
-        "tip": "Tip: Eco alternatives enregistrer 2kg plastic/year",
-        "title": "Score écoresponsable"
+      "merchantDialog": {
+        "buttons": {
+          "openInMaps": "Ouvrir dans Maps"
+        },
+        "description": "Informations sur {merchantName}",
+        "fields": {
+          "address": "Adresse",
+          "parentCompany": "Société mère",
+          "phone": "Téléphone"
+        },
+        "noMerchantLinked": "Aucun commerçant lié à cette facture",
+        "title": "Détails du commerçant"
       },
-      "stockLevels": {
-        "daysRemaining": "~{count} jours",
-        "title": "Niveaux de stock des fournitures (estimés)"
+      "merchantReceiptsDialog": {
+        "buttons": {
+          "next": "Suivant",
+          "previous": "Précédent"
+        },
+        "dateOptions": {
+          "allTime": "Toute la période",
+          "last30Days": "30 derniers jours",
+          "last90Days": "90 derniers jours",
+          "thisYear": "Cette année"
+        },
+        "description": "Voir et filtrer tous vos reçus de ce commerçant",
+        "filters": {
+          "date": "Date",
+          "sort": "Tri"
+        },
+        "footer": {
+          "page": "Page {current} sur {total}",
+          "receiptsFound": "{count} reçus trouvés (affichage de {showing})"
+        },
+        "searchPlaceholder": "Rechercher receipts...",
+        "sortOptions": {
+          "newest": "Plus récents d’abord",
+          "oldest": "Plus anciens d’abord"
+        },
+        "table": {
+          "actions": "Opérations",
+          "date": "Date",
+          "itemsCount": "Articles #",
+          "receipt": "Reçu",
+          "view": "Voir"
+        },
+        "title": "Tous les reçus de {merchant}"
       },
-      "supplyNames": {
-        "dishSoap": "Liquide vaisselle",
-        "floorCleaner": "Nettoyant pour sols",
-        "laundryDetergent": "Lessive",
-        "paperProducts": "Produits en papier"
+      "metadataDialog": {
+        "add": {
+          "description": "Ajouter des informations supplémentaires à cette facture",
+          "title": "Ajouter des métadonnées"
+        },
+        "buttons": {
+          "cancel": "Annuler",
+          "delete": "Supprimer",
+          "save": "Enregistrer"
+        },
+        "delete": {
+          "description": "Êtes-vous sûr de vouloir supprimer ces métadonnées ?",
+          "title": "Supprimer les métadonnées"
+        },
+        "edit": {
+          "description": "Mettre à jour la valeur de ce champ de métadonnées",
+          "fieldLabel": "Champ de métadonnées",
+          "title": "Modifier les métadonnées"
+        },
+        "fields": {
+          "keyLabel": "Clé de métadonnées",
+          "keyPlaceholder": "Saisir la clé",
+          "valueLabel": "Valeur de métadonnées",
+          "valuePlaceholder": "Saisir la valeur"
+        }
       },
-      "title": "Inventaire du domicile et fournitures"
-    },
-    "imageCard": {
-      "aria": {
-        "expandImage": "Cliquer pour agrandir l’image"
+      "recipeDialog": {
+        "actions": {
+          "enhanceInstructions": "Améliorer les instructions",
+          "generateName": "Générer un nom",
+          "unavailable": "Cette action d’assistance pour les recettes n’est pas encore disponible"
+        },
+        "buttons": {
+          "add": "Ajouter",
+          "cancel": "Annuler",
+          "close": "Fermer",
+          "delete": "Supprimer",
+          "deleting": "Suppression...",
+          "save": "Enregistrer",
+          "saving": "Enregistrement..."
+        },
+        "create": {
+          "description": "Remplissez les détails pour créer une recette.",
+          "error": "Échec de la création de la recette.",
+          "success": "Recette créée avec succès.",
+          "title": "Ajouter une nouvelle recette"
+        },
+        "delete": {
+          "description": "Cette action est irréversible. Cela supprimera définitivement la recette <strong>{name}</strong> et toutes ses données associées.",
+          "error": "Échec de la suppression de la recette",
+          "missingRecipe": "Les détails de la recette ne sont pas disponibles.",
+          "success": "Recette supprimée avec succès",
+          "title": "Êtes-vous sûr ?"
+        },
+        "difficulty": {
+          "easy": "Facile",
+          "hard": "Difficile",
+          "medium": "Moyen"
+        },
+        "fields": {
+          "complexity": "Niveau de complexité",
+          "cookTime": "Temps de cuisson",
+          "description": "Présentation",
+          "difficulty": "Niveau de difficulté",
+          "ingredients": "Ingrédients",
+          "instructions": "Étapes",
+          "prepTime": "Temps de préparation",
+          "recipeName": "Nom de la recette",
+          "totalDuration": "Durée totale"
+        },
+        "minutes": "minutes",
+        "placeholders": {
+          "cookTime": "ex. 30 minutes",
+          "description": "Saisissez une brève description de la recette",
+          "instructions": "Saisir les instructions de cuisson",
+          "prepTime": "ex. 15 minutes",
+          "recipeName": "Saisir le nom de la recette",
+          "selectDifficulty": "Sélectionner la difficulté"
+        },
+        "read": {
+          "description": "Détails de la recette et instructions de préparation",
+          "missingRecipe": "Les détails de la recette ne sont pas disponibles.",
+          "noDescription": "Aucune description fournie.",
+          "notSpecified": "Non spécifié"
+        },
+        "share": {
+          "copied": "Lien de recette copié",
+          "copy": "Copier le lien",
+          "copyFailed": "Échec de la copie du lien de recette",
+          "description": "Partagez le lien de référence de la recette lorsqu’il est disponible.",
+          "missingRecipe": "Les détails de la recette ne sont pas disponibles.",
+          "title": "Partager la recette",
+          "unavailable": "Le partage de recette n’est pas encore disponible pour cette recette."
+        },
+        "tooltips": {
+          "enhanceInstructions": "Utiliser l’AI pour enrichir vos instructions avec davantage de détails",
+          "generateName": "Générer un nom de recette selon vos ingrédients et votre niveau de difficulté avec l’AI"
+        },
+        "update": {
+          "description": "Mettre à jour les détails de la recette.",
+          "error": "Échec de la mise à jour de la recette",
+          "missingRecipe": "Les détails de la recette ne sont pas disponibles.",
+          "success": "Recette mise à jour avec succès",
+          "title": "Mettre à jour la recette"
+        }
       },
-      "buttons": {
-        "addScan": "Ajouter un scan",
-        "expand": "Agrandir l’image",
-        "next": "Suivant",
-        "previous": "Précédent",
-        "remove": "Supprimer"
+      "removeScanDialog": {
+        "buttons": {
+          "cancel": "Annuler",
+          "remove": "Supprimer le scan",
+          "removing": "Suppression..."
+        },
+        "console": {
+          "deleteError": "Erreur suppression de scan:"
+        },
+        "description": "Êtes-vous sûr de vouloir supprimer le scan {current} sur {total} ?",
+        "descriptionLastScan": "C’est le seul scan joint à cette facture. Vous ne pouvez pas le supprimer.",
+        "errors": {
+          "unknown": "Une erreur inconnue est survenue"
+        },
+        "scanAlt": "Numérisation {index}",
+        "scanCaption": "Numérisation {index}",
+        "title": "Supprimer scan",
+        "toasts": {
+          "cannotDeleteLastDescription": "Une facture doit avoir au moins un scan joint",
+          "cannotDeleteLastTitle": "Impossible de supprimer le dernier scan",
+          "removedDescription": "Le scan a été retiré de la facture",
+          "removedTitle": "Scan supprimé avec succès",
+          "removeFailedTitle": "Échec de la suppression du scan"
+        },
+        "warning": {
+          "description": "Chaque facture doit avoir au moins un scan joint. Ajoutez un autre scan avant de supprimer celui-ci.",
+          "title": "Impossible de supprimer le dernier scan"
+        }
       },
-      "dialogTitle": "Image du reçu",
-      "dialogTitleWithIndex": "Image du reçu ({current}/{total})",
-      "scanAlt": "Scan du reçu {index}",
-      "scanAltFullSize": "Scan du reçu {index} - taille réelle",
-      "title": "Scan du reçu",
-      "titleWithIndex": "Scan du reçu ({current}/{total})",
-      "tooltips": {
-        "addScan": "Téléverser et joindre un nouveau scan du reçu",
-        "expand": "Voir l’image du reçu en taille réelle",
-        "next": "Voir le scan suivant du reçu",
-        "previous": "Voir le scan précédent du reçu",
-        "remove": "Supprimer le scan actuel du reçu"
+      "shareAnalyticsDialog": {
+        "description": "Partagez vos analyses de dépenses pour {merchant} avec d’autres personnes.",
+        "email": {
+          "description": "Envoyez les analyses à une adresse e-mail.",
+          "label": "E-mail address",
+          "placeholder": "nom@exemple.com",
+          "send": "Envoyer E-mail"
+        },
+        "image": {
+          "copyToClipboard": "Copier le graphique dans le presse-papiers",
+          "description": "Téléchargez ou copiez le graphique d’analyses en image PNG afin de le partager ou de l’enregistrer.",
+          "download": "Télécharger le graphique",
+          "previewPlaceholder": "Aperçu des analyses"
+        },
+        "tabs": {
+          "email": "E-mail",
+          "image": "Aperçu image"
+        },
+        "title": "Partager Analytics",
+        "toasts": {
+          "emailSent": {
+            "description": "Rapport d’analyses envoyé à {email}",
+            "title": "E-mail envoyé !"
+          },
+          "imageCopied": {
+            "description": "L’image des analyses a été copiée dans votre presse-papiers",
+            "title": "Image copiée !"
+          },
+          "imageSaved": {
+            "description": "Les analyses de dépenses pour {merchant} ont été téléchargées au format PNG",
+            "title": "Image enregistrée !"
+          }
+        }
+      },
+      "shareInvoiceDialog": {
+        "dialogDescription": {
+          "currentlyPublic": "\"{invoiceName}\" est actuellement publique",
+          "private": "Envoyer \"{invoiceName}\" en privé",
+          "public": "Partager \"{invoiceName}\" publiquement",
+          "selection": "Choisissez comment partager « {invoiceName} »"
+        },
+        "errors": {
+          "qrNotFound": "Élément de code QR introuvable"
+        },
+        "selection": {
+          "description": "Choisissez comment vous souhaitez partager cette facture. Votre choix détermine qui peut y accéder.",
+          "privacyNoticeDescription": "Les liens publics sont accessibles à toute personne disposant de l’URL. Le partage privé limite l’accès au destinataire spécifié.",
+          "privacyNoticeTitle": "Avis de confidentialité",
+          "privateDescription": "Envoyez une invitation par e-mail à une <strong>personne spécifique</strong>. Seule cette personne aura accès.",
+          "privateTitle": "Privé sharing",
+          "publicDescription": "Générez un lien ou un code QR que <strong>n’importe qui</strong> peut utiliser pour voir cette facture.",
+          "publicTitle": "Partage publique"
+        },
+        "title": "Partager facture",
+        "toasts": {
+          "copyLink": {
+            "error": "Échoué: {message}",
+            "loadingMakePublic": "La facture devient publique...",
+            "loadingPublic": "Copie du lien...",
+            "successMadePublic": "La facture est maintenant publique ! Lien copié dans le presse-papiers.",
+            "successPublic": "Lien copié dans le presse-papiers !"
+          },
+          "copyQr": {
+            "error": "Échoué: {message}",
+            "loadingMakePublic": "La facture devient publique...",
+            "loadingPublic": "Copie du code QR...",
+            "successMadePublic": "La facture est maintenant publique ! Code QR copié dans le presse-papiers.",
+            "successPublic": "Code QR copié dans le presse-papiers !"
+          },
+          "revoke": {
+            "error": "Échec de la révocation de l’accès : {message}",
+            "loading": "Envoi de la demande de révocation au serveur...",
+            "success": "La facture est maintenant privée. Les liens existants ne fonctionneront plus."
+          },
+          "sendEmail": {
+            "comingSoon": "Le partage par e-mail arrive bientôt",
+            "error": "Échoué: {message}",
+            "loading": "Envoi de l’invitation à {email}...",
+            "success": "Invitation envoyée à {email} !"
+          }
+        }
+      },
+      "shareInvoiceDialogPrivate": {
+        "backToOptions": "Retour aux options",
+        "comingSoonTooltip": "La fonction de partage par e-mail sera bientôt disponible",
+        "description": "L’invitation sera envoyée directement à l’adresse e-mail que vous indiquez. Seul ce destinataire recevra l’accès pour consulter la facture.",
+        "emailHint": "Une invitation par e-mail sera envoyée à cette adresse avec un lien privé pour consulter la facture.",
+        "emailLabel": "Recipient's e-mail address",
+        "emailPlaceholder": "nom@exemple.com",
+        "sending": "Envoi de l'invitation...",
+        "sendInvitation": "Envoyer une invitation privée",
+        "title": "Privé sharing"
+      },
+      "shareInvoiceDialogPublic": {
+        "alreadyPublic": {
+          "description": "Cette facture est accessible publiquement. <strong>Toute personne disposant du lien peut la consulter</strong>, y compris tous les détails de la facture, les articles et les montants. Vous pouvez révoquer l’accès public à tout moment pour la rendre privée à nouveau.",
+          "revoke": "Révoquer l’accès public",
+          "revokeHint": "Cela rendra la facture privée. Les liens existants cesseront de fonctionner.",
+          "revoking": "Révocation de l’accès...",
+          "title": "Cette facture est actuellement publique"
+        },
+        "backToOptions": "Retour aux options",
+        "copyQrImage": "Copier le code QR en tant qu’image",
+        "hints": {
+          "link": "Copiez ce lien et partagez-le. Toute personne qui le reçoit pourra consulter la facture.",
+          "qr": "Toute personne qui scanne ce QR code sera redirigée pour consulter la facture."
+        },
+        "tabs": {
+          "directLink": "Lien direct",
+          "qrCode": "Code QR"
+        },
+        "warning": {
+          "description": "En partageant cette facture publiquement, <strong>toute personne disposant du lien pourra la consulter</strong>. Cela inclut tous les détails de la facture, les articles et les montants. Continuez uniquement si vous souhaitez rendre cette facture accessible au publique.",
+          "title": "Avertissement d’accès public"
+        }
+      }
+    }
+  },
+  "emails": {
+    "accountInactivity": {
+      "badge": "Compte",
+      "cta": {
+        "primary": "Se connecter",
+        "secondary": "Contacter le support"
+      },
+      "footnote": "Note : Cet avis est informatif et destiné à vous aider à éviter de perdre l'accès. Les politiques réelles de rétention des comptes peuvent varier selon la région et le produit.",
+      "greeting": "Bonjour {name},",
+      "heading": "Avis d'inactivité du compte",
+      "intro": "Ceci est un avertissement que votre compte est inactif depuis <count>{inactiveDays}</count> jours.",
+      "preview": "Bonjour {name} — votre compte est inactif depuis {inactiveDays} jours.",
+      "signOff": {
+        "line1": "Cordialement,",
+        "line2": "L'équipe {brand}"
+      },
+      "subject": "Vous nous manquez chez {brand}",
+      "supportPrompt": "Si vous pensez avoir reçu ce message par erreur ou si vous avez besoin d'aide, veuillez contacter <link>{supportEmail}</link>.",
+      "timeline": {
+        "daysValue": "{days} jours",
+        "inactiveFor": "Inactif depuis",
+        "timeRemaining": "Temps restant",
+        "title": "Chronologie"
+      },
+      "whatThisMeans": {
+        "bullet1": "Se connecter gardera votre compte actif.",
+        "bullet2": "S'il n'y a aucune activité pendant les prochains {daysUntilClosure} jours, le compte pourrait être programmé pour fermeture.",
+        "bullet3": "Si vous souhaitez conserver vos données, veuillez agir avant la date limite.",
+        "title": "Ce que cela signifie"
       }
     },
-    "invoiceCard": {
-      "descriptionPlaceholder": "Saisissez la description de la facture...",
-      "fromMerchant": "De {merchant}",
-      "importantBadge": "IMPORTANT",
-      "labels": {
-        "category": "Catégorie",
-        "dateUtc": "Date et heure (UTC)",
-        "hours": "Heures",
-        "minutes": "Min",
-        "paymentMethod": "Mode de paiement",
-        "totalAmount": "Montant total",
-        "utc": "UTC"
+    "firstInvoiceUploaded": {
+      "badge": "Étape importante",
+      "body": "Plus vous téléchargez de factures, plus vos informations sur les dépenses deviennent riches. Essayez de télécharger quelques reçus cette semaine pour voir votre tableau de bord prendre vie.",
+      "ctaPrimary": "Voir votre facture",
+      "ctaSecondary": "Télécharger un autre reçu",
+      "featuresToExplore": {
+        "item0": "Partagez des factures avec votre famille ou vos collègues pour un suivi des dépenses conjoint",
+        "item1": "Consultez les suggestions de recettes générées par l'IA à partir de vos articles d'épicerie",
+        "item2": "Vérifiez les avertissements sur les allergènes pour les produits alimentaires détectés",
+        "item3": "Suivez les modèles de dépenses par commerçant, catégorie et période"
       },
-      "markImportant": "Marquer comme important",
-      "placeholders": {
-        "selectCategory": "Sélectionner catégorie",
-        "selectPaymentType": "Sélectionner le type de paiement"
+      "featuresToExploreTitle": "Fonctionnalités à explorer",
+      "feedbackPrompt": "Besoin d'aide ou avez-vous des commentaires ? Contactez-nous à <email></email>.",
+      "greeting": "Bonjour {name},",
+      "heading": "Votre première facture est arrivée !",
+      "intro": "Félicitations pour le téléchargement de votre première facture ! Vous avez fait le premier pas vers un suivi organisé et perspicace des dépenses. Voici ce que nous avons jusqu'à présent :",
+      "invoiceSummary": {
+        "invoiceName": "Nom de la facture",
+        "status": "Statut",
+        "uploaded": "Téléchargé"
       },
-      "title": "Détails de la facture",
-      "tooltips": {
-        "markFavorite": "Cliquer pour ajouter aux favoris",
-        "unmarkFavorite": "Cliquer pour retirer des favoris"
-      }
+      "invoiceSummaryTitle": "Votre Première Facture",
+      "preview": "Félicitations, {name} ! Votre première facture est arrivée.",
+      "signOff": {
+        "line1": "Cordialement,",
+        "line2": "L'équipe {brand}"
+      },
+      "statusValue": "Prêt pour l'analyse",
+      "subject": "Votre première facture est arrivée !",
+      "untitledFallback": "Sans titre",
+      "whatHappensNext": {
+        "item0": "Nous analysons votre reçu — notre IA extrait les articles, les prix et les informations sur le commerçant",
+        "item1": "Vous examinez les résultats — vérifiez l'analyse et corrigez tout ce qui semble incorrect",
+        "item2": "Votre tableau de bord se met à jour — graphiques de dépenses, répartitions par catégorie et tendances commencent à se construire"
+      },
+      "whatHappensNextTitle": "Ce qui va suivre"
     },
-    "invoiceDetailsCard": {
-      "itemsTitle": "Articles ({count})",
-      "labels": {
-        "category": "Catégorie",
-        "countryRegion": "Pays/Région",
-        "dateUtc": "Date et heure (UTC)",
-        "payment": "Paiement",
-        "receiptType": "Type de reçu",
-        "ronEquivalent": "Équivalent RON",
-        "subtotal": "Sous-total",
-        "tip": "Pourboire",
+    "incompleteInvoice": {
+      "analyzedOnLabel": "Analysée le",
+      "badge": "Rappel",
+      "bodyText": "Compléter ces détails prend moins d'une minute et garantit que vos rapports de dépenses restent précis.",
+      "feedback": "Bloqué ou besoin d’aide ? Contactez-nous à <link>{supportEmail}</link>.",
+      "greeting": "Bonjour {name},",
+      "heading": "Votre facture nécessite une mise à jour rapide",
+      "intro": "Nous avons analysé votre facture {invoiceName}, mais n'avons pas pu tout extraire. Quelques détails manquent, et les compléter vous donnera de meilleures informations sur vos dépenses et des tableaux de bord plus précis.",
+      "invoiceDetailsTitle": "Détails de la facture",
+      "invoiceLabel": "Facture",
+      "missingFields": {
+        "category": {
+          "label": "Catégorie de facture",
+          "suggestion": "Sélectionnez une catégorie (épicerie, restauration rapide, ménage, etc.)"
+        },
+        "items": {
+          "label": "Articles ligne par ligne",
+          "suggestion": "Essayez de télécharger à nouveau une photo plus claire, ou ajoutez les articles manuellement"
+        },
+        "merchant": {
+          "label": "Commerçant",
+          "suggestion": "Ajoutez manuellement le nom du magasin dans la vue d'édition"
+        },
+        "payment": {
+          "label": "Informations de paiement",
+          "suggestion": "Entrez le montant total et le mode de paiement dans la vue d'édition"
+        },
+        "unknown": {
+          "label": "{field}",
+          "suggestion": "Veuillez réviser et mettre à jour ces informations"
+        }
+      },
+      "missingFieldsLabel": "Champs manquants",
+      "preview": "{name}, votre facture \"{invoiceName}\" nécessite une attention.",
+      "primaryCta": "Compléter votre facture",
+      "secondaryCta": "Réanalyser",
+      "signOff": {
+        "line1": "Cordialement,",
+        "line2": "L'équipe {brand}"
+      },
+      "subject": "Vous avez des factures incomplètes",
+      "tips": {
+        "item0": "Utilisez une surface bien éclairée et plate lors de la photographie des reçus",
+        "item1": "Assurez-vous que le reçu entier est visible et net",
+        "item2": "Les reçus PDF des commandes en ligne ont tendance à être mieux analysés",
+        "item3": "Vous pouvez toujours ajouter ou corriger les détails manuellement après l'analyse"
+      },
+      "tipsTitle": "Conseils pour une meilleure analyse",
+      "whatsMissingTitle": "Ce qui manque"
+    },
+    "invoiceAnalyzed": {
+      "badge": "Factures • Analyse Terminée",
+      "body": "Cliquez sur le bouton ci-dessus pour voir l'analyse complète. Si quelque chose ne va pas—peut-être qu'un produit a été mal catégorisé ou qu'un prix n'a pas été détecté correctement—vous pouvez modifier la facture directement dans votre tableau de bord et les aperçus se mettront à jour automatiquement.",
+      "ctaPrimary": "Voir l'analyse complète",
+      "feedbackPrompt": "Vous avez des questions sur votre analyse ou besoin d'aide ? Contactez-nous à <email></email>.",
+      "greeting": "Bonjour {name},",
+      "heading": "L'analyse de votre facture est prête",
+      "intro": "Bonne nouvelle ! Notre IA a terminé l'analyse de votre facture. Nous avons extrait toutes les informations clés, catégorisé vos articles et généré des aperçus de dépenses pour vous aider à suivre vos finances.",
+      "preview": "Votre facture est prête, {name}. Analyse terminée !",
+      "signOff": {
+        "line1": "Cordialement,",
+        "line2": "L'équipe {brand}"
+      },
+      "subject": "Votre facture a été analysée",
+      "summary": {
+        "invoiceName": "Nom de la facture",
+        "itemsDetected": "Articles détectés",
+        "merchantId": "ID Commerçant",
+        "notIdentified": "Pas encore identifié",
         "totalAmount": "Montant total"
       },
-      "pagination": {
-        "next": "Suivant",
-        "pageOf": "Page {current} sur {total}",
-        "previous": "Précédent"
+      "summaryTitle": "Résumé de la facture",
+      "whatWasAnalyzed": {
+        "item0": "Identification et catégorisation du commerçant",
+        "item1": "Extraction ligne par ligne des articles avec les prix",
+        "item2": "Catégorisation automatique des produits (épicerie, boissons, articles ménagers, etc.)",
+        "item3": "Détection de la devise et validation du montant",
+        "item4": "Extraction de la date et de l'heure lorsque disponible"
       },
-      "sections": {
-        "paymentMethods": "Modes de paiement",
-        "taxBreakdown": "Détail des taxes"
-      },
-      "table": {
-        "grandTotal": "Total général",
-        "item": "Article",
-        "price": "Prix",
-        "qty": "Qté",
-        "total": "Somme",
-        "unit": "Unité"
-      },
-      "taxLabels": {
-        "net": "Net",
-        "tax": "Taxe"
-      },
-      "title": "Détails de la facture",
-      "tooltips": {
-        "exchangeRate": "1 {fromCurrency} = {rate} RON (moy. {year})"
-      }
+      "whatWasAnalyzedTitle": "Ce qui a été analysé"
     },
-    "merchantCard": {
-      "addressLabel": "Adresse : {address}",
-      "buttons": {
-        "viewAllReceipts": "Voir tous les reçus",
-        "viewMerchantDetails": "Voir les détails du commerçant"
-      },
-      "noMerchantLinked": "Aucun commerçant lié à cette facture",
-      "title": "Commerçant",
-      "tooltips": {
-        "viewAllReceipts": "Voir tous les reçus de ce commerçant",
-        "viewMerchantDetails": "Voir des informations détaillées sur ce commerçant"
-      }
-    },
-    "merchantInfoCard": {
-      "categoryDistribution": "Répartition par catégorie",
-      "noMerchantLinked": "Aucun commerçant lié à cette facture",
-      "spendingHistory": "Historique des dépenses",
-      "stats": {
-        "avgSpend": "Dépense moyenne",
-        "daysAgo": "il y a quelques jours",
-        "visits": "visites"
-      },
-      "title": "Informations sur le commerçant",
-      "viewAllInvoices": "Voir toutes les factures",
-      "viewAllReceipts": "Voir tous les reçus",
-      "viewOnMap": "Voir sur la carte"
-    },
-    "nutritionCard": {
-      "allergens": {
-        "foundInItems": "Trouvé dans {count} article(s)",
-        "title": "Allergènes détectés"
-      },
-      "composition": {
-        "dairyOther": "Produits laitiers/Autre",
-        "processed": "Transformés",
-        "title": "Composition de votre panier",
-        "wholeFoods": "Aliments complets"
-      },
-      "foodGroups": {
-        "fruits": "Fruits frais",
-        "grains": "Céréales",
-        "itemsCount": "{count} article(s)",
-        "protein": "Protéines",
-        "vegetables": "Légumes"
-      },
-      "score": {
-        "excellent": "Très bon",
-        "fair": "Moyen",
-        "good": "Bon",
-        "needsWork": "À améliorer",
-        "title": "Score d’équilibre alimentaire"
-      },
-      "suggestions": {
-        "addFruits": "Ajouter des fruits améliorerait l’équilibre nutritionnel",
-        "addFruitsAndVegetables": "Ajoutez davantage de fruits et légumes pour équilibrer votre panier",
-        "addVegetables": "Pensez à ajouter des légumes pour une alimentation plus équilibrée",
-        "greatBalance": "Excellent équilibre d’achats !",
-        "swapProcessed": "Essayez de remplacer certains produits transformés par des aliments complets"
-      },
-      "title": "Vue d’ensemble nutritionnelle"
-    },
-    "receiptScanCard": {
-      "buttons": {
-        "expand": "Agrandir l’image",
-        "nextScan": "Scan suivant",
-        "previousScan": "Scan précédent"
-      },
-      "controls": {
-        "download": "Télécharger",
-        "fullScreen": "Plein écran",
-        "reset": "Réinitialiser le zoom",
-        "rotate": "Pivoter",
-        "toggleZoom": "Basculer le zoom",
-        "zoomIn": "Zoom avant",
-        "zoomOut": "Zoom arrière"
-      },
-      "dialogTitle": "Image du reçu",
-      "dialogTitleWithIndex": "Image du reçu ({current}/{total})",
-      "navigation": {
-        "next": "Suivant",
-        "of": "sur",
-        "previous": "Précédent"
-      },
-      "scanAlt": "Scan du reçu {index}",
-      "scanAltFullSize": "Scan du reçu {index} - taille réelle",
-      "title": "Scan du reçu",
-      "titleWithIndex": "Scan du reçu ({current}/{total})",
-      "tooltips": {
-        "expand": "Voir l’image du reçu en taille réelle",
-        "nextScan": "Voir le scan suivant du reçu",
-        "previousScan": "Voir le scan précédent du reçu"
-      }
-    },
-    "recipeCard": {
-      "buttons": {
-        "viewRecipe": "Voir la recette",
-        "visitReference": "Visiter la référence"
-      },
-      "complexity": {
-        "easy": "Facile",
-        "hard": "Difficile",
-        "normal": "Normal",
-        "unknown": "Inconnu"
-      },
-      "dropdown": {
-        "delete": "Supprimer",
-        "edit": "Modifier",
-        "markAsFavorite": "Marquer comme favori",
-        "share": "Partager",
-        "view": "Voir"
-      },
-      "ingredients": {
-        "additionalLabel": "Ingrédients supplémentaires :",
-        "label": "Ingrédients :",
-        "more": "+{count} de plus"
-      },
-      "timing": {
-        "cookLabel": "Cuisson : {minutes}′",
-        "cookTooltip": "Le temps de cuisson est de {minutes} minutes.",
-        "prepLabel": "Prépa : {minutes}′",
-        "prepTooltip": "Le temps de préparation est de {minutes} minutes."
-      }
-    },
-    "seasonalInsightsCard": {
-      "insights": {
-        "holidaySeason": {
-          "description": "Les dépenses de décembre sont généralement 35% plus élevées",
-          "title": "Saison des fêtes"
-        },
-        "normalPattern": {
-          "description": "Vos dépenses sont dans la plage habituelle",
-          "title": "Habitude d’achat normale"
-        },
-        "spike": {
-          "description": "+{percent}% vs votre moyenne",
-          "title": "Pic de {category}"
-        },
-        "stockUpTip": {
-          "description": "Les prix augmentent d’environ 15% après le 15 décembre",
-          "title": "Conseil de stock"
-        },
-        "insufficientData": {
-          "description": "Il n’y a pas encore assez de données pour afficher des tendances saisonnières fiables.",
-          "title": "Données insuffisantes"
-        }
-      },
-      "month": {
-        "spendingSoFar": "{month} jusqu’à présent",
-        "vsAverage": "vs moyenne de {month} : {amount}"
-      },
-      "title": "Insight saisonnier"
-    },
-    "sharingCard": {
-      "buttons": {
-        "manageSharing": "Gérer Partage",
-        "markAsPrivate": "Marquer comme privée",
-        "revokingAccess": "Révocation de l’accès...",
-        "shareInvoice": "Partager Facture"
-      },
-      "emptyShared": {
-        "private": "Non partagée",
-        "public": "Aucun utilisateur supplémentaire n’a d’accès direct"
-      },
-      "owner": "Propriétaire",
-      "ownerAvatarAlt": "Utilisateur",
-      "publicInvoice": {
-        "description": "Cette facture est accessible publiquement. Toute personne disposant du lien peut la consulter.",
-        "title": "Facture publique"
-      },
-      "sharedWith": "Partagée avec",
-      "title": "Partage",
-      "toasts": {
-        "removeAccessComingSoon": {
-          "description": "Cette fonctionnalité est en cours de développement.",
-          "title": "La suppression d’accès sera bientôt disponible"
-        },
-        "revoke": {
-          "error": "Échec du passage en privé : {message}",
-          "loading": "Révocation de l’accès public...",
-          "success": "La facture est maintenant privée. Les liens existants ne fonctionneront plus."
-        }
-      },
-      "tooltips": {
-        "manageSharing": "Gérer les paramètres de partage de cette facture",
-        "markAsPrivate": "Marquer la facture comme privée",
-        "removeAccess": "Supprimer l’accès",
-        "shareInvoice": "Partager cette facture avec d’autres utilisateurs"
-      },
-      "userWithId": "Utilisateur {id}"
-    },
-    "shoppingCalendarCard": {
-      "insights": {
-        "days": "{count} jours",
-        "mostActiveOn": "Plus actif le",
-        "onAverage": "en moyenne",
-        "perTrip": " par achat",
-        "shopEveryPrefix": "Vous faites vos achats tous les",
-        "spendingPrefix": ", dépensant",
-        "weekdayLabel": "{weekday}"
-      },
-      "legend": {
-        "less": "Moins",
-        "more": "Plus"
-      },
-      "stats": {
-        "monthTotal": "Total du mois",
-        "shoppingDays": "Jours d’achats"
-      },
-      "title": "Calendrier d’achats",
-      "tooltip": {
-        "basedOnCachedInvoices": "Basé sur {count} factures en cache",
-        "currentInvoice": "Facture actuelle",
-        "currentInvoiceOnly": "Affichage de la facture actuelle uniquement",
-        "invoiceCount": "{count} facture(s)",
-        "more": "+{count} de plus",
-        "vsAverage": "vs moy ({years} ans de données)"
-      }
-    },
-    "summaryStatsCard": {
-      "description": "Statistiques clés en un coup d’œil",
-      "extremes": {
-        "highest": "Le plus élevé",
-        "lowest": "Le plus bas"
-      },
-      "stats": {
-        "averagePrice": {
-          "description": "{currency} par article",
-          "label": "Prix moyen"
-        },
-        "categories": {
-          "description": "Catégories uniques",
-          "label": "Catégories"
-        },
-        "taxRate": {
-          "description": "{amount} {currency}",
-          "label": "Taux de taxe"
-        },
-        "totalItems": {
-          "description": "Produits achetés",
-          "label": "Articles totaux"
-        }
-      },
-      "title": "Résumé de la facture"
-    },
-    "vehicleCard": {
-      "buttons": {
-        "addVehicle": "Ajouter Véhicule",
-        "fullReport": "Rapport complet"
-      },
-      "chart": {
-        "amount": "Montant",
-        "title": "Dépenses mensuelles en carburant"
-      },
+    "invoiceDeleted": {
+      "badge": "Factures • Supprimé",
+      "body": "Si vous n'avez pas initié cette suppression ou si vous devez récupérer la facture, veuillez nous contacter immédiatement à <email></email>. Nous sommes là pour vous aider.",
+      "ctaPrimary": "Voir vos factures",
       "details": {
-        "liters": "Litres",
-        "notSet": "Non défini",
-        "pricePerLiter": "Prix/L",
-        "station": "Station-service",
-        "vehicle": "Véhicule"
+        "invoice": "Facture",
+        "invoiceId": "ID facture",
+        "status": "Statut"
       },
-      "expenseType": "Type de dépense : Carburant",
-      "maintenance": {
-        "title": "Rappels d’entretien"
+      "detailsTitle": "Détails de la suppression",
+      "greeting": "Bonjour {name},",
+      "heading": "Facture retirée de votre compte",
+      "intro": "Cet email confirme qu'une facture a été retirée de votre compte {brand}. La suppression a été traitée avec succès.",
+      "placeholder": "—",
+      "preview": "La facture {invoiceLabel} a été retirée de votre compte.",
+      "signOff": {
+        "line1": "Cordialement,",
+        "line2": "L'équipe {brand}"
       },
-      "months": {
-        "dec": "déc.",
-        "nov": "nov.",
-        "oct": "oct.",
-        "sep": "sept."
+      "statusValue": "Supprimé (suppression douce)",
+      "subject": "Votre facture a été supprimée",
+      "whatYouShouldKnow": {
+        "item0": "Il s'agit d'une suppression douce—les données de la facture peuvent être conservées pendant 30 jours à des fins de récupération.",
+        "item1": "Tout accès partagé à cette facture a été automatiquement révoqué.",
+        "item2": "Les statistiques et informations seront recalculées pour exclure cette facture.",
+        "item3": "Si vous devez récupérer cette facture, contactez le support dans les 30 jours."
       },
-      "reminders": {
-        "oilChange": "Vidange à prévoir dans ~1 200 km",
-        "tireRotation": "Rotation des pneus recommandée"
+      "whatYouShouldKnowTitle": "Ce que vous devez savoir"
+    },
+    "invoiceInactivity": {
+      "badge": {
+        "item14": "Inactivité • 14 jours",
+        "item3": "Inactivité • 3 jours",
+        "item30": "Inactivité • 30 jours",
+        "item7": "Inactivité • 7 jours"
       },
-      "stats": {
-        "costPerKm": "Coût/km",
-        "estimated": "estimé",
-        "fillUps": "{count} pleins",
-        "fuelPrice": "Fuel Prix",
-        "thisMonth": "Ce mois-ci",
-        "thisMonthSuffix": "ce mois-ci"
+      "cta": {
+        "primary": "Télécharger une facture",
+        "secondary": "Voir les factures"
       },
+      "greeting": "Bonjour {name},",
+      "heading": {
+        "item14": "Reprenons le fil",
+        "item3": "Vérification rapide",
+        "item30": "Cela fait un moment",
+        "item7": "Un rappel doux"
+      },
+      "helpPrompt": "Besoin d'aide ou avez des questions? Envoyez un email à <link>{supportEmail}</link>.",
+      "important": {
+        "message": "Si vous êtes bloqué ou si quelque chose ne fonctionne pas, répondez à cet email ou contactez le support — nous vous aiderons.",
+        "title": "Important"
+      },
+      "intro": {
+        "item14": "Deux semaines sans téléchargements — besoin d'un petit coup de pouce pour reprendre l'habitude?",
+        "item3": "Nous avons remarqué que vous n'avez téléchargé aucune facture récemment.",
+        "item30": "Cela fait environ un mois depuis votre dernier téléchargement — nous pouvons vous aider à reprendre là où vous en étiez.",
+        "item7": "Il semble qu'une semaine se soit écoulée depuis votre dernier téléchargement de facture."
+      },
+      "preview": "Bonjour {name} — {days} jours depuis votre dernier téléchargement.",
+      "signOff": {
+        "line1": "Cordialement",
+        "line2": "L'équipe {brand}"
+      },
+      "status": {
+        "daysWithoutUpload": "Jours sans téléchargement",
+        "lastUpload": "Dernier téléchargement",
+        "title": "Statut"
+      },
+      "subject": "Cela fait {daysWithoutUpload} jours depuis votre dernière facture",
       "tip": {
-        "perLiter": "L",
-        "title": "Le moins cher à proximité"
+        "message": "Téléchargez une facture récente aujourd'hui — une petite constance vaut mieux qu'un gros rattrapage.",
+        "title": "Astuce (30 secondes)"
       },
-      "title": "Analyse des dépenses du véhicule"
+      "whyWorthIt": {
+        "bullet1": "Gardez votre chronologie de dépenses précise.",
+        "bullet2": "Obtenez des totaux plus propres par commerçant et catégorie.",
+        "bullet3": "Trouvez les reçus plus rapidement quand vous en avez besoin.",
+        "title": "Pourquoi c'est utile"
+      }
+    },
+    "invoiceMadePublic": {
+      "accessValue": "Public (n'importe qui avec le lien)",
+      "badge": "Factures • Lien Public",
+      "ctaPrimary": "Ouvrir la facture publique",
+      "details": {
+        "access": "Accès",
+        "created": "Créé",
+        "invoiceId": "ID facture",
+        "invoiceName": "Nom de la facture",
+        "merchant": "Commerçant",
+        "total": "Total"
+      },
+      "detailsTitle": "Détails de la facture",
+      "directLinkLabel": "Lien direct :",
+      "feedbackPrompt": "Des questions sur le partage ou les paramètres de confidentialité ? Contactez-nous à <email></email>.",
+      "greeting": "Bonjour {name},",
+      "heading": "Votre facture est maintenant publique",
+      "howToShare": {
+        "item0": "Copiez le lien direct ci-dessous et envoyez par email ou message",
+        "item1": "Imprimez ou capturez le code QR pour un partage en personne",
+        "item2": "Incluez dans les rapports de dépenses ou les demandes de remboursement"
+      },
+      "howToShareTitle": "Comment partager",
+      "intro": "Vous avez réussi à rendre votre facture publique. Toute personne possédant le lien ou le code QR ci-dessous peut désormais consulter cette facture—sans connexion requise. C'est parfait pour partager des reçus avec des collègues, des comptables ou pour les rapports de dépenses.",
+      "preview": "Votre facture \"{invoiceName}\" est désormais publique et partageable.",
+      "privacyNoticeBody": "Les factures publiques peuvent être consultées par toute personne possédant l'URL ou le code QR. Pour rendre cette facture privée à nouveau, mettez à jour les paramètres de partage depuis votre page de facture à tout moment.",
+      "privacyNoticeTitle": "Avis de Confidentialité",
+      "qrAlt": "Code QR pour l'accès à la facture",
+      "qrSubText": "Scannez avec l'appareil photo de votre téléphone pour un accès instantané.",
+      "qrTitle": "Code QR d'Accès Rapide",
+      "signOff": {
+        "line1": "Cordialement,",
+        "line2": "L'équipe {brand}"
+      },
+      "subject": "Votre facture est maintenant publique"
+    },
+    "invoiceShared": {
+      "badge": "Factures • Partagées",
+      "body": "Cliquez sur le bouton ci-dessus pour accéder à la facture partagée. Ce lien restera actif tant que les autorisations de partage seront en place.",
+      "ctaPrimary": "Voir la facture partagée",
+      "details": {
+        "invoiceId": "ID Facture",
+        "sharedBy": "Partagé par"
+      },
+      "detailsTitle": "Détails du partage",
+      "feedbackPrompt": "Vous avez des questions sur ce partage ou besoin d'aide ? Contactez-nous à <email></email>.",
+      "greeting": "Bonjour {toName},",
+      "heading": "Une facture a été partagée avec vous",
+      "intro": "Bonne nouvelle ! <from></from> a partagé une facture avec vous sur {brand}. Cela vous donne accès à tous les détails de la facture, y compris les produits détaillés, les informations sur le commerçant et les analyses.",
+      "preview": "{fromName} a partagé une facture avec vous.",
+      "signOff": {
+        "line1": "Cordialement,",
+        "line2": "L'équipe {brand}"
+      },
+      "subject": "{fromName} a partagé une facture avec vous",
+      "whatYouCanDo": {
+        "item0": "Voir les détails complets de la facture et la ventilation par article",
+        "item1": "Consulter les analyses et les catégories de dépenses",
+        "item2": "Télécharger ou imprimer la facture pour vos archives"
+      },
+      "whatYouCanDoTitle": "Ce que vous pouvez faire"
+    },
+    "invoiceStats": {
+      "badge": "Factures",
+      "body": "Pour une répartition complète de vos dépenses, visitez votre liste de factures pour consulter les tendances, les commerçants, les catégories et les totaux au fil du temps. Ces informations peuvent vous aider à identifier les habitudes de dépenses et à prendre des décisions financières plus éclairées.",
+      "breakdownCardTitle": "Répartition des dépenses (par catégorie)",
+      "breakdownNote": "Remarque : Ce graphique utilise les données de classement par catégorie disponibles pour la période.",
+      "breakdownTableTitle": "Répartition",
+      "ctaPrimary": "Voir les factures",
+      "ctaSecondary": "Télécharger une nouvelle facture",
+      "donutChartAlt": "Graphique en anneau montrant la répartition des dépenses par catégorie.",
+      "donutChartTitle": "Distribution des dépenses par catégorie",
+      "feedbackPrompt": "Des questions ou quelque chose ne semble pas correct ? Écrivez-nous à <email></email>.",
+      "frequencyLabel": "{frequency, select, daily {Quotidienne} weekly {Hebdomadaire} monthly {Mensuelle} yearly {Annuelle} other {Périodique}}",
+      "greeting": "Bonjour {name},",
+      "heading": "Statistiques {frequencyLabel} de factures",
+      "intro": "Voici votre résumé d'activité et de dépenses pour la période <start></start> → <end></end>.",
+      "metrics": {
+        "averagePerInvoice": "Moy. / facture",
+        "invoices": "Factures",
+        "scans": "Analyses",
+        "totalSpend": "Dépenses totales"
+      },
+      "noDataFallback": "Pas encore de données — téléchargez quelques factures pour débloquer les statistiques.",
+      "preview": "Statistiques {frequencyLabel} pour {name} — {totalSpend} au total.",
+      "reportDetails": {
+        "currency": "Devise",
+        "period": "Période"
+      },
+      "reportDetailsTitle": "Détails du rapport",
+      "signOff": {
+        "line1": "Cordialement,",
+        "line2": "L'équipe {brand}"
+      },
+      "subject": "Vos statistiques {frequency, select, daily {quotidiennes} weekly {hebdomadaires} monthly {mensuelles} yearly {annuelles} other {périodiques}} de factures",
+      "title": "Statistiques de factures {frequencyLabel}",
+      "topCategoriesTitle": "Top catégories",
+      "topMerchantsTitle": "Top commerçants"
+    },
+    "invoiceUnshared": {
+      "badge": "Factures • Accès Révoqué",
+      "body": "Si vous pensez que ce changement a été effectué par erreur, veuillez contacter <from></from> ou notre équipe d'assistance. Les révocations d'accès sont parfois accidentelles et nous sommes heureux de faciliter la communication si nécessaire.",
+      "ctaPrimary": "Voir vos factures",
+      "ctaSecondary": "Contacter le support",
+      "details": {
+        "accessRevoked": "Révoqué",
+        "invoiceId": "ID Facture",
+        "notProvided": "—",
+        "revokedAt": "Révoqué le",
+        "revokedBy": "Révoqué par",
+        "yourAccess": "Votre accès"
+      },
+      "detailsTitle": "Détails de la révocation",
+      "feedbackPrompt": "Besoin d'aide ? Envoyez-nous un email à <email></email>.",
+      "greeting": "Bonjour {toName},",
+      "heading": "Votre accès à une facture a été révoqué",
+      "intro": "Nous vous écrivons pour vous informer que <from></from> a révoqué votre accès à une facture qui avait été partagée avec vous auparavant. Cela signifie que vous ne pourrez plus consulter cette facture.",
+      "preview": "{fromName} a révoqué votre accès à une facture partagée.",
+      "signOff": {
+        "line1": "Cordialement,",
+        "line2": "L'équipe {brand}"
+      },
+      "subject": "L'accès à une facture partagée a été révoqué",
+      "whatThisMeans": {
+        "item0": "Tous les liens enregistrés vers cette facture ne fonctionneront plus pour vous.",
+        "item1": "Cette facture n'apparaîtra plus dans votre liste de factures partagées.",
+        "item2": "Si vous avez besoin d'un nouvel accès, contactez directement le propriétaire de la facture."
+      },
+      "whatThisMeansTitle": "Ce que cela signifie"
+    },
+    "layout": {
+      "allRightsReserved": "© 2022-{year} {brand}. Tous droits réservés.",
+      "buttonFallback": "Si le bouton ne fonctionne pas, ouvrez ce lien :",
+      "managePreferences": "Gérer les préférences d'email",
+      "secondaryFallback": "Ou :",
+      "tagline": "Outils pratiques. Informations claires. Conçu pour les dépenses quotidiennes.",
+      "unsubscribe": "Se désabonner"
+    },
+    "newsletterSubscribed": {
+      "badge": "Newsletter",
+      "body": "Votre boîte de réception est sacrée—je respecte cela. Chaque email est conçu pour apporter une véritable valeur, que ce soit un conseil qui vous fait gagner des heures ou une perspective qui change votre vision des finances personnelles.",
+      "ctaPrimary": "Visiter arolariu.ro",
+      "feedbackPrompt": "Des questions, des commentaires ou juste envie de dire bonjour ? Répondez à cet email ou contactez-moi directement à <email></email>.",
+      "greeting": "Bonjour {name},",
+      "heading": "Vous êtes inscrit — bienvenue à bord",
+      "intro": "Merci de vous être abonné à la newsletter <brand>{brandName}</brand>. Je suis sincèrement ravi de vous avoir ici. Je garderai les communications légères, significatives et dignes de votre temps.",
+      "preview": "Bienvenue, {name} — vous êtes abonné.",
+      "signOff": {
+        "line1": "Cordialement",
+        "line2": "L'équipe {brand}"
+      },
+      "subject": "Vous êtes abonné !",
+      "whatToExpect": {
+        "item0": "Mises à jour de produits et nouvelles fonctionnalités au fur et à mesure de leur lancement",
+        "item1": "Nouveaux articles et écrits sur la technologie, la productivité et les finances personnelles",
+        "item2": "Points forts occasionnels et ressources sélectionnées (1 à 2 emails par trimestre)"
+      },
+      "whatToExpectTitle": "À quoi s'attendre"
+    },
+    "newsletterUnsubscribed": {
+      "badge": "Newsletter",
+      "body": "J'apprécie le temps que vous avez passé avec nous. Si vous avez des commentaires sur les raisons de votre départ ou sur la façon dont je peux m'améliorer, j'aimerais sincèrement les entendre—répondez simplement à cet email.",
+      "ctaPrimary": "Revoir les préférences",
+      "ctaSecondary": "Se réabonner",
+      "feedbackPrompt": "Si vous n'avez pas demandé cette désinscription, ou si vous avez besoin d'aide, veuillez contacter <email></email>.",
+      "greeting": "Bonjour {name},",
+      "heading": "Vous avez été désabonné",
+      "intro": "Cet email confirme que vous avez été retiré de la liste de newsletter <brand>{brandName}</brand>. Je suis désolé de vous voir partir.",
+      "preview": "Bonjour {name} — vous avez été désabonné.",
+      "signOff": {
+        "line1": "Cordialement",
+        "line2": "L'équipe {brand}"
+      },
+      "subject": "Vous avez été désabonné",
+      "whatHappensNext": {
+        "item0": "Vous ne recevrez plus de newsletters de notre part à l'avenir.",
+        "item1": "Vous pourriez toujours recevoir des emails essentiels de compte et de service si vous utilisez le produit.",
+        "item2": "Vous avez changé d'avis ? Vous pouvez vous réabonner à tout moment en utilisant le bouton ci-dessus."
+      },
+      "whatHappensNextTitle": "Ce qui se passe ensuite"
+    },
+    "spendingAlert": {
+      "badge": "Alerte Dépenses • {percent}%",
+      "chartAlt": "Répartition des dépenses par catégorie pour {period}",
+      "chartTitle": "Dépenses par catégorie",
+      "ctaPrimary": "Voir le tableau de bord",
+      "detailsLabels": {
+        "budget": "Budget",
+        "category": "Catégorie",
+        "period": "Période",
+        "spent": "Dépensé"
+      },
+      "detailsTitle": "Détails du Budget",
+      "feedbackPrompt": "Des questions ? Contactez-nous à <email></email>.",
+      "greeting": "Bonjour {name},",
+      "heading": "{percent, select, 80 {Attention : vous approchez de la limite de votre budget} 90 {Presque terminé : 90% de votre budget utilisé} 100 {Budget atteint : vous avez atteint votre limite de dépenses} other {Alerte de dépenses}}",
+      "intro": "{state, select, over {Vous avez atteint votre limite de dépenses pour {category} en {period}. Voici un résumé de votre situation.} other {Vous avez utilisé {percent}% de votre budget {category} pour {period}. Voici un résumé rapide pour vous aider à planifier le reste de la période.}}",
+      "metricsLabels": {
+        "budgetLimit": "Limite du budget",
+        "currentSpending": "Dépenses actuelles",
+        "remaining": "Restant",
+        "threshold": "Seuil"
+      },
+      "notificationsLink": "paramètres de notification",
+      "notificationsParagraph": "Vous pouvez ajuster vos seuils de budget et vos préférences de notification dans vos <settings></settings>.",
+      "overBudgetValue": "Au-dessus du budget",
+      "overBudgetWarning": "Vos dépenses ont atteint ou dépassé le budget que vous avez défini. Examinez vos achats récents pour rester sur la bonne voie.",
+      "preview": "{name}, vous avez utilisé {percent}% de votre budget {category} pour {period}.",
+      "signOff": {
+        "line1": "Cordialement",
+        "line2": "L'équipe {brand}"
+      },
+      "subject": "Alerte de seuil de dépenses",
+      "tipsOnTrack": {
+        "item0": "Vérifiez vos achats récents pour voir où va la majeure partie",
+        "item1": "Priorisez les dépenses essentielles pour le reste de la période",
+        "item2": "Envisagez de cuisiner davantage à la maison si les restaurants augmentent les coûts"
+      },
+      "tipsOverBudget": {
+        "item0": "Examinez les achats récents pour identifier les dépenses non essentielles",
+        "item1": "Envisagez d'ajuster votre budget s'il ne reflète plus la réalité",
+        "item2": "Définissez un seuil plus strict (par exemple 80%) pour des avertissements plus précoces"
+      },
+      "tipsTitle": "{state, select, over {Ce que vous pouvez faire} other {Conseils pour rester sur la bonne voie}}"
+    },
+    "unanalyzedInvoices": {
+      "analysisProvidedTitle": "Ce que l'analyse fournit",
+      "analysisProvides": {
+        "item0": "Extraction ligne par ligne des articles avec prix et catégories",
+        "item1": "Identification et catégorisation des commerçants",
+        "item2": "Détection des allergènes sur les produits alimentaires",
+        "item3": "Suggestions de recettes basées sur vos articles d'épicerie",
+        "item4": "Catégorisation automatique des dépenses pour les informations du tableau de bord"
+      },
+      "andMore": "…et {remaining} de plus. Voir tout dans votre <dashboard></dashboard>.",
+      "badge": "Rappel",
+      "bodyText": "L'analyse prend généralement moins d'une minute par facture. Une fois terminée, vous recevrez une notification avec les résultats.",
+      "feedback": "Besoin d’aide ? Contactez-nous à <link>{supportEmail}</link>.",
+      "greeting": "Bonjour {name},",
+      "heading": "{count, plural, =1 {1 facture en attente d'analyse} other {# factures en attente d'analyse}}",
+      "intro": "{count, plural, =1 {Vous avez 1 facture qui n'a pas encore été analysée. L'exécution de notre analyse AI débloque toute la valeur de vos reçus téléchargés.} other {Vous avez # factures qui n'ont pas encore été analysées. L'exécution de notre analyse AI débloque toute la valeur de vos reçus téléchargés.}}",
+      "invoicesAwaitingTitle": "Factures en attente d'analyse",
+      "preview": "{name}, vous avez {count, plural, =1 {1 facture} other {# factures}} en attente d'analyse AI.",
+      "primaryCta": "Voir les factures",
+      "signOff": {
+        "line1": "Cordialement,",
+        "line2": "L'équipe {brand}"
+      },
+      "subject": "Vous avez des factures non analysées",
+      "uploadedDate": "Téléchargée le {date}"
+    },
+    "weeklyUploadReminder": {
+      "badge": "Rappel Hebdomadaire",
+      "bodyText": "Chaque reçu que vous suivez rend vos informations de dépenses plus précises et vos tableaux de bord plus utiles.",
+      "feedback": "Questions ou retours ? Contactez-nous à <link>{supportEmail}</link>.",
+      "greeting": "Bonjour {name},",
+      "heading": "Votre contrôle hebdomadaire des reçus",
+      "intro": "Voici un aperçu rapide de votre activité de suivi des reçus. Un téléchargement régulier vous donne les informations les plus précises sur vos dépenses.",
+      "metricsLabels": {
+        "lastWeek": "La semaine dernière",
+        "thisWeek": "Cette semaine",
+        "totalInvoices": "Total factures",
+        "totalTracked": "Total suivi"
+      },
+      "preview": "Bonjour {name} — voici votre contrôle hebdomadaire des reçus.",
+      "primaryCta": "Télécharger les reçus de cette semaine",
+      "quickTips": {
+        "item0": "Téléchargez les reçus juste après les achats — cela prend moins de 30 secondes",
+        "item1": "Téléchargez par lot en fin de journée si vous préférez",
+        "item2": "Même les petits achats aident à construire une image complète des dépenses"
+      },
+      "quickTipsTitle": "Conseils rapides",
+      "secondaryCta": "Voir le tableau de bord",
+      "signOff": {
+        "line1": "Cordialement,",
+        "line2": "L'équipe {brand}"
+      },
+      "subject": "Votre rappel hebdomadaire de téléchargement"
+    },
+    "welcome": {
+      "badge": "Bienvenue",
+      "body": "Prêt à commencer ? Téléversez votre premier reçu et regardez la magie opérer. Le processus prend moins d'une minute.",
+      "ctaPrimary": "Téléversez votre premier reçu",
+      "ctaSecondary": "Explorez le tableau de bord",
+      "feedbackPrompt": "Des questions ou des commentaires ? Nous serions ravis de vous entendre à <email></email>.",
+      "greeting": "Bonjour {name},",
+      "heading": "Bienvenue chez {brand}",
+      "howItWorks": {
+        "item0": "Téléversez — prenez une photo ou téléversez un PDF d'un reçu",
+        "item1": "Analysez — notre IA extrait les articles, les prix, les marchands et suggère même des recettes à partir des reçus d'épicerie",
+        "item2": "Suivez — consultez des tableaux de dépenses par marchand, catégorie, mois ou année"
+      },
+      "howItWorksTitle": "Comment ça marche",
+      "intro": "Merci d'avoir rejoint {brand}. Nous sommes ravis de vous compter parmi nous. Notre plateforme vous aide à transformer vos reçus quotidiens en informations financières organisées, grâce à l'analyse par IA.",
+      "preview": "Bienvenue chez {brand}, {name} ! Commençons.",
+      "signOff": {
+        "line1": "Cordialement,",
+        "line2": "L'équipe {brand}"
+      },
+      "subject": "Bienvenue chez {brand}",
+      "whatYouCanDo": {
+        "item0": "Recevez des alertes sur les allergènes des produits alimentaires",
+        "item1": "Partagez des factures avec votre famille ou vos collègues",
+        "item2": "Exportez des statistiques et des rapports de dépenses",
+        "item3": "Accédez à vos données depuis n'importe quel appareil"
+      },
+      "whatYouCanDoTitle": "Ce que vous pouvez faire"
     }
   },
-  "IMS--Common": {
-    "commandPalette": {
-      "actions": {
-        "createInvoice": "Créer une facture",
-        "uploadScans": "Télécharger des numérisations",
-        "viewAll": "Voir toutes les factures",
-        "viewStatistics": "Voir les statistiques"
-      },
-      "groups": {
-        "quickActions": "Actions rapides",
-        "recentInvoices": "Factures récentes",
-        "searchResults": "Résultats de recherche"
-      },
-      "noResults": "Aucun résultat trouvé",
-      "placeholder": "Rechercher des factures, commerçants, articles..."
-    },
-    "invoiceHeader": {
-      "buttons": {
-        "analyzeWithAi": "Analyser avec l'IA",
-        "delete": "Supprimer",
-        "discard": "Annuler",
-        "edit": "Modifier",
-        "export": "Exporter",
-        "print": "Imprimer",
-        "save": "Enregistrer",
-        "saving": "Enregistrement..."
-      },
-      "id": "ID : {id}",
-      "tooltips": {
-        "analyzeSpendingPatterns": "Analyser les habitudes de dépenses de cette facture",
-        "delete": "Supprimer définitivement cette facture",
-        "deleteInvoicePermanently": "Supprimer cette facture définitivement",
-        "discardAllPendingChanges": "Annuler toutes les modifications en attente",
-        "edit": "Modifier cette facture",
-        "export": "Exporter les données de la facture dans différents formats",
-        "importantInvoice": "Facture importante",
-        "print": "Imprimer cette facture",
-        "printInvoiceWithAllDetails": "Imprimer cette facture avec tous les détails",
-        "saveAllPendingChanges": "Enregistrer toutes les modifications en attente"
-      }
-    },
-    "invoicesNotFound": {
-      "cta": "Téléverser une facture ici.",
-      "description": "Il semble que vous n’ayez aucune facture associée à votre compte. Veuillez téléverser des factures puis revenir plus tard.",
-      "title": "Il manque quelque chose ici..."
-    },
-    "loadingInvoices": {
-      "description": "Chargement factures...",
-      "title": "Chargement factures"
-    },
-    "mobileNav": {
-      "ariaLabel": "Navigation mobile",
-      "home": "Accueil",
-      "invoices": "Factures",
-      "profile": "Profil",
-      "scan": "Numériser"
-    },
-    "notifications": {
-      "markAllRead": "Tout marquer comme lu",
-      "noNotifications": "Aucune notification pour le moment",
-      "timeAgo": {
-        "days": "{count, plural, one {il y a # jour} other {il y a # jours}}",
-        "hours": "{count, plural, one {il y a # heure} other {il y a # heures}}",
-        "minutes": "{count, plural, one {il y a # minute} other {il y a # minutes}}",
-        "now": "À l'instant"
-      },
-      "title": "Notifications",
-      "types": {
-        "analysisComplete": "Analyse IA terminée",
-        "invoiceCreated": "Facture créée",
-        "monthlyReport": "Rapport mensuel prêt"
-      }
-    },
-    "onboarding": {
-      "back": "Retour",
-      "dontShowAgain": "Ne plus afficher",
-      "getStarted": "Commencer",
-      "next": "Suivant",
-      "skip": "Passer",
-      "stepOf": "Étape {current} sur {total}",
-      "steps": {
-        "analyze": {
-          "description": "Notre système alimenté par l'IA extrait automatiquement les noms des commerçants, les dates, les montants et les articles de vos reçus avec une grande précision.",
-          "title": "L'IA extrait les détails"
+  "forms": {
+    "invoices": {
+      "createInvoice": {
+        "detailsForm": {
+          "fields": {
+            "category": {
+              "label": "Catégorie",
+              "options": {
+                "carAuto": "Auto et véhicule",
+                "fastFood": "Restauration",
+                "grocery": "Épicerie",
+                "homeCleaning": "Maison et entretien",
+                "notDefined": "Non catégorisé",
+                "other": "Autre"
+              },
+              "placeholder": "Sélectionner une catégorie"
+            },
+            "description": {
+              "hint": "Notes facultatives sur cet achat",
+              "label": "Description",
+              "placeholder": "Ajoutez des notes sur cette facture (facultatif)"
+            },
+            "name": {
+              "hint": "Donnez un nom descriptif à votre facture",
+              "label": "Nom de la facture",
+              "placeholder": "ex. Courses hebdomadaires"
+            },
+            "paymentType": {
+              "label": "Mode de paiement",
+              "options": {
+                "card": "Carte",
+                "cash": "Espèces",
+                "mobilePayment": "Paiement mobile",
+                "other": "Autre",
+                "transfer": "Virement bancaire",
+                "unknown": "Inconnu",
+                "voucher": "Bon d'achat"
+              },
+              "placeholder": "Sélectionner un mode de paiement"
+            },
+            "transactionDate": {
+              "label": "Date de transaction"
+            }
+          },
+          "scanPreview": {
+            "title": "Aperçu de la numérisation"
+          },
+          "subtitle": "Renseignez les détails de votre nouvelle facture",
+          "title": "Détails de la facture"
         },
-        "track": {
-          "description": "Consultez des analyses détaillées et des informations sur vos habitudes de dépenses. Comprenez où va votre argent grâce à des graphiques et rapports interactifs.",
-          "title": "Suivez vos dépenses"
+        "emptyState": {
+          "description": "Téléchargez d'abord des numérisations de reçus pour créer une facture.",
+          "title": "Aucune numérisation disponible",
+          "uploadButton": "Télécharger des numérisations",
+          "viewScansButton": "Voir les numérisations"
         },
-        "upload": {
-          "description": "Prenez une photo ou téléchargez un PDF de votre reçu. Notre système prend en charge plusieurs formats et peut traiter des lots de reçus en même temps.",
-          "title": "Téléchargez vos reçus"
-        }
-      }
-    },
-    "preferences": {
-      "currency": "Devise",
-      "defaultView": "Vue par défaut",
-      "pageSize": "Éléments par page",
-      "save": "Enregistrer les préférences",
-      "saved": "Préférences enregistrées avec succès",
-      "showStats": "Afficher les statistiques sur l'accueil",
-      "sortBy": "Trier par",
-      "sortOptions": {
-        "amountAsc": "Montant (croissant)",
-        "amountDesc": "Montant (décroissant)",
-        "dateAsc": "Date (plus ancienne)",
-        "dateDesc": "Date (plus récente)",
-        "nameAsc": "Nom (A à Z)"
-      },
-      "title": "Préférences de facturation",
-      "views": {
-        "grid": "Vue grille",
-        "table": "Vue tableau"
-      }
-    },
-    "shortcuts": {
-      "close": "Fermer",
-      "closeDialog": "Fermer la boîte de dialogue",
-      "description": "Accès rapide aux actions courantes via votre clavier",
-      "newInvoice": "Nouvelle facture",
-      "openSearch": "Ouvrir la recherche",
-      "showHelp": "Afficher cette aide",
-      "title": "Raccourcis clavier",
-      "uploadScan": "Télécharger une numérisation"
-    },
-    "statesLoading": {
-      "description": "Chargement de la facture avec l'identifiant {invoiceIdentifier}.",
-      "title": "Chargement de la Facture"
-    },
-    "statesNotFound": {
-      "description": "La facture avec l'identifiant {invoiceIdentifier} n'a pas été trouvée.",
-      "title": "Facture Non Trouvée"
-    },
-    "unknownMerchant": "Commerçant inconnu",
-    "workflowProgress": {
-      "create": "Créer",
-      "review": "Vérifier",
-      "upload": "Télécharger"
-    }
-  },
-  "IMS--Create": {
-    "detailsForm": {
-      "fields": {
-        "category": {
-          "label": "Catégorie",
-          "options": {
+        "header": {
+          "backToInvoices": "Retour aux factures",
+          "subtitle": "Suivez les étapes ci-dessous pour créer une nouvelle facture à partir de vos numérisations",
+          "title": "Créer une facture"
+        },
+        "metadata": {
+          "description": "Créez une nouvelle facture à partir de vos numérisations téléchargées.",
+          "title": "Système de gestion des factures - Créer une facture"
+        },
+        "navigation": {
+          "back": "Retour",
+          "next": "Suivant"
+        },
+        "reviewStep": {
+          "actions": {
+            "create": "Créer la facture",
+            "creating": "Création de la facture...",
+            "hint": "Ceci créera la facture et téléchargera les numérisations sélectionnées."
+          },
+          "categories": {
             "carAuto": "Auto et véhicule",
             "fastFood": "Restauration",
             "grocery": "Épicerie",
@@ -2035,21 +2185,7 @@
             "notDefined": "Non catégorisé",
             "other": "Autre"
           },
-          "placeholder": "Sélectionner une catégorie"
-        },
-        "description": {
-          "hint": "Notes facultatives sur cet achat",
-          "label": "Description",
-          "placeholder": "Ajoutez des notes sur cette facture (facultatif)"
-        },
-        "name": {
-          "hint": "Donnez un nom descriptif à votre facture",
-          "label": "Nom de la facture",
-          "placeholder": "ex. Courses hebdomadaires"
-        },
-        "paymentType": {
-          "label": "Mode de paiement",
-          "options": {
+          "paymentTypes": {
             "card": "Carte",
             "cash": "Espèces",
             "mobilePayment": "Paiement mobile",
@@ -2058,1260 +2194,52 @@
             "unknown": "Inconnu",
             "voucher": "Bon d'achat"
           },
-          "placeholder": "Sélectionner un mode de paiement"
-        },
-        "transactionDate": {
-          "label": "Date de transaction"
-        }
-      },
-      "scanPreview": {
-        "title": "Aperçu de la numérisation"
-      },
-      "subtitle": "Renseignez les détails de votre nouvelle facture",
-      "title": "Détails de la facture"
-    },
-    "emptyState": {
-      "description": "Téléchargez d'abord des numérisations de reçus pour créer une facture.",
-      "title": "Aucune numérisation disponible",
-      "uploadButton": "Télécharger des numérisations",
-      "viewScansButton": "Voir les numérisations"
-    },
-    "header": {
-      "backToInvoices": "Retour aux factures",
-      "subtitle": "Suivez les étapes ci-dessous pour créer une nouvelle facture à partir de vos numérisations",
-      "title": "Créer une facture"
-    },
-    "metadata": {
-      "description": "Créez une nouvelle facture à partir de vos numérisations téléchargées.",
-      "title": "Système de gestion des factures - Créer une facture"
-    },
-    "navigation": {
-      "back": "Retour",
-      "next": "Suivant"
-    },
-    "reviewStep": {
-      "actions": {
-        "create": "Créer la facture",
-        "creating": "Création de la facture...",
-        "hint": "Ceci créera la facture et téléchargera les numérisations sélectionnées."
-      },
-      "categories": {
-        "carAuto": "Auto et véhicule",
-        "fastFood": "Restauration",
-        "grocery": "Épicerie",
-        "homeCleaning": "Maison et entretien",
-        "notDefined": "Non catégorisé",
-        "other": "Autre"
-      },
-      "paymentTypes": {
-        "card": "Carte",
-        "cash": "Espèces",
-        "mobilePayment": "Paiement mobile",
-        "other": "Autre",
-        "transfer": "Virement bancaire",
-        "unknown": "Inconnu",
-        "voucher": "Bon d'achat"
-      },
-      "sections": {
-        "details": {
-          "category": "Catégorie",
-          "description": "Description",
-          "name": "Nom",
-          "paymentType": "Mode de paiement",
-          "title": "Détails de la facture",
-          "transactionDate": "Date de transaction"
-        },
-        "scans": {
-          "title": "Numérisations"
-        }
-      },
-      "subtitle": "Vérifiez les détails de votre facture avant de la créer",
-      "title": "Vérifier et créer"
-    },
-    "scanSelector": {
-      "clearAll": "Effacer",
-      "next": "Suivant",
-      "noScans": "Aucune numérisation disponible",
-      "previous": "Précédent",
-      "scansCount": "scans",
-      "selectAll": "Tout sélectionner",
-      "selectedCount": "{count} sélectionnée(s)",
-      "subtitle": "Choisissez les numérisations qui correspondent à cette facture",
-      "title": "Sélectionner les numérisations"
-    },
-    "steps": {
-      "details": "Détails de la facture",
-      "detailsDesc": "Remplir les informations de la facture",
-      "review": "Vérifier et créer",
-      "reviewDesc": "Confirmer et créer",
-      "selectScans": "Sélectionner les numérisations",
-      "selectScansDesc": "Choisir les numérisations de reçus"
-    }
-  },
-  "IMS--Dialogs": {
-    "addScanDialog": {
-      "buttons": {
-        "cancel": "Annuler",
-        "upload": "Téléverser le scan",
-        "uploading": "Téléversement..."
-      },
-      "console": {
-        "uploadError": "Erreur lors du téléversement du scan :"
-      },
-      "description": "Téléversez une nouvelle image ou un nouveau document de reçu à joindre à cette facture.",
-      "dropzone": {
-        "dragAndDrop": "Glissez-déposez un fichier ici",
-        "dropHere": "Déposez le fichier ici...",
-        "formats": "JPEG, PNG, PDF (max 10 Mo)",
-        "orClickBrowse": "ou cliquez pour parcourir"
-      },
-      "errors": {
-        "unknown": "Une erreur inconnue est survenue",
-        "uploadStorageFailed": "Échec du téléversement du scan dans le stockage"
-      },
-      "scanType": {
-        "jpeg": "Image JPEG",
-        "label": "Type de scan",
-        "other": "Autre",
-        "pdf": "Document PDF",
-        "placeholder": "Sélectionnez le type de scan",
-        "png": "Image PNG"
-      },
-      "title": "Ajouter un nouveau scan",
-      "toasts": {
-        "fileTooLargeDescription": "La taille maximale du fichier est de 10 Mo",
-        "fileTooLargeTitle": "Fichier trop volumineux",
-        "scanAddedDescription": "Le scan a été joint à la facture",
-        "scanAddedTitle": "Scan ajouté avec succès",
-        "scanFailedTitle": "Échec de l’ajout du scan"
-      }
-    },
-    "allergenDialog": {
-      "aria": {
-        "removeAllergen": "Retirer l'allergène {name}"
-      },
-      "buttons": {
-        "add": "Ajouter",
-        "cancel": "Annuler",
-        "save": "Enregistrer les modifications",
-        "saving": "Enregistrement..."
-      },
-      "defaultDescription": "Contient {name}",
-      "description": "Gérer les allergènes pour {productName}",
-      "empty": {
-        "noAllergens": "Aucun allergène détecté"
-      },
-      "errors": {
-        "duplicate": "L''allergène {name} a déjà été ajouté",
-        "emptyName": "Le nom de l'allergène ne peut pas être vide",
-        "missingData": "Données de produit manquantes",
-        "saveFailed": "Échec de l'enregistrement des allergènes"
-      },
-      "labels": {
-        "currentAllergens": "Allergènes actuels",
-        "customAllergen": "Ajouter un allergène personnalisé",
-        "quickAdd": "Ajout rapide d'allergènes courants"
-      },
-      "placeholders": {
-        "customAllergen": "Entrez le nom de l'allergène..."
-      },
-      "success": {
-        "added": "Allergène ajouté : {name}",
-        "removed": "Allergène retiré : {name}",
-        "saved": "Allergènes mis à jour avec succès"
-      },
-      "title": "Modifier les allergènes"
-    },
-    "analyzeDialog": {
-      "analysisSteps": {
-        "analyzingWithAi": "Analyse avec l'IA...",
-        "categorizingItems": "Catégorisation des articles...",
-        "finalizingResults": "Finalisation des résultats...",
-        "preparingDocument": "Préparation du document...",
-        "processing": "Traitement...",
-        "runningOcrExtraction": "Exécution de l'extraction OCR..."
-      },
-      "analyzing": {
-        "progressComplete": "{progress}% terminé",
-        "title": "Analyse de la facture"
-      },
-      "badges": {
-        "recommended": "Recommandé"
-      },
-      "buttons": {
-        "analyzing": "Analyse en cours...",
-        "cancel": "Annuler",
-        "startAnalysis": "Démarrer l'analyse"
-      },
-      "enhancements": {
-        "priceComparison": {
-          "description": "Comparer les prix avec les données historiques",
-          "label": "Comparaison des prix"
-        },
-        "quickExtract": {
-          "description": "Prioriser la vitesse plutôt que la précision",
-          "label": "Mode extraction rapide"
-        },
-        "savingsTips": {
-          "description": "Obtenir des recommandations d'économies par IA",
-          "label": "Suggestions d'économies"
-        }
-      },
-      "header": {
-        "description": "Configurer une analyse alimentée par IA pour la facture",
-        "title": "Analyser la facture"
-      },
-      "options": {
-        "completeAnalysis": {
-          "description": "Analyse IA complète incluant toutes les données de la facture, les articles et les informations du commerçant.",
-          "estimatedTime": "2-3 min",
-          "features": {
-            "itemCategorization": "Catégorisation des articles",
-            "merchantIdentification": "Identification du commerçant",
-            "ocrExtraction": "Extraction OCR",
-            "priceAnalysis": "Analyse des prix",
-            "receiptValidation": "Validation du reçu"
+          "sections": {
+            "details": {
+              "category": "Catégorie",
+              "description": "Description",
+              "name": "Nom",
+              "paymentType": "Mode de paiement",
+              "title": "Détails de la facture",
+              "transactionDate": "Date de transaction"
+            },
+            "scans": {
+              "title": "Numérisations"
+            }
           },
-          "title": "Analyse complète"
+          "subtitle": "Vérifiez les détails de votre facture avant de la créer",
+          "title": "Vérifier et créer"
         },
-        "invoiceOnly": {
-          "description": "Analyser les informations de base de la facture comme les totaux, dates et détails de paiement.",
-          "estimatedTime": "30-60 s",
-          "features": {
-            "dateParsing": "Analyse des dates",
-            "paymentMethodDetection": "Détection du mode de paiement",
-            "totalExtraction": "Extraction du total"
-          },
-          "title": "Données de facture uniquement"
+        "scanSelector": {
+          "clearAll": "Effacer",
+          "next": "Suivant",
+          "noScans": "Aucune numérisation disponible",
+          "previous": "Précédent",
+          "scansCount": "scans",
+          "selectAll": "Tout sélectionner",
+          "selectedCount": "{count} sélectionnée(s)",
+          "subtitle": "Choisissez les numérisations qui correspondent à cette facture",
+          "title": "Sélectionner les numérisations"
         },
-        "itemsOnly": {
-          "description": "Se concentrer sur l'extraction et la catégorisation des lignes d'articles de la facture.",
-          "estimatedTime": "1-2 min",
-          "features": {
-            "categoryAssignment": "Attribution des catégories",
-            "itemExtraction": "Extraction des articles",
-            "pricePerItem": "Prix par article",
-            "quantityDetection": "Détection des quantités"
-          },
-          "title": "Analyse des articles"
-        },
-        "merchantOnly": {
-          "description": "Identifier et analyser les informations du commerçant, y compris localisation et catégorie.",
-          "estimatedTime": "30-45 s",
-          "features": {
-            "businessCategory": "Catégorie commerciale",
-            "contactInfo": "Coordonnées",
-            "locationExtraction": "Extraction de la localisation",
-            "merchantIdentification": "Identification du commerçant"
-          },
-          "title": "Analyse du commerçant"
+        "steps": {
+          "details": "Détails de la facture",
+          "detailsDesc": "Remplir les informations de la facture",
+          "review": "Vérifier et créer",
+          "reviewDesc": "Confirmer et créer",
+          "selectScans": "Sélectionner les numérisations",
+          "selectScansDesc": "Choisir les numérisations de reçus"
         }
-      },
-      "sections": {
-        "analysisType": "Type d'analyse",
-        "enhancementsOptional": "Améliorations (optionnel)",
-        "includedFeatures": "Fonctionnalités incluses"
-      },
-      "summary": {
-        "enhancementsSelected": "+ {count} amélioration(s)",
-        "estimatedTime": "Durée estimée",
-        "noEnhancementsSelected": "Aucune amélioration sélectionnée"
-      },
-      "toasts": {
-        "analysisComplete": {
-          "description": "Votre facture a été analysée avec succès.",
-          "title": "Analyse terminée"
-        },
-        "analysisFailed": {
-          "description": "Nous n'avons pas pu analyser votre facture. Veuillez réessayer.",
-          "title": "Échec de l'analyse"
-        }
-      }
-    },
-    "bulkCategoryDialog": {
-      "buttons": {
-        "cancel": "Annuler",
-        "save": "Appliquer à tous",
-        "saving": "Enregistrement..."
-      },
-      "description": "{count, plural, one {Changer la catégorie pour # produit} other {Changer la catégorie pour # produits}}",
-      "errors": {
-        "allFailed": "Echec de la mise a jour de tous les produits",
-        "missingData": "Données manquantes",
-        "noProducts": "Aucun produit sélectionné",
-        "saveFailed": "Échec de la mise à jour des catégories"
-      },
-      "labels": {
-        "andMore": "...et {count} de plus",
-        "newCategory": "Nouvelle catégorie",
-        "progress": "Progression",
-        "selectedProducts": "Produits sélectionnés"
-      },
-      "placeholders": {
-        "selectCategory": "Sélectionner une catégorie"
-      },
-      "progress": {
-        "updating": "Mise a jour {current} sur {total}..."
-      },
-      "success": {
-        "partialSuccess": "{success} produits mis a jour, {failed} echoues",
-        "saved": "{count, plural, one {Catégorie mise à jour pour # produit} other {Catégorie mise à jour pour # produits}}"
-      },
-      "title": "Changer de catégorie"
-    },
-    "createInvoiceDialog": {
-      "batchMode": {
-        "description": "Crée 1 facture avec les {count} scans attachés. Idéal pour les reçus multi-pages.",
-        "title": "Combiner en une seule facture"
-      },
-      "buttons": {
-        "cancel": "Annuler",
-        "close": "Fermer",
-        "createMultiple": "Lancer l'analyse sur {count} scans",
-        "createSingle": "Lancer l'analyse"
-      },
-      "chooseMode": "Choisir le Mode de Création",
-      "complete": {
-        "description": "Votre facture est prête à être consultée et modifiée.",
-        "descriptionPlural": "Vos factures sont prêtes à être consultées et modifiées.",
-        "errorsLabel": "Scans échoués :",
-        "failureDescription": "Nous n'avons pas pu créer de factures. Veuillez vérifier les erreurs ci-dessous et réessayer.",
-        "failureTitle": "Échec de la création",
-        "nextSteps": "Prochaines étapes :",
-        "nextStepsDescription": "Examinez votre facture, vérifiez les données extraites et effectuez les modifications nécessaires. Vous pouvez également demander une analyse IA pour des informations sur vos dépenses.",
-        "nextStepsDescriptionPlural": "Examinez vos factures, vérifiez les données extraites et effectuez les modifications nécessaires. Vous pouvez également demander une analyse IA pour des informations sur vos dépenses.",
-        "partialDescription": "Certains scans n'ont pas pu être traités. Les factures créées avec succès sont prêtes à être consultées.",
-        "partialTitle": "{created} factures créées sur {total}",
-        "retryButton": "Réessayer",
-        "title": "{count} Facture Créée !",
-        "titlePlural": "{count} Factures Créées !",
-        "viewButton": "Voir la Facture",
-        "viewButtonPlural": "Voir les Factures"
-      },
-      "creating": {
-        "processing": "Traitement de {count} scan...",
-        "processingPlural": "Traitement de {count} scans...",
-        "step1Description": "Envoi de vos scans vers nos serveurs",
-        "step1Title": "Téléchargement des scans",
-        "step2Description": "Configuration des structures de données de factures",
-        "step2Title": "Création des enregistrements de factures",
-        "step3Description": "Préparation des factures pour la visualisation",
-        "step3Title": "Finalisation",
-        "title": "Création de Votre Facture",
-        "titlePlural": "Création de Vos Factures"
-      },
-      "description": "Transformez vos scans en données de facture structurées.",
-      "errors": {
-        "createFailed": "Échec de la création des factures : {message}",
-        "partialFail": "Échec de la création de {count} facture(s)",
-        "unknown": "Erreur inconnue"
-      },
-      "selectedScans": "Scans Sélectionnés",
-      "singleMode": {
-        "description": "Crée {count} factures séparées. Idéal lorsque chaque scan est un reçu différent.",
-        "title": "Une facture par scan"
-      },
-      "singleScanInfo": {
-        "description": "Notre IA analysera votre scan et extraira automatiquement les détails du commerçant, les articles, les prix et les totaux. Vous pourrez examiner et modifier les résultats par la suite.",
-        "title": "Que se passe-t-il ensuite ?"
-      },
-      "title": "Lancer l'analyse IA",
-      "titlePlural": "Lancer l'analyse IA",
-      "totalSize": "total"
-    },
-    "deleteInvoiceDialog": {
-      "buttons": {
-        "cancel": "Annuler",
-        "deletePermanently": "Supprimer définitivement",
-        "deleting": "Suppression..."
-      },
-      "confirmation": {
-        "typeToConfirm": "Tapez <highlight>{name}</highlight> pour confirmer :",
-        "understoodDescription": "Cette facture et toutes ses données seront définitivement supprimées et ne pourront pas être récupérées.",
-        "understoodLabel": "Je comprends que cette action est définitive"
-      },
-      "console": {
-        "deleteError": "Erreur suppression de facture:"
-      },
-      "deleting": {
-        "description": "Veuillez patienter pendant que nous supprimons toutes les données associées.",
-        "title": "Suppression de facture..."
-      },
-      "description": "Cette action est irréversible. Veuillez vérifier attentivement avant de continuer.",
-      "impact": {
-        "intro": "Les données suivantes seront supprimées définitivement :",
-        "invoiceRecord": "Enregistrement de facture et métadonnées",
-        "lineItems": "{count} line article(s)",
-        "sharedAccess": "Accès partagé pour {count} utilisateur(s)",
-        "title": "Suppression définitive",
-        "uploadedScans": "{count} scan(s) téléversé(s)"
-      },
-      "title": "Supprimer facture",
-      "toasts": {
-        "deletedDescription": "La facture a été supprimée avec succès.",
-        "deletedTitle": "Facture supprimée",
-        "deleteFailedDescription": "Nous n’avons pas pu supprimer cette facture. Veuillez réessayer.",
-        "deleteFailedTitle": "Supprimer échoué"
-      }
-    },
-    "exportDialog": {
-      "buttons": {
-        "cancel": "Annuler",
-        "copied": "Copié !",
-        "copy": "Copier dans le presse-papiers",
-        "export": "Exporter"
-      },
-      "description": "Exporter {count} factures dans le format de votre choix.",
-      "estimate": {
-        "label": "Taille estimée du fichier :"
-      },
-      "filename": {
-        "hint": "Le fichier sera enregistré avec l'extension basée sur le format",
-        "label": "Nom du fichier"
-      },
-      "format": {
-        "descriptions": {
-          "csv": "Format tableur, compatible avec Excel",
-          "json": "Format de données structurées",
-          "pdf": "Format de document imprimable"
-        },
-        "labels": {
-          "csv": "CSV",
-          "json": "JSON",
-          "pdf": "PDF"
-        },
-        "title": "Format d’export"
-      },
-      "options": {
-        "csv": {
-          "delimiterLabel": "Séparateur CSV personnalisé (facultatif) :",
-          "delimiterPlaceholder": ",",
-          "includeHeaders": "Inclure les en-têtes CSV"
-        },
-        "includeMerchant": "Inclure le commerçant",
-        "includeMetadata": "Inclure les métadonnées",
-        "includeProducts": "Inclure les produits",
-        "json": {
-          "prettyPrint": "Formatage lisible (2 espaces)"
-        },
-        "title": "Paramètres"
-      },
-      "title": "Exporter des factures"
-    },
-    "feedbackDialog": {
-      "buttons": {
-        "cancel": "Annuler",
-        "submit": "Envoyer le retour"
-      },
-      "commentsPlaceholder": "Partagez vos impressions sur les analyses...",
-      "description": "Aidez-nous à améliorer les analyses pour {merchant} en partageant votre avis",
-      "features": {
-        "categoryBreakdown": "Catégorie Breakdown",
-        "merchantAnalysis": "Merchant Analyse",
-        "priceComparisons": "Prix Comparisons",
-        "savingsTips": "Conseils d’économie",
-        "spendingTrends": "Tendances de dépenses",
-        "visualCharts": "Graphiques visuels"
-      },
-      "sections": {
-        "comments": "Commentaires supplémentaires (facultatifs)",
-        "features": "Quelles fonctionnalités ont été les plus utiles ? (Sélectionnez toutes les réponses pertinentes)",
-        "rating": "Comment évalueriez-vous les analyses ?"
-      },
-      "title": "Donner un retour",
-      "toasts": {
-        "error": {
-          "description": "Veuillez réessayer plus tard.",
-          "title": "Une erreur est survenue lors de l’envoi du retour"
-        },
-        "ratingRequired": {
-          "description": "Veuillez attribuer une note en étoiles avant l’envoi",
-          "title": "Note requise"
-        },
-        "sending": {
-          "description": "Veuillez patienter pendant l’envoi de votre retour.",
-          "title": "Envoi du retour..."
-        },
-        "success": {
-          "description": "Retour envoyé avec succès",
-          "title": "Retour envoyé !"
-        }
-      }
-    },
-    "imageDialog": {
-      "imageAlt": "Photo du reçu",
-      "title": "Aperçu ({image})"
-    },
-    "importDialog": {
-      "buttons": {
-        "cancel": "Annuler",
-        "import": "Importer",
-        "importWithCount": "Importer ({count})"
-      },
-      "description": "Téléversez vos fichiers de factures pour les importer dans le système.",
-      "dropzone": {
-        "acceptsCsv": "Accepte les fichiers .csv (max 10 Mo)",
-        "acceptsPdf": "Accepte les fichiers .pdf (max 10 Mo)",
-        "acceptsXlsx": "Accepte les fichiers .xlsx et .xls (max. 10 Mo)",
-        "dragAndDrop": "Glissez-déposez les fichiers ici",
-        "dropHere": "Déposez les fichiers ici...",
-        "orClickBrowse": "ou cliquez pour parcourir les fichiers"
-      },
-      "remove": "Supprimer",
-      "selectedFiles": "Fichiers sélectionnés",
-      "status": {
-        "error": "Erreur lors de l’import des fichiers. Veuillez réessayer.",
-        "success": "Fichiers importés avec succès !"
-      },
-      "tabs": {
-        "csv": "CSV",
-        "pdf": "PDF",
-        "xlsx": "Excel"
-      },
-      "title": "Importer des factures"
-    },
-    "itemsDialog": {
-      "aria": {
-        "addItem": "Ajouter un nouvel article à la facture",
-        "cancel": "Annuler la modification et fermer la boîte de dialogue",
-        "deleteItem": "Supprimer article: {name}",
-        "nextPage": "Aller à la page suivante (page {page})",
-        "previousPage": "Aller à la page précédente (page {page})",
-        "save": "Enregistrer les modifications des articles de la facture",
-        "unnamedItem": "unnamed article"
-      },
-      "buttons": {
-        "addItem": "Ajouter article",
-        "cancel": "Annuler",
-        "next": "Suivant",
-        "previous": "Précédent",
-        "saveChanges": "Enregistrer changes"
-      },
-      "description": "Mettez à jour les quantités, les prix ou ajoutez de nouveaux articles à cette facture",
-      "footer": {
-        "itemsFound": "{total} articles trouvés (affichage de {shown})",
-        "itemsTotal": "{count, plural, one {# article au total} other {# articles au total}}",
-        "page": "Page {current} sur {total}"
-      },
-      "table": {
-        "actions": "Opérations",
-        "item": "Article",
-        "price": "Prix",
-        "quantity": "Quantité",
-        "total": "Somme",
-        "unit": "Unité"
-      },
-      "title": "Modifier facture articles"
-    },
-    "merchantDialog": {
-      "buttons": {
-        "openInMaps": "Ouvrir dans Maps"
-      },
-      "description": "Informations sur {merchantName}",
-      "fields": {
-        "address": "Adresse",
-        "parentCompany": "Société mère",
-        "phone": "Téléphone"
-      },
-      "noMerchantLinked": "Aucun commerçant lié à cette facture",
-      "title": "Détails du commerçant"
-    },
-    "merchantReceiptsDialog": {
-      "buttons": {
-        "next": "Suivant",
-        "previous": "Précédent"
-      },
-      "dateOptions": {
-        "allTime": "Toute la période",
-        "last30Days": "30 derniers jours",
-        "last90Days": "90 derniers jours",
-        "thisYear": "Cette année"
-      },
-      "description": "Voir et filtrer tous vos reçus de ce commerçant",
-      "filters": {
-        "date": "Date",
-        "sort": "Tri"
-      },
-      "footer": {
-        "page": "Page {current} sur {total}",
-        "receiptsFound": "{count} reçus trouvés (affichage de {showing})"
-      },
-      "searchPlaceholder": "Rechercher receipts...",
-      "sortOptions": {
-        "newest": "Plus récents d’abord",
-        "oldest": "Plus anciens d’abord"
-      },
-      "table": {
-        "actions": "Opérations",
-        "date": "Date",
-        "itemsCount": "Articles #",
-        "receipt": "Reçu",
-        "view": "Voir"
-      },
-      "title": "Tous les reçus de {merchant}"
-    },
-    "metadataDialog": {
-      "add": {
-        "description": "Ajouter des informations supplémentaires à cette facture",
-        "title": "Ajouter des métadonnées"
-      },
-      "buttons": {
-        "cancel": "Annuler",
-        "delete": "Supprimer",
-        "save": "Enregistrer"
-      },
-      "delete": {
-        "description": "Êtes-vous sûr de vouloir supprimer ces métadonnées ?",
-        "title": "Supprimer les métadonnées"
-      },
-      "edit": {
-        "description": "Mettre à jour la valeur de ce champ de métadonnées",
-        "fieldLabel": "Champ de métadonnées",
-        "title": "Modifier les métadonnées"
-      },
-      "fields": {
-        "keyLabel": "Clé de métadonnées",
-        "keyPlaceholder": "Saisir la clé",
-        "valueLabel": "Valeur de métadonnées",
-        "valuePlaceholder": "Saisir la valeur"
-      }
-    },
-    "recipeDialog": {
-      "actions": {
-        "enhanceInstructions": "Améliorer les instructions",
-        "generateName": "Générer un nom"
-      },
-      "buttons": {
-        "add": "Ajouter",
-        "cancel": "Annuler",
-        "close": "Fermer",
-        "delete": "Supprimer",
-        "save": "Enregistrer",
-        "saving": "Enregistrement..."
-      },
-      "create": {
-        "description": "Remplissez les détails pour créer une recette.",
-        "title": "Ajouter une nouvelle recette",
-        "error": "Échec de la création de la recette.",
-        "success": "Recette créée avec succès."
-      },
-      "delete": {
-        "description": "Cette action est irréversible. Cela supprimera définitivement la recette <strong>{name}</strong> et toutes ses données associées.",
-        "title": "Êtes-vous sûr ?"
-      },
-      "difficulty": {
-        "easy": "Facile",
-        "hard": "Difficile",
-        "medium": "Moyen"
-      },
-      "fields": {
-        "complexity": "Niveau de complexité",
-        "cookTime": "Temps de cuisson",
-        "description": "Présentation",
-        "difficulty": "Niveau de difficulté",
-        "ingredients": "Ingrédients",
-        "instructions": "Étapes",
-        "prepTime": "Temps de préparation",
-        "recipeName": "Nom de la recette",
-        "totalDuration": "Durée totale"
-      },
-      "placeholders": {
-        "cookTime": "ex. 30 minutes",
-        "description": "Saisissez une brève description de la recette",
-        "instructions": "Saisir les instructions de cuisson",
-        "prepTime": "ex. 15 minutes",
-        "recipeName": "Saisir le nom de la recette",
-        "selectDifficulty": "Sélectionner la difficulté"
-      },
-      "read": {
-        "description": "Détails de la recette et instructions de préparation",
-        "noDescription": "Aucune description fournie.",
-        "notSpecified": "Non spécifié"
-      },
-      "tooltips": {
-        "enhanceInstructions": "Utiliser l’AI pour enrichir vos instructions avec davantage de détails",
-        "generateName": "Générer un nom de recette selon vos ingrédients et votre niveau de difficulté avec l’AI"
-      },
-      "update": {
-        "description": "Mettre à jour les détails de la recette.",
-        "title": "Mettre à jour la recette"
-      },
-      "minutes": "minutes"
-    },
-    "removeScanDialog": {
-      "buttons": {
-        "cancel": "Annuler",
-        "remove": "Supprimer le scan",
-        "removing": "Suppression..."
-      },
-      "console": {
-        "deleteError": "Erreur suppression de scan:"
-      },
-      "description": "Êtes-vous sûr de vouloir supprimer le scan {current} sur {total} ?",
-      "descriptionLastScan": "C’est le seul scan joint à cette facture. Vous ne pouvez pas le supprimer.",
-      "errors": {
-        "unknown": "Une erreur inconnue est survenue"
-      },
-      "scanAlt": "Numérisation {index}",
-      "scanCaption": "Numérisation {index}",
-      "title": "Supprimer scan",
-      "toasts": {
-        "cannotDeleteLastDescription": "Une facture doit avoir au moins un scan joint",
-        "cannotDeleteLastTitle": "Impossible de supprimer le dernier scan",
-        "removedDescription": "Le scan a été retiré de la facture",
-        "removedTitle": "Scan supprimé avec succès",
-        "removeFailedTitle": "Échec de la suppression du scan"
-      },
-      "warning": {
-        "description": "Chaque facture doit avoir au moins un scan joint. Ajoutez un autre scan avant de supprimer celui-ci.",
-        "title": "Impossible de supprimer le dernier scan"
-      }
-    },
-    "shareAnalyticsDialog": {
-      "description": "Partagez vos analyses de dépenses pour {merchant} avec d’autres personnes.",
-      "email": {
-        "description": "Envoyez les analyses à une adresse e-mail.",
-        "label": "E-mail address",
-        "placeholder": "nom@exemple.com",
-        "send": "Envoyer E-mail"
-      },
-      "image": {
-        "copyToClipboard": "Copier le graphique dans le presse-papiers",
-        "description": "Téléchargez ou copiez le graphique d’analyses en image PNG afin de le partager ou de l’enregistrer.",
-        "download": "Télécharger le graphique",
-        "previewPlaceholder": "Aperçu des analyses"
-      },
-      "tabs": {
-        "email": "E-mail",
-        "image": "Aperçu image"
-      },
-      "title": "Partager Analytics",
-      "toasts": {
-        "emailSent": {
-          "description": "Rapport d’analyses envoyé à {email}",
-          "title": "E-mail envoyé !"
-        },
-        "imageCopied": {
-          "description": "L’image des analyses a été copiée dans votre presse-papiers",
-          "title": "Image copiée !"
-        },
-        "imageSaved": {
-          "description": "Les analyses de dépenses pour {merchant} ont été téléchargées au format PNG",
-          "title": "Image enregistrée !"
-        }
-      }
-    },
-    "shareInvoiceDialog": {
-      "dialogDescription": {
-        "currentlyPublic": "\"{invoiceName}\" est actuellement publique",
-        "private": "Envoyer \"{invoiceName}\" en privé",
-        "public": "Partager \"{invoiceName}\" publiquement",
-        "selection": "Choisissez comment partager « {invoiceName} »"
-      },
-      "errors": {
-        "qrNotFound": "Élément de code QR introuvable"
-      },
-      "selection": {
-        "description": "Choisissez comment vous souhaitez partager cette facture. Votre choix détermine qui peut y accéder.",
-        "privacyNoticeDescription": "Les liens publics sont accessibles à toute personne disposant de l’URL. Le partage privé limite l’accès au destinataire spécifié.",
-        "privacyNoticeTitle": "Avis de confidentialité",
-        "privateDescription": "Envoyez une invitation par e-mail à une <strong>personne spécifique</strong>. Seule cette personne aura accès.",
-        "privateTitle": "Privé sharing",
-        "publicDescription": "Générez un lien ou un code QR que <strong>n’importe qui</strong> peut utiliser pour voir cette facture.",
-        "publicTitle": "Partage publique"
-      },
-      "title": "Partager facture",
-      "toasts": {
-        "copyLink": {
-          "error": "Échoué: {message}",
-          "loadingMakePublic": "La facture devient publique...",
-          "loadingPublic": "Copie du lien...",
-          "successMadePublic": "La facture est maintenant publique ! Lien copié dans le presse-papiers.",
-          "successPublic": "Lien copié dans le presse-papiers !"
-        },
-        "copyQr": {
-          "error": "Échoué: {message}",
-          "loadingMakePublic": "La facture devient publique...",
-          "loadingPublic": "Copie du code QR...",
-          "successMadePublic": "La facture est maintenant publique ! Code QR copié dans le presse-papiers.",
-          "successPublic": "Code QR copié dans le presse-papiers !"
-        },
-        "revoke": {
-          "error": "Échec de la révocation de l’accès : {message}",
-          "loading": "Envoi de la demande de révocation au serveur...",
-          "success": "La facture est maintenant privée. Les liens existants ne fonctionneront plus."
-        },
-        "sendEmail": {
-          "comingSoon": "Le partage par e-mail arrive bientôt",
-          "error": "Échoué: {message}",
-          "loading": "Envoi de l’invitation à {email}...",
-          "success": "Invitation envoyée à {email} !"
-        }
-      }
-    },
-    "shareInvoiceDialogPrivate": {
-      "backToOptions": "Retour aux options",
-      "comingSoonTooltip": "La fonction de partage par e-mail sera bientôt disponible",
-      "description": "L’invitation sera envoyée directement à l’adresse e-mail que vous indiquez. Seul ce destinataire recevra l’accès pour consulter la facture.",
-      "emailHint": "Une invitation par e-mail sera envoyée à cette adresse avec un lien privé pour consulter la facture.",
-      "emailLabel": "Recipient's e-mail address",
-      "emailPlaceholder": "nom@exemple.com",
-      "sending": "Envoi de l'invitation...",
-      "sendInvitation": "Envoyer une invitation privée",
-      "title": "Privé sharing"
-    },
-    "shareInvoiceDialogPublic": {
-      "alreadyPublic": {
-        "description": "Cette facture est accessible publiquement. <strong>Toute personne disposant du lien peut la consulter</strong>, y compris tous les détails de la facture, les articles et les montants. Vous pouvez révoquer l’accès public à tout moment pour la rendre privée à nouveau.",
-        "revoke": "Révoquer l’accès public",
-        "revokeHint": "Cela rendra la facture privée. Les liens existants cesseront de fonctionner.",
-        "revoking": "Révocation de l’accès...",
-        "title": "Cette facture est actuellement publique"
-      },
-      "backToOptions": "Retour aux options",
-      "copyQrImage": "Copier le code QR en tant qu’image",
-      "hints": {
-        "link": "Copiez ce lien et partagez-le. Toute personne qui le reçoit pourra consulter la facture.",
-        "qr": "Toute personne qui scanne ce QR code sera redirigée pour consulter la facture."
-      },
-      "tabs": {
-        "directLink": "Lien direct",
-        "qrCode": "Code QR"
-      },
-      "warning": {
-        "description": "En partageant cette facture publiquement, <strong>toute personne disposant du lien pourra la consulter</strong>. Cela inclut tous les détails de la facture, les articles et les montants. Continuez uniquement si vous souhaitez rendre cette facture accessible au publique.",
-        "title": "Avertissement d’accès public"
-      }
-    }
-  },
-  "IMS--Edit": {
-    "changeHistory": {
-      "changes": {
-        "categoryUpdated": "Catégorie mise à jour",
-        "descriptionChanged": "Description modifiée",
-        "importanceChanged": "Importance modifiée",
-        "markedImportant": "Marqué comme important",
-        "nameChanged": "Nom modifié",
-        "paymentTypeChanged": "Type de paiement modifié",
-        "transactionDateChanged": "Date de transaction modifiée",
-        "unmarkedImportant": "Retiré des favoris"
-      },
-      "created": "Facture créée",
-      "modified": "Dernière modification",
-      "pending": "En attente",
-      "time": {
-        "daysAgo": "il y a {days} jours",
-        "hoursAgo": "il y a {hours} heures",
-        "justNow": "À l'instant",
-        "minutesAgo": "il y a {minutes} minutes",
-        "secondsAgo": "il y a {seconds} secondes"
-      },
-      "title": "Historique des modifications",
-      "unsavedChanges": "Modifications non enregistrées"
-    },
-    "editInvoiceContext": {
-      "console": {
-        "saveFailed": "Échec de l’enregistrement de la facture :"
-      },
-      "toasts": {
-        "noChanges": "Aucune modification à enregistrer",
-        "saveFailed": "Échec de l’enregistrement des modifications",
-        "updated": "Facture mise à jour avec succès"
-      }
-    },
-    "guidedEditBanner": {
-      "actions": {
-        "dismiss": "Fermer",
-        "reviewAll": "Tout réviser"
-      },
-      "badges": {
-        "lowConfidence": "{count, plural, one {# faible confiance} other {# faible confiance}}",
-        "missingName": "{count, plural, one {# nom manquant} other {# noms manquants}}",
-        "uncategorized": "{count, plural, one {# non catégorisé} other {# non catégorisés}}"
-      },
-      "summary": {
-        "lowConfidence": "{count, plural, one {# faible confiance} other {# faible confiance}}",
-        "missingName": "{count, plural, one {# nom manquant} other {# noms manquants}}",
-        "uncategorized": "{count, plural, one {# non catégorisé} other {# non catégorisés}}"
-      },
-      "title": "{count, plural, one {# produit nécessite une révision} other {# produits nécessitent une révision}}"
-    },
-    "itemsTable": {
-      "actions": {
-        "editAllergens": "Modifier les allergènes",
-        "remove": "Supprimer l'article",
-        "restore": "Restaurer l'article"
-      },
-      "bulkCategory": {
-        "noSelection": "Veuillez sélectionner au moins un produit"
-      },
-      "bulkToolbar": {
-        "changeCategory": "Changer de catégorie",
-        "deleteSelected": "Supprimer la sélection",
-        "noSelection": "Aucun produit sélectionné",
-        "selectedCount": "{count, plural, one {# article sélectionné} other {# articles sélectionnés}}"
-      },
-      "buttons": {
-        "addItem": "Ajouter un article",
-        "editItems": "Modifier les articles"
-      },
-      "columns": {
-        "actions": "Actions",
-        "name": "Nom",
-        "price": "Prix",
-        "quantity": "Quantité",
-        "selectAll": "Tout sélectionner",
-        "selectRow": "Sélectionner {name}",
-        "total": "Total",
-        "unit": "Unité"
-      },
-      "deleteConfirm": {
-        "cancel": "Annuler",
-        "confirm": "Supprimer",
-        "description": "{count, plural, one {Êtes-vous sûr de vouloir supprimer cet article ?} other {Êtes-vous sûr de vouloir supprimer # articles ?}}",
-        "success": "{count, plural, one {# article supprimé} other {# articles supprimés}}",
-        "title": "Supprimer les articles"
-      },
-      "editing": {
-        "cancel": "Modification annulée",
-        "fieldLabel": "Modifier {field} pour {name}",
-        "saved": "Article mis à jour avec succès"
-      },
-      "footer": {
-        "total": "Total"
-      },
-      "indicators": {
-        "allergens": "{count, plural, one {# allergène} other {# allergènes}}",
-        "edited": "Modifié",
-        "editedTooltip": "Ce produit a été modifié manuellement",
-        "lowConfidence": "Faible confiance",
-        "lowConfidenceTooltip": "La confiance OCR est de {confidence}% - révision manuelle recommandée",
-        "missingName": "Nom manquant",
-        "missingNameTooltip": "La traduction du nom générique est manquante ou identique au texte OCR brut",
-        "uncategorized": "Non catégorisé",
-        "uncategorizedTooltip": "Ce produit nécessite une catégorie pour un meilleur suivi des dépenses"
-      },
-      "newItem": {
-        "added": "Nouvel article ajouté",
-        "defaultName": "Nouvel article"
-      },
-      "pagination": {
-        "next": "Suivant",
-        "pageOf": "Page {currentPage} sur {totalPages}",
-        "previous": "Précédent",
-        "totalItems": "{count, plural, one {# article au total} other {# articles au total}}"
-      },
-      "restore": {
-        "error": "Échec de la restauration de l'article",
-        "success": "Article {name} restauré"
-      },
-      "search": {
-        "placeholder": "Rechercher des articles..."
-      },
-      "softDelete": {
-        "error": "Échec de la suppression de l'article",
-        "success": "Article {name} supprimé"
-      },
-      "tableHeaders": {
-        "item": "Article",
-        "price": "Prix",
-        "quantity": "Qté",
-        "total": "Total"
-      },
-      "title": "Articles",
-      "tooltips": {
-        "editInvoiceItemsAndQuantities": "Modifier les articles et les quantités de la facture"
-      }
-    },
-    "metadata": {
-      "description": "Consultez et modifiez les détails de votre facture, les articles, les recettes et les paramètres de partage.",
-      "title": "Système de Gestion des Factures - Modifier la Facture"
-    },
-    "metadataTab": {
-      "badges": {
-        "readonly": "Lecture seule"
-      },
-      "buttons": {
-        "addField": "Ajouter un champ",
-        "addFirstMetadataField": "Ajouter votre premier champ de métadonnées"
-      },
-      "dropdown": {
-        "delete": "Supprimer",
-        "edit": "Modifier"
-      },
-      "emptyState": {
-        "noMetadataFields": "Aucun champ de métadonnées ajouté"
-      },
-      "header": {
-        "description": "Métadonnées associées à cette facture",
-        "title": "Informations supplémentaires"
-      },
-      "tooltips": {
-        "addCustomMetadata": "Ajouter des métadonnées personnalisées à cette facture"
-      }
-    },
-    "recipesTab": {
-      "buttons": {
-        "addRecipe": "Ajouter une recette",
-        "createFirstRecipe": "Créer votre première recette",
-        "generate": "Générer"
-      },
-      "emptyState": {
-        "noRecipesAvailable": "Aucune recette disponible pour le moment"
-      },
-      "header": {
-        "description": "Basé sur les articles de cette facture",
-        "title": "Recettes que vous pouvez préparer"
-      },
-      "pagination": {
-        "next": "Suivant",
-        "pageOf": "Page {currentPage} sur {totalPages}",
-        "previous": "Précédent"
-      },
-      "toasts": {
-        "aiGenerationComingSoon": {
-          "description": "Cette fonctionnalité est en cours de développement.",
-          "title": "La génération de recettes par IA arrive bientôt"
-        }
-      },
-      "tooltips": {
-        "createRecipeWithIngredients": "Créer une nouvelle recette avec ces ingrédients",
-        "generateRecipeUsingAi": "Générer une recette avec l'IA !"
-      }
-    },
-    "triviaTips": {
-      "banner": {
-        "hint": "Appliquez ces astuces pour économiser lors de votre prochaine visite chez {merchantName}",
-        "potentialSavingsLabel": "Économies potentielles"
-      },
-      "buttons": {
-        "viewMoreSavingsTips": "Voir plus d'astuces économies"
-      },
-      "completeLabel": "La facture est entièrement complète !",
-      "completeness": "La facture est complète à {percentage}%",
-      "contextActions": {
-        "addDescription": "Ajouter une description",
-        "analyze": "Lancer l'analyse",
-        "setCategory": "Définir la catégorie"
-      },
-      "contextTips": {
-        "defaultCategory": "Changez la catégorie de « Non catégorisé » pour un meilleur suivi",
-        "noCategory": "Définissez une catégorie pour suivre vos habitudes de dépenses",
-        "noDescription": "Ajoutez une description pour vous souvenir de cet achat",
-        "noItems": "Lancez l'analyse IA pour extraire les articles de votre reçu",
-        "noRecipes": "L'IA peut suggérer des recettes basées sur vos articles d'épicerie"
-      },
-      "difficulty": {
-        "easy": "Facile",
-        "medium": "Moyen"
-      },
-      "disclaimer": "Les économies sont des estimations basées sur les prix et promotions moyens",
-      "tips": {
-        "bulkPurchase": {
-          "description": "Achetez les produits non périssables en gros pour réduire le coût unitaire.",
-          "title": "Acheter en gros"
-        },
-        "digitalCoupons": {
-          "description": "Consultez l'application de {merchantName} pour des coupons numériques avant vos achats.",
-          "title": "Utiliser des coupons numériques"
-        },
-        "loyaltyProgram": {
-          "description": "Inscrivez-vous au programme fidélité de {merchantName} pour gagner des points à chaque achat.",
-          "title": "Rejoindre le programme fidélité"
-        }
-      },
-      "title": "Astuces économies",
-      "tooltips": {
-        "estimatedSavings": "Économies estimées avec cette astuce"
-      }
-    }
-  },
-  "IMS--Landing": {
-    "bento": {
-      "ai": {
-        "description": "Extraction GPT-4",
-        "title": "Alimenté par l'IA"
-      },
-      "analyticsCard": {
-        "description": "Aperçu des dépenses",
-        "title": "Analyse"
-      },
-      "cloud": {
-        "description": "Accès partout",
-        "title": "Sync Cloud"
-      },
-      "description": "Des fonctionnalités puissantes conçues pour rendre la gestion des factures sans effort",
-      "mobile": "Fonctionne parfaitement sur mobile",
-      "ocr": {
-        "description": "Capture auto des données",
-        "title": "OCR Intelligent"
-      },
-      "secure": {
-        "description": "Chiffrement bancaire",
-        "title": "Sécurisé"
-      },
-      "share": {
-        "description": "Collaboration facile",
-        "title": "Partager"
-      },
-      "title": "Tout Ce Dont Vous Avez Besoin"
-    },
-    "cta": {
-      "badges": {
-        "ai": "Alimenté par l'IA",
-        "cloud": "Synchronisé dans le Cloud",
-        "secure": "Sécurisé et Privé"
-      },
-      "description": "Téléchargez votre premier scan et découvrez la magie de la gestion des factures alimentée par l'IA.",
-      "learnMore": "En Savoir Plus",
-      "title": "Prêt à Commencer?",
-      "uploadButton": "Télécharger Votre Premier Scan"
-    },
-    "features": {
-      "analytics": {
-        "description": "Obtenez des informations détaillées sur vos habitudes de dépenses avec des graphiques et rapports.",
-        "title": "Analyse des Dépenses"
-      },
-      "batch": {
-        "description": "Traitez plusieurs scans à la fois - créez des factures individuelles ou combinez-les en une seule.",
-        "title": "Traitement par Lots"
-      },
-      "description": "Tout ce dont vous avez besoin pour gérer vos factures efficacement",
-      "imageAlt": "Illustration des fonctionnalités des factures",
-      "ocr": {
-        "description": "Notre IA extrait automatiquement les noms des commerçants, dates, montants et articles de vos scans.",
-        "title": "Extraction OCR Intelligente"
-      },
-      "signIn": "Connectez-vous",
-      "signInPrompt": "Connectez-vous pour sauvegarder vos factures de façon permanente et y accéder depuis n'importe quel appareil.",
-      "title": "Fonctionnalités Puissantes"
-    },
-    "hero": {
-      "description": "Téléchargez vos reçus et factures, organisez-les et obtenez des informations sur vos habitudes de dépenses. Notre système alimenté par l'IA extrait les données automatiquement.",
-      "getStarted": "Commencer",
-      "imageAlt": "Illustration de gestion des factures",
-      "title": "Gérez Vos",
-      "titleHighlight": "Factures",
-      "titleSuffix": "Facilement",
-      "viewMyInvoices": "Voir Mes Factures"
-    },
-    "metadata": {
-      "description": "Gérez vos reçus, créez des factures et obtenez des informations sur vos habitudes de dépenses.",
-      "title": "Système de Gestion des Factures"
-    },
-    "workflow": {
-      "description": "Trois étapes simples pour numériser et organiser vos documents financiers",
-      "step1": {
-        "button": "Télécharger",
-        "description": "Glissez-déposez vos reçus, factures ou notes. Nous acceptons les fichiers JPG, PNG et PDF jusqu'à 10 Mo chacun.",
-        "title": "Télécharger des Scans"
-      },
-      "step2": {
-        "button": "Voir les Scans",
-        "description": "Examinez vos scans téléchargés, sélectionnez ceux que vous voulez et créez des factures individuellement ou par lots.",
-        "title": "Voir et Organiser"
-      },
-      "step3": {
-        "button": "Voir les Factures",
-        "description": "Consultez vos factures, analysez les habitudes de dépenses et obtenez des informations alimentées par l'IA sur vos habitudes financières.",
-        "title": "Gérer les Factures"
-      },
-      "title": "Comment Ça Marche"
-    }
-  },
-  "IMS--List": {
-    "bulkActions": {
-      "categories": {
-        "carAuto": "Auto et véhicule",
-        "fastFood": "Restauration rapide",
-        "grocery": "Épicerie",
-        "homeCleaning": "Entretien ménager",
-        "notDefined": "Non défini",
-        "other": "Autre"
-      },
-      "categoryChanged": "{count, plural, one {Catégorie de la facture mise à jour avec succès} other {Catégories de # factures mises à jour avec succès}}",
-      "categoryChangeError": "Échec de la mise à jour des catégories de factures. Veuillez réessayer.",
-      "categoryPartialSuccess": "{success} facture(s) mise(s) à jour, {failed} en échec",
-      "changeCategory": "Changer de catégorie",
-      "clearSelection": "Effacer la sélection",
-      "delete": "Supprimer",
-      "deleteConfirm": {
-        "cancel": "Annuler",
-        "confirm": "Supprimer",
-        "description": "{count, plural, one {Êtes-vous sûr de vouloir supprimer cette facture ? Cette action est irréversible.} other {Êtes-vous sûr de vouloir supprimer ces # factures ? Cette action est irréversible.}}",
-        "title": "Supprimer les factures"
-      },
-      "deleteError": "Échec de la suppression des factures. Veuillez réessayer.",
-      "deletePartialSuccess": "{success} facture(s) supprimée(s), {failed} en échec",
-      "deleteSuccess": "{count, plural, one {Facture supprimée avec succès} other {# factures supprimées avec succès}}",
-      "export": "Exporter",
-      "selected": "{count, plural, one {# facture sélectionnée} other {# factures sélectionnées}}"
-    },
-    "generativeView": {
-      "chatDescription": "Discutez avec l’AI pour analyser vos factures et obtenir des analyses utiles. Essayez des commandes comme /find pour rechercher des factures.",
-      "help": "Aide",
-      "settings": {
-        "allowInvoiceData": "Autoriser l’accès aux données de la facture",
-        "allowMerchantData": "Autoriser l’accès aux données du commerçant",
-        "dataAccessTitle": "Accès aux données",
-        "description": "Configurez les préférences de votre assistant AI",
-        "historyLabel": "Chat historique",
-        "notificationPreferences": "Préférences de notification",
-        "notifyInsights": "Me notifier des nouvelles analyses",
-        "retention": {
-          "30": "Conserver pendant 30 jours",
-          "60": "Conserver pendant 60 jours",
-          "90": "Conserver pendant 90 jours",
-          "none": "Don't enregistrer historique"
-        },
-        "retentionPlaceholder": "Sélectionnez la durée de conservation",
-        "save": "Enregistrer paramètres",
-        "title": "Chat paramètres"
-      },
-      "subtitle": "Discutez avec l’AI pour analyser vos factures et obtenir des analyses utiles",
-      "tabs": {
-        "chat": "Discussion",
-        "settings": "Paramètres"
-      },
-      "title": "Analyse en direct",
-      "welcomeMessage": "Bonjour ! Je suis votre assistant d’analyse de factures. Comment puis-je vous aider aujourd’hui ? Essayez des commandes comme /find pour rechercher des factures."
-    },
-    "gridView": {
-      "itemCount": "{count, plural, one {# article} other {# articles}}",
-      "tooltips": {
-        "viewDetails": "Voir les détails"
-      }
-    },
-    "invoicesHeader": {
-      "actions": {
-        "export": "Exporter",
-        "import": "Importer",
-        "newInvoice": "Nouvelle facture",
-        "print": "Imprimer"
-      },
-      "description": "Gérez vos reçus et suivez vos habitudes de dépenses",
-      "title": "Gestion des factures",
-      "tooltips": {
-        "export": "Exporter toutes les factures",
-        "import": "Importer des factures depuis des fichiers",
-        "newInvoice": "Créer une nouvelle facture",
-        "print": "Imprimer les factures"
-      }
-    },
-    "invoicesView": {
-      "categories": {
-        "all": "Toutes les catégories",
-        "dining": "Restauration",
-        "entertainment": "Divertissement",
-        "groceries": "Épicerie",
-        "other": "Autre",
-        "travel": "Voyage",
-        "utilities": "Services"
       },
       "filters": {
         "activeCount": "{count} actifs",
         "amountMax": "Montant max.",
         "amountMin": "Montant min.",
+        "amountPresets": {
+          "value0to50": "0-50",
+          "value100to500": "100-500",
+          "value500plus": "500+",
+          "value50to100": "50-100"
+        },
         "amountRange": "Plage de montants",
         "anyValue": "tout",
         "button": "Filtres",
@@ -3322,15 +2250,24 @@
         "currencyAny": "toutes",
         "dateFrom": "Date de début",
         "datePresets": {
-          "30d": "30j",
-          "90d": "90j",
           "all": "Tout",
           "custom": "Personnalisé",
+          "value30d": "30j",
+          "value90d": "90j",
           "ytd": "Année"
         },
         "dateRange": "Plage de dates",
         "dateTo": "Date de fin",
         "defaultValue": "défaut",
+        "dynamicHint": "Ces options sont remplies à partir de vos factures — seules les valeurs présentes dans vos données apparaissent ici.",
+        "paymentTypeLabels": {
+          "card": "Carte",
+          "cash": "Espèces",
+          "mobile": "Mobile",
+          "other": "Autre",
+          "transfer": "Virement",
+          "voucher": "Bon"
+        },
         "paymentTypes": "Types de paiement",
         "showResults": "Afficher {count, plural, one {# résultat} other {# résultats}}",
         "sortBy": "Trier par",
@@ -3343,1976 +2280,3119 @@
           "nameZA": "Nom (Z-A)"
         },
         "timeOfDay": "Moment de la journée",
-        "title": "Filtres",
-        "amountPresets": {
-          "0to50": "0-50",
-          "100to500": "100-500",
-          "500plus": "500+",
-          "50to100": "50-100"
-        },
-        "dynamicHint": "Ces options sont remplies à partir de vos factures — seules les valeurs présentes dans vos données apparaissent ici.",
-        "paymentTypeLabels": {
-          "card": "Carte",
-          "cash": "Espèces",
-          "mobile": "Mobile",
-          "other": "Autre",
-          "transfer": "Virement",
-          "voucher": "Bon"
+        "title": "Filtres"
+      }
+    }
+  },
+  "pages": {
+    "about": {
+      "author": {
+        "metadata": {
+          "description": "En savoir plus sur l'auteur, Alexandru-Razvan Olariu.",
+          "title": "Alexandru-Razvan Olariu"
         }
       },
-      "placeholderPanel": "D’autres filtres seront bientôt disponibles.",
-      "searchPlaceholder": "Rechercher des factures...",
-      "times": {
-        "all": "Tous les horaires",
-        "day": "Journée (6h-18h)",
-        "night": "Nuit (18h-6h)"
-      },
-      "viewModes": {
-        "grid": "Grid voir",
-        "table": "Table voir"
-      }
-    },
-    "messageList": {
-      "aiAssistant": "Assistant IA",
-      "you": "Vous"
-    },
-    "metadata": {
-      "description": "Lister toutes les factures du système de gestion des factures.",
-      "title": "Système de Gestion des Factures - Liste des Factures"
-    },
-    "subtitle": "Ceci est votre inventaire de reçus numériques. <br></br> Ici vous pouvez trouver les reçus que vous avez téléchargés jusqu'à présent. <br></br> En cliquant sur un reçu, vous serez redirigé vers la page de ce reçu spécifique.",
-    "tableView": {
-      "aria": {
-        "rowsPerPage": "Lignes par page",
-        "selectAllInvoices": "Sélectionner toutes les factures",
-        "selectInvoice": "Sélectionner facture {name}",
-        "sortByAmount": "Trier par montant",
-        "sortByDate": "Trier par date"
-      },
-      "columns": {
-        "actions": "Opérations",
-        "amount": "Montant",
-        "category": "Catégorie",
-        "date": "Date",
-        "invoice": "Facture"
-      },
-      "empty": {
-        "description": "Commencez par télécharger vos reçus pour créer votre première facture",
-        "title": "Aucune facture trouvée",
-        "uploadCta": "Télécharger votre premier reçu"
-      },
-      "nextPage": "Page suivante",
-      "pageOf": "Page {current} sur {total}",
-      "previousPage": "Page précédente",
-      "rowsPerPage": "Lignes par page:",
-      "tooltips": {
-        "notAnalyzed": "Cette facture n'a pas encore été analysée"
-      },
-      "viewInvoice": "Voir Facture"
-    },
-    "tableViewActions": {
-      "actions": {
-        "delete": "Supprimer",
-        "edit": "Modifier",
-        "share": "Partager"
-      },
-      "tooltips": {
-        "delete": "Supprimer définitivement cette facture",
-        "edit": "Modifier les détails de la facture",
-        "moreActions": "Plus d'actions",
-        "share": "Partager facture via lien or e-mail"
-      }
-    },
-    "title": "Bienvenue, {name} !",
-    "viewInvoicesIsland": {
-      "tabs": {
-        "invoices": "Factures",
-        "liveAnalysis": "Analyse en direct",
-        "statistics": "Statistiques"
-      }
-    },
-    "viewInvoicesPage": {
-      "guestName": "cher invité"
-    }
-  },
-  "IMS--Stats": {
-    "allergenSummary": {
-      "ariaLabel": "Résumé de la fréquence des allergènes",
-      "description": "Exposition aux allergènes dans vos produits",
-      "empty": "Aucun allergène détecté dans vos achats",
-      "stats": {
-        "ofTotal": "du total",
-        "products": "produits"
-      },
-      "title": "Résumé des allergènes"
-    },
-    "calendarHeatmap": {
-      "aria": {
-        "calendarGrid": "Calendrier des dépenses quotidiennes"
-      },
-      "days": {
-        "fri": "Ven",
-        "mon": "Lun",
-        "sat": "Sam",
-        "sun": "Dim",
-        "thu": "Jeu",
-        "tue": "Mar",
-        "wed": "Mer"
-      },
-      "description": "Intensité des dépenses quotidiennes au fil du temps",
-      "legend": {
-        "less": "Moins",
-        "more": "Plus"
-      },
-      "navigation": {
-        "next": "Mois suivant",
-        "previous": "Mois précédent"
-      },
-      "title": "Calendrier des dépenses",
-      "tooltip": {
-        "amount": "Dépensé",
-        "invoices": "{count} factures",
-        "noSpending": "Aucune dépense"
-      }
-    },
-    "categoryBreakdown": {
-      "description": "Répartition par catégories",
-      "title": "Dépenses par catégorie",
-      "tooltip": {
-        "invoiceCount": "{count} factures"
-      },
-      "totalLabel": "Dépenses totales"
-    },
-    "comparison": {
-      "decrease": "diminution",
-      "description": "Comparaison avec le mois précédent",
-      "discovered": "découverts",
-      "increase": "augmentation",
-      "invoiceCount": "Nombre de factures",
-      "newMerchants": "Nouveaux commerçants",
-      "none": "aucun",
-      "spendingDelta": "Variation des dépenses",
-      "title": "Mois par mois"
-    },
-    "currencyDistribution": {
-      "description": "Répartition des dépenses par devise avec conversion en RON",
-      "invoiceCount": "Factures",
-      "originalAmount": "Original",
-      "ronEquivalent": "Équivalent RON",
-      "showOriginal": "Afficher l''original",
-      "showRON": "Afficher en RON",
-      "singleCurrency": "Toutes les factures en {currency} ({symbol})",
-      "title": "Répartition par devise",
-      "toggleLabel": "Basculer la vue des devises",
-      "totalAmount": "Montant total",
-      "totalCurrencies": "Total des devises",
-      "totalSpending": "Dépenses totales"
-    },
-    "empty": {
-      "cta": "Télécharger un reçu",
-      "subtitle": "Téléchargez des reçus pour voir les analyses",
-      "title": "Pas encore de statistiques"
-    },
-    "kpi": {
-      "acrossInvoices": "sur {count} factures",
-      "averageItems": "Articles moy.",
-      "avgPerInvoice": "moy. {amount} par facture",
-      "invoiceCount": "Nombre de factures",
-      "noneYet": "Pas encore de données",
-      "topMerchant": "Commerçant principal",
-      "totalSpending": "Dépenses totales",
-      "visits": "{count} visites",
-      "vsLastMonth": "{delta}% par rapport au mois dernier"
-    },
-    "merchantLeaderboard": {
-      "description": "Où vous dépensez le plus",
-      "empty": "Aucune donnée de marchand disponible",
-      "labels": {
-        "totalSpent": "Total dépensé"
-      },
-      "title": "Principaux commerçants",
-      "tooltip": {
-        "invoiceCount": "{count} factures"
-      },
-      "unknownMerchant": "Commerçant inconnu"
-    },
-    "merchantTrends": {
-      "aria": {
-        "sparkline": "Tendance des dépenses pour {merchant}"
-      },
-      "description": "Évolution mensuelle des dépenses chez les principaux commerçants",
-      "empty": "Aucune donnée de commerçant disponible",
-      "labels": {
-        "merchant": "Commerçant",
-        "totalSpend": "Total dépensé",
-        "trend": "Tendance (6 derniers mois)"
-      },
-      "title": "Tendances de dépenses par commerçant"
-    },
-    "merchantVisit": {
-      "description": "Fréquence d'achat et aperçu du panier",
-      "empty": "Aucune donnée de visite disponible",
-      "metrics": {
-        "avgSpend": "Dépense moy./visite",
-        "basketSize": "Panier moyen",
-        "preferredDay": "Jour préféré",
-        "totalVisits": "Visites totales",
-        "visitsPerMonth": "Visites/mois"
-      },
-      "title": "Fréquentation des commerçants"
-    },
-    "priceDistribution": {
-      "description": "Distribution des prix des articles",
-      "labels": {
-        "itemCount": "Nombre d'articles"
-      },
-      "title": "Distribution des prix",
-      "tooltip": {
-        "itemCount": "{count} articles"
-      }
-    },
-    "productAnalytics": {
-      "subtitle": "Aperçu de vos articles achetés",
-      "title": "Analyse des produits"
-    },
-    "productCategory": {
-      "description": "Répartition des dépenses par type de produit",
-      "empty": "Aucun produit à analyser pour le moment",
-      "title": "Dépenses par catégorie de produit",
-      "tooltip": {
-        "productCount": "{count} produits"
-      }
-    },
-    "spendingOverTime": {
-      "description": "",
-      "labels": {
-        "amount": ""
-      },
-      "title": "",
-      "tooltip": {
-        "andMore": "et {count} de plus...",
-        "invoiceCount": ""
-      }
-    },
-    "subtitle": "Gérez vos reçus et suivez vos habitudes de dépenses",
-    "timeOfDay": {
-      "description": "Quand vous faites vos achats",
-      "labels": {
-        "invoiceCount": "Nombre de factures"
-      },
-      "title": "Habitudes d'achat",
-      "tooltip": {
-        "invoiceCount": "{count} factures"
-      }
-    },
-    "title": "Statistiques des factures",
-    "topProducts": {
-      "ariaLabel": "Classement des produits les plus achetés",
-      "description": "Articles les plus achetés",
-      "empty": "Aucun produit acheté pour le moment",
-      "headers": {
-        "avgPrice": "Prix moyen",
-        "product": "Produit",
-        "purchases": "Achats",
-        "quantity": "Qté",
-        "rank": "#",
-        "totalSpent": "Total"
-      },
-      "title": "Produits principaux"
-    }
-  },
-  "IMS--UploadScans": {
-    "breadcrumb": "Retour aux Factures",
-    "buttons": {
-      "myInvoices": "Mes Factures",
-      "uploadFirst": "Télécharger Votre Premier Scan",
-      "viewScans": "Voir Vos Scans"
-    },
-    "errors": {
-      "tooLarge": "Fichier trop volumineux : {name} (max 10 Mo)",
-      "unsupportedType": "Type de fichier non pris en charge : {type}"
-    },
-    "header": {
-      "description": "Téléchargez des images de reçus ou des PDF. Créez des factures à partir de ceux-ci plus tard.",
-      "title": "Télécharger des Scans",
-      "tooltip": "Téléchargez vos reçus, factures ou notes ici. Vous pouvez sélectionner plusieurs fichiers et les organiser en factures plus tard depuis la page Voir les Scans."
-    },
-    "metadata": {
-      "description": "Téléchargez des scans de reçus sur votre compte pour un traitement ultérieur en factures.",
-      "title": "Système de Gestion des Factures - Télécharger des Scans"
-    },
-    "postUpload": {
-      "createInvoice": "Oui, lancer l'analyse",
-      "dismiss": "Fermer",
-      "subtitle": "{count, plural, one {Cette numérisation représente-t-elle un seul achat ?} other {Ces numérisations représentent-elles un seul achat ?}}",
-      "title": "Téléchargement terminé !",
-      "viewScans": "Non, analyser séparément"
-    },
-    "preview": {
-      "pagination": {
-        "next": "Suivant",
-        "pageInfo": "{current} / {total} ({count} scans)",
-        "previous": "Précédent"
-      },
-      "pendingTooltip": "Ce scan ne sera pas enregistré tant que vous n'aurez pas cliqué sur Télécharger",
-      "removeTooltip": "Supprimer ce fichier",
-      "retryAttempt": "Nouvelle tentative {attempt}",
-      "status": {
-        "completed": "Terminé",
-        "failed": "Échoué",
-        "pending": "En attente",
-        "retrying": "Nouvelle tentative",
-        "uploading": "Téléversement"
-      },
-      "title": "Téléversements en attente ({count})"
-    },
-    "sidebar": {
-      "formats": {
-        "documentExtensions": ".pdf",
-        "documents": "Documents",
-        "imageExtensions": ".jpg, .jpeg, .png",
-        "images": "Images",
-        "maxSize": "Taille maximale du fichier : 10 Mo par fichier",
-        "title": "Formats Pris en Charge"
-      },
-      "nextSteps": {
-        "button": "Continuer vers Voir les Scans",
-        "description": "Vos scans sont prêts. Allez sur Voir les Scans pour les organiser en factures.",
-        "title": "Tous les téléchargements terminés !"
-      },
-      "security": {
-        "description": "Vos scans sont chiffrés et stockés en toute sécurité. Vous seul pouvez y accéder.",
-        "title": "Stockage Sécurisé"
-      },
-      "tips": {
-        "tip1": "Utilisez un bon éclairage lors de la photographie des reçus",
-        "tip2": "Assurez-vous que le texte est clair et lisible",
-        "tip3": "Évitez les ombres et les reflets",
-        "tip4": "Capturez tout le reçu dans le cadre",
-        "tip5": "Les PDF fonctionnent mieux pour les reçus numériques",
-        "title": "Conseils pour de Meilleurs Résultats"
-      }
-    },
-    "stats": {
-      "added": "Ajouté",
-      "completed": "Terminé",
-      "failed": "Échoué",
-      "pending": "En attente",
-      "uploading": "Téléchargement"
-    },
-    "subtitle": "Téléchargez des images de reçus ou des PDF. Créez des factures à partir de ceux-ci plus tard.",
-    "title": "Télécharger des Scans",
-    "upload": {
-      "browse": "Parcourir les fichiers",
-      "dropzone": "Glissez et déposez vos images de reçus ou PDF ici",
-      "or": "ou"
-    },
-    "uploadArea": {
-      "actions": {
-        "clearAll": "Tout effacer",
-        "uploading": "Téléversement...",
-        "uploadScans": "Téléverser les scans"
-      },
-      "aria": {
-        "uploadFiles": "Téléverser des fichiers"
-      },
-      "compact": {
-        "dropActive": "Déposez les fichiers pour les ajouter",
-        "dropInactive": "Glissez des fichiers ici ou cliquez pour parcourir",
-        "subtitle": "JPG, PNG, PDF jusqu'à 10 Mo"
-      },
-      "empty": {
-        "chooseFiles": "Choisir des fichiers",
-        "dropActive": "Déposez les fichiers pour les téléverser",
-        "dropInactive": "Cliquez ou glissez des fichiers pour les téléverser",
-        "formats": "Formats pris en charge : JPG, PNG, PDF (10 Mo max chacun)",
-        "note": "Vous pouvez sélectionner plusieurs fichiers.",
-        "pasteHint": "Astuce : vous pouvez aussi coller une image depuis le presse-papiers (Ctrl+V).",
-        "title": "Glissez-déposez vos fichiers ici"
-      },
-      "tooltips": {
-        "clearAll": "Supprimer tous les téléversements en attente",
-        "uploadScans": "Démarrer le téléversement de tous les scans en attente"
-      }
-    }
-  },
-  "IMS--View": {
-    "analysisPanel": {
-      "analyzing": {
-        "progress": "{progress}% terminé",
-        "title": "Analyse en cours..."
-      },
-      "buttons": {
-        "reanalyze": "Réanalyser la facture"
-      },
-      "description": "Réanalyser cette facture avec l'IA pour extraire ou mettre à jour les données",
-      "labels": {
-        "analysisComplete": "Analyse terminée — Toutes les données ont été extraites",
-        "granularOptions": "Ou choisissez une analyse spécifique",
-        "lastAnalyzed": "Dernière analyse",
-        "updates": "{count, plural, one {# mise à jour} other {# mises à jour}}"
-      },
-      "options": {
-        "completeAnalysis": "Analyse complète",
-        "invoiceOnly": "Facture uniquement",
-        "itemsOnly": "Articles uniquement",
-        "merchantOnly": "Commerçant uniquement"
-      },
-      "steps": {
-        "analyzing": "Analyse en cours avec l'IA...",
-        "complete": "Analyse terminée !",
-        "extracting": "Extraction OCR en cours...",
-        "finalizing": "Finalisation des résultats...",
-        "preparing": "Préparation du document...",
-        "processing": "Traitement des articles..."
-      },
-      "tip": "Astuce : L'analyse complète prend 30 à 60 secondes mais fournit les résultats les plus précis.",
-      "title": "Analyse IA",
-      "toasts": {
-        "error": {
-          "description": "Impossible d'analyser la facture. Veuillez réessayer plus tard.",
-          "title": "Échec de l'analyse"
+      "hub": {
+        "cta": {
+          "footer": "Construit avec passion en Roumanie",
+          "primary": "Voir sur GitHub",
+          "secondary": "Prendre contact",
+          "subtitle": "Commencez votre voyage à travers la plateforme ou connectez-vous avec l'auteur.",
+          "title": "Prêt à explorer ?"
         },
-        "success": {
-          "description": "La facture a été réanalysée avec succès avec des données mises à jour.",
-          "title": "Analyse terminée"
+        "faq": {
+          "questions": {
+            "q1": {
+              "answer": "arolariu.ro est une plateforme full-stack complète qui sert à la fois de portfolio personnel et de vitrine technologique. Elle démontre les pratiques modernes de développement web utilisant Next.js, .NET et les services cloud Azure.",
+              "question": "Qu'est-ce que arolariu.ro ?"
+            },
+            "q2": {
+              "answer": "Oui ! Toute la plateforme est open source et disponible sur GitHub. Vous pouvez explorer le code, en apprendre et même contribuer à son développement.",
+              "question": "Cette plateforme est-elle open source ?"
+            },
+            "q3": {
+              "answer": "La plateforme utilise Next.js 16 avec React 19 pour le frontend, .NET 10 avec ASP.NET Core pour le backend et Azure pour l'infrastructure cloud. Elle comprend également une bibliothèque de composants complète et des tests extensifs.",
+              "question": "Quelles technologies sont utilisées ?"
+            },
+            "q4": {
+              "answer": "Absolument ! La plateforme est conçue pour présenter les meilleures pratiques en ingénierie logicielle. N'hésitez pas à l'utiliser comme référence pour l'architecture, les modèles et les détails d'implémentation.",
+              "question": "Puis-je utiliser ceci comme référence pour mes propres projets ?"
+            }
+          },
+          "subtitle": "Questions courantes sur la plateforme et son objectif",
+          "title": "Questions fréquentes"
+        },
+        "hero": {
+          "badge": "À propos",
+          "ctaPrimary": "Explorer la plateforme",
+          "ctaSecondary": "Rencontrer l'auteur",
+          "subtitle": "Une plateforme full-stack moderne construite avec passion, conçue pour l'innovation et créée avec attention aux détails.",
+          "title": "Découvrez arolariu.ro"
+        },
+        "mission": {
+          "description": "arolariu.ro est plus qu'un simple site web - c'est un terrain de jeu pour les technologies modernes, une vitrine des meilleures pratiques et une plateforme qui démontre ce qui est possible quand l'excellence en ingénierie rencontre la vision créative.",
+          "pillars": {
+            "innovation": {
+              "description": "Adopter les technologies de pointe et les modèles architecturaux modernes",
+              "title": "Innovation"
+            },
+            "openness": {
+              "description": "Open source, transparent et orienté communauté",
+              "title": "Ouverture"
+            },
+            "quality": {
+              "description": "Maintenir des standards élevés avec plus de 90% de couverture de tests",
+              "title": "Qualité"
+            }
+          },
+          "statement": "Construire des logiciels qui font la différence.",
+          "title": "Notre mission"
+        },
+        "navigation": {
+          "author": {
+            "cta": "Rencontrer Alexandru",
+            "features": {
+              "item0": "Ingénieur Microsoft",
+              "item1": "Architecte de solutions",
+              "item2": "Passionné de technologie"
+            },
+            "subtitle": "Rencontrez Alexandru-Razvan Olariu, l'ingénieur logiciel derrière cette plateforme.",
+            "title": "L'auteur"
+          },
+          "platform": {
+            "cta": "Explorer la plateforme",
+            "features": {
+              "item0": "Frontend Next.js 16",
+              "item1": "Backend .NET 10",
+              "item2": "Infrastructure Azure Cloud"
+            },
+            "subtitle": "Découvrez l'architecture, le stack technologique et les fonctionnalités qui alimentent arolariu.ro.",
+            "title": "La plateforme"
+          },
+          "subtitle": "Plongez plus profondément dans ce qui rend arolariu.ro unique",
+          "title": "Explorer davantage"
+        },
+        "stats": {
+          "items": {
+            "linesOfCode": {
+              "description": "Entre frontend et backend",
+              "label": "Lignes de code",
+              "value": "50K+"
+            },
+            "technologies": {
+              "description": "Stack technologique moderne",
+              "label": "Technologies",
+              "value": "25+"
+            },
+            "testCoverage": {
+              "description": "Standard d'assurance qualité",
+              "label": "Couverture tests",
+              "value": "90%"
+            },
+            "yearsActive": {
+              "description": "En évolution continue depuis 2022",
+              "label": "Années actives",
+              "value": "3+"
+            }
+          },
+          "subtitle": "Métriques clés qui démontrent notre engagement envers la qualité",
+          "title": "En chiffres"
+        },
+        "values": {
+          "items": {
+            "accessibility": {
+              "description": "Conçu pour tous avec navigation clavier et support lecteur d'écran.",
+              "title": "Design accessible"
+            },
+            "community": {
+              "description": "Open source dans l'âme, contribuant à la communauté des développeurs.",
+              "title": "Communauté d'abord"
+            },
+            "engineering": {
+              "description": "Chaque fonctionnalité est construite avec une architecture propre, des tests appropriés et la maintenabilité à l'esprit.",
+              "title": "Excellence en ingénierie"
+            },
+            "learning": {
+              "description": "Cette plateforme sert de terrain d'essai pour les nouvelles technologies et approches.",
+              "title": "Apprentissage continu"
+            },
+            "performance": {
+              "description": "Optimisé pour la vitesse avec rendu côté serveur et déploiements edge.",
+              "title": "Orienté performance"
+            },
+            "privacy": {
+              "description": "La protection des données et la vie privée sont fondamentales, pas des réflexions après coup.",
+              "title": "Axé sur la confidentialité"
+            }
+          },
+          "subtitle": "Les principes qui guident chaque ligne de code",
+          "title": "Valeurs fondamentales"
         }
       },
-      "tooltips": {
-        "completeAnalysis": "Extraction OCR complète + traitement IA de toutes les données de la facture",
-        "invoiceOnly": "Réextraire les informations de base de la facture (date, total, paiement)",
-        "itemsOnly": "Recatégoriser et analyser uniquement les articles",
-        "merchantOnly": "Réidentifier le commerçant et les données de localisation",
-        "reanalyze": "Relancer l'analyse complète avec toutes les fonctionnalités IA"
+      "platform": {
+        "metadata": {
+          "description": "En savoir plus sur la plateforme, arolariu.ro.",
+          "title": "La plateforme"
+        }
       }
     },
-    "categoryComparisonChart": {
-      "description": "Cette facture vs votre moyenne",
-      "labels": {
-        "average": "Moyenne",
-        "current": "Actuel"
+    "auth": {
+      "button": {
+        "login": "Connexion",
+        "logout": "Déconnexion"
       },
-      "title": "Comparaison des catégories"
-    },
-    "export": {
-      "copyError": "Échec de la copie du résumé",
-      "copySuccess": "Résumé copié dans le presse-papiers",
-      "copySummary": {
-        "description": "Copier le résumé texte dans le presse-papiers",
-        "title": "Copier le résumé"
-      },
-      "csv": {
-        "description": "Télécharger les articles sous forme de feuille de calcul",
-        "title": "Exporter en CSV"
-      },
-      "csvError": "Échec de l'export CSV",
-      "csvSuccess": "Fichier CSV téléchargé avec succès",
-      "description": "Exportez vos données de facture dans différents formats",
-      "json": {
-        "description": "Télécharger les données complètes de la facture",
-        "title": "Exporter en JSON"
-      },
-      "jsonError": "Échec de l'export JSON",
-      "jsonSuccess": "Fichier JSON téléchargé avec succès",
-      "pdf": {
-        "description": "Télécharger un document de facture professionnel",
-        "title": "Exporter en PDF"
-      },
-      "pdfError": "Échec de la génération du PDF",
-      "pdfGenerating": "Génération du PDF en cours...",
-      "pdfSuccess": "Fichier PDF téléchargé avec succès",
-      "print": {
-        "description": "Imprimer la facture via le navigateur",
-        "title": "Imprimer"
-      },
-      "printError": "Échec de l'ouverture de la boîte de dialogue d'impression",
-      "printSuccess": "Boîte de dialogue d'impression ouverte",
-      "title": "Exporter la facture"
-    },
-    "healthScore": {
-      "cta": {
-        "analyze": "Lancer l'analyse IA",
-        "edit": "Modifier la facture"
-      },
-      "dialogTitle": "Rapport de santé de la facture",
-      "factors": {
-        "categoriesAssigned": "Catégories attribuées",
-        "merchantLinked": "Commerçant associé",
-        "ocrConfidence": "Confiance OCR",
-        "paymentInfo": "Informations de paiement",
-        "productCompleteness": "Complétude des produits",
-        "productsPresent": "Produits extraits",
-        "recipesGenerated": "Recettes générées"
-      },
-      "hideDetails": "Hide details",
-      "points": "points",
-      "seeReport": "Voir le rapport détaillé",
-      "showDetails": "Show details",
-      "status": {
-        "excellent": "Excellent",
-        "good": "Bon",
-        "incomplete": "Incomplet",
-        "needsAttention": "Nécessite une attention"
-      },
-      "subtitle": "How complete is your invoice data",
-      "suggestions": {
-        "fix": "Corriger",
-        "incompletePayment": "Informations de paiement incomplètes — ajoutez la date, le montant et la devise de la transaction",
-        "incompleteProducts": "<strong>{count}</strong> produits incomplets — vérifiez et complétez les champs manquants",
-        "lowOcrConfidence": "Faible confiance OCR sur <strong>{count}</strong> produits — vérifiez manuellement pour plus de précision",
-        "noMerchant": "Aucun commerçant associé — ajoutez les détails du commerçant pour de meilleures analyses",
-        "noProducts": "Aucun produit trouvé — téléchargez un reçu ou ajoutez des articles manuellement",
-        "noRecipes": "Aucune recette générée — lancez l'analyse IA pour découvrir des idées de repas",
-        "title": "Améliorations suggérées",
-        "uncategorizedProducts": "<strong>{count}</strong> produits non catégorisés — attribuez des catégories pour l'analyse des dépenses"
-      },
-      "title": "Invoice Completeness"
-    },
-    "invoiceAnalytics": {
-      "tabs": {
-        "compare": "Comparaison",
-        "current": "Cette facture"
-      },
-      "title": "Analyses et insights",
-      "emptyState": {
-        "description": "Ajoutez plus de données à cette facture pour afficher des analyses et des insights.",
-        "title": "Aucune analyse disponible"
-      }
-    },
-    "invoiceGuestBanner": {
-      "description": "Vous n’êtes actuellement pas le propriétaire de cette facture. L’affichage est limité à ce que le propriétaire a défini dans les paramètres de partage.",
-      "title": "Vue invité"
-    },
-    "invoiceTabs": {
-      "actions": {
-        "generate": "Générer des recettes",
-        "regenerate": "Régénérer les recettes",
-        "regenerateTooltip": "Réanalyser la facture pour générer de nouvelles suggestions de recettes"
-      },
-      "empty": {
-        "additionalInfo": "Aucune information supplémentaire disponible",
-        "recipes": "Aucune suggestion de recette disponible"
-      },
-      "recipe": {
-        "duration": "{minutes} min",
-        "ingredients": "Ingrédients",
-        "instructions": "Instructions",
-        "prepCook": "Prépa : {prep}m • Cuisson : {cook}m",
-        "viewRecipe": "Voir Recipe"
-      },
-      "tabs": {
-        "additionalInfo": "Infos supplémentaires",
-        "possibleRecipes": "Recettes possibles"
-      }
-    },
-    "invoiceTimeline": {
-      "eventCount": "{count, plural, one {# événement} other {# événements}}",
-      "subtitle": "Historique complet des actions et modifications",
-      "title": "Chronologie de la facture"
-    },
-    "itemAnalytics": {
-      "columns": {
-        "category": "Catégorie",
-        "name": "Nom",
-        "price": "Prix",
-        "quantity": "Qté",
-        "total": "Total"
-      },
-      "confidence": {
-        "ariaLabel": "Confiance {level}: {percent}%",
-        "high": "Elevee",
-        "label": "Confiance OCR",
-        "low": "Faible",
-        "lowWarning": "Faible confiance — vérifiez cet article",
-        "medium": "Moyenne"
-      },
-      "empty": {
-        "subtitle": "Lancez l'analyse IA pour extraire les articles de votre reçu",
-        "title": "Aucun article"
-      },
-      "searchPlaceholder": "Rechercher des articles...",
-      "summary": {
-        "allergens": "{count} allergènes détectés",
-        "categories": "{count} catégories",
-        "cheapest": "Le moins cher",
-        "mostExpensive": "Le plus cher",
-        "title": "Résumé"
-      },
-      "title": "Articles",
-      "totalLabel": "TOTAL"
-    },
-    "itemsBreakdownChart": {
-      "description": "Articles avec les plus fortes dépenses",
-      "labels": {
-        "price": "Prix",
-        "quantity": "Qté"
-      },
-      "title": "Articles les plus coûteux"
-    },
-    "merchantBreakdownChart": {
-      "description": "Totaux cumulés sur tous les commerçants",
-      "labels": {
-        "averagePerVisit": "Moy./visite",
-        "total": "Total",
-        "totalSpent": "Total dépensé",
-        "visits": "Visites"
-      },
-      "title": "Dépenses par magasin",
-      "unknownMerchant": "Commerçant inconnu"
-    },
-    "metadata": {
-      "description": "Consultez les détails de votre facture, les articles et les informations du commerçant associé.",
-      "title": "Système de Gestion des Factures - Voir la Facture"
-    },
-    "priceDistributionChart": {
-      "description": "Articles par tranche de prix ({currency})",
-      "labels": {
-        "items": "Articles"
-      },
-      "title": "Répartition des prix",
-      "tooltip": {
-        "itemCount": "{count, plural, one {# article} other {# articles}}"
-      }
-    },
-    "print": {
-      "generatedOn": "Imprimé le {date}",
-      "labels": {
-        "date": "Date",
-        "items": "Articles",
-        "merchant": "Commerçant",
-        "total": "Montant total"
-      },
-      "page": "Page"
-    },
-    "relatedInvoices": {
-      "noRelated": "Aucune facture associée trouvée",
-      "sameCategory": "Même catégorie",
-      "sameMerchant": "Même commerçant",
-      "similarAmount": "Montant similaire",
-      "subtitle": "Factures similaires par commerçant, catégorie ou montant",
-      "title": "Factures associées",
-      "viewInvoice": "Afficher"
-    },
-    "shareCollaborate": {
-      "activity": {
-        "created": "Créé {time}",
-        "daysAgo": "{count, plural, one {il y a # jour} other {il y a # jours}}",
-        "modified": "Dernière modification {time}",
-        "title": "Activité",
-        "today": "aujourd'hui"
-      },
-      "copied": "Lien copié dans le presse-papiers !",
-      "copyError": "Échec de la copie du lien",
-      "copyLink": "Copier le lien",
-      "madePrivate": "La facture est maintenant privée",
-      "madePublic": "La facture est maintenant publique",
-      "manageSharing": "Gérer le partage",
-      "private": "Privé",
-      "public": "Public",
-      "publicAccess": "Accès public",
-      "publicAccessDescription": "Toute personne ayant le lien peut voir cette facture",
-      "qrCode": "Code QR",
-      "qrCopied": "Lien copié ! Génération du code QR bientôt disponible.",
-      "shared": "Partagé",
-      "sharedWith": "Partagé avec",
-      "shareEmail": "Partager par e-mail",
-      "title": "Partage et collaboration",
-      "toggleError": "Échec de la mise à jour des paramètres de partage"
-    },
-    "spendingByCategoryChart": {
-      "description": "Répartition des dépenses",
-      "title": "Dépenses par catégorie",
-      "tooltip": {
-        "itemCount": "{count, plural, one {# article} other {# articles}}"
-      },
-      "totalLabel": "Total des dépenses"
-    },
-    "spendingTrendChart": {
-      "description": "Tendance de votre historique de factures",
-      "labels": {
-        "amount": "Montant"
-      },
-      "title": "Évolution des dépenses",
-      "tooltip": {
-        "currentInvoice": "Facture actuelle",
-        "andMore": "et {count} de plus…"
-      }
-    },
-    "timelineItem": {
-      "aria": {
-        "moreInfo": "Plus d’infos sur {title}"
-      },
-      "confidence": "Confiance : {value}%",
-      "events": {
-        "aiAnalysis": {
-          "description": "{count, plural, one {# article détecté et catégorisé} other {# articles détectés et catégorisés}}",
-          "title": "Analyse IA terminée"
+      "island": {
+        "callToAction": "S'authentifier",
+        "description": "Connectez-vous en utilisant notre serveur d'authentification OAuth 2.0 sécurisé. Votre profil sera synchronisé pendant cette session de navigation. Vous pouvez utiliser vos comptes de réseaux sociaux pour vous connecter.",
+        "footer": "Vous pouvez changer de fournisseur à tout moment. L'authentification est gérée par notre fournisseur d'identité de confiance.",
+        "hero": {
+          "badge": "Authentification Sécurisée",
+          "subtitle": "Choisissez un chemin et continuez avec votre fournisseur préféré. Tout reste rapide, sécurisé et localisé.",
+          "title": "Bienvenue au point d'entrée sécurisé"
         },
-        "categorized": {
-          "description": "Catégorisation automatique selon les articles",
-          "title": "Catégorie attribuée"
+        "signIn": {
+          "bullets": {
+            "first": "Continuez avec le fournisseur d'identité que vous utilisez déjà.",
+            "second": "Reprenez là où vous vous êtes arrêté sur n'importe quel appareil.",
+            "third": "La session reste synchronisée pendant votre navigation."
+          },
+          "cta": "Se connecter",
+          "description": "Accédez à votre compte et gardez votre session synchronisée pendant cette session de navigation.",
+          "illustrationAlt": "Illustration pour la connexion",
+          "secondaryAction": "En créer un",
+          "secondaryPrompt": "Vous n'avez pas de compte ?",
+          "title": "Se connecter"
         },
-        "created": {
-          "description": "Scannée et numérisée depuis le reçu",
-          "title": "Facture créée"
+        "signUp": {
+          "bullets": {
+            "first": "Créez un compte en quelques secondes avec les fournisseurs OAuth.",
+            "second": "Pas de mots de passe à retenir.",
+            "third": "Commencez à utiliser la plateforme immédiatement."
+          },
+          "cta": "Créer un compte",
+          "description": "Rejoignez la plateforme et débloquez les expériences réservées aux membres dans l'espace du domaine.",
+          "illustrationAlt": "Illustration pour l'inscription",
+          "secondaryAction": "Se connecter",
+          "secondaryPrompt": "Vous avez déjà un compte ?",
+          "title": "S'inscrire"
         },
-        "edited": {
-          "title": "Facture mise à jour"
-        },
-        "exported": {
-          "title": "Facture exportée"
-        },
-        "markedImportant": {
-          "description": "Signalée pour un suivi prioritaire",
-          "title": "Marquée importante"
-        },
-        "recipesGenerated": {
-          "description": "{count, plural, one {# recette suggérée} other {# recettes suggérées}}",
-          "title": "Recettes générées"
-        },
-        "shared": {
-          "description": "Partagée avec {count, plural, one {# personne} other {# personnes}}",
-          "title": "Partagée avec d’autres"
+        "step1": "Étape 1",
+        "step2": "Étape 2",
+        "title": "Authentifiez-vous avec notre serveur d'authentification OAuth 2.0 sécurisé.",
+        "trust": {
+          "oauth": "OAuth 2.0",
+          "privacy": "Confidentialité d'abord",
+          "session": "Synchronisation de session"
         }
       },
-      "fallbacks": {
-        "ocr": "OCR",
-        "pdf": "PDF"
-      },
-      "relativeTime": {
-        "now": "À l’instant"
-      },
-      "tooltips": {
-        "aiAnalysis": "L’IA a traité cette facture en {duration} et analysé {count, plural, one {# article} other {# articles}}.",
-        "categorized": "La facture a reçu une catégorie pour une meilleure organisation.",
-        "created": "La facture a été scannée et numérisée avec {method}.",
-        "edited": "Des modifications manuelles ont été apportées à la facture.",
-        "exported": "La facture a été exportée au format {format}.",
-        "markedImportant": "La facture a été marquée importante pour un accès rapide.",
-        "recipesGenerated": "D’après les ingrédients achetés, {count, plural, one {# recette a été générée} other {# recettes ont été générées}}.",
-        "shared": "La facture a été partagée avec {count, plural, one {# utilisateur} other {# utilisateurs}}.",
-        "unavailable": "Détails de l’événement indisponibles"
-      }
-    },
-    "timelineSharedWithList": {
-      "actions": {
-        "manageSharing": "Gérer le partage",
-        "sendEmail": "Envoyer un e-mail"
-      },
-      "aria": {
-        "sendEmail": "Envoyer un e-mail à {user}"
-      },
-      "header": {
-        "publicBadge": "Public",
-        "title": "Partagée avec"
-      },
-      "publicAccess": {
-        "description": "Cette facture est accessible publiquement. Toute personne disposant du lien peut la voir, y compris les invités sans compte.",
-        "title": "Accès public activé"
-      }
-    }
-  },
-  "IMS--ViewScans": {
-    "breadcrumb": "Retour aux Factures",
-    "createFromAll": {
-      "button": "Créer à partir de toutes les numérisations",
-      "description": "Créer des factures à partir de l'ensemble des {count} numérisations",
-      "title": "Toutes les numérisations sont prêtes !"
-    },
-    "emptyState": {
-      "description": "Commencez par télécharger vos reçus et factures. Voici comment cela fonctionne :",
-      "learnMoreButton": "En Savoir Plus",
-      "step1Description": "Prenez des photos de reçus ou téléchargez des PDF de factures numériques",
-      "step1Title": "Téléchargez vos scans",
-      "step2Description": "Choisissez quels scans convertir en factures",
-      "step2Title": "Sélectionnez et organisez",
-      "step3Description": "Notre IA extrait automatiquement toutes les données pour vous",
-      "step3Title": "Créez des factures",
-      "title": "Pas encore de scans",
-      "uploadButton": "Télécharger Votre Premier Scan"
-    },
-    "groupBanner": {
-      "createInvoice": "Créer une facture",
-      "dismiss": "Fermer",
-      "subtitle": "Créer une facture à partir de ces numérisations ?",
-      "title": "{count} scans uploaded together — combine?"
-    },
-    "header": {
-      "invoices": "Factures",
-      "lastSynced": "Dernière synchronisation : {time}",
-      "myInvoices": "Mes Factures",
-      "myInvoicesTooltip": "Voir vos factures créées",
-      "subtitle": "Sélectionnez des scans pour créer des factures à partir de ceux-ci",
-      "sync": "Synchroniser",
-      "syncing": "Synchronisation...",
-      "syncTooltip": "Actualiser les scans depuis le serveur",
-      "title": "Vos Scans",
-      "titleWithCount": "Vos Scans ({count})",
-      "tooltip": "Sélectionnez des scans pour créer des factures. Vous pouvez créer une facture par scan ou combiner plusieurs scans en une seule facture.",
-      "upload": "Télécharger",
-      "uploadMore": "Télécharger Plus",
-      "uploadTooltip": "Téléchargez plus de scans sur votre compte"
-    },
-    "metadata": {
-      "description": "Consultez et gérez vos scans téléchargés. Créez des factures à partir des scans sélectionnés.",
-      "title": "Système de Gestion des Factures - Voir les Scans"
-    },
-    "pagination": {
-      "next": "Suivant",
-      "pageInfo": "{current} / {total} ({count} scans)",
-      "previous": "Précédent"
-    },
-    "scanCard": {
-      "actions": {
-        "delete": "Supprimer le scan",
-        "rename": "Renommer le scan",
-        "rotateCCW": "Pivoter de 90° dans le sens antihoraire",
-        "rotateCW": "Pivoter de 90° dans le sens horaire",
-        "rotateError": "Échec de la rotation de l'image",
-        "rotateSuccess": "Image pivotée avec succès",
-        "rotateUnsupported": "Impossible de pivoter les fichiers PDF",
-        "rotating": "Rotation en cours..."
-      },
-      "delete": "Supprimer le scan",
-      "deleteDialog": {
-        "cancel": "Annuler",
-        "delete": "Supprimer",
-        "deleting": "Suppression...",
-        "description": "Êtes-vous sûr de vouloir supprimer \"{name}\" ? Cette action ne peut pas être annulée et le scan sera définitivement supprimé du stockage.",
-        "error": "Échec de la suppression du scan",
-        "linkedDescription": "Le supprimer retirera le scan du stockage, mais la facture conservera une copie de l'image. Cette action ne peut pas être annulée.",
-        "linkedWarning": "Ce scan est lié à une facture.",
-        "success": "Scan supprimé avec succès",
-        "title": "Supprimer le scan ?"
-      },
-      "linked": "Lié",
-      "loading": "Chargement...",
-      "preview": "Aperçu du scan",
-      "previewTitle": "Aperçu du scan",
-      "rename": "Renommer le scan",
-      "renamePlaceholder": "Entrez le nouveau nom"
-    },
-    "sidebar": {
-      "howTo": {
-        "step1Description": "Cliquez sur les scans pour les sélectionner",
-        "step1Title": "Sélectionner des Scans",
-        "step2Description": "Une facture par scan ou combiner plusieurs",
-        "step2Title": "Choisir le Mode",
-        "step3Description": "L'IA extrait les données automatiquement",
-        "step3Title": "Créer la Facture",
-        "title": "Comment Créer des Factures"
-      },
-      "quickUpload": {
-        "button": "Télécharger",
-        "description": "Téléchargez des reçus supplémentaires",
-        "title": "Besoin de plus de scans ?"
-      },
-      "selectionStatus": {
-        "plural": "scans sélectionnés",
-        "readyPlural": "Créez plusieurs factures ou combinez en une seule",
-        "readySingular": "Prêt à créer une facture",
-        "singular": "scan sélectionné"
-      }
-    },
-    "stats": {
-      "ready": "Prêt",
-      "selected": "Sélectionné",
-      "selectHint": "Cliquez sur les scans pour les sélectionner pour la création de factures",
-      "tapHint": "Appuyez pour sélectionner",
-      "totalScans": "Total des Scans"
-    },
-    "subtitle": "Sélectionnez des scans pour créer des factures à partir de ceux-ci.",
-    "title": "Vos Scans",
-    "toolbar": {
-      "clearSelection": "Effacer",
-      "createInvoice": "Créer une Facture",
-      "createInvoices": "Créer des Factures",
-      "delete": {
-        "button": "Supprimer ({count})",
-        "cancel": "Annuler",
-        "confirm": "Supprimer",
-        "confirmDescription": "Cela supprimera définitivement {count} scan(s) du stockage. Cette action est irréversible.",
-        "confirmTitle": "Supprimer les scans sélectionnés ?",
-        "error": "Une erreur est survenue lors de la suppression des scans",
-        "failed": "Échec de la suppression des scans",
-        "partial": "{success} supprimé(s), {failed} échoué(s)",
-        "success": "{count} scan(s) supprimé(s) avec succès"
-      },
-      "selected": "sélectionné"
-    }
-  },
-  "Legal": {
-    "PrivacyPolicy": {
-      "contactInformation": {
-        "content": "Si vous avez des questions concernant notre Politique de Confidentialité, veuillez nous contacter à admin@arolariu.ro",
-        "title": "Informations de Contact"
-      },
-      "last_updated": "Dernière mise à jour : 2024-01-01",
       "metadata": {
-        "description": "La page de politique de confidentialité de la plateforme `arolariu.ro`.",
-        "title": "Politique de Confidentialité"
+        "description": "La page d'authentification pour la plateforme arolariu.ro.",
+        "title": "Authentification"
       },
-      "terms": {
-        "childrenPrivacy": {
-          "content": "Notre site web n'est pas destiné aux enfants de moins de 13 ans. Nous ne collectons pas sciemment de données personnelles auprès d'enfants de moins de 13 ans. Si vous êtes un parent ou un tuteur et que vous savez que votre enfant nous a fourni des données personnelles, veuillez nous contacter. Si nous apprenons que nous avons collecté des données personnelles d'enfants sans vérification du consentement parental, nous prendrons des mesures pour supprimer ces informations de nos serveurs.",
-          "title": "Confidentialité des Enfants"
+      "signIn": {
+        "bullets": {
+          "first": "Connexion rapide avec des fournisseurs de confiance.",
+          "second": "Votre session reste cohérente dans toute l'application.",
+          "third": "Conçu pour fonctionner parfaitement sur mobile et ordinateur."
         },
-        "cookiesDefinition": {
-          "content": "Les cookies sont de petits fichiers de données stockés sur votre appareil (ordinateur ou appareil mobile). Les cookies sont utilisés pour améliorer votre expérience sur notre site web et pour vous fournir un contenu pertinent. Pour plus d'informations sur les cookies, veuillez visiter https://www.allaboutcookies.org/ <br></br><br></br><br></br> Nous utilisons des cookies pour collecter des informations sur votre appareil et votre utilisation de notre site web. Notre fournisseur d'analyses de site web utilise des cookies pour générer des informations statistiques et autres sur l'utilisation du site web au moyen de cookies. <br></br><br></br><br></br> Vous pouvez refuser les cookies en utilisant les paramètres de votre navigateur. Veuillez noter que si vous désactivez les cookies, vous ne pourrez peut-être pas utiliser toutes les fonctionnalités de notre site web. <br></br><br></br><br></br> Nous ne conserverons vos données personnelles que le temps nécessaire à la finalité pour laquelle ces données ont été collectées et dans la mesure requise par la loi applicable. Lorsque nous n'avons plus besoin de données personnelles, nous les supprimons de nos systèmes et/ou prenons des mesures pour les anonymiser.",
-          "title": "Que sont les Cookies ?"
+        "footer": "Protégé par une sécurité de niveau entreprise.",
+        "form": {
+          "kicker": "Connectez-vous avec votre fournisseur préféré",
+          "secondaryAction": "Créer un compte",
+          "secondaryPrompt": "Nouveau ici ?"
         },
-        "dataCollectionTerms": {
-          "content": "a) Lorsque vous effectuez un achat ou tentez d'effectuer un achat, nous collectons les types de données personnelles suivants : <ul> <li> Informations de paiement telles que votre adresse de facturation, numéro de téléphone, carte de crédit, carte de débit et/ou autres informations de méthode de paiement ; </li><li> Informations de compte telles que votre nom, nom d'utilisateur, adresse e-mail ; </li><li> Informations d'achat spécifiquement si personnalisées ou uniques ;</li> <li>Données démographiques ;</li> <li>Données de localisation.</li> </ul> <br></br><br></br> b) Lorsque vous visitez et utilisez notre site web, nous collectons automatiquement les types de données personnelles suivants : <ul> <li> Informations de paiement telles que votre adresse de facturation, numéro de téléphone, carte de crédit, carte de débit et/ou autres informations de méthode de paiement ; </li> <li>Données d'appareil, telles que votre ordinateur, téléphone, tablette ou autre appareil que vous utilisez pour accéder à notre site web ;</li> <li>Données de communication, telles que vos préférences pour recevoir des communications de notre part ;</li> <li>Commentaires, tels que le support client, les avis sur les produits, les sondages et/ou autres commentaires ;</li> <li>Données de contenu, telles que le contenu que vous nous soumettez : publications, documents, audio, images, etc. ;</li> <li>Données d'utilisation, telles que la façon dont vous utilisez notre site web, produits et services ;</li> <li>Informations de compte telles que votre nom, nom d'utilisateur, adresse e-mail ;</li> <li>Informations d'achat spécifiquement si personnalisées ou uniques ;</li> <li>Données démographiques ;</li> <li>Données de localisation ;</li></ul>",
-          "title": "Quelles Données Personnelles Nous Collectons"
+        "hero": {
+          "subtitle": "Utilisez le fournisseur en qui vous avez confiance et continuez instantanément.",
+          "title": "Bon retour"
         },
-        "dataTransferTerms": {
-          "content": "Dans la mesure du possible, nous stockons et traitons les données sur des serveurs situés dans la région géographique générale où vous résidez (remarque : cela peut ne pas être dans le pays dans lequel vous résidez). <span> Plus précisément, pour les utilisateurs, entreprises et clients basés en Europe, nous avons des serveurs dans l'Espace économique européen (EEE). </span> Vos données personnelles peuvent également être transférées vers des serveurs situés en dehors de votre état, province, pays ou autre juridiction gouvernementale où les lois sur les données peuvent différer de celles de votre juridiction, et y être conservées. Nous prendrons les mesures appropriées pour garantir que vos données personnelles sont traitées de manière sécurisée et conformément à cette politique ainsi qu'à la législation applicable en matière de protection des données. Les données peuvent être conservées dans d'autres pays considérés comme adéquats en vertu de vos lois. <br></br><br></br><br></br><br></br> Plus d'informations sur ces clauses peuvent être trouvées ici : https://eur-lex.europa.eu/legal-content/en/TXT/?uri=CELEX:32021D0914",
-          "title": "Transfert et Stockage International des Données"
-        },
-        "deviceUsageTerms": {
-          "content": "Lorsque vous visitez un site web <code>AROLARIU.RO</code> et/ou une application mobile, nous collectons et stockons automatiquement des informations sur votre visite en utilisant des cookies de navigateur (fichiers que nous envoyons à votre ordinateur), ou des technologies similaires. Vous pouvez configurer votre navigateur pour refuser tous les cookies ou pour indiquer quand un cookie est envoyé. La fonction `Aide` de la plupart des navigateurs fournira des informations sur la façon d'accepter les cookies, de désactiver les cookies ou de vous notifier lors de la réception d'un nouveau cookie. Si vous n'acceptez pas les cookies, vous ne pourrez peut-être pas utiliser certaines fonctionnalités de notre Service et nous vous recommandons de les laisser activés. <br></br><br></br><br></br> Nous traitons également des informations lorsque vous utilisez nos services et produits. Ces informations peuvent inclure : <ul> <li>   Des informations sur vos interactions avec nos services, y compris l'heure et la date de vos interactions,   et vos interactions avec nos e-mails ; </li> <li>   Des informations sur votre utilisation de nos services, y compris le type de navigateur que vous utilisez, les heures d'accès, les pages   consultées, votre adresse IP ; </li> <li>   Des informations sur vos achats, y compris les articles que vous achetez, la date d'achat et la méthode de paiement   que vous utilisez ; </li> <li>   Des informations sur votre appareil, y compris le type d'appareil, son système d'exploitation et les informations sur le réseau   mobile ; </li> <li>   D'autres informations que vous nous fournissez, y compris vos commentaires, remarques et autres informations que vous nous fournissez ; </li> <li>Des informations sur votre localisation, y compris votre localisation générale basée sur votre adresse IP ;</li> <li>D'autres informations que nous collectons avec votre consentement ou comme permis ou requis par la loi ;</li> <li>Des informations sur vos préférences, y compris vos préférences linguistiques.</li> </ul>",
-          "title": "Données d'Appareil et d'Utilisation"
-        },
-        "exerciseRights": {
-          "content": "Pour exercer vos droits, veuillez nous contacter en utilisant les coordonnées fournies dans la section « Nous Contacter » ci-dessous. Nous répondrons à votre demande dans un délai raisonnable et conformément à la loi applicable. <br></br><br></br> Pour votre propre sécurité, nous pouvons avoir besoin de vérifier votre identité avant de répondre à votre demande. Nous ferons des efforts raisonnables pour vérifier votre identité en demandant des informations que nous avons dans nos dossiers à votre sujet.",
-          "title": "Comment Exercer Vos Droits"
-        },
-        "howWeCollectDataTerms": {
-          "content": "Nous collectons des données personnelles de la manière suivante : <br></br><br></br> <span>1. Directement de vous.</span> <br></br> Nous collectons des données personnelles de votre part lorsque vous nous les fournissez directement ou indirectement, en utilisant notre site web, nos produits ou nos services. Cela inclut : <br></br> <ul> <li>Lorsque vous créez un compte ou achetez des produits sur notre site web ;</li> <li>Lorsque vous téléchargez des logiciels et/ou notre application mobile ;</li> <li>Lorsque vous participez à nos sondages, concours ou promotions ;</li> <li>Lorsque vous créez du contenu à travers nos produits et services ;</li> <li>Lorsque vous nous contactez avec une demande ou pour signaler un problème ;</li> <li>Lorsque vous exprimez un intérêt pour nos produits et services ;</li> <li>Lorsque vous utilisez notre site web, nos produits ou nos services ;</li> <li>Lorsque vous interagissez avec nous sur les réseaux sociaux ;</li> <li>Lorsque vous vous abonnez à notre newsletter ;</li> <li>Lorsque vous nous les fournissez directement ;</li> <li>Lorsque vous communiquez avec nous.</li> </ul> <br></br><br></br><br></br><br></br> <span>2. Technologies automatisées ou interactions.</span> <br></br> <br></br> Lorsque vous interagissez avec notre site web, nous pouvons automatiquement collecter les types de données suivants (tous décrits ci-dessus) : Données d'appareil concernant votre équipement, Données d'utilisation concernant vos actions et modèles de navigation, et Données de contact lorsque des tâches effectuées via notre site web restent inachevées, comme des commandes incomplètes ou des paniers abandonnés. Nous collectons ces données en utilisant des cookies, des journaux de serveur et d'autres technologies similaires. Veuillez consulter notre section Cookies (ci-dessous) pour plus de détails. <br></br><br></br><br></br><br></br> <span>3. Tiers ou sources accessibles au public.</span> <br></br><br></br> Nous pouvons recevoir des données personnelles vous concernant de divers tiers, notamment : <ul> <li>   Informations de compte et données de paiement de tiers, y compris des organisations (telles que les forces de l'ordre),   des associations et des groupes, qui partagent des données à des fins de prévention et de détection de la fraude et   de réduction du risque de crédit </li> <li>Données de contact, financières et de transaction des fournisseurs de services techniques, de paiement et de livraison</li> <li>Données techniques des fournisseurs d'analyses tels que Google Analytics</li> <li>Données d'identité et de contact des courtiers ou agrégateurs de données</li> <li>Données d'identité et de contact provenant de sources accessibles au public</li> </ul> <br></br><br></br><br></br><br></br><span> Si vous nous fournissez, ou fournissez à nos prestataires de services, des données personnelles relatives à d'autres personnes, vous déclarez avoir l'autorité de le faire et reconnaissez qu'elles seront utilisées conformément à cette politique. Si vous pensez que vos données personnelles nous ont été fournies de manière inappropriée, ou pour exercer autrement vos droits relatifs à vos données personnelles, veuillez nous contacter en utilisant les informations indiquées dans la section « Nous Contacter » ci-dessous.</span>",
-          "title": "Comment Nous Collectons les Données Personnelles"
-        },
-        "legalTerms": {
-          "content": "Nous pouvons utiliser ou divulguer vos données personnelles afin de nous conformer à une obligation légale, en relation avec une demande d'une autorité publique ou gouvernementale, ou en relation avec des procédures judiciaires ou tribunales, pour prévenir la perte de vie ou les blessures, ou pour protéger nos droits ou notre propriété. Dans la mesure du possible et pratique, nous vous informerons à l'avance d'une telle divulgation.",
-          "title": "Exigences Légales"
-        },
-        "personalDataRights": {
-          "content": "Vous avez le droit d'accéder, de corriger, de mettre à jour ou de supprimer vos données personnelles. Vous avez également le droit de vous opposer au traitement de vos données personnelles, de nous demander de restreindre le traitement de vos données personnelles ou de demander la portabilité de vos données personnelles. Vous pouvez exercer ces droits en nous contactant en utilisant les coordonnées fournies dans la section « Nous Contacter » ci-dessous. <br></br><br></br><br></br> Selon votre situation géographique et votre citoyenneté, vos droits sont soumis aux réglementations locales sur la confidentialité des données. Ces droits peuvent inclure : <ul> <li>   Droit à l'oubli (droit à l'effacement) (RGPD Article 17, CCPA/CPRA, CPA, VCDPA, CTDPA, UCPA, LGPD,   POPIA) </li> <li>Droit d'accès (PIPEDA, RGPD Article 15, CCPA/CPRA, CPA, VCDPA, CTDPA, UCPA, LGPD, POPIA)</li> <li>Droit de rectification (PIPEDA, RGPD Article 16, CPRA, CPA, VCDPA, CTDPA, LGPD, POPIA)</li> <li>Non-discrimination et non-représailles (CCPA/CPRA, CPA, VCDPA, CTDPA, UCPA)</li> <li>Droit à la limitation du traitement (RGPD Article 18, LGPD)</li> <li>Droit de retrait (CPRA, CPA, VCDPA, CTDPA, UCPA)</li> <li>Droit à la portabilité (PIPEDA, RGPD Article 20, LGPD)</li> <li>Droit d'opposition (RGPD Article 21, LGPD, POPIA)</li> </ul> <br></br><br></br><br></br> Si vous souhaitez faire appel ou déposer une plainte concernant la façon dont nous traitons vos données personnelles, vous pouvez nous contacter en utilisant les coordonnées fournies dans la section « Nous Contacter » ci-dessous. Vous avez également le droit de déposer une plainte auprès de l'autorité de protection des données de votre juridiction. <br></br> Dans le cas où vous nous avez contactés et que vous n'êtes pas satisfait de notre réponse, vous avez le droit de faire appel auprès du procureur général situé ici : <ul> <li>   Si vous êtes basé dans l'EEE, veuillez visiter le site https://edpb.europa.eu/about-edpb/about-edpb/members_en pour une liste des autorités locales de protection des données. </li> <li>   Si vous êtes basé dans le Connecticut, veuillez visiter le site https://portal.ct.gov/AG/Common/Complaint-Form-Landing-page pour déposer une plainte. </li> <li> Si vous êtes basé dans le Colorado, veuillez visiter le site https://complaints.coag.gov/s/contact-us pour déposer une plainte. </li> <li> Si vous êtes basé en Virginie, veuillez visiter le site https://www.oag.state.va.us/consumer-protection/index.php/file-a-complaint pour déposer une plainte. </li></ul>",
-          "title": "Vos Droits Concernant Vos Données Personnelles"
-        },
-        "policyChanges": {
-          "content": "Nous pouvons mettre à jour cette politique de temps à autre. Si nous apportons des modifications importantes, nous vous en informerons, mais veuillez vérifier régulièrement cette politique pour vous assurer que vous êtes au courant de la version la plus récente.",
-          "title": "Modifications de Cette Politique"
-        },
-        "processingDataTerms": {
-          "content": "Nous collectons et utilisons vos données personnelles avec votre consentement pour fournir, maintenir et développer nos produits et services et comprendre comment les améliorer davantage. <br></br><br></br><br></br> Ces finalités incluent : <ul> <li>Construire un environnement sûr et sécurisé pour nos utilisateurs et notre communauté ;</li> <li>Mener des recherches et des analyses pour améliorer nos produits et services ;</li> <li>Communiquer avec vous concernant votre compte, vos achats ou vos demandes ;</li> <li>Enquêter et prévenir les incidents de sécurité et autres activités illégales ;</li> <li>Personnaliser votre expérience avec nos produits et services ;</li> <li>Fournir, maintenir et améliorer nos produits et services ;</li> <li>Vous fournir les produits et services que vous demandez ;</li> <li>Vous fournir des communications marketing ;</li> <li>Vous fournir un support client ;</li> <li>Protéger nos produits et services ;</li> <li>Autres finalités avec votre consentement ;</li> <li>Se conformer aux obligations légales.</li> </ul> <br></br><br></br><br></br><br></br> Lorsque nous traitons vos données personnelles pour fournir un produit ou un service, nous le faisons parce que c'est nécessaire pour exécuter des obligations contractuelles. Tout le traitement ci-dessus est nécessaire dans nos intérêts légitimes pour fournir des produits et services et pour maintenir notre relation avec vous et pour protéger notre entreprise par exemple contre la fraude. Le consentement sera requis pour initier les services avec vous. Un nouveau consentement sera requis si des modifications sont apportées au type de données collectées. Dans le cadre de notre contrat, si vous ne fournissez pas votre consentement, certains services peuvent ne pas vous être disponibles.",
-          "title": "Finalité et Base Légale du Traitement des Données Personnelles"
-        },
-        "processingTerms": {
-          "content": "Cette politique s'applique lorsque vous visitez notre site web, utilisez nos produits ou services, ou interagissez avec nous. <br></br> De plus, cette politique s'applique lorsque vous : <ul> <li> Utilisez notre application et nos services en tant qu'utilisateur autorisé ;</li> <li>Visitez l'un de nos sites web liés à cette Politique de Confidentialité ;</li> <li>Recevez toute communication de notre part, y compris les e-mails.</li></ul>",
-          "title": "Activités de Traitement"
-        },
-        "safeDataTerms": {
-          "content": "Nous avons mis en place des mesures de sécurité techniques et organisationnelles appropriées conçues pour protéger la sécurité de toute donnée personnelle que nous traitons. Cependant, veuillez également vous rappeler que nous ne pouvons pas garantir que l'internet lui-même est 100% sécurisé. Bien que nous fassions de notre mieux pour protéger vos données personnelles, la transmission de données personnelles vers et depuis notre site web se fait à vos propres risques. Vous ne devez accéder aux services que dans un environnement sécurisé. <br></br><br></br><br></br> Nous avons mis en place des garanties organisationnelles et des mesures de sécurité appropriées pour protéger vos données personnelles contre la perte accidentelle, l'utilisation ou l'accès non autorisé, la modification ou la divulgation. <br></br><br></br><br></br> La communication entre votre navigateur et notre site web utilise une connexion chiffrée sécurisée partout où vos données personnelles sont impliquées. <br></br><br></br><br></br> Nous exigeons que tout tiers contracté pour traiter vos données personnelles en notre nom ait des mesures de sécurité en place pour protéger vos données et traiter ces données conformément à la loi. <br></br><br></br><br></br> Dans le cas malheureux d'une violation de données personnelles, nous vous informerons ainsi que tout régulateur applicable lorsque nous sommes légalement tenus de le faire.",
-          "title": "Comment Nous Gardons Vos Données en Sécurité"
-        },
-        "scopeTerms": {
-          "content": "Cette politique s'applique au site web <code> AROLARIU.RO </code>, aux produits et aux services. Elle s'applique également à l'utilisation de notre site web, de nos produits et de nos services par nos clients, partenaires et visiteurs. <br></br><br></br> Cette politique ne s'applique pas aux applications, sites web, produits, services ou plateformes tiers qui peuvent être accessibles via des liens (non-<code>AROLARIU.RO</code>) que nous pouvons vous fournir. Ces sites sont détenus et exploités indépendamment de nous, et ils ont leurs propres pratiques distinctes en matière de confidentialité et de collecte de données. Toute donnée personnelle que vous fournissez à ces sites web sera régie par la propre politique de confidentialité du tiers. Nous ne pouvons pas accepter de responsabilité pour les actions ou les politiques de ces sites indépendants, et nous ne sommes pas responsables du contenu ou des pratiques de confidentialité de ces sites.",
-          "title": "Portée de la Politique"
-        },
-        "serviceProviderTerms": {
-          "content": "Nous pouvons utiliser des prestataires de services tiers, des entrepreneurs indépendants, des agences ou des consultants pour fournir et nous aider à améliorer nos produits et services. Nous pouvons partager vos données personnelles avec des agences de marketing, des fournisseurs de services de bases de données, des fournisseurs de services de sauvegarde et de reprise après sinistre, des fournisseurs de services de messagerie et d'autres, mais uniquement pour maintenir et améliorer nos produits et services. <br></br><br></br> Pour plus d'informations sur les destinataires de vos données personnelles, veuillez nous contacter en utilisant les informations de la section « Nous Contacter » ci-dessous.",
-          "title": "Prestataires de Services et Autres Tiers"
-        },
-        "sharingAndDisclosureTerms": {
-          "content": "Nous partagerons vos données personnelles avec des tiers uniquement de la manière indiquée dans cette politique ou au moment où les données personnelles sont collectées. <br></br><br></br><br></br> Nous utilisons également Google Analytics pour nous aider à comprendre comment nos clients utilisent le site. Vous pouvez en savoir plus sur la façon dont Google utilise vos données personnelles ici : https://www.google.com/intl/en/policies/privacy/ <br></br><br></br><br></br> Vous pouvez également vous désinscrire de Google Analytics ici : https://tools.google.com/dlpage/gaoptout <br></br><br></br><br></br> Nous pouvons également partager vos données personnelles avec des tiers lorsque la loi l'exige, lorsqu'il est nécessaire d'administrer la relation entre nous ou lorsque nous avons un autre intérêt légitime à le faire. Nous pouvons également partager vos données personnelles avec des tiers à qui nous pouvons choisir de vendre, transférer ou fusionner des parties de notre entreprise ou de nos actifs. Alternativement, nous pouvons chercher à acquérir d'autres entreprises ou à fusionner avec elles. <br></br><br></br><br></br> Pour plus d'informations sur le fonctionnement de la publicité ciblée, vous pouvez visiter la page éducative de la Network Advertising Initiative (NAI) à : https://www.networkadvertising.org/understanding-online-advertising/how-does-it-work <br></br><br></br><br></br> De plus, vous pouvez vous désinscrire de certains de ces services en visitant la page de désinscription de la Digital Advertising Alliance : https: //optout.aboutads.info/",
-          "title": "Partage et Divulgation des Données Personnelles"
-        },
-        "thirdPartyData": {
-          "content": "Nous pouvons recevoir vos données personnelles de tiers tels que des entreprises abonnées aux services <code>AROLARIU.RO</code>, des partenaires et d'autres sources. Ces données personnelles ne sont pas collectées par nous mais par un tiers et sont soumises aux politiques distinctes de confidentialité et de collecte de données de ce tiers. Nous n'avons aucun contrôle ou influence sur la façon dont vos données personnelles sont traitées par des tiers. Comme toujours, vous avez le droit de consulter et de rectifier ces informations. Si vous avez des questions, vous devez d'abord contacter le tiers concerné pour plus d'informations sur vos données personnelles. Lorsque ce tiers ne répond pas à vos droits, vous pouvez contacter le Délégué à la Protection des Données chez <code> AROLARIU.RO </code> (coordonnées ci-dessous). <br></br><br></br><br></br> Nos sites web et services peuvent contenir des liens vers d'autres sites web, applications et services maintenus par des tiers. Les pratiques d'information de ces autres services, ou des réseaux de médias sociaux qui hébergent nos pages de médias sociaux de marque, sont régies par les déclarations de confidentialité de ces tiers, que vous devriez consulter pour mieux comprendre les pratiques de confidentialité de ces tiers.",
-          "title": "Données que nous collectons auprès de tiers"
-        },
-        "whatIsTerms": {
-          "content": "Chez <code> AROLARIU.RO </code> (« nous », « notre » ou la « Société »), nous accordons de l'importance à votre vie privée et à l'importance de protéger vos données. Cette Politique de Confidentialité (la « Politique ») décrit nos pratiques de confidentialité pour les activités décrites ci-dessous. <br></br> <br></br> Conformément à vos droits, nous vous informons de la manière dont nous collectons, stockons, accédons et traitons autrement les informations relatives aux individus. Dans cette Politique, les données personnelles (« Données Personnelles ») désignent toute information qui, seule ou en combinaison avec d'autres informations disponibles, peut identifier un individu. <br></br> <br></br> Nous nous engageons à protéger votre vie privée conformément au plus haut niveau de réglementation en matière de confidentialité. En tant que tel, nous respectons les obligations des réglementations suivantes : <ul> <li> Le California Consumer Privacy Act (CCPA) / California Privacy Rights Act (CPRA) et le California Online Privacy Protection Act (CalOPPA) </li> <li> Le Personal Information Protection and Electronic Documents Act (PIPEDA) du Canada et les législations provinciales applicables </li> <li> Le Règlement Général sur la Protection des Données (RGPD) de l'Union Européenne </li> <li> Le Protection of Personal Information Act (POPIA) d'Afrique du Sud </li> <li> Le Virginia Consumer Data Protection Act (VCDPA) </li> <li> La législation brésilienne sur la protection des données (LGPD) </li> <li> Le Connecticut Data Privacy Act (CTDPA) </li> <li> Le Utah Consumer Privacy Act (UCPA) et le Colorado Privacy Act (CPA) </li> </ul>",
-          "title": "Qu'est-ce que AROLARIU.RO ?"
-        },
-        "withdrawingConsent": {
-          "content": "Si vous avez donné votre consentement au traitement de vos données personnelles, vous avez le droit de retirer votre consentement à tout moment. Pour retirer votre consentement, veuillez nous contacter en utilisant les coordonnées fournies dans la section « Nous Contacter » ci-dessous.",
-          "title": "Retrait du Consentement"
+        "illustrationAlt": "Illustration pour la page de connexion",
+        "metadata": {
+          "description": "Connectez-vous pour continuer votre session sur arolariu.ro.",
+          "title": "Connexion"
         }
       },
-      "title": "Politique de Confidentialité"
+      "signUp": {
+        "bullets": {
+          "first": "Intégration rapide avec les fournisseurs OAuth.",
+          "second": "Pas de carte de crédit requise.",
+          "third": "Commencez à explorer la plateforme immédiatement."
+        },
+        "footer": "Inscription rapide et sécurisée.",
+        "form": {
+          "kicker": "Créez votre compte avec votre fournisseur préféré",
+          "secondaryAction": "Se connecter",
+          "secondaryPrompt": "Vous avez déjà un compte ?"
+        },
+        "hero": {
+          "subtitle": "Créez votre compte en quelques secondes et commencez.",
+          "title": "Rejoignez-nous aujourd'hui"
+        },
+        "illustrationAlt": "Illustration pour la page d'inscription",
+        "metadata": {
+          "description": "Créez un compte et commencez à utiliser arolariu.ro.",
+          "title": "Inscription"
+        }
+      }
     },
-    "TermsOfService": {
-      "contactInformation": {
-        "content": "Si vous avez des questions concernant nos Conditions de Service, veuillez nous contacter à admin@arolariu.ro",
-        "title": "Informations de Contact"
-      },
-      "last_updated": "Dernière mise à jour : 2024-01-01",
+    "domains": {
       "metadata": {
-        "description": "Les conditions de service pour arolariu.ro",
-        "title": "Conditions de Service"
+        "description": "Les services de l'espace de domaine sont des services offerts aux visiteurs et membres de l'espace de domaine `arolariu.ro`",
+        "title": "Services de l'Espace de Domaine"
       },
-      "terms": {
-        "amendmentsTerms": {
-          "content": "Nous nous réservons le droit de modifier, compléter ou remplacer les termes de l'Accord, prenant effet dès la publication sur www.arolariu.ro ou en vous en informant autrement. Si vous ne souhaitez pas accepter les modifications de l'Accord, vous pouvez résilier l'Accord à tout moment conformément aux termes des présentes. Si une révision est importante, nous fournirons un préavis d'au moins 30 jours avant l'entrée en vigueur de nouveaux termes. Ce qui constitue un changement important sera déterminé à notre seule discrétion. En continuant à accéder ou à utiliser notre service après que les révisions deviennent effectives, vous acceptez d'être lié par les termes révisés. Si vous n'acceptez pas les nouveaux termes, vous n'êtes plus autorisé à utiliser notre service.",
-          "title": "Modifications de l'Accord"
-        },
-        "arbitrateTerms": {
-          "content": "Cet Accord et tout litige ou réclamation découlant de, ou lié à, celui-ci, son interprétation, ou la violation, résiliation ou validité de celui-ci, les relations qui résultent de cet Accord, y compris l'exécution, la violation ou la validité de cet Accord, seront régis par les lois de la Roumanie. La juridiction et le lieu exclusifs pour toute action en vertu de cet Accord seront les tribunaux situés en Roumanie et vous vous soumettez par les présentes à la juridiction personnelle de ces tribunaux. Vous renoncez par les présentes à tout droit à un procès devant jury dans toute procédure découlant de ou liée à cet Accord. La Convention des Nations Unies sur les Contrats de Vente Internationale de Marchandises ne s'applique pas à cet Accord. Le terme « litige » désigne tout litige, action ou autre controverse entre vous et nous concernant les Services ou cet accord, que ce soit en matière de contrat, garantie, délit, loi, règlement, ordonnance ou toute autre base légale ou équitable. « Litige » aura le sens le plus large possible autorisé par la loi.",
-          "title": "Arbitrage"
-        },
-        "changesToTos": {
-          "content": "AROLARIU.RO se réserve le droit de modifier ces Conditions de Service à tout moment. Nous vous recommandons cependant de lire cette page régulièrement pour vous assurer que vous êtes au courant de tout changement. Votre utilisation continue du site web suite à la publication de modifications signifiera que vous acceptez et êtes d'accord avec les modifications. Vous reconnaissez et acceptez que nous pouvons arrêter (de façon permanente ou temporaire) de fournir le Service (ou toute fonctionnalité au sein du Service) à vous ou aux utilisateurs en général à notre seule discrétion, sans préavis. Vous pouvez cesser d'utiliser le Service à tout moment. Vous n'avez pas besoin de nous informer spécifiquement lorsque vous cessez d'utiliser le Service. Vous reconnaissez et acceptez que si nous désactivons l'accès à votre compte, vous pouvez être empêché d'accéder au Service, aux détails de votre compte ou à tout fichier ou autre matériel contenu dans votre compte",
-          "title": "Modifications des Conditions de Service"
-        },
-        "consentTerms": {
-          "content": "Nous avons mis à jour nos Termes et Conditions pour vous fournir une transparence complète sur ce qui est défini lorsque vous visitez notre site et comment il est utilisé. En utilisant notre site web, vous consentez par les présentes à nos Conditions de Service et acceptez les Termes et Conditions.",
-          "title": "Votre Consentement"
-        },
-        "cookiesTerms": {
-          "content": "Nous utilisons des 'Cookies' pour identifier les zones de notre site web que vous avez visitées. Un Cookie est un petit fichier de données stocké sur votre ordinateur ou appareil mobile par votre navigateur web. Nous utilisons des Cookies pour améliorer les performances et la fonctionnalité de notre service mais ils ne sont pas essentiels à leur utilisation. Cependant, sans ces cookies, certaines fonctionnalités comme les vidéos peuvent devenir indisponibles ou vous seriez obligé de saisir vos identifiants de connexion chaque fois que vous visitez notre plateforme car nous ne pourrions pas nous souvenir que vous vous étiez connecté précédemment. La plupart des navigateurs web peuvent être configurés pour désactiver l'utilisation des Cookies. Cependant, si vous désactivez les Cookies, vous pourriez ne pas être en mesure d'accéder correctement ou pas du tout aux fonctionnalités de notre site web. Nous ne plaçons jamais d'informations personnellement identifiables dans les Cookies.",
-          "title": "Cookies"
-        },
-        "copyrightTerms": {
-          "content": "Si vous êtes titulaire de droits d'auteur ou l'agent de ce titulaire et que vous croyez qu'un matériel de notre part constitue une violation de vos droits d'auteur, veuillez nous contacter en fournissant les informations suivantes : (a) une signature physique ou électronique du titulaire des droits d'auteur ou d'une personne autorisée à agir en son nom ; (b) l'identification du matériel présumé contrefaisant ; (c) vos coordonnées, y compris votre adresse, numéro de téléphone et email ; (d) une déclaration de votre part indiquant que vous croyez de bonne foi que l'utilisation du matériel n'est pas autorisée par les titulaires des droits d'auteur ; et (e) une déclaration que les informations dans la notification sont exactes, et, sous peine de parjure, que vous êtes autorisé à agir au nom du titulaire.",
-          "title": "Protection des Droits d'Auteur"
-        },
-        "definitionTerms": {
-          "content": "Les termes 'nous' ou 'notre' font référence à AROLARIU.RO, le propriétaire du site web. Un client est la personne ou l'organisation qui achète ou accepte d'acheter le produit. Notre 'produit' fait référence au site web, aux produits ou aux services proposés à la vente sur notre site web. Un 'utilisateur' est une personne qui utilise notre site web ou nos services. Le terme 'vous' fait référence à l'utilisateur ou au visiteur de notre site web.",
-          "title": "Définitions"
-        },
-        "disclaimerTerms": {
-          "content": "Dans la mesure maximale permise par la loi applicable, nous excluons toutes les déclarations, garanties et conditions relatives à notre site web et à l'utilisation de ce site web. Nous ne serons pas responsables des dommages résultant de l'utilisation ou de l'incapacité d'utiliser les matériaux sur le site web d'AROLARIU.RO, même si AROLARIU.RO ou un représentant autorisé d'AROLARIU.RO a été informé, oralement ou par écrit, de la possibilité de tels dommages. Parce que certaines juridictions n'autorisent pas les limitations sur les garanties implicites, ou les limitations de responsabilité pour les dommages consécutifs ou accessoires, ces limitations peuvent ne pas s'appliquer à vous. Nous ne sommes pas responsables du contenu, du code ou de toute autre imprécision. Nous ne fournissons pas de garanties. En aucun cas, nous ne serons responsables de dommages spéciaux, directs, indirects, consécutifs ou accessoires ou de tout dommage quel qu'il soit, que ce soit dans une action contractuelle, par négligence ou autre délit, découlant de ou en relation avec l'utilisation du Service ou du contenu du Service. Nous nous réservons le droit d'effectuer des ajouts, des suppressions ou des modifications au contenu du Service à tout moment sans préavis. Notre Service et son contenu sont fournis 'EN L'ÉTAT' et 'SELON DISPONIBILITÉ' sans aucune garantie ou représentation d'aucune sorte, qu'elle soit expresse ou implicite. Nous sommes un distributeur et non un éditeur du contenu fourni par des tiers ; en tant que tel, nous n'exerçons aucun contrôle éditorial sur ce contenu et ne faisons aucune garantie ou représentation quant à l'exactitude, la fiabilité ou l'actualité de toute information, contenu, service ou marchandise fourni par ou accessible via notre Service. Sans limiter ce qui précède, nous déclinons spécifiquement toutes les garanties et représentations dans tout contenu transmis sur ou en relation avec notre Service ou sur des sites qui peuvent apparaître comme des liens sur notre Service, ou dans les produits fournis dans le cadre de, ou autrement en relation avec, notre Service, y compris sans limitation toute garantie de qualité marchande, d'adéquation à un usage particulier ou de non-violation des droits de tiers. Aucun conseil oral ou information écrite donnée par nous ou par l'un de ses affiliés, employés, dirigeants, directeurs, agents, ou similaires ne créera une garantie. Les informations sur les prix et la disponibilité sont sujettes à modification sans préavis. Sans limiter ce qui précède, nous ne garantissons pas que notre Service sera ininterrompu, non corrompu, opportun ou sans erreur.",
-          "title": "Avertissement"
-        },
-        "disputeNoticeTerms": {
-          "content": "En cas de litige, vous ou AROLARIU.RO devez donner à l'autre un Avis de Litige, qui est une déclaration écrite indiquant le nom, l'adresse et les coordonnées de la partie qui le donne, les faits donnant lieu au litige et le recours demandé. Vous devez envoyer tout Avis de Litige par email à : admin@arolariu.ro. AROLARIU.RO vous enverra tout Avis de Litige par courrier à votre adresse si nous l'avons, ou sinon à votre adresse email. Vous et AROLARIU.RO tenterez de résoudre tout litige par négociation informelle dans les soixante (60) jours à compter de la date d'envoi de l'Avis de Litige. Après soixante (60) jours, vous ou AROLARIU.RO pouvez engager un arbitrage.",
-          "title": "Avis de Litige"
-        },
-        "entireAgreementTerms": {
-          "content": "Les Conditions de Service constituent l'intégralité de l'accord entre vous et AROLARIU.RO concernant votre utilisation du service et remplacent tous les accords écrits ou oraux antérieurs et contemporains entre vous et AROLARIU.RO. Vous pouvez être soumis à des termes et conditions supplémentaires qui s'appliquent lorsque vous utilisez ou achetez d'autres services d'AROLARIU.RO, qu'AROLARIU.RO vous fournira au moment d'une telle utilisation ou d'un tel achat.",
-          "title": "Accord Intégral"
-        },
-        "generalTerms": {
-          "content": "En accédant et en passant une commande auprès d'AROLARIU.RO, vous confirmez que vous êtes en accord avec et lié par les conditions de service contenues dans les Termes et Conditions décrits ci-dessous. Ces termes s'appliquent à l'ensemble du site web et à tout email ou autre type de communication entre vous et AROLARIU.RO. En aucun cas l'équipe AROLARIU.RO ne sera responsable de dommages directs, indirects, spéciaux, accessoires ou consécutifs, y compris, mais sans s'y limiter, la perte de données ou de profit, découlant de l'utilisation, ou de l'incapacité d'utiliser, les matériaux sur ce site, même si l'équipe AROLARIU.RO ou un représentant autorisé a été informé de la possibilité de tels dommages. Si votre utilisation des matériaux de ce site entraîne le besoin d'entretien, de réparation ou de correction d'équipement ou de données, vous assumez tous les coûts y afférents. AROLARIU.RO ne sera pas responsable de tout résultat qui pourrait survenir au cours de l'utilisation de nos ressources. Nous nous réservons le droit de modifier les prix et de réviser la politique d'utilisation des ressources à tout moment.",
-          "title": "Conditions Générales"
-        },
-        "liabilityTerms": {
-          "content": "Dans la mesure la plus complète permise par la loi applicable, en aucun cas AROLARIU.RO ne sera responsable envers vous sur quelque théorie juridique que ce soit pour tout dommage accessoire, direct, indirect, punitif, réel, consécutif, spécial, exemplaire ou autre, y compris sans limitation, la perte de revenus ou de bénéfices, les profits perdus, la douleur et la souffrance, la détresse émotionnelle, le coût des biens ou services de substitution, ou des dommages similaires subis ou encourus par vous ou tout tiers qui surviennent en relation avec le service (ou sa résiliation pour quelque raison que ce soit), même si AROLARIU.RO a été informé de la possibilité de tels dommages. AROLARIU.RO ne sera pas responsable de tout dommage, responsabilité ou perte découlant de : (i) votre utilisation ou votre confiance dans le service ou votre incapacité à accéder ou à utiliser le service ; ou (ii) toute transaction ou relation entre vous et tout fournisseur tiers, même si AROLARIU.RO a été informé de la possibilité de tels dommages. AROLARIU.RO ne sera pas responsable de tout retard ou défaut d'exécution résultant de causes échappant au contrôle raisonnable d'AROLARIU.RO. Vous reconnaissez que le service peut être soumis à des limitations, des retards et d'autres problèmes inhérents à l'utilisation d'internet et des communications électroniques. AROLARIU.RO n'est pas responsable des retards, des échecs de livraison ou d'autres dommages résultant de tels problèmes. Dans la mesure maximale permise par la loi applicable, en aucun cas nous ou nos fournisseurs ne serons responsables de dommages spéciaux, accessoires, indirects ou consécutifs quels qu'ils soient (y compris, mais sans s'y limiter, les dommages pour perte de profits, pour perte de données ou d'autres informations, pour interruption d'activité, pour blessure personnelle, pour perte de vie privée découlant de ou de quelque manière que ce soit liée à l'utilisation ou à l'incapacité d'utiliser le service, les logiciels tiers et/ou le matériel tiers utilisé avec le service, ou autrement en relation avec toute disposition du présent Accord), même si nous ou tout fournisseur avons été informés de la possibilité de tels dommages et même si le recours échoue dans son objectif essentiel. Certains états/juridictions n'autorisent pas l'exclusion ou la limitation des dommages accessoires ou consécutifs, de sorte que la limitation ou l'exclusion ci-dessus peut ne pas s'appliquer à vous.",
-          "title": "Limitation de Responsabilité"
-        },
-        "licenseTerms": {
-          "content": "En achetant un produit d'AROLARIU.RO, vous recevez une licence non exclusive et non transférable pour accéder au produit. Le produit est destiné à un usage personnel et commercial. Vous êtes autorisé à installer le produit sur plus d'un ordinateur ou appareil, mais vous n'êtes pas autorisé à partager le produit avec d'autres personnes. Vous ne pouvez pas modifier, adapter, traduire, rétro-concevoir, décompiler, désassembler ou créer des œuvres dérivées basées sur le produit sans le consentement écrit préalable d'AROLARIU.RO. Vous ne pouvez pas vendre, louer, donner en location ou sous-licencier le produit. Vous ne pouvez pas rendre le produit disponible sur un réseau où il pourrait être utilisé par plusieurs appareils en même temps. Vous ne pouvez pas utiliser le produit pour enfreindre tout droit d'auteur ou marque de commerce. Vous ne pouvez pas utiliser le produit pour créer tout matériel qui est illégal, nuisible, menaçant, abusif, harcelant, délictueux, diffamatoire, vulgaire, obscène, calomnieux, envahissant la vie privée d'autrui, haineux, ou racialement, ethniquement ou autrement répréhensible.",
-          "title": "Conditions de Licence"
-        },
-        "linksToOtherSitesTerms": {
-          "content": "Notre service peut contenir des liens vers d'autres sites web qui ne sont pas exploités par nous. Si vous cliquez sur un lien tiers, vous serez dirigé vers le site de ce tiers. Nous vous conseillons fortement de consulter les Termes et Conditions de chaque site que vous visitez. Nous n'avons aucun contrôle sur et n'assumons aucune responsabilité pour le contenu, les Termes et Conditions ou les pratiques de tout site ou service tiers.",
-          "title": "Liens vers d'Autres Sites Web"
-        },
-        "miscellaneousTerms": {
-          "content": "Si, pour quelque raison que ce soit, un tribunal compétent juge qu'une disposition ou une partie de ces Termes et Conditions est inapplicable, le reste de ces Termes et Conditions continuera de s'appliquer pleinement. Toute renonciation à une disposition de ces Termes et Conditions ne sera effective que si elle est écrite et signée par un représentant autorisé de notre part. Nous aurons droit à une injonction ou à une autre réparation équitable (sans obligation de fournir une caution ou une garantie) en cas de violation ou de violation anticipée de votre part. Nous exploitons et contrôlons notre Service depuis nos bureaux en Roumanie. Le Service n'est pas destiné à être distribué ou utilisé par toute personne ou entité dans une juridiction ou un pays où une telle distribution ou utilisation serait contraire à la loi ou à la réglementation. En conséquence, les personnes qui choisissent d'accéder à notre Service depuis d'autres emplacements le font de leur propre initiative et sont seules responsables de la conformité aux lois locales, si et dans la mesure où les lois locales sont applicables. Ces Termes et Conditions (qui incluent et incorporent notre Politique de Confidentialité) contiennent l'intégralité de l'accord, et remplacent tous les accords antérieurs, entre vous et nous concernant son objet, et ne peuvent pas être modifiés par vous. Les titres de section utilisés dans cet Accord sont à des fins de commodité uniquement et n'auront aucune portée juridique. Le fait qu'une partie n'exerce pas à quelque égard que ce soit tout droit prévu aux présentes ne sera pas considéré comme une renonciation à d'autres droits en vertu des présentes. AROLARIU.RO ne sera pas responsable de tout manquement à l'exécution de ses obligations en vertu des présentes lorsqu'un tel manquement résulte d'une cause",
-          "title": "Divers"
-        },
-        "noWarrantiesTerms": {
-          "content": "Ce site web est fourni 'tel quel', avec tous ses défauts, et AROLARIU.RO ne fait aucune déclaration ou garantie expresse ou implicite, de quelque nature que ce soit, liée à ce site web ou aux matériaux contenus sur ce site web. De plus, rien de ce qui est contenu sur ce site web ne doit être interprété comme vous fournissant des conseils ou un avis. Le service vous est fourni 'EN L'ÉTAT' et 'SELON DISPONIBILITÉ' et avec tous les défauts et imperfections sans garantie d'aucune sorte. Dans la mesure maximale permise par la loi applicable, nous, en notre propre nom et au nom de nos affiliés et de nos concédants de licence et prestataires de services respectifs, déclinons expressément toutes les garanties, qu'elles soient expresses, implicites, statutaires ou autres, concernant le service, y compris toutes les garanties implicites de qualité marchande, d'adéquation à un usage particulier, de titre et de non-contrefaçon, et les garanties qui peuvent découler des usages commerciaux, de l'exécution, de l'utilisation ou de la pratique commerciale. Sans limitation de ce qui précède, nous ne fournissons aucune garantie ou engagement, et ne faisons aucune déclaration d'aucune sorte que le service répondra à vos exigences, atteindra les résultats prévus, sera compatible ou fonctionnera avec tout autre logiciel, site web, système ou service, fonctionnera sans interruption, répondra à toute norme de performance ou de fiabilité ou sera exempt d'erreurs ou que toute erreur ou défaut puisse ou sera corrigé. Sans limiter ce qui précède, ni nous ni aucun fournisseur ne faisons de déclaration ou de garantie d'aucune sorte, expresse ou implicite : (i) quant au fonctionnement ou à la disponibilité du service, ou aux informations, contenus et matériaux ou produits qui y sont inclus ; (ii) que le service sera ininterrompu ou sans erreur ; (iii) quant à l'exactitude, la fiabilité ou l'actualité de toute information ou contenu fourni par le service ; ou (iv) que le service, ses serveurs, le contenu ou les e-mails envoyés par nous ou en notre nom sont exempts de virus, scripts, chevaux de Troie, vers, logiciels malveillants, bombes à retardement ou autres composants nuisibles. Certaines juridictions n'autorisent pas l'exclusion ou les limitations sur les garanties implicites ou les limitations sur les droits statutaires applicables d'un consommateur, de sorte que certaines ou toutes les exclusions et limitations ci-dessus peuvent ne pas s'appliquer à vous.",
-          "title": "Absence de Garanties"
-        },
-        "promotionTerms": {
-          "content": "Nous pouvons, de temps à autre, inclure des concours, des promotions, des tirages au sort ou d'autres activités (« Promotions ») qui vous obligent à soumettre du matériel ou des informations vous concernant. Veuillez noter que toutes les Promotions peuvent être régies par des règles distinctes qui peuvent contenir certaines conditions d'éligibilité, telles que des restrictions d'âge et de situation géographique. Vous êtes responsable de lire toutes les règles des Promotions pour déterminer si vous êtes éligible ou non à participer. Si vous participez à une Promotion, vous acceptez de respecter et de vous conformer à toutes les Règles des Promotions. Des termes et conditions supplémentaires peuvent s'appliquer aux achats de biens ou de services sur ou via les Services, ces termes et conditions faisant partie intégrante du présent Accord par cette référence. Toute promotion rendue disponible via le service peut être régie par des règles distinctes de ces Termes. Si vous participez à des promotions, veuillez consulter les règles applicables ainsi que notre Politique de Confidentialité. Si les règles d'une promotion entrent en conflit avec ces Termes, les règles de la promotion s'appliqueront.",
-          "title": "Promotions"
-        },
-        "restrictionTerms": {
-          "content": "Il vous est spécifiquement interdit de publier, vendre, sous-licencier ou autrement commercialiser tout matériel du site web ; d'utiliser ce site web de toute manière qui est ou pourrait être préjudiciable à ce site web ; d'utiliser ce site web de toute manière qui affecte l'accès des utilisateurs à ce site web ; d'utiliser ce site web contrairement aux lois et réglementations applicables, ou de toute manière susceptible de causer un préjudice au site web, ou à toute personne ou entité commerciale ; de s'engager dans toute exploration de données, récolte de données, extraction de données ou toute autre activité similaire en relation avec ce site web ; d'utiliser ce site web pour s'engager dans toute publicité ou marketing.",
-          "title": "Restrictions"
-        },
-        "severabilityTerms": {
-          "content": "Si une disposition de ces Termes est jugée inapplicable ou invalide, cette disposition sera modifiée et interprétée pour accomplir les objectifs de cette disposition dans la mesure la plus large possible en vertu de la loi applicable et les dispositions restantes continueront de s'appliquer pleinement. Cet Accord, avec la Politique de Confidentialité et tout autre avis juridique publié par nous sur les Services, constituera l'intégralité de l'accord entre vous et nous concernant les Services. Si une disposition du présent Accord est jugée invalide par un tribunal compétent, l'invalidité de cette disposition n'affectera pas la validité des dispositions restantes du présent Accord, qui resteront pleinement en vigueur. Aucune renonciation à un terme de cet Accord ne sera considérée comme une renonciation supplémentaire ou continue à ce terme ou à tout autre terme, et notre défaut de faire valoir tout droit ou disposition en vertu du présent Accord ne constituera pas une renonciation à ce droit ou à cette disposition. VOUS ET NOUS CONVENONS QUE TOUTE CAUSE D'ACTION DÉCOULANT DE OU LIÉE AUX SERVICES DOIT COMMENCER DANS L'ANNÉE (1) SUIVANT L'ACCUMULATION DE LA CAUSE D'ACTION. SINON, UNE TELLE CAUSE D'ACTION EST DÉFINITIVEMENT IRRECEVABLE.",
-          "title": "Divisibilité"
-        },
-        "submissionsAndPrivacyTerms": {
-          "content": "Lorsque vous visitez le site web ou nous envoyez des e-mails, vous communiquez avec nous électroniquement. Vous consentez à recevoir des communications de notre part par voie électronique. Nous communiquerons avec vous par e-mail ou en publiant des avis sur le site web. Vous acceptez que tous les accords, avis, divulgations et autres communications que nous fournissons électroniquement satisfont toute exigence légale que ces communications soient par écrit. AROLARIU.RO peut, mais n'est pas obligé de, surveiller, examiner ou modifier le Contenu Utilisateur. Dans tous les cas, AROLARIU.RO se réserve le droit de supprimer ou de désactiver l'accès à tout Contenu Utilisateur pour quelque raison que ce soit ou sans raison, y compris, mais sans s'y limiter, le Contenu Utilisateur qui, à la seule discrétion d'AROLARIU.RO, viole les Accords. AROLARIU.RO peut prendre ces mesures sans notification préalable à vous ou à un tiers. La suppression ou la désactivation de l'accès au Contenu Utilisateur sera à notre seule discrétion, et nous ne promettons pas de supprimer ou de désactiver l'accès à tout Contenu Utilisateur spécifique. Dans le cas où vous soumettez ou publiez des idées, suggestions créatives, designs, photographies, informations, publicités, données ou propositions, y compris des idées pour des produits, services, fonctionnalités, technologies ou promotions nouveaux ou améliorés, vous acceptez expressément que ces soumissions seront automatiquement traitées comme non confidentielles et non propriétaires et deviendront notre propriété exclusive sans aucune compensation ni crédit à vous. Nous et nos affiliés n'aurons aucune obligation concernant ces soumissions ou publications et pourrons utiliser les idées contenues dans ces soumissions ou publications à toutes fins dans tout média à perpétuité, y compris, mais sans s'y limiter, le développement, la fabrication et la commercialisation de produits et services utilisant ces idées.",
-          "title": "Soumissions et Confidentialité"
-        },
-        "terminationTerms": {
-          "content": "Nous pouvons résilier ou suspendre votre compte et interdire l'accès au service immédiatement, sans préavis ni responsabilité, à notre seule discrétion, pour quelque raison que ce soit et sans limitation, y compris, mais sans s'y limiter, une violation des Termes. Si vous souhaitez résilier votre compte, vous pouvez simplement cesser d'utiliser le service. Toutes les dispositions des Termes qui par leur nature devraient survivre à la résiliation survivront à la résiliation, y compris, sans limitation, les dispositions relatives à la propriété, les exclusions de garantie, l'indemnisation et les limitations de responsabilité.",
-          "title": "Résiliation"
-        },
-        "thirdPartyTerms": {
-          "content": "En utilisant le service, vous pouvez utiliser des services, produits, logiciels, intégrations ou applications tiers développés par un tiers ('Services Tiers'). Toute utilisation d'un Service Tiers est à vos propres risques, et nous ne serons pas responsables envers quiconque pour les sites web ou Services Tiers. Vous reconnaissez et acceptez que nous ne serons pas responsables de tout dommage ou perte causé ou prétendument causé par ou en relation avec l'utilisation de tout contenu, bien ou service disponible sur ou via de tels sites web ou services. Nous n'assumons et n'aurons aucune responsabilité envers vous ou toute autre personne ou entité pour tout Service Tiers. Les Services Tiers et les liens sont donc fournis uniquement pour votre commodité et vous y accédez et les utilisez entièrement à vos propres risques et sous réserve des termes et conditions de ces tiers.",
-          "title": "Services Tiers"
-        },
-        "typographyErrorsTerms": {
-          "content": "Dans le cas où un produit AROLARIU.RO est par erreur affiché à un prix incorrect, AROLARIU.RO se réserve le droit de refuser ou d'annuler toute commande passée pour le produit affiché au prix incorrect. AROLARIU.RO se réserve le droit de refuser ou d'annuler toute commande de ce type, que la commande ait été confirmée ou non et que votre carte de crédit ait été débitée ou non. Si votre carte de crédit a déjà été débitée pour l'achat et que votre commande est annulée, AROLARIU.RO émettra un crédit sur votre compte de carte de crédit du montant du prix incorrect.",
-          "title": "Erreurs Typographiques"
-        },
-        "updateOfServicesTerms": {
-          "content": "AROLARIU.RO met constamment à jour ses services, ce qui signifie que nous pouvons ajouter ou supprimer des fonctionnalités, des produits ou des fonctionnalités, et nous pouvons également suspendre ou arrêter complètement le service. Nous pouvons prendre n'importe laquelle de ces mesures à tout moment, et lorsque nous le faisons, nous pouvons ne pas vous fournir de préavis. Vous reconnaissez qu'AROLARIU.RO peut établir des pratiques générales et des limites concernant l'utilisation du service, y compris sans limitation la période maximale pendant laquelle les données ou autres contenus seront conservés par le service et l'espace de stockage maximal qui sera alloué sur les serveurs d'AROLARIU.RO en votre nom. Vous acceptez qu'AROLARIU.RO n'a aucune responsabilité pour la suppression ou l'échec de stockage de toute donnée ou autre contenu maintenu ou téléchargé par le service. Vous reconnaissez qu'AROLARIU.RO se réserve le droit de résilier les comptes inactifs pendant une période prolongée. Vous acceptez que nous n'avons aucune obligation de (i) fournir des Mises à jour, ou (ii) continuer à fournir ou activer des fonctionnalités et/ou fonctionnalités particulières du service pour vous. Vous acceptez en outre que toutes les Mises à jour seront (i) considérées comme faisant partie intégrante du service, et (ii) soumises aux termes et conditions du présent Accord.",
-          "title": "Mises à Jour du Service"
-        },
-        "waiverTerms": {
-          "content": "Sauf disposition contraire des présentes, le fait de ne pas exercer un droit ou d'exiger l'exécution d'une obligation en vertu du présent Accord n'affectera pas la capacité d'une partie à exercer ce droit ou à exiger cette exécution à tout moment par la suite, et la renonciation à une violation ne constituera pas une renonciation à toute violation ultérieure. Aucun manquement à exercer, et aucun retard dans l'exercice, de la part de l'une ou l'autre partie, de tout droit ou pouvoir en vertu du présent Accord ne fonctionnera comme une renonciation à ce droit ou pouvoir. L'exercice unique ou partiel d'un droit ou d'un pouvoir en vertu du présent Accord n'empêchera pas non plus l'exercice ultérieur de ce droit ou de tout autre droit accordé aux présentes. En cas de conflit entre le présent Accord et tout achat applicable ou d'autres conditions, les termes du présent Accord prévaudront.",
-          "title": "Renonciation"
+      "services": {
+        "callToAction": "Visiter ce service de domaine",
+        "invoices": {
+          "card": {
+            "description": "Ce service de l'espace de domaine aide à la transformation numérique des reçus physiques. Il permet aux utilisateurs de télécharger des reçus et d'obtenir des informations soigneusement élaborées sur leurs habitudes de dépenses.",
+            "imageAlt": "Illustration du système de gestion des factures montrant la numérisation des reçus",
+            "title": "Système de Gestion des Factures"
+          }
         }
       },
-      "title": "Conditions de Service"
-    }
-  },
-  "Navigation": {
-    "about": "À propos",
-    "domains": "Domaines",
-    "invoices": "Factures",
-    "mobile": {
-      "closeNavigation": "Fermer la navigation",
-      "openNavigation": "Ouvrir la navigation",
-      "title": "Navigation"
+      "subtitle": "La plateforme <code>arolariu.ro</code> offre une large gamme de services sous son parapluie. <br></br> La plupart des services nécessitent que vous ayez un compte créé sur cette plateforme, afin que vos données puissent être synchronisées en toute sécurité entre tous les services du domaine. <br></br> <br></br> Ici vous pouvez voir une vitrine de tous les services de domaine disponibles pour l'exploration.",
+      "title": "Services de l'Espace de Domaine"
     },
-    "myInvoices": "Mes Factures",
-    "myProfile": "Mon Profil",
-    "theAuthor": "L'Auteur",
-    "thePlatform": "La Plateforme",
-    "uploadScans": "Télécharger des Scans",
-    "viewScans": "Voir les Scans"
-  },
-  "Profile": {
-    "header": {
-      "completionHint": "Complétez votre profil pour débloquer toutes les fonctionnalités",
-      "daysActive": "jours actifs",
-      "editProfile": "Modifier le Profil",
-      "editProfileClerkNote": "Les informations du profil sont gérées via Clerk. Cliquez ci-dessous pour mettre à jour vos détails.",
-      "editProfileDescription": "Mettez à jour vos informations de profil",
-      "editProfileTitle": "Modifier le Profil",
-      "manageOnClerk": "Gérer sur Clerk",
-      "memberSince": "Membre depuis {date}",
-      "premium": "Premium",
-      "profileCompletion": "Complétion du Profil",
-      "userId": "ID Utilisateur"
-    },
-    "island": {
-      "merchants": "{count} commerçants",
-      "scans": "{count} numérisations",
-      "settingsNavigationAriaLabel": "Navigation des paramètres",
-      "totalInvoices": "Total factures"
-    },
-    "metadata": {
-      "description": "Gérez les paramètres et préférences de votre compte",
-      "title": "Mon Profil"
-    },
-    "settings": {
-      "ai": {
-        "behavior": {
-          "description": "Choisissez comment l'IA répond",
-          "title": "Préréglage de Comportement"
+    "home": {
+      "appreciation": "MERCI POUR LE TEMPS PASSÉ SUR LE SITE WEB.",
+      "cta": "Commencer l'Exploration",
+      "featuresTab": {
+        "azure": {
+          "description": "Le cloud Microsoft Azure est utilisé pour héberger la plateforme et tous ses services. Cela garantit que la plateforme est toujours disponible et qu'elle peut évoluer à la demande.",
+          "title": "Microsoft Azure"
         },
-        "description": "Configurez le comportement et les préférences de votre assistant IA",
+        "csharp": {
+          "description": "La plateforme est construite avec .NET 8 LTS - la dernière version stable de .NET. Cela garantit que la plateforme est rapide, fiable et facile à utiliser. La plateforme est construite avec C# et F#.",
+          "title": ".NET 8 LTS"
+        },
+        "description": "La plateforme `arolariu.ro` est construite avec les dernières technologies stables.",
+        "githubActions": {
+          "description": "L'expérience DevOps est alimentée par GitHub Actions. (CI/CD, Tests, etc.)",
+          "title": "GitHub Actions"
+        },
+        "learnMoreBtn": "Intéressant ? Cliquez ici pour en savoir plus...",
+        "nextJs": {
+          "description": "La plateforme est construite avec NextJS - le framework React le plus populaire pour la production. Il est conçu pour des applications React de niveau production. NextJS est le framework React le plus populaire pour une bonne raison : il est rapide, fiable et facile à utiliser.",
+          "title": "Next.JS 15"
+        },
+        "otel": {
+          "description": "Observabilité complète avec métriques, traces et logs intégrés. Tout est instrumenté avec OpenTelemetry. Cela permet une expérience de télémétrie unifiée sur toute la ligne. (3PO : métriques, logs, traces)",
+          "title": "Open Telemetry"
+        },
+        "svelte": {
+          "description": "Utilisation de Svelte pour des composants UI réactifs ultra-rapides. La plateforme `cv.arolariu.ro` est construite exclusivement avec Svelte et SvelteKit (v5)",
+          "title": "Svelte"
+        },
+        "title": "Fonctionnalités Clés"
+      },
+      "subtitle": "Cette plateforme a été construite par Alexandru-Razvan Olariu comme terrain de jeu pour les nouvelles technologies. La plateforme est construite avec des technologies de pointe et de niveau entreprise. <br> </br> <br> </br> Vous êtes invité à explorer toutes les applications et services hébergés sur cet espace de domaine.",
+      "technologyTab": {
+        "badgeTitle": "Architecture Moderne",
+        "description": "Cette plateforme exploite les dernières technologies web, combinant Next.js pour le frontend avec .NET pour des services backend robustes, le tout déployé sur Microsoft Azure.",
+        "learnMoreBtn": "Explorer l'Architecture",
+        "points": {
+          "point1": "Architecture serverless pour une mise à l'échelle et des performances optimales",
+          "point2": "TypeScript full-stack pour la sécurité des types dans toute l'application",
+          "point3": "Télémétrie et surveillance complètes avec OpenTelemetry"
+        },
+        "title": "Construit pour l'Avenir."
+      },
+      "title": "Bienvenue sur arolariu.ro"
+    },
+    "invoices": {
+      "editInvoice": {
+        "changeHistory": {
+          "changes": {
+            "categoryUpdated": "Catégorie mise à jour",
+            "descriptionChanged": "Description modifiée",
+            "importanceChanged": "Importance modifiée",
+            "markedImportant": "Marqué comme important",
+            "nameChanged": "Nom modifié",
+            "paymentTypeChanged": "Type de paiement modifié",
+            "transactionDateChanged": "Date de transaction modifiée",
+            "unmarkedImportant": "Retiré des favoris"
+          },
+          "created": "Facture créée",
+          "modified": "Dernière modification",
+          "pending": "En attente",
+          "time": {
+            "daysAgo": "il y a {days} jours",
+            "hoursAgo": "il y a {hours} heures",
+            "justNow": "À l'instant",
+            "minutesAgo": "il y a {minutes} minutes",
+            "secondsAgo": "il y a {seconds} secondes"
+          },
+          "title": "Historique des modifications",
+          "unsavedChanges": "Modifications non enregistrées"
+        },
+        "editInvoiceContext": {
+          "console": {
+            "saveFailed": "Échec de l’enregistrement de la facture :"
+          },
+          "toasts": {
+            "noChanges": "Aucune modification à enregistrer",
+            "saveFailed": "Échec de l’enregistrement des modifications",
+            "updated": "Facture mise à jour avec succès"
+          }
+        },
+        "guidedEditBanner": {
+          "actions": {
+            "dismiss": "Fermer",
+            "reviewAll": "Tout réviser"
+          },
+          "badges": {
+            "lowConfidence": "{count, plural, one {# faible confiance} other {# faible confiance}}",
+            "missingName": "{count, plural, one {# nom manquant} other {# noms manquants}}",
+            "uncategorized": "{count, plural, one {# non catégorisé} other {# non catégorisés}}"
+          },
+          "summary": {
+            "lowConfidence": "{count, plural, one {# faible confiance} other {# faible confiance}}",
+            "missingName": "{count, plural, one {# nom manquant} other {# noms manquants}}",
+            "uncategorized": "{count, plural, one {# non catégorisé} other {# non catégorisés}}"
+          },
+          "title": "{count, plural, one {# produit nécessite une révision} other {# produits nécessitent une révision}}"
+        },
+        "itemsTable": {
+          "actions": {
+            "editAllergens": "Modifier les allergènes",
+            "remove": "Supprimer l'article",
+            "restore": "Restaurer l'article"
+          },
+          "bulkCategory": {
+            "noSelection": "Veuillez sélectionner au moins un produit"
+          },
+          "bulkToolbar": {
+            "changeCategory": "Changer de catégorie",
+            "deleteSelected": "Supprimer la sélection",
+            "noSelection": "Aucun produit sélectionné",
+            "selectedCount": "{count, plural, one {# article sélectionné} other {# articles sélectionnés}}"
+          },
+          "buttons": {
+            "addItem": "Ajouter un article",
+            "editItems": "Modifier les articles"
+          },
+          "columns": {
+            "actions": "Actions",
+            "name": "Nom",
+            "price": "Prix",
+            "quantity": "Quantité",
+            "selectAll": "Tout sélectionner",
+            "selectRow": "Sélectionner {name}",
+            "total": "Total",
+            "unit": "Unité"
+          },
+          "deleteConfirm": {
+            "cancel": "Annuler",
+            "confirm": "Supprimer",
+            "description": "{count, plural, one {Êtes-vous sûr de vouloir supprimer cet article ?} other {Êtes-vous sûr de vouloir supprimer # articles ?}}",
+            "success": "{count, plural, one {# article supprimé} other {# articles supprimés}}",
+            "title": "Supprimer les articles"
+          },
+          "editing": {
+            "cancel": "Modification annulée",
+            "fieldLabel": "Modifier {field} pour {name}",
+            "saved": "Article mis à jour avec succès"
+          },
+          "footer": {
+            "total": "Total"
+          },
+          "indicators": {
+            "allergens": "{count, plural, one {# allergène} other {# allergènes}}",
+            "edited": "Modifié",
+            "editedTooltip": "Ce produit a été modifié manuellement",
+            "lowConfidence": "Faible confiance",
+            "lowConfidenceTooltip": "La confiance OCR est de {confidence}% - révision manuelle recommandée",
+            "missingName": "Nom manquant",
+            "missingNameTooltip": "La traduction du nom générique est manquante ou identique au texte OCR brut",
+            "uncategorized": "Non catégorisé",
+            "uncategorizedTooltip": "Ce produit nécessite une catégorie pour un meilleur suivi des dépenses"
+          },
+          "newItem": {
+            "added": "Nouvel article ajouté",
+            "defaultName": "Nouvel article"
+          },
+          "pagination": {
+            "next": "Suivant",
+            "pageOf": "Page {currentPage} sur {totalPages}",
+            "previous": "Précédent",
+            "totalItems": "{count, plural, one {# article au total} other {# articles au total}}"
+          },
+          "restore": {
+            "error": "Échec de la restauration de l'article",
+            "success": "Article {name} restauré"
+          },
+          "search": {
+            "placeholder": "Rechercher des articles..."
+          },
+          "softDelete": {
+            "error": "Échec de la suppression de l'article",
+            "success": "Article {name} supprimé"
+          },
+          "tableHeaders": {
+            "item": "Article",
+            "price": "Prix",
+            "quantity": "Qté",
+            "total": "Total"
+          },
+          "title": "Articles",
+          "tooltips": {
+            "editInvoiceItemsAndQuantities": "Modifier les articles et les quantités de la facture"
+          }
+        },
+        "metadata": {
+          "description": "Consultez et modifiez les détails de votre facture, les articles, les recettes et les paramètres de partage.",
+          "title": "Système de Gestion des Factures - Modifier la Facture"
+        },
+        "metadataTab": {
+          "badges": {
+            "readonly": "Lecture seule"
+          },
+          "buttons": {
+            "addField": "Ajouter un champ",
+            "addFirstMetadataField": "Ajouter votre premier champ de métadonnées"
+          },
+          "dropdown": {
+            "delete": "Supprimer",
+            "edit": "Modifier"
+          },
+          "emptyState": {
+            "noMetadataFields": "Aucun champ de métadonnées ajouté"
+          },
+          "header": {
+            "description": "Métadonnées associées à cette facture",
+            "title": "Informations supplémentaires"
+          },
+          "tooltips": {
+            "addCustomMetadata": "Ajouter des métadonnées personnalisées à cette facture"
+          }
+        },
+        "recipesTab": {
+          "buttons": {
+            "addRecipe": "Ajouter une recette",
+            "createFirstRecipe": "Créer votre première recette",
+            "generate": "Générer"
+          },
+          "emptyState": {
+            "noRecipesAvailable": "Aucune recette disponible pour le moment"
+          },
+          "header": {
+            "description": "Basé sur les articles de cette facture",
+            "title": "Recettes que vous pouvez préparer"
+          },
+          "pagination": {
+            "next": "Suivant",
+            "pageOf": "Page {currentPage} sur {totalPages}",
+            "previous": "Précédent"
+          },
+          "toasts": {
+            "aiGenerationComingSoon": {
+              "description": "Cette fonctionnalité est en cours de développement.",
+              "title": "La génération de recettes par IA arrive bientôt"
+            }
+          },
+          "tooltips": {
+            "createRecipeWithIngredients": "Créer une nouvelle recette avec ces ingrédients",
+            "generateRecipeUsingAi": "Générer une recette avec l'IA !"
+          }
+        },
+        "triviaTips": {
+          "banner": {
+            "hint": "Appliquez ces astuces pour économiser lors de votre prochaine visite chez {merchantName}",
+            "potentialSavingsLabel": "Économies potentielles"
+          },
+          "buttons": {
+            "viewMoreSavingsTips": "Voir plus d'astuces économies"
+          },
+          "completeLabel": "La facture est entièrement complète !",
+          "completeness": "La facture est complète à {percentage}%",
+          "contextActions": {
+            "addDescription": "Ajouter une description",
+            "analyze": "Lancer l'analyse",
+            "setCategory": "Définir la catégorie"
+          },
+          "contextTips": {
+            "defaultCategory": "Changez la catégorie de « Non catégorisé » pour un meilleur suivi",
+            "noCategory": "Définissez une catégorie pour suivre vos habitudes de dépenses",
+            "noDescription": "Ajoutez une description pour vous souvenir de cet achat",
+            "noItems": "Lancez l'analyse IA pour extraire les articles de votre reçu",
+            "noRecipes": "L'IA peut suggérer des recettes basées sur vos articles d'épicerie"
+          },
+          "difficulty": {
+            "easy": "Facile",
+            "medium": "Moyen"
+          },
+          "disclaimer": "Les économies sont des estimations basées sur les prix et promotions moyens",
+          "tips": {
+            "bulkPurchase": {
+              "description": "Achetez les produits non périssables en gros pour réduire le coût unitaire.",
+              "title": "Acheter en gros"
+            },
+            "digitalCoupons": {
+              "description": "Consultez l'application de {merchantName} pour des coupons numériques avant vos achats.",
+              "title": "Utiliser des coupons numériques"
+            },
+            "loyaltyProgram": {
+              "description": "Inscrivez-vous au programme fidélité de {merchantName} pour gagner des points à chaque achat.",
+              "title": "Rejoindre le programme fidélité"
+            }
+          },
+          "title": "Astuces économies",
+          "tooltips": {
+            "estimatedSavings": "Économies estimées avec cette astuce"
+          }
+        }
+      },
+      "landing": {
+        "bento": {
+          "ai": {
+            "description": "Extraction GPT-4",
+            "title": "Alimenté par l'IA"
+          },
+          "analyticsCard": {
+            "description": "Aperçu des dépenses",
+            "title": "Analyse"
+          },
+          "cloud": {
+            "description": "Accès partout",
+            "title": "Sync Cloud"
+          },
+          "description": "Des fonctionnalités puissantes conçues pour rendre la gestion des factures sans effort",
+          "mobile": "Fonctionne parfaitement sur mobile",
+          "ocr": {
+            "description": "Capture auto des données",
+            "title": "OCR Intelligent"
+          },
+          "secure": {
+            "description": "Chiffrement bancaire",
+            "title": "Sécurisé"
+          },
+          "share": {
+            "description": "Collaboration facile",
+            "title": "Partager"
+          },
+          "title": "Tout Ce Dont Vous Avez Besoin"
+        },
+        "cta": {
+          "badges": {
+            "ai": "Alimenté par l'IA",
+            "cloud": "Synchronisé dans le Cloud",
+            "secure": "Sécurisé et Privé"
+          },
+          "description": "Téléchargez votre premier scan et découvrez la magie de la gestion des factures alimentée par l'IA.",
+          "learnMore": "En Savoir Plus",
+          "title": "Prêt à Commencer?",
+          "uploadButton": "Télécharger Votre Premier Scan"
+        },
         "features": {
-          "autoSuggest": "Auto-Suggestion",
-          "autoSuggestHint": "Obtenez des suggestions automatiques pendant que vous travaillez",
-          "contextAwareness": "Conscience du Contexte",
-          "contextAwarenessHint": "L'IA utilise le contexte de vos factures",
-          "description": "Activer ou désactiver les capacités IA",
-          "memory": "Mémoire de Conversation",
-          "memoryHint": "L'IA se souvient des conversations précédentes",
-          "title": "Fonctionnalités IA"
+          "analytics": {
+            "description": "Obtenez des informations détaillées sur vos habitudes de dépenses avec des graphiques et rapports.",
+            "title": "Analyse des Dépenses"
+          },
+          "batch": {
+            "description": "Traitez plusieurs scans à la fois - créez des factures individuelles ou combinez-les en une seule.",
+            "title": "Traitement par Lots"
+          },
+          "description": "Tout ce dont vous avez besoin pour gérer vos factures efficacement",
+          "imageAlt": "Illustration des fonctionnalités des factures",
+          "ocr": {
+            "description": "Notre IA extrait automatiquement les noms des commerçants, dates, montants et articles de vos scans.",
+            "title": "Extraction OCR Intelligente"
+          },
+          "signIn": "Connectez-vous",
+          "signInPrompt": "Connectez-vous pour sauvegarder vos factures de façon permanente et y accéder depuis n'importe quel appareil.",
+          "title": "Fonctionnalités Puissantes"
         },
-        "maxTokens": {
-          "description": "Tokens maximum par réponse",
-          "title": "Longueur de Réponse"
+        "hero": {
+          "description": "Téléchargez vos reçus et factures, organisez-les et obtenez des informations sur vos habitudes de dépenses. Notre système alimenté par l'IA extrait les données automatiquement.",
+          "getStarted": "Commencer",
+          "imageAlt": "Illustration de gestion des factures",
+          "title": "Gérez Vos",
+          "titleHighlight": "Factures",
+          "titleSuffix": "Facilement",
+          "viewMyInvoices": "Voir Mes Factures"
         },
-        "model": {
-          "description": "Sélectionnez le modèle IA pour votre assistant",
-          "title": "Modèle IA"
+        "metadata": {
+          "description": "Gérez vos reçus, créez des factures et obtenez des informations sur vos habitudes de dépenses.",
+          "title": "Système de Gestion des Factures"
         },
-        "temperature": {
-          "creative": "Créatif",
-          "description": "Équilibre entre précision et créativité",
-          "precise": "Précis",
-          "title": "Style de Réponse"
-        },
-        "title": "Paramètres de l'Assistant IA",
-        "voice": {
-          "description": "Configurer l'interaction vocale",
-          "enabled": "Entrée Vocale",
-          "enabledHint": "Utiliser des commandes vocales avec l'IA",
-          "title": "Paramètres Vocaux"
+        "workflow": {
+          "description": "Trois étapes simples pour numériser et organiser vos documents financiers",
+          "step1": {
+            "button": "Télécharger",
+            "description": "Glissez-déposez vos reçus, factures ou notes. Nous acceptons les fichiers JPG, PNG et PDF jusqu'à 10 Mo chacun.",
+            "title": "Télécharger des Scans"
+          },
+          "step2": {
+            "button": "Voir les Scans",
+            "description": "Examinez vos scans téléchargés, sélectionnez ceux que vous voulez et créez des factures individuellement ou par lots.",
+            "title": "Voir et Organiser"
+          },
+          "step3": {
+            "button": "Voir les Factures",
+            "description": "Consultez vos factures, analysez les habitudes de dépenses et obtenez des informations alimentées par l'IA sur vos habitudes financières.",
+            "title": "Gérer les Factures"
+          },
+          "title": "Comment Ça Marche"
         }
       },
-      "analytics": {
-        "advanced": {
-          "benchmarking": "Comparaison",
-          "benchmarkingHint": "Comparer avec des utilisateurs similaires",
-          "description": "Fonctionnalités d'analyse premium",
-          "predictive": "Analyse Prédictive",
-          "predictiveHint": "Prédictions de dépenses basées sur l'IA",
-          "title": "Analyses Avancées"
+      "uploadScans": {
+        "breadcrumb": "Retour aux Factures",
+        "buttons": {
+          "myInvoices": "Mes Factures",
+          "uploadFirst": "Télécharger Votre Premier Scan",
+          "viewScans": "Voir Vos Scans"
         },
-        "dataUsage": {
-          "info": "Vos données d'analyse sont traitées localement et ne sont jamais partagées sans votre consentement explicite.",
-          "title": "Utilisation des Données"
+        "errors": {
+          "tooLarge": "Fichier trop volumineux : {name} (max 10 Mo)",
+          "unsupportedType": "Type de fichier non pris en charge : {type}"
         },
-        "description": "Configurez comment vos données sont analysées et rapportées",
-        "enabled": {
-          "description": "Activer ou désactiver les fonctionnalités d'analyse",
-          "hint": "Suivre et analyser vos habitudes de dépenses",
-          "label": "Activer les Analyses",
-          "title": "Analyses"
+        "header": {
+          "description": "Téléchargez des images de reçus ou des PDF. Créez des factures à partir de ceux-ci plus tard.",
+          "title": "Télécharger des Scans",
+          "tooltip": "Téléchargez vos reçus, factures ou notes ici. Vous pouvez sélectionner plusieurs fichiers et les organiser en factures plus tard depuis la page Voir les Scans."
         },
-        "export": {
-          "description": "Format par défaut pour les exports de données",
-          "title": "Format d'Export"
+        "metadata": {
+          "description": "Téléchargez des scans de reçus sur votre compte pour un traitement ultérieur en factures.",
+          "title": "Système de Gestion des Factures - Télécharger des Scans"
         },
-        "granularity": {
-          "description": "Niveau de détail de vos analyses",
-          "title": "Granularité des Données"
+        "postUpload": {
+          "createInvoice": "Oui, lancer l'analyse",
+          "dismiss": "Fermer",
+          "subtitle": "{count, plural, one {Cette numérisation représente-t-elle un seul achat ?} other {Ces numérisations représentent-elles un seul achat ?}}",
+          "title": "Téléchargement terminé !",
+          "viewScans": "Non, analyser séparément"
         },
-        "title": "Paramètres d'Analyse",
-        "tracking": {
-          "categories": "Suivre les Catégories",
-          "categoriesHint": "Analyser les dépenses par catégorie",
-          "description": "Choisissez ce qu'il faut suivre",
-          "merchants": "Suivre les Commerçants",
-          "merchantsHint": "Surveiller les données spécifiques aux commerçants",
-          "spending": "Suivre les Dépenses",
-          "spendingHint": "Surveiller vos dépenses globales",
-          "title": "Options de Suivi"
+        "preview": {
+          "pagination": {
+            "next": "Suivant",
+            "pageInfo": "{current} / {total} ({count} scans)",
+            "previous": "Précédent"
+          },
+          "pendingTooltip": "Ce scan ne sera pas enregistré tant que vous n'aurez pas cliqué sur Télécharger",
+          "removeTooltip": "Supprimer ce fichier",
+          "retryAttempt": "Nouvelle tentative {attempt}",
+          "status": {
+            "completed": "Terminé",
+            "failed": "Échoué",
+            "pending": "En attente",
+            "retrying": "Nouvelle tentative",
+            "uploading": "Téléversement"
+          },
+          "title": "Téléversements en attente ({count})"
+        },
+        "sidebar": {
+          "formats": {
+            "documentExtensions": ".pdf",
+            "documents": "Documents",
+            "imageExtensions": ".jpg, .jpeg, .png",
+            "images": "Images",
+            "maxSize": "Taille maximale du fichier : 10 Mo par fichier",
+            "title": "Formats Pris en Charge"
+          },
+          "nextSteps": {
+            "button": "Continuer vers Voir les Scans",
+            "description": "Vos scans sont prêts. Allez sur Voir les Scans pour les organiser en factures.",
+            "title": "Tous les téléchargements terminés !"
+          },
+          "security": {
+            "description": "Vos scans sont chiffrés et stockés en toute sécurité. Vous seul pouvez y accéder.",
+            "title": "Stockage Sécurisé"
+          },
+          "tips": {
+            "tip1": "Utilisez un bon éclairage lors de la photographie des reçus",
+            "tip2": "Assurez-vous que le texte est clair et lisible",
+            "tip3": "Évitez les ombres et les reflets",
+            "tip4": "Capturez tout le reçu dans le cadre",
+            "tip5": "Les PDF fonctionnent mieux pour les reçus numériques",
+            "title": "Conseils pour de Meilleurs Résultats"
+          }
+        },
+        "stats": {
+          "added": "Ajouté",
+          "completed": "Terminé",
+          "failed": "Échoué",
+          "pending": "En attente",
+          "uploading": "Téléchargement"
+        },
+        "subtitle": "Téléchargez des images de reçus ou des PDF. Créez des factures à partir de ceux-ci plus tard.",
+        "title": "Télécharger des Scans",
+        "upload": {
+          "browse": "Parcourir les fichiers",
+          "dropzone": "Glissez et déposez vos images de reçus ou PDF ici",
+          "or": "ou"
+        },
+        "uploadArea": {
+          "actions": {
+            "clearAll": "Tout effacer",
+            "uploading": "Téléversement...",
+            "uploadScans": "Téléverser les scans"
+          },
+          "aria": {
+            "uploadFiles": "Téléverser des fichiers"
+          },
+          "compact": {
+            "dropActive": "Déposez les fichiers pour les ajouter",
+            "dropInactive": "Glissez des fichiers ici ou cliquez pour parcourir",
+            "subtitle": "JPG, PNG, PDF jusqu'à 10 Mo"
+          },
+          "empty": {
+            "chooseFiles": "Choisir des fichiers",
+            "dropActive": "Déposez les fichiers pour les téléverser",
+            "dropInactive": "Cliquez ou glissez des fichiers pour les téléverser",
+            "formats": "Formats pris en charge : JPG, PNG, PDF (10 Mo max chacun)",
+            "note": "Vous pouvez sélectionner plusieurs fichiers.",
+            "pasteHint": "Astuce : vous pouvez aussi coller une image depuis le presse-papiers (Ctrl+V).",
+            "title": "Glissez-déposez vos fichiers ici"
+          },
+          "tooltips": {
+            "clearAll": "Supprimer tous les téléversements en attente",
+            "uploadScans": "Démarrer le téléversement de tous les scans en attente"
+          }
         }
       },
-      "appearance": {
-        "advanced": {
-          "animations": "Animations",
-          "animationsHint": "Activer les animations de l'interface",
-          "compactMode": "Mode Compact",
-          "compactModeHint": "Réduire l'espacement pour plus de contenu",
-          "description": "Options de personnalisation supplémentaires",
-          "title": "Options Avancées"
+      "viewInvoice": {
+        "analysisPanel": {
+          "analyzing": {
+            "progress": "{progress}% terminé",
+            "title": "Analyse en cours..."
+          },
+          "buttons": {
+            "reanalyze": "Réanalyser la facture"
+          },
+          "description": "Réanalyser cette facture avec l'IA pour extraire ou mettre à jour les données",
+          "labels": {
+            "analysisComplete": "Analyse terminée — Toutes les données ont été extraites",
+            "granularOptions": "Ou choisissez une analyse spécifique",
+            "lastAnalyzed": "Dernière analyse",
+            "updates": "{count, plural, one {# mise à jour} other {# mises à jour}}"
+          },
+          "options": {
+            "completeAnalysis": "Analyse complète",
+            "invoiceOnly": "Facture uniquement",
+            "itemsOnly": "Articles uniquement",
+            "merchantOnly": "Commerçant uniquement"
+          },
+          "steps": {
+            "analyzing": "Analyse en cours avec l'IA...",
+            "complete": "Analyse terminée !",
+            "extracting": "Extraction OCR en cours...",
+            "finalizing": "Finalisation des résultats...",
+            "preparing": "Préparation du document...",
+            "processing": "Traitement des articles..."
+          },
+          "tip": "Astuce : L'analyse complète prend 30 à 60 secondes mais fournit les résultats les plus précis.",
+          "title": "Analyse IA",
+          "toasts": {
+            "error": {
+              "description": "Impossible d'analyser la facture. Veuillez réessayer plus tard.",
+              "title": "Échec de l'analyse"
+            },
+            "success": {
+              "description": "La facture a été réanalysée avec succès avec des données mises à jour.",
+              "title": "Analyse terminée"
+            }
+          },
+          "tooltips": {
+            "completeAnalysis": "Extraction OCR complète + traitement IA de toutes les données de la facture",
+            "invoiceOnly": "Réextraire les informations de base de la facture (date, total, paiement)",
+            "itemsOnly": "Recatégoriser et analyser uniquement les articles",
+            "merchantOnly": "Réidentifier le commerçant et les données de localisation",
+            "reanalyze": "Relancer l'analyse complète avec toutes les fonctionnalités IA"
+          }
         },
-        "colors": {
-          "description": "Personnalisez votre palette de couleurs",
-          "preview": "Aperçu du Dégradé",
-          "previewText": "Exemple de Texte en Dégradé",
-          "primary": "Couleur Principale",
-          "secondary": "Couleur Secondaire",
-          "intermediary": "Couleur Intermédiaire",
-          "title": "Couleurs Personnalisées"
+        "categoryComparisonChart": {
+          "description": "Cette facture vs votre moyenne",
+          "labels": {
+            "average": "Moyenne",
+            "current": "Actuel"
+          },
+          "title": "Comparaison des catégories"
         },
-        "description": "Personnalisez l'apparence de votre expérience",
-        "font": {
-          "description": "Sélectionnez une police confortable",
-          "dyslexic": "Adapté aux dyslexiques",
-          "dyslexicHint": "Police OpenDyslexic pour une meilleure lisibilité",
-          "normal": "Standard",
-          "title": "Police"
-        },
-        "locale": {
-          "description": "Définissez votre langue préférée",
-          "title": "Langue"
-        },
-        "presets": {
-          "custom": "Personnalisé",
-          "customDescription": "Créez votre propre jeu de couleurs",
-          "description": "Choisissez un jeu de couleurs prédéfini ou créez le vôtre",
-          "title": "Thème Prédéfini"
-        },
-        "theme": {
-          "dark": "Sombre",
-          "description": "Choisissez votre palette de couleurs préférée",
-          "hint": "Basculez entre clair, sombre ou la préférence de votre système",
-          "light": "Clair",
-          "system": "Système",
-          "title": "Thème"
-        },
-        "title": "Paramètres d'Apparence"
-      },
-      "data": {
-        "backup": {
-          "autoBackup": "Sauvegarde Automatique",
-          "autoBackupHint": "Sauvegarder automatiquement vos données",
-          "description": "Configuration de la sauvegarde automatique",
-          "frequency": "Fréquence de Sauvegarde",
-          "title": "Paramètres de Sauvegarde"
-        },
-        "danger": {
-          "deleteAccount": "Supprimer le Compte",
-          "deleteAccountHint": "Supprimez définitivement votre compte",
-          "deleteButton": "Supprimer les Données",
-          "deleteData": "Supprimer Toutes les Données",
-          "deleteDataHint": "Supprimez définitivement toutes vos factures et scans",
-          "description": "Actions irréversibles",
-          "manageAccount": "Gérer sur Clerk",
-          "title": "Zone de Danger"
-        },
-        "description": "Contrôlez le stockage de vos données et les paramètres de confidentialité",
         "export": {
-          "description": "Téléchargez une copie de vos données",
-          "downloadAll": "Télécharger Toutes les Données",
-          "hint": "L'export inclura toutes les factures, scans et paramètres",
-          "title": "Exporter les Données"
+          "copyError": "Échec de la copie du résumé",
+          "copySuccess": "Résumé copié dans le presse-papiers",
+          "copySummary": {
+            "description": "Copier le résumé texte dans le presse-papiers",
+            "title": "Copier le résumé"
+          },
+          "csv": {
+            "description": "Télécharger les articles sous forme de feuille de calcul",
+            "title": "Exporter en CSV"
+          },
+          "csvError": "Échec de l'export CSV",
+          "csvSuccess": "Fichier CSV téléchargé avec succès",
+          "description": "Exportez vos données de facture dans différents formats",
+          "json": {
+            "description": "Télécharger les données complètes de la facture",
+            "title": "Exporter en JSON"
+          },
+          "jsonError": "Échec de l'export JSON",
+          "jsonSuccess": "Fichier JSON téléchargé avec succès",
+          "pdf": {
+            "description": "Télécharger un document de facture professionnel",
+            "title": "Exporter en PDF"
+          },
+          "pdfError": "Échec de la génération du PDF",
+          "pdfGenerating": "Génération du PDF en cours...",
+          "pdfSuccess": "Fichier PDF téléchargé avec succès",
+          "print": {
+            "description": "Imprimer la facture via le navigateur",
+            "title": "Imprimer"
+          },
+          "printError": "Échec de l'ouverture de la boîte de dialogue d'impression",
+          "printSuccess": "Boîte de dialogue d'impression ouverte",
+          "title": "Exporter la facture"
         },
-        "privacy": {
-          "description": "Contrôlez comment vos données sont utilisées",
-          "shareAnonymous": "Partager des Données Anonymes",
-          "shareAnonymousHint": "Aidez à améliorer le service avec des données anonymisées",
-          "title": "Paramètres de Confidentialité"
+        "healthScore": {
+          "cta": {
+            "analyze": "Lancer l'analyse IA",
+            "edit": "Modifier la facture"
+          },
+          "dialogTitle": "Rapport de santé de la facture",
+          "factors": {
+            "categoriesAssigned": "Catégories attribuées",
+            "merchantLinked": "Commerçant associé",
+            "ocrConfidence": "Confiance OCR",
+            "paymentInfo": "Informations de paiement",
+            "productCompleteness": "Complétude des produits",
+            "productsPresent": "Produits extraits",
+            "recipesGenerated": "Recettes générées"
+          },
+          "hideDetails": "Hide details",
+          "points": "points",
+          "seeReport": "Voir le rapport détaillé",
+          "showDetails": "Show details",
+          "status": {
+            "excellent": "Excellent",
+            "good": "Bon",
+            "incomplete": "Incomplet",
+            "needsAttention": "Nécessite une attention"
+          },
+          "subtitle": "How complete is your invoice data",
+          "suggestions": {
+            "fix": "Corriger",
+            "incompletePayment": "Informations de paiement incomplètes — ajoutez la date, le montant et la devise de la transaction",
+            "incompleteProducts": "<strong>{count}</strong> produits incomplets — vérifiez et complétez les champs manquants",
+            "lowOcrConfidence": "Faible confiance OCR sur <strong>{count}</strong> produits — vérifiez manuellement pour plus de précision",
+            "noMerchant": "Aucun commerçant associé — ajoutez les détails du commerçant pour de meilleures analyses",
+            "noProducts": "Aucun produit trouvé — téléchargez un reçu ou ajoutez des articles manuellement",
+            "noRecipes": "Aucune recette générée — lancez l'analyse IA pour découvrir des idées de repas",
+            "title": "Améliorations suggérées",
+            "uncategorizedProducts": "<strong>{count}</strong> produits non catégorisés — attribuez des catégories pour l'analyse des dépenses"
+          },
+          "title": "Invoice Completeness"
         },
-        "retention": {
-          "description": "Durée de conservation de vos données",
-          "hint": "Les données plus anciennes seront automatiquement archivées",
-          "title": "Conservation des Données"
+        "invoiceAnalytics": {
+          "emptyState": {
+            "description": "Ajoutez plus de données à cette facture pour afficher des analyses et des insights.",
+            "title": "Aucune analyse disponible"
+          },
+          "tabs": {
+            "compare": "Comparaison",
+            "current": "Cette facture"
+          },
+          "title": "Analyses et insights"
         },
-        "title": "Gestion des Données"
+        "invoiceGuestBanner": {
+          "description": "Vous n’êtes actuellement pas le propriétaire de cette facture. L’affichage est limité à ce que le propriétaire a défini dans les paramètres de partage.",
+          "title": "Vue invité"
+        },
+        "invoiceTabs": {
+          "actions": {
+            "generate": "Générer des recettes",
+            "regenerate": "Régénérer les recettes",
+            "regenerateTooltip": "Réanalyser la facture pour générer de nouvelles suggestions de recettes"
+          },
+          "empty": {
+            "additionalInfo": "Aucune information supplémentaire disponible",
+            "recipes": "Aucune suggestion de recette disponible"
+          },
+          "recipe": {
+            "duration": "{minutes} min",
+            "ingredients": "Ingrédients",
+            "instructions": "Instructions",
+            "prepCook": "Prépa : {prep}m • Cuisson : {cook}m",
+            "viewRecipe": "Voir Recipe"
+          },
+          "tabs": {
+            "additionalInfo": "Infos supplémentaires",
+            "possibleRecipes": "Recettes possibles"
+          }
+        },
+        "invoiceTimeline": {
+          "eventCount": "{count, plural, one {# événement} other {# événements}}",
+          "subtitle": "Historique complet des actions et modifications",
+          "title": "Chronologie de la facture"
+        },
+        "itemAnalytics": {
+          "columns": {
+            "category": "Catégorie",
+            "name": "Nom",
+            "price": "Prix",
+            "quantity": "Qté",
+            "total": "Total"
+          },
+          "confidence": {
+            "ariaLabel": "Confiance {level}: {percent}%",
+            "high": "Elevee",
+            "label": "Confiance OCR",
+            "low": "Faible",
+            "lowWarning": "Faible confiance — vérifiez cet article",
+            "medium": "Moyenne"
+          },
+          "empty": {
+            "subtitle": "Lancez l'analyse IA pour extraire les articles de votre reçu",
+            "title": "Aucun article"
+          },
+          "searchPlaceholder": "Rechercher des articles...",
+          "summary": {
+            "allergens": "{count} allergènes détectés",
+            "categories": "{count} catégories",
+            "cheapest": "Le moins cher",
+            "mostExpensive": "Le plus cher",
+            "title": "Résumé"
+          },
+          "title": "Articles",
+          "totalLabel": "TOTAL"
+        },
+        "itemsBreakdownChart": {
+          "description": "Articles avec les plus fortes dépenses",
+          "labels": {
+            "price": "Prix",
+            "quantity": "Qté"
+          },
+          "title": "Articles les plus coûteux"
+        },
+        "merchantBreakdownChart": {
+          "description": "Totaux cumulés sur tous les commerçants",
+          "labels": {
+            "averagePerVisit": "Moy./visite",
+            "total": "Total",
+            "totalSpent": "Total dépensé",
+            "visits": "Visites"
+          },
+          "title": "Dépenses par magasin",
+          "unknownMerchant": "Commerçant inconnu"
+        },
+        "metadata": {
+          "description": "Consultez les détails de votre facture, les articles et les informations du commerçant associé.",
+          "title": "Système de Gestion des Factures - Voir la Facture"
+        },
+        "priceDistributionChart": {
+          "description": "Articles par tranche de prix ({currency})",
+          "labels": {
+            "items": "Articles"
+          },
+          "title": "Répartition des prix",
+          "tooltip": {
+            "itemCount": "{count, plural, one {# article} other {# articles}}"
+          }
+        },
+        "print": {
+          "generatedOn": "Imprimé le {date}",
+          "labels": {
+            "date": "Date",
+            "items": "Articles",
+            "merchant": "Commerçant",
+            "total": "Montant total"
+          },
+          "page": "Page"
+        },
+        "relatedInvoices": {
+          "noRelated": "Aucune facture associée trouvée",
+          "sameCategory": "Même catégorie",
+          "sameMerchant": "Même commerçant",
+          "similarAmount": "Montant similaire",
+          "subtitle": "Factures similaires par commerçant, catégorie ou montant",
+          "title": "Factures associées",
+          "viewInvoice": "Afficher"
+        },
+        "shareCollaborate": {
+          "activity": {
+            "created": "Créé {time}",
+            "daysAgo": "{count, plural, one {il y a # jour} other {il y a # jours}}",
+            "modified": "Dernière modification {time}",
+            "title": "Activité",
+            "today": "aujourd'hui"
+          },
+          "copied": "Lien copié dans le presse-papiers !",
+          "copyError": "Échec de la copie du lien",
+          "copyLink": "Copier le lien",
+          "madePrivate": "La facture est maintenant privée",
+          "madePublic": "La facture est maintenant publique",
+          "manageSharing": "Gérer le partage",
+          "private": "Privé",
+          "public": "Public",
+          "publicAccess": "Accès public",
+          "publicAccessDescription": "Toute personne ayant le lien peut voir cette facture",
+          "qrCode": "Code QR",
+          "qrCopied": "Lien copié ! Génération du code QR bientôt disponible.",
+          "shared": "Partagé",
+          "sharedWith": "Partagé avec",
+          "shareEmail": "Partager par e-mail",
+          "title": "Partage et collaboration",
+          "toggleError": "Échec de la mise à jour des paramètres de partage"
+        },
+        "spendingByCategoryChart": {
+          "description": "Répartition des dépenses",
+          "title": "Dépenses par catégorie",
+          "tooltip": {
+            "itemCount": "{count, plural, one {# article} other {# articles}}"
+          },
+          "totalLabel": "Total des dépenses"
+        },
+        "spendingTrendChart": {
+          "description": "Tendance de votre historique de factures",
+          "labels": {
+            "amount": "Montant"
+          },
+          "title": "Évolution des dépenses",
+          "tooltip": {
+            "andMore": "et {count} de plus…",
+            "currentInvoice": "Facture actuelle"
+          }
+        },
+        "timelineSharedWithList": {
+          "actions": {
+            "manageSharing": "Gérer le partage",
+            "sendEmail": "Envoyer un e-mail"
+          },
+          "aria": {
+            "sendEmail": "Envoyer un e-mail à {user}"
+          },
+          "header": {
+            "publicBadge": "Public",
+            "title": "Partagée avec"
+          },
+          "publicAccess": {
+            "description": "Cette facture est accessible publiquement. Toute personne disposant du lien peut la voir, y compris les invités sans compte.",
+            "title": "Accès public activé"
+          }
+        }
       },
-      "notifications": {
-        "description": "Gérez comment et quand vous recevez des notifications",
-        "email": {
-          "description": "Configurer les préférences de communication par email",
-          "enabled": "Activer les Notifications par Email",
-          "enabledHint": "Recevoir des mises à jour par email",
-          "title": "Notifications par Email"
+      "viewInvoices": {
+        "bulkActions": {
+          "categories": {
+            "carAuto": "Auto et véhicule",
+            "fastFood": "Restauration rapide",
+            "grocery": "Épicerie",
+            "homeCleaning": "Entretien ménager",
+            "notDefined": "Non défini",
+            "other": "Autre"
+          },
+          "categoryChanged": "{count, plural, one {Catégorie de la facture mise à jour avec succès} other {Catégories de # factures mises à jour avec succès}}",
+          "categoryChangeError": "Échec de la mise à jour des catégories de factures. Veuillez réessayer.",
+          "categoryPartialSuccess": "{success} facture(s) mise(s) à jour, {failed} en échec",
+          "changeCategory": "Changer de catégorie",
+          "clearSelection": "Effacer la sélection",
+          "delete": "Supprimer",
+          "deleteConfirm": {
+            "cancel": "Annuler",
+            "confirm": "Supprimer",
+            "description": "{count, plural, one {Êtes-vous sûr de vouloir supprimer cette facture ? Cette action est irréversible.} other {Êtes-vous sûr de vouloir supprimer ces # factures ? Cette action est irréversible.}}",
+            "title": "Supprimer les factures"
+          },
+          "deleteError": "Échec de la suppression des factures. Veuillez réessayer.",
+          "deletePartialSuccess": "{success} facture(s) supprimée(s), {failed} en échec",
+          "deleteSuccess": "{count, plural, one {Facture supprimée avec succès} other {# factures supprimées avec succès}}",
+          "export": "Exporter",
+          "selected": "{count, plural, one {# facture sélectionnée} other {# factures sélectionnées}}"
         },
-        "financial": {
-          "budgetAlerts": "Alertes de Budget",
-          "budgetAlertsHint": "Alerte lorsque vous approchez des limites budgétaires",
-          "description": "Être notifié concernant les dépenses",
-          "spendingAlerts": "Alertes de Dépenses",
-          "spendingAlertsHint": "Notification quand les dépenses dépassent le seuil",
-          "title": "Alertes Financières"
+        "generativeView": {
+          "chatDescription": "Discutez avec l’AI pour analyser vos factures et obtenir des analyses utiles. Essayez des commandes comme /find pour rechercher des factures.",
+          "help": "Aide",
+          "settings": {
+            "allowInvoiceData": "Autoriser l’accès aux données de la facture",
+            "allowMerchantData": "Autoriser l’accès aux données du commerçant",
+            "dataAccessTitle": "Accès aux données",
+            "description": "Configurez les préférences de votre assistant AI",
+            "historyLabel": "Chat historique",
+            "notificationPreferences": "Préférences de notification",
+            "notifyInsights": "Me notifier des nouvelles analyses",
+            "retention": {
+              "item30": "Conserver pendant 30 jours",
+              "item60": "Conserver pendant 60 jours",
+              "item90": "Conserver pendant 90 jours",
+              "none": "Don't enregistrer historique"
+            },
+            "retentionPlaceholder": "Sélectionnez la durée de conservation",
+            "save": "Enregistrer paramètres",
+            "title": "Chat paramètres"
+          },
+          "subtitle": "Discutez avec l’AI pour analyser vos factures et obtenir des analyses utiles",
+          "tabs": {
+            "chat": "Discussion",
+            "settings": "Paramètres"
+          },
+          "title": "Analyse en direct",
+          "welcomeMessage": "Bonjour ! Je suis votre assistant d’analyse de factures. Comment puis-je vous aider aujourd’hui ? Essayez des commandes comme /find pour rechercher des factures."
         },
-        "reports": {
-          "description": "Livraison programmée des rapports",
-          "monthlyReport": "Rapport Mensuel",
-          "monthlyReportHint": "Analyse détaillée des dépenses mensuelles",
-          "title": "Rapports",
-          "weeklyDigest": "Résumé Hebdomadaire",
-          "weeklyDigestHint": "Résumé de votre activité hebdomadaire"
+        "gridView": {
+          "itemCount": "{count, plural, one {# article} other {# articles}}",
+          "tooltips": {
+            "viewDetails": "Voir les détails"
+          }
+        },
+        "invoicesHeader": {
+          "actions": {
+            "export": "Exporter",
+            "import": "Importer",
+            "newInvoice": "Nouvelle facture",
+            "print": "Imprimer"
+          },
+          "description": "Gérez vos reçus et suivez vos habitudes de dépenses",
+          "title": "Gestion des factures",
+          "tooltips": {
+            "export": "Exporter toutes les factures",
+            "import": "Importer des factures depuis des fichiers",
+            "newInvoice": "Créer une nouvelle facture",
+            "print": "Imprimer les factures"
+          }
+        },
+        "invoicesView": {
+          "categories": {
+            "all": "Toutes les catégories",
+            "dining": "Restauration",
+            "entertainment": "Divertissement",
+            "groceries": "Épicerie",
+            "other": "Autre",
+            "travel": "Voyage",
+            "utilities": "Services"
+          },
+          "placeholderPanel": "D’autres filtres seront bientôt disponibles.",
+          "searchPlaceholder": "Rechercher des factures...",
+          "times": {
+            "all": "Tous les horaires",
+            "day": "Journée (6h-18h)",
+            "night": "Nuit (18h-6h)"
+          },
+          "viewModes": {
+            "grid": "Grid voir",
+            "table": "Table voir"
+          }
+        },
+        "messageList": {
+          "aiAssistant": "Assistant IA",
+          "you": "Vous"
+        },
+        "metadata": {
+          "description": "Lister toutes les factures du système de gestion des factures.",
+          "title": "Système de Gestion des Factures - Liste des Factures"
+        },
+        "subtitle": "Ceci est votre inventaire de reçus numériques. <br></br> Ici vous pouvez trouver les reçus que vous avez téléchargés jusqu'à présent. <br></br> En cliquant sur un reçu, vous serez redirigé vers la page de ce reçu spécifique.",
+        "tableView": {
+          "aria": {
+            "rowsPerPage": "Lignes par page",
+            "selectAllInvoices": "Sélectionner toutes les factures",
+            "selectInvoice": "Sélectionner facture {name}",
+            "sortByAmount": "Trier par montant",
+            "sortByDate": "Trier par date"
+          },
+          "columns": {
+            "actions": "Opérations",
+            "amount": "Montant",
+            "category": "Catégorie",
+            "date": "Date",
+            "invoice": "Facture"
+          },
+          "empty": {
+            "description": "Commencez par télécharger vos reçus pour créer votre première facture",
+            "title": "Aucune facture trouvée",
+            "uploadCta": "Télécharger votre premier reçu"
+          },
+          "nextPage": "Page suivante",
+          "pageOf": "Page {current} sur {total}",
+          "previousPage": "Page précédente",
+          "rowsPerPage": "Lignes par page:",
+          "tooltips": {
+            "notAnalyzed": "Cette facture n'a pas encore été analysée"
+          },
+          "viewInvoice": "Voir Facture"
+        },
+        "tableViewActions": {
+          "actions": {
+            "delete": "Supprimer",
+            "edit": "Modifier",
+            "share": "Partager"
+          },
+          "tooltips": {
+            "delete": "Supprimer définitivement cette facture",
+            "edit": "Modifier les détails de la facture",
+            "moreActions": "Plus d'actions",
+            "share": "Partager facture via lien or e-mail"
+          }
+        },
+        "title": "Bienvenue, {name} !",
+        "viewInvoicesIsland": {
+          "tabs": {
+            "invoices": "Factures",
+            "liveAnalysis": "Analyse en direct",
+            "statistics": "Statistiques"
+          }
+        },
+        "viewInvoicesPage": {
+          "guestName": "cher invité"
+        }
+      },
+      "viewScans": {
+        "breadcrumb": "Retour aux Factures",
+        "createFromAll": {
+          "button": "Créer à partir de toutes les numérisations",
+          "description": "Créer des factures à partir de l'ensemble des {count} numérisations",
+          "title": "Toutes les numérisations sont prêtes !"
+        },
+        "emptyState": {
+          "description": "Commencez par télécharger vos reçus et factures. Voici comment cela fonctionne :",
+          "learnMoreButton": "En Savoir Plus",
+          "step1Description": "Prenez des photos de reçus ou téléchargez des PDF de factures numériques",
+          "step1Title": "Téléchargez vos scans",
+          "step2Description": "Choisissez quels scans convertir en factures",
+          "step2Title": "Sélectionnez et organisez",
+          "step3Description": "Notre IA extrait automatiquement toutes les données pour vous",
+          "step3Title": "Créez des factures",
+          "title": "Pas encore de scans",
+          "uploadButton": "Télécharger Votre Premier Scan"
+        },
+        "groupBanner": {
+          "createInvoice": "Créer une facture",
+          "dismiss": "Fermer",
+          "subtitle": "Créer une facture à partir de ces numérisations ?",
+          "title": "{count} scans uploaded together — combine?"
+        },
+        "header": {
+          "invoices": "Factures",
+          "lastSynced": "Dernière synchronisation : {time}",
+          "myInvoices": "Mes Factures",
+          "myInvoicesTooltip": "Voir vos factures créées",
+          "subtitle": "Sélectionnez des scans pour créer des factures à partir de ceux-ci",
+          "sync": "Synchroniser",
+          "syncing": "Synchronisation...",
+          "syncTooltip": "Actualiser les scans depuis le serveur",
+          "title": "Vos Scans",
+          "titleWithCount": "Vos Scans ({count})",
+          "tooltip": "Sélectionnez des scans pour créer des factures. Vous pouvez créer une facture par scan ou combiner plusieurs scans en une seule facture.",
+          "upload": "Télécharger",
+          "uploadMore": "Télécharger Plus",
+          "uploadTooltip": "Téléchargez plus de scans sur votre compte"
+        },
+        "metadata": {
+          "description": "Consultez et gérez vos scans téléchargés. Créez des factures à partir des scans sélectionnés.",
+          "title": "Système de Gestion des Factures - Voir les Scans"
+        },
+        "pagination": {
+          "next": "Suivant",
+          "pageInfo": "{current} / {total} ({count} scans)",
+          "previous": "Précédent"
+        },
+        "scanCard": {
+          "actions": {
+            "delete": "Supprimer le scan",
+            "rename": "Renommer le scan",
+            "rotateCCW": "Pivoter de 90° dans le sens antihoraire",
+            "rotateCW": "Pivoter de 90° dans le sens horaire",
+            "rotateError": "Échec de la rotation de l'image",
+            "rotateSuccess": "Image pivotée avec succès",
+            "rotateUnsupported": "Impossible de pivoter les fichiers PDF",
+            "rotating": "Rotation en cours..."
+          },
+          "delete": "Supprimer le scan",
+          "deleteDialog": {
+            "cancel": "Annuler",
+            "delete": "Supprimer",
+            "deleting": "Suppression...",
+            "description": "Êtes-vous sûr de vouloir supprimer \"{name}\" ? Cette action ne peut pas être annulée et le scan sera définitivement supprimé du stockage.",
+            "error": "Échec de la suppression du scan",
+            "linkedDescription": "Le supprimer retirera le scan du stockage, mais la facture conservera une copie de l'image. Cette action ne peut pas être annulée.",
+            "linkedWarning": "Ce scan est lié à une facture.",
+            "success": "Scan supprimé avec succès",
+            "title": "Supprimer le scan ?"
+          },
+          "linked": "Lié",
+          "loading": "Chargement...",
+          "preview": "Aperçu du scan",
+          "previewTitle": "Aperçu du scan",
+          "rename": "Renommer le scan",
+          "renamePlaceholder": "Entrez le nouveau nom"
+        },
+        "sidebar": {
+          "howTo": {
+            "step1Description": "Cliquez sur les scans pour les sélectionner",
+            "step1Title": "Sélectionner des Scans",
+            "step2Description": "Une facture par scan ou combiner plusieurs",
+            "step2Title": "Choisir le Mode",
+            "step3Description": "L'IA extrait les données automatiquement",
+            "step3Title": "Créer la Facture",
+            "title": "Comment Créer des Factures"
+          },
+          "quickUpload": {
+            "button": "Télécharger",
+            "description": "Téléchargez des reçus supplémentaires",
+            "title": "Besoin de plus de scans ?"
+          },
+          "selectionStatus": {
+            "plural": "scans sélectionnés",
+            "readyPlural": "Créez plusieurs factures ou combinez en une seule",
+            "readySingular": "Prêt à créer une facture",
+            "singular": "scan sélectionné"
+          }
+        },
+        "stats": {
+          "ready": "Prêt",
+          "selected": "Sélectionné",
+          "selectHint": "Cliquez sur les scans pour les sélectionner pour la création de factures",
+          "tapHint": "Appuyez pour sélectionner",
+          "totalScans": "Total des Scans"
+        },
+        "subtitle": "Sélectionnez des scans pour créer des factures à partir de ceux-ci.",
+        "title": "Vos Scans",
+        "toolbar": {
+          "clearSelection": "Effacer",
+          "createInvoice": "Créer une Facture",
+          "createInvoices": "Créer des Factures",
+          "delete": {
+            "button": "Supprimer ({count})",
+            "cancel": "Annuler",
+            "confirm": "Supprimer",
+            "confirmDescription": "Cela supprimera définitivement {count} scan(s) du stockage. Cette action est irréversible.",
+            "confirmTitle": "Supprimer les scans sélectionnés ?",
+            "error": "Une erreur est survenue lors de la suppression des scans",
+            "failed": "Échec de la suppression des scans",
+            "partial": "{success} supprimé(s), {failed} échoué(s)",
+            "success": "{count} scan(s) supprimé(s) avec succès"
+          },
+          "selected": "sélectionné"
+        }
+      }
+    },
+    "legal": {
+      "acknowledgements": {
+        "metadata": {
+          "description": "Page de remerciements pour les packages tiers utilisés dans ce projet et les collaborateurs.",
+          "title": "Remerciements"
+        }
+      },
+      "eula": {
+        "accept": "Accepter le CLUF",
+        "content": "En utilisant ce site web, vous acceptez les termes et conditions et la politique de confidentialité du Contrat de Licence Utilisateur Final (CLUF). Veuillez lire attentivement les documents suivants avant d'utiliser le site web :",
+        "cookiesPolicy": {
+          "cookies": {
+            "analytics": {
+              "checkbox": "Activer les cookies analytiques nous aide à améliorer notre site web.",
+              "description": "Ces cookies nous permettent de compter les visites et les sources de trafic, afin que nous puissions mesurer et améliorer les performances de notre site. Ils nous aident à savoir quelles pages sont les plus et les moins populaires et à voir comment les visiteurs naviguent sur le site. Toutes les informations que ces cookies collectent sont agrégées et peuvent donc être considérées comme anonymes.",
+              "title": "Cookies Analytiques"
+            },
+            "cta": "Enregistrer la configuration des cookies",
+            "essential": {
+              "checkbox": "Cette option ne peut pas être désactivée. Les cookies essentiels sont toujours activés.",
+              "description": "Les cookies essentiels sont nécessaires au bon fonctionnement du site web. Cette catégorie n'inclut que les cookies qui assurent les fonctionnalités de base et les caractéristiques de sécurité du site web.",
+              "title": "Cookies Essentiels"
+            }
+          },
+          "subtitle": "Gérez vos paramètres de cookies. Vous pouvez activer ou désactiver différents types de cookies ci-dessous.",
+          "title": "Préférences de Cookies"
+        },
+        "language": "Langue",
+        "privacyPolicy": {
+          "cta": "Voir la Politique",
+          "subtitle": "Notre Politique de Confidentialité explique comment nous collectons, utilisons et protégeons vos informations personnelles lorsque vous utilisez nos services.",
+          "title": "Politique de Confidentialité"
+        },
+        "subtitle": "Veuillez consulter nos termes et conditions avant d'utiliser le site web.",
+        "termsOfService": {
+          "cta": "Voir les Conditions",
+          "subtitle": "Nos Conditions de Service décrivent les règles et directives pour l'utilisation de notre plateforme, y compris les responsabilités de l'utilisateur et nos obligations.",
+          "title": "Conditions de Service"
+        },
+        "title": "Contrat de Licence Utilisateur Final (CLUF)"
+      },
+      "privacyPolicy": {
+        "metadata": {
+          "description": "La page de politique de confidentialité de la plateforme `arolariu.ro`.",
+          "title": "Politique de Confidentialité"
+        }
+      },
+      "termsOfService": {
+        "metadata": {
+          "description": "Les conditions de service pour arolariu.ro",
+          "title": "Conditions de Service"
+        }
+      }
+    },
+    "profile": {
+      "header": {
+        "completionHint": "Complétez votre profil pour débloquer toutes les fonctionnalités",
+        "daysActive": "jours actifs",
+        "editProfile": "Modifier le Profil",
+        "editProfileClerkNote": "Les informations du profil sont gérées via Clerk. Cliquez ci-dessous pour mettre à jour vos détails.",
+        "editProfileDescription": "Mettez à jour vos informations de profil",
+        "editProfileTitle": "Modifier le Profil",
+        "manageOnClerk": "Gérer sur Clerk",
+        "memberSince": "Membre depuis {date}",
+        "premium": "Premium",
+        "profileCompletion": "Complétion du Profil",
+        "userId": "ID Utilisateur"
+      },
+      "island": {
+        "merchants": "{count} commerçants",
+        "scans": "{count} numérisations",
+        "settingsNavigationAriaLabel": "Navigation des paramètres",
+        "totalInvoices": "Total factures"
+      },
+      "metadata": {
+        "description": "Gérez les paramètres et préférences de votre compte",
+        "title": "Mon Profil"
+      },
+      "settings": {
+        "ai": {
+          "behavior": {
+            "description": "Choisissez comment l'IA répond",
+            "title": "Préréglage de Comportement"
+          },
+          "description": "Configurez le comportement et les préférences de votre assistant IA",
+          "features": {
+            "autoSuggest": "Auto-Suggestion",
+            "autoSuggestHint": "Obtenez des suggestions automatiques pendant que vous travaillez",
+            "contextAwareness": "Conscience du Contexte",
+            "contextAwarenessHint": "L'IA utilise le contexte de vos factures",
+            "description": "Activer ou désactiver les capacités IA",
+            "memory": "Mémoire de Conversation",
+            "memoryHint": "L'IA se souvient des conversations précédentes",
+            "title": "Fonctionnalités IA"
+          },
+          "maxTokens": {
+            "description": "Tokens maximum par réponse",
+            "title": "Longueur de Réponse"
+          },
+          "model": {
+            "description": "Sélectionnez le modèle IA pour votre assistant",
+            "title": "Modèle IA"
+          },
+          "temperature": {
+            "creative": "Créatif",
+            "description": "Équilibre entre précision et créativité",
+            "precise": "Précis",
+            "title": "Style de Réponse"
+          },
+          "title": "Paramètres de l'Assistant IA",
+          "voice": {
+            "description": "Configurer l'interaction vocale",
+            "enabled": "Entrée Vocale",
+            "enabledHint": "Utiliser des commandes vocales avec l'IA",
+            "title": "Paramètres Vocaux"
+          }
+        },
+        "analytics": {
+          "advanced": {
+            "benchmarking": "Comparaison",
+            "benchmarkingHint": "Comparer avec des utilisateurs similaires",
+            "description": "Fonctionnalités d'analyse premium",
+            "predictive": "Analyse Prédictive",
+            "predictiveHint": "Prédictions de dépenses basées sur l'IA",
+            "title": "Analyses Avancées"
+          },
+          "dataUsage": {
+            "info": "Vos données d'analyse sont traitées localement et ne sont jamais partagées sans votre consentement explicite.",
+            "title": "Utilisation des Données"
+          },
+          "description": "Configurez comment vos données sont analysées et rapportées",
+          "enabled": {
+            "description": "Activer ou désactiver les fonctionnalités d'analyse",
+            "hint": "Suivre et analyser vos habitudes de dépenses",
+            "label": "Activer les Analyses",
+            "title": "Analyses"
+          },
+          "export": {
+            "description": "Format par défaut pour les exports de données",
+            "title": "Format d'Export"
+          },
+          "granularity": {
+            "description": "Niveau de détail de vos analyses",
+            "title": "Granularité des Données"
+          },
+          "title": "Paramètres d'Analyse",
+          "tracking": {
+            "categories": "Suivre les Catégories",
+            "categoriesHint": "Analyser les dépenses par catégorie",
+            "description": "Choisissez ce qu'il faut suivre",
+            "merchants": "Suivre les Commerçants",
+            "merchantsHint": "Surveiller les données spécifiques aux commerçants",
+            "spending": "Suivre les Dépenses",
+            "spendingHint": "Surveiller vos dépenses globales",
+            "title": "Options de Suivi"
+          }
+        },
+        "appearance": {
+          "advanced": {
+            "animations": "Animations",
+            "animationsHint": "Activer les animations de l'interface",
+            "compactMode": "Mode Compact",
+            "compactModeHint": "Réduire l'espacement pour plus de contenu",
+            "description": "Options de personnalisation supplémentaires",
+            "title": "Options Avancées"
+          },
+          "colors": {
+            "description": "Personnalisez votre palette de couleurs",
+            "intermediary": "Couleur Intermédiaire",
+            "preview": "Aperçu du Dégradé",
+            "previewText": "Exemple de Texte en Dégradé",
+            "primary": "Couleur Principale",
+            "secondary": "Couleur Secondaire",
+            "title": "Couleurs Personnalisées"
+          },
+          "description": "Personnalisez l'apparence de votre expérience",
+          "font": {
+            "description": "Sélectionnez une police confortable",
+            "dyslexic": "Adapté aux dyslexiques",
+            "dyslexicHint": "Police OpenDyslexic pour une meilleure lisibilité",
+            "normal": "Standard",
+            "title": "Police"
+          },
+          "locale": {
+            "description": "Définissez votre langue préférée",
+            "title": "Langue"
+          },
+          "presets": {
+            "custom": "Personnalisé",
+            "customDescription": "Créez votre propre jeu de couleurs",
+            "description": "Choisissez un jeu de couleurs prédéfini ou créez le vôtre",
+            "title": "Thème Prédéfini"
+          },
+          "theme": {
+            "dark": "Sombre",
+            "description": "Choisissez votre palette de couleurs préférée",
+            "hint": "Basculez entre clair, sombre ou la préférence de votre système",
+            "light": "Clair",
+            "system": "Système",
+            "title": "Thème"
+          },
+          "title": "Paramètres d'Apparence"
+        },
+        "data": {
+          "backup": {
+            "autoBackup": "Sauvegarde Automatique",
+            "autoBackupHint": "Sauvegarder automatiquement vos données",
+            "description": "Configuration de la sauvegarde automatique",
+            "frequency": "Fréquence de Sauvegarde",
+            "title": "Paramètres de Sauvegarde"
+          },
+          "danger": {
+            "deleteAccount": "Supprimer le Compte",
+            "deleteAccountHint": "Supprimez définitivement votre compte",
+            "deleteButton": "Supprimer les Données",
+            "deleteData": "Supprimer Toutes les Données",
+            "deleteDataHint": "Supprimez définitivement toutes vos factures et scans",
+            "description": "Actions irréversibles",
+            "manageAccount": "Gérer sur Clerk",
+            "title": "Zone de Danger"
+          },
+          "description": "Contrôlez le stockage de vos données et les paramètres de confidentialité",
+          "export": {
+            "description": "Téléchargez une copie de vos données",
+            "downloadAll": "Télécharger Toutes les Données",
+            "hint": "L'export inclura toutes les factures, scans et paramètres",
+            "title": "Exporter les Données"
+          },
+          "privacy": {
+            "description": "Contrôlez comment vos données sont utilisées",
+            "shareAnonymous": "Partager des Données Anonymes",
+            "shareAnonymousHint": "Aidez à améliorer le service avec des données anonymisées",
+            "title": "Paramètres de Confidentialité"
+          },
+          "retention": {
+            "description": "Durée de conservation de vos données",
+            "hint": "Les données plus anciennes seront automatiquement archivées",
+            "title": "Conservation des Données"
+          },
+          "title": "Gestion des Données"
+        },
+        "notifications": {
+          "description": "Gérez comment et quand vous recevez des notifications",
+          "email": {
+            "description": "Configurer les préférences de communication par email",
+            "enabled": "Activer les Notifications par Email",
+            "enabledHint": "Recevoir des mises à jour par email",
+            "title": "Notifications par Email"
+          },
+          "financial": {
+            "budgetAlerts": "Alertes de Budget",
+            "budgetAlertsHint": "Alerte lorsque vous approchez des limites budgétaires",
+            "description": "Être notifié concernant les dépenses",
+            "spendingAlerts": "Alertes de Dépenses",
+            "spendingAlertsHint": "Notification quand les dépenses dépassent le seuil",
+            "title": "Alertes Financières"
+          },
+          "reports": {
+            "description": "Livraison programmée des rapports",
+            "monthlyReport": "Rapport Mensuel",
+            "monthlyReportHint": "Analyse détaillée des dépenses mensuelles",
+            "title": "Rapports",
+            "weeklyDigest": "Résumé Hebdomadaire",
+            "weeklyDigestHint": "Résumé de votre activité hebdomadaire"
+          },
+          "security": {
+            "alwaysOnNote": "Les alertes de sécurité ne peuvent pas être entièrement désactivées pour votre protection",
+            "description": "Alertes de sécurité critiques",
+            "securityAlerts": "Alertes de Sécurité",
+            "securityAlertsHint": "Notifications importantes de sécurité",
+            "title": "Notifications de Sécurité"
+          },
+          "title": "Paramètres de Notification",
+          "updates": {
+            "description": "Restez informé des nouvelles fonctionnalités",
+            "marketing": "Emails Marketing",
+            "marketingHint": "Contenu promotionnel et offres",
+            "newFeatures": "Nouvelles Fonctionnalités",
+            "newFeaturesHint": "Être notifié des nouvelles fonctionnalités",
+            "title": "Mises à Jour Produit"
+          }
         },
         "security": {
-          "alwaysOnNote": "Les alertes de sécurité ne peuvent pas être entièrement désactivées pour votre protection",
-          "description": "Alertes de sécurité critiques",
-          "securityAlerts": "Alertes de Sécurité",
-          "securityAlertsHint": "Notifications importantes de sécurité",
-          "title": "Notifications de Sécurité"
-        },
-        "title": "Paramètres de Notification",
-        "updates": {
-          "description": "Restez informé des nouvelles fonctionnalités",
-          "marketing": "Emails Marketing",
-          "marketingHint": "Contenu promotionnel et offres",
-          "newFeatures": "Nouvelles Fonctionnalités",
-          "newFeaturesHint": "Être notifié des nouvelles fonctionnalités",
-          "title": "Mises à Jour Produit"
+          "description": "Protégez votre compte avec des mesures de sécurité renforcées",
+          "devices": {
+            "current": "Actuel",
+            "description": "Gérez les appareils pouvant accéder à votre compte",
+            "empty": "Aucun appareil de confiance configuré",
+            "lastUsed": "Dernière utilisation",
+            "title": "Appareils de Confiance"
+          },
+          "password": {
+            "changePassword": "Changer le Mot de Passe",
+            "clerkNote": "La gestion du mot de passe se fait via Clerk",
+            "description": "Gérez vos identifiants de compte",
+            "title": "Mot de Passe et Accès"
+          },
+          "session": {
+            "description": "Gérez vos sessions de connexion",
+            "hour": "heure",
+            "hours": "heures",
+            "loginNotifications": "Notifications de Connexion",
+            "loginNotificationsHint": "Être notifié des nouvelles connexions",
+            "minutes": "minutes",
+            "timeout": "Expiration de Session",
+            "title": "Paramètres de Session"
+          },
+          "title": "Paramètres de Sécurité",
+          "twoFactor": {
+            "activeMessage": "L'authentification à deux facteurs est active",
+            "description": "Ajoutez une couche de sécurité supplémentaire à votre compte",
+            "enabled": "Activer 2FA",
+            "enabledHint": "Exiger un second facteur lors de la connexion",
+            "title": "Authentification à Deux Facteurs"
+          }
         }
       },
-      "security": {
-        "description": "Protégez votre compte avec des mesures de sécurité renforcées",
-        "devices": {
-          "current": "Actuel",
-          "description": "Gérez les appareils pouvant accéder à votre compte",
-          "empty": "Aucun appareil de confiance configuré",
-          "lastUsed": "Dernière utilisation",
-          "title": "Appareils de Confiance"
+      "sidebar": {
+        "account": "Compte",
+        "daysActive": "jours actifs",
+        "manageClerk": "Gérer le Compte sur Clerk",
+        "nav": {
+          "ai": "Assistant IA",
+          "analytics": "Analyses",
+          "appearance": "Apparence",
+          "data": "Données",
+          "notifications": "Notifications",
+          "profile": "Profil",
+          "security": "Sécurité"
         },
-        "password": {
-          "changePassword": "Changer le Mot de Passe",
-          "clerkNote": "La gestion du mot de passe se fait via Clerk",
-          "description": "Gérez vos identifiants de compte",
-          "title": "Mot de Passe et Accès"
+        "preferences": "Préférences",
+        "premium": "Premium",
+        "profileCompletion": "Complétion du Profil"
+      },
+      "stats": {
+        "aiQueries": {
+          "description": "Interactions avec l'assistant IA",
+          "title": "Requêtes IA"
         },
-        "session": {
-          "description": "Gérez vos sessions de connexion",
-          "hour": "heure",
-          "hours": "heures",
-          "loginNotifications": "Notifications de Connexion",
-          "loginNotificationsHint": "Être notifié des nouvelles connexions",
-          "minutes": "minutes",
-          "timeout": "Expiration de Session",
-          "title": "Paramètres de Session"
+        "description": "Aperçu de l'activité de votre compte",
+        "invoices": {
+          "description": "Factures traitées et stockées",
+          "title": "Total des Factures"
         },
-        "title": "Paramètres de Sécurité",
-        "twoFactor": {
-          "activeMessage": "L'authentification à deux facteurs est active",
-          "description": "Ajoutez une couche de sécurité supplémentaire à votre compte",
-          "enabled": "Activer 2FA",
-          "enabledHint": "Exiger un second facteur lors de la connexion",
-          "title": "Authentification à Deux Facteurs"
-        }
+        "merchants": {
+          "description": "Commerçants uniques suivis",
+          "title": "Commerçants"
+        },
+        "monthly": {
+          "description": "Dépenses mensuelles moyennes",
+          "title": "Moyenne Mensuelle"
+        },
+        "saved": {
+          "description": "Économies estimées grâce au suivi",
+          "title": "Total Économisé"
+        },
+        "scans": {
+          "description": "Scans de reçus téléchargés",
+          "title": "Total des Scans"
+        },
+        "storage": {
+          "description": "Allocation de votre espace de stockage",
+          "title": "Utilisation du Stockage",
+          "used": "utilisé"
+        },
+        "title": "Statistiques Rapides"
       }
-    },
-    "sidebar": {
-      "account": "Compte",
-      "daysActive": "jours actifs",
-      "manageClerk": "Gérer le Compte sur Clerk",
-      "nav": {
-        "ai": "Assistant IA",
-        "analytics": "Analyses",
-        "appearance": "Apparence",
-        "data": "Données",
-        "notifications": "Notifications",
-        "profile": "Profil",
-        "security": "Sécurité"
-      },
-      "preferences": "Préférences",
-      "premium": "Premium",
-      "profileCompletion": "Complétion du Profil"
-    },
-    "stats": {
-      "aiQueries": {
-        "description": "Interactions avec l'assistant IA",
-        "title": "Requêtes IA"
-      },
-      "description": "Aperçu de l'activité de votre compte",
-      "invoices": {
-        "description": "Factures traitées et stockées",
-        "title": "Total des Factures"
-      },
-      "merchants": {
-        "description": "Commerçants uniques suivis",
-        "title": "Commerçants"
-      },
-      "monthly": {
-        "description": "Dépenses mensuelles moyennes",
-        "title": "Moyenne Mensuelle"
-      },
-      "saved": {
-        "description": "Économies estimées grâce au suivi",
-        "title": "Total Économisé"
-      },
-      "scans": {
-        "description": "Scans de reçus téléchargés",
-        "title": "Total des Scans"
-      },
-      "storage": {
-        "description": "Allocation de votre espace de stockage",
-        "title": "Utilisation du Stockage",
-        "used": "utilisé"
-      },
-      "title": "Statistiques Rapides"
     }
   },
-  "email": {
-    "layout": {
-      "tagline": "Outils pratiques. Informations claires. Conçu pour les dépenses quotidiennes.",
-      "managePreferences": "Gérer les préférences d'email",
-      "unsubscribe": "Se désabonner",
-      "buttonFallback": "Si le bouton ne fonctionne pas, ouvrez ce lien :",
-      "secondaryFallback": "Ou :",
-      "allRightsReserved": "© 2022-{year} {brand}. Tous droits réservés."
-    },
-    "welcome": {
-      "subject": "Bienvenue chez {brand}",
-      "badge": "Bienvenue",
-      "heading": "Bienvenue chez {brand}",
-      "preview": "Bienvenue chez {brand}, {name} ! Commençons.",
-      "greeting": "Bonjour {name},",
-      "intro": "Merci d'avoir rejoint {brand}. Nous sommes ravis de vous compter parmi nous. Notre plateforme vous aide à transformer vos reçus quotidiens en informations financières organisées, grâce à l'analyse par IA.",
-      "howItWorksTitle": "Comment ça marche",
-      "howItWorks": {
-        "0": "Téléversez — prenez une photo ou téléversez un PDF d'un reçu",
-        "1": "Analysez — notre IA extrait les articles, les prix, les marchands et suggère même des recettes à partir des reçus d'épicerie",
-        "2": "Suivez — consultez des tableaux de dépenses par marchand, catégorie, mois ou année"
+  "sections": {
+    "about": {
+      "author": {
+        "biography": {
+          "fifthPoint": "Alexandru est ouvert à la collaboration dans des projets impliquant l'Internet des objets, l'ingénierie logicielle et l'ingénierie réseau. Il a fait ses preuves en fournissant des solutions de haute qualité à des problèmes complexes et est toujours à la recherche de nouveaux défis.",
+          "firstPoint": "Alexandru est un ingénieur logiciel et architecte de solutions de {age} ans. Il travaille actuellement chez Microsoft en tant qu'ingénieur logiciel dans l'organisation E+D MSAI FAST, développant des solutions utilisées par des millions d'utilisateurs dans le monde entier.",
+          "fourthPoint": "Alexandru aime lire des livres techniques et expérimenter de nouvelles technologies. Il a construit cette plateforme comme un \"banc d'essai\" pour les nouvelles technologies et comme un moyen d'apprendre de nouvelles choses. Il est également un grand partisan du mouvement \"open-source\" et a contribué aux dépôts OSS de Microsoft (dotnet/core, dotnet/docs, azure/docs).",
+          "secondPoint": "Alexandru est né le 8 janvier 2000 dans une petite ville appelée Curtea de Argeș en Roumanie. Il a eu son premier ordinateur à l'âge de 5 ans - un Pentium 4 E2200 2,2 GHz Dual-Core avec 512 Mo de RAM. Depuis lors, il a utilisé différentes versions de Windows (en commençant par Windows 98 !), bricolant son ordinateur personnel et développant ses compétences informatiques en jouant à des jeux vidéo. Il a également appris beaucoup d'anglais et était capable de lire, écrire et parler couramment l'anglais à l'âge de 12 ans !",
+          "thirdPoint": "Alexandru est un passionné de jeux vidéo. Il était autrefois joueur professionnel, classé n°70 en Roumanie pour le jeu vidéo \"DotA 2\". Il aime les jeux de stratégie axés sur la mécanique et l'aspect technique comme Age of Empires, Age of Mythology, etc. Il apprécie également les jeux tels que Red Alert, StarCraft et d'autres jeux RTS.",
+          "title": "À propos d'Alexandru"
+        },
+        "certifications": {
+          "certificates": {
+            "ab730": {
+              "code": "AB-730",
+              "coreSkills": "# Stratégie IA # Adoption de l'IA # IA responsable # Valeur métier de l'IA # Identification des cas d'usage IA",
+              "description": "Valide les connaissances orientées métier en IA pour les professionnels qui dirigent ou influencent les initiatives IA au sein de leur organisation. Destinée aux décideurs, product owners et consultants qui définissent la stratégie IA plutôt que sa mise en œuvre.",
+              "issuer": "Microsoft",
+              "issuerDate": "2026",
+              "link": "https://learn.microsoft.com/en-us/credentials/certifications/ai-business-professional/",
+              "name": "Microsoft Certified: AI Business Professional"
+            },
+            "ab731": {
+              "code": "AB-731",
+              "coreSkills": "# Transformation IA d'entreprise # Stratégie IA # Conduite du changement # Gouvernance IA # Leadership exécutif",
+              "description": "Valide la capacité à diriger des initiatives de transformation IA à l'échelle de l'entreprise — définition de la stratégie, conduite du changement organisationnel et mise en place de la gouvernance pour opérationnaliser l'IA dans toute l'organisation.",
+              "issuer": "Microsoft",
+              "issuerDate": "2026",
+              "link": "https://learn.microsoft.com/en-us/credentials/certifications/ai-transformation-leader/",
+              "name": "Microsoft Certified: AI Transformation Leader"
+            },
+            "ai900": {
+              "code": "AI-900",
+              "coreSkills": "# Machine Learning # Vision par ordinateur # Traitement du langage naturel # IA conversationnelle # IA responsable",
+              "description": "Démontre la connaissance des charges de travail courantes en IA et en apprentissage automatique et comment les implémenter sur Azure. Cette certification est destinée aux candidats ayant des antécédents techniques et non techniques.",
+              "issuer": "Microsoft",
+              "issuerDate": "2023",
+              "link": "https://learn.microsoft.com/en-us/certifications/azure-ai-fundamentals/",
+              "name": "Microsoft Certified: Azure AI Fundamentals"
+            },
+            "az900": {
+              "code": "AZ-900",
+              "coreSkills": "# Concepts Cloud # Services Azure principaux # Sécurité, confidentialité, conformité et confiance # Tarification Azure, SLA et cycle de vie",
+              "description": "Valide les connaissances fondamentales des services cloud et la manière dont ces services sont fournis avec Microsoft Azure. Cette certification est destinée aux candidats qui commencent à travailler avec des solutions et services basés sur le cloud.",
+              "issuer": "Microsoft",
+              "issuerDate": "2023",
+              "link": "https://learn.microsoft.com/en-us/certifications/azure-fundamentals/",
+              "name": "Microsoft Certified: Azure Fundamentals"
+            },
+            "gh100": {
+              "code": "GH-100",
+              "coreSkills": "# Authentification # Gestion des utilisateurs et équipes # Politiques de référentiel # Configuration Enterprise # Sécurité et conformité",
+              "description": "Valide les compétences nécessaires pour administrer les organisations GitHub Enterprise — gestion des utilisateurs, équipes, dépôts, politiques et intégrations à grande échelle.",
+              "issuer": "GitHub",
+              "issuerDate": "2026",
+              "link": "https://learn.microsoft.com/en-us/credentials/certifications/github-administration/",
+              "name": "GitHub Certified: Administration"
+            },
+            "gh200": {
+              "code": "GH-200",
+              "coreSkills": "# Création de workflows # Runners auto-hébergés # Sécurité des workflows # Workflows réutilisables # Pipelines CI/CD",
+              "description": "Valide l'expertise dans la création, la configuration et la maintenance des workflows GitHub Actions pour l'automatisation du build, des tests et du déploiement tout au long du cycle de vie logiciel.",
+              "issuer": "GitHub",
+              "issuerDate": "2026",
+              "link": "https://learn.microsoft.com/en-us/credentials/certifications/github-actions/",
+              "name": "GitHub Certified: Actions"
+            },
+            "gh300": {
+              "code": "GH-300",
+              "coreSkills": "# Plans et fonctionnalités Copilot # Suggestions de code # Prompt engineering # Utilisation responsable de l'IA # Copilot Chat",
+              "description": "Valide les compétences nécessaires pour exploiter efficacement GitHub Copilot dans le développement logiciel assisté par IA — couvrant les fonctionnalités, la personnalisation, le prompt engineering et l'utilisation responsable.",
+              "issuer": "GitHub",
+              "issuerDate": "2026",
+              "link": "https://learn.microsoft.com/en-us/credentials/certifications/github-copilot/",
+              "name": "GitHub Certified: Copilot"
+            },
+            "gh900": {
+              "code": "GH-900",
+              "coreSkills": "# Bases de GitHub # Dépôts # Collaboration # Produits GitHub # Issues, pull requests et workflows",
+              "description": "Valide les connaissances fondamentales sur GitHub — couvrant les dépôts, les fonctionnalités de collaboration, la famille de produits GitHub et les workflows essentiels du développeur.",
+              "issuer": "GitHub",
+              "issuerDate": "2026",
+              "link": "https://learn.microsoft.com/en-us/credentials/certifications/github-foundations/",
+              "name": "GitHub Certified: Foundations"
+            },
+            "sc900": {
+              "code": "SC-900",
+              "coreSkills": "# Concepts de sécurité # Principes d'identité # Microsoft Entra # Solutions de conformité # Confidentialité et protection des informations",
+              "description": "Valide les connaissances fondamentales en matière de sécurité, conformité et identité, ainsi que les solutions Microsoft cloud associées — Entra, Defender et Purview.",
+              "issuer": "Microsoft",
+              "issuerDate": "2023",
+              "link": "https://learn.microsoft.com/en-us/credentials/certifications/security-compliance-and-identity-fundamentals/",
+              "name": "Microsoft Certified: Security, Compliance & Identity Fundamentals"
+            }
+          },
+          "coreSkillsLabel": "Compétences clés démontrées :",
+          "subtitle": "Certifications professionnelles et accréditations qu'Alexandru a obtenues tout au long de sa carrière.",
+          "title": "Certifications",
+          "viewCertification": "Voir la certification"
+        },
+        "competencies": {
+          "competences": {
+            "agileMethodologies": {
+              "description": "Alexandru a appris le travail agile et les méthodologies agiles depuis qu'il était étudiant en licence. Il suit le manifeste agile et est un grand adepte de la technique Kanban pour la planification.",
+              "title": "Méthodologies Agiles"
+            },
+            "algorithmicSkills": {
+              "description": "Alexandru a complété de nombreux défis Hacker Rank, Hacker Earth et Leet Code publiés de 2019 à 2021. Il possède une forte pensée algorithmique et est capable de construire des algorithmes complexes avec facilité.",
+              "title": "Compétences Algorithmiques"
+            },
+            "customerCentric": {
+              "description": "Alexandru travaille avec des clients depuis de nombreuses années chez Microsoft. Il a acquis beaucoup de connaissances et est capable de se mettre à la place du client. Il est capable de comprendre les besoins du client et de fournir des solutions exactement adaptées à leurs besoins.",
+              "title": "Orienté Client"
+            },
+            "domainDrivenDesign": {
+              "description": "Alexandru suit fortement les principes de conception pilotée par le domaine. Il est capable de combiner DDD avec TDD pour créer des solutions complexes faciles à maintenir et à étendre. Il est également un grand adepte des approches \"architecture en oignon\" et \"architecture propre\".",
+              "title": "Domain-Driven Design (DDD)"
+            },
+            "engineeringExcellence": {
+              "description": "Alexandru est passionné par la fourniture des meilleures solutions pour le problème et pour le client. Il s'efforce toujours de livrer le meilleur logiciel et de suivre les pratiques d'excellence en ingénierie reconnues. Une solution parfaite est une solution facile à maintenir, étendre et comprendre, pas celle qui est la plus complexe.",
+              "title": "Excellence en Ingénierie"
+            },
+            "testDrivenDevelopment": {
+              "description": "Alexandru croit fermement au développement piloté par les tests. Il applique constamment cette approche à ses projets et essaie toujours d'améliorer ses compétences en test. Il est également un grand adepte de l'approche \"red-green-refactor\".",
+              "title": "Test-Driven Development (TDD)"
+            }
+          },
+          "subtitle": "Une vitrine des compétences techniques et professionnelles d'Alexandru.",
+          "title": "Les Compétences d'Alexandru"
+        },
+        "contact": {
+          "collaborate": {
+            "discipline1": "Ingénierie Logicielle",
+            "discipline2": "Internet des Objets",
+            "discipline3": "Applications Cloud Native",
+            "discipline4": "Ingénierie Réseau",
+            "footer": " Si vous avez un projet ou une opportunité intéressante qui correspond à l'expertise d'Alexandru, n'hésitez pas à le contacter. Il est toujours désireux d'explorer de nouveaux défis et collaborations.",
+            "subtitle": "Alexandru est ouvert à la collaboration dans des projets impliquant l'un des domaines suivants :",
+            "title": "Collaborons ensemble !"
+          },
+          "footer": "Merci.",
+          "socials": {
+            "footer": "Pour le contacter, utilisez l'une des méthodes de contact ci-dessus.",
+            "subtitle": "N'hésitez pas à nous contacter pour des collaborations, des questions, ou simplement pour dire bonjour !",
+            "title": "Entrer en contact"
+          },
+          "subtitle": "Si vous souhaitez contacter Alexandru, veuillez utiliser les moyens de contact ci-dessous.",
+          "title": "Contactez Alexandru"
+        },
+        "education": {
+          "subtitle": "Le parcours académique et d'apprentissage d'Alexandru.",
+          "title": "Formation",
+          "university": {
+            "aseBucharest": {
+              "aboutTheProgramCta": "Voir plus de détails",
+              "aboutTheProgramDescription": "La licence en informatique à l'Université de Bucarest est un programme rigoureux qui fournit aux étudiants une base solide en informatique théorique et en développement logiciel pratique. Le programme met l'accent sur les compétences en résolution de problèmes, la pensée algorithmique et les principes d'ingénierie logicielle.",
+              "aboutTheProgramLearnings": "# Concevoir et analyser des algorithmes et des structures de données # Développer des logiciels utilisant différents paradigmes de programmation # Implémenter des systèmes de bases de données et gérer les données # Comprendre les réseaux informatiques et les systèmes distribués # Appliquer les principes d'ingénierie logicielle aux problèmes du monde réel",
+              "aboutTheProgramLearningsTitle": "Résultats d'apprentissage clés",
+              "aboutTheProgramTitle": "À propos du programme",
+              "degree": "Licence en Informatique et Économie",
+              "description": "Licence en informatique et économie de l'Université des Études Économiques de Bucarest, Roumanie. Diplômé dans le top 1% selon les statistiques de notation des thèses.",
+              "institution": "Academia de Studii Economice",
+              "keyCourses": "# Ingénierie Logicielle # Réseaux Informatiques # Systèmes d'Exploitation # Algorithmes et Structures de Données # Systèmes de Gestion de Bases de Données # Développement Web # Développement Mobile",
+              "keyCoursesTitle": "Cours principaux",
+              "location": "Bucarest, Roumanie",
+              "period": "2019 - 2022",
+              "status": "Terminé"
+            },
+            "malmoSweden": {
+              "aboutTheProgramCta": "Voir plus de détails",
+              "aboutTheProgramDescription": "Le Master en Internet des Objets à l'Université de Malmö est un programme de pointe qui prépare les étudiants aux défis et opportunités de la révolution IoT. Le programme met l'accent sur l'apprentissage pratique, la collaboration interdisciplinaire et les applications du monde réel.",
+              "aboutTheProgramLearnings": "# Concevoir et implémenter des systèmes IoT utilisant diverses plateformes matérielles et logicielles # Analyser et gérer les données générées par les appareils IoT # Appliquer les techniques d'apprentissage automatique et d'intelligence artificielle aux applications IoT # Comprendre les implications de sécurité et de confidentialité des systèmes IoT # Collaborer avec des partenaires industriels sur des projets réels",
+              "aboutTheProgramLearningsTitle": "Résultats d'apprentissage clés",
+              "aboutTheProgramTitle": "À propos du programme",
+              "degree": "Master en Internet des Objets",
+              "description": "Précédemment inscrit au programme de Master Internet des Objets à l'Université de Malmö, Suède. Interrompu en raison de circonstances personnelles et imprévues en 2024.",
+              "institution": "Malmö University",
+              "keyCourses": "# Internet des Objets # Cloud Computing # Science des Données # Apprentissage Automatique # Intelligence Artificielle # Vision par Ordinateur # Robotique",
+              "keyCoursesTitle": "Cours principaux",
+              "location": "Malmö, Suède",
+              "period": "2023 - 2024",
+              "status": "Interrompu"
+            }
+          }
+        },
+        "experiences": {
+          "achievementsLabel": "Réalisations",
+          "intel": {
+            "achievements": "# Développement de convertisseurs d'espace colorimétrique (CSC) en C et Assembly x8086 (YUV->RGB, Niveaux de gris).# Création de plus de 10 types de filtres d'image tels que Fish Eye, Sobel, Détection de contours, Flou de boîte, etc.# Refactorisation du code .ASM pour de meilleures performances sur les appareils IoT et Systèmes Embarqués.",
+            "company": "Intel",
+            "description": "Le site de Timisoara aborde plusieurs domaines où des logiciels pour divers composants matériels, des algorithmes de traitement d'image et des implémentations de bas niveau et de haut niveau de parties de réseaux neuronaux sont activement développés.",
+            "location": "Télétravail (Roumanie - Timisoara)",
+            "period": "2021 (6 Mois)",
+            "responsibilites": "#Maîtriser les compétences dans le monde du traitement d'image. #Acquérir une compréhension du domaine de l'apprentissage automatique (ML). #Mettre en pratique les connaissances acquises en développant différents convertisseurs d'espace colorimétrique.",
+            "techAndSkills": "# C # C++ #Intel x8086 Assembly # Convertisseurs d'espace colorimétrique # Python # Calcul embarqué # Internet des Objets",
+            "title": "Ingénieur Systèmes Embarqués"
+          },
+          "microsoft1": {
+            "achievements": "# (Excellence en Ingénierie) Je me suis constamment poussé pour obtenir les meilleurs retours clients. (Score actuel : 4,94 / 5,00) # (Interactions Proactives) Fourniture de retours continus au Product Group concernant le produit Azure Virtual Desktop (AVD), au sujet de l'implémentation de fonctionnalités et services spécifiques. # (Expérience Client) Développement de la documentation existante sur les fonctionnalités des services Azure Core tels qu'Azure Virtual Desktop, Azure Virtual Machines, Azure Networks. # Travail exclusif avec des clients TOP 100 et Fortune 500 et des professionnels leaders du secteur.",
+            "company": "Microsoft",
+            "description": "Avec plus de 12 000 employés dans le monde, l'organisation Microsoft Customer Experience & Success (CE&S) est responsable de la stratégie, de la conception et de la mise en œuvre de l'expérience client de bout en bout de Microsoft.",
+            "location": "Roumanie",
+            "period": "03/2021 – 03/2023",
+            "responsibilites": "# Fournir le partage de connaissances, le coaching technique et le mentorat aux collègues ; # Résolution de problèmes par un dépannage approfondi, débogage, analyse de logs, tests A/B ; # Identifier et répondre aux problèmes critiques des clients spécifiques aux services Azure tels qu'Azure Virtual Desktop ; # Travailler exclusivement avec des clients Fortune 500 pour comprendre leurs besoins techniques et définir un plan d'action pour y répondre, en collaborant régulièrement avec des pairs ou d'autres équipes.",
+            "techAndSkills": "# Analyse du trafic réseau # Azure # Approche centrée client # Relations commerciales # Gestionnaire d'incidents",
+            "title": "Ingénieur Technique Azure"
+          },
+          "microsoft2": {
+            "achievements": "# (Observabilité-as-a-Service) Orchestration et implémentation complète des trois piliers de l'observabilité dans notre architecture microservices utilisant les standards Open Telemetry ; j'ai également construit des déclencheurs automatisés de surveillance et d'alerte basés sur les statistiques p95/p99 pour le trafic réel et synthétique. # (Recherche & Développement) Contributions majeures au développement d'une bibliothèque .NET interne implémentant le protocole de consommation de données ODataV4 pour les moteurs de bases de données NoSQL tels qu'Azure Data Explorer (ADX), en utilisant les pratiques Domain-Driven Design (DDD) (par ex. aggregator roots) (brevet en cours). # (Expérience de Développement) Prise de leadership sur deux domaines clés pour la DX : documentation et couches de consommation. Construction d'une documentation exceptionnelle et utilisation d'outils de génération de sites statiques (DocFX) pour générer automatiquement la documentation API à partir du code ; offre de couches de consommation API sous forme d'UI frontend, outillage CLI et fichiers de spécification OpenAPI. # (Croissance) J'ai assisté et participé à des entretiens d'embauche pour les postes SWE II et Senior SWE.",
+            "company": "Microsoft",
+            "description": "Alors que les gouvernements d'aujourd'hui envisagent l'innovation technologique, il est nécessaire de répondre aux demandes en rapide évolution de leurs citoyens tout en protégeant les données les plus sensibles et en tenant les promesses de confiance et de sécurité.",
+            "location": "EMEA",
+            "period": "03/2023 – 12/2024",
+            "responsibilites": "# Livrer une plateforme de données E+C capable de fonctionner multi-cloud et multi-tenant dans des environnements souverains et des scénarios air-gap. # Gérer et assurer le bon fonctionnement des opérations de la plateforme de données Runtime in Sovereign Environments (RISE). # Construire une architecture d'entreprise data mesh innovante utilisant des concepts d'ingénierie de données, des outils comme Azure Data Factory et d'autres notions d'entrepôt de données.",
+            "techAndSkills": "# .NET # Azure # Microservices # Applications Cloud-Native # Méthodologies Agiles # DevOps # Domain-Driven Design # Test-Driven Development # Gestion de Projet",
+            "title": "E + D Ingénieur Logiciel II - Clouds Souverains"
+          },
+          "microsoft3": {
+            "achievements": " ",
+            "company": "Microsoft",
+            "description": "Alexandru travaille actuellement chez Microsoft en tant qu'ingénieur logiciel dans l'organisation E+D MSAI (M365 AI Experiences).",
+            "location": "Télétravail (Norvège)",
+            "period": "11/2024 - Présent",
+            "responsibilites": " ",
+            "techAndSkills": "# React # GraphQL # Développement à grande échelle # Applications Cloud-Native # Méthodologies Agiles # Excellence en Ingénierie # Leadership",
+            "title": "E + D Ingénieur Logiciel Fullstack II - M365 AI"
+          },
+          "responsibilitiesLabel": "Responsabilités",
+          "subtitle": "Un parcours à travers la carrière professionnelle d'Alexandru et les entreprises avec lesquelles il a travaillé.",
+          "techSkillsLabel": "Technologies et Compétences",
+          "title": "Expérience Professionnelle",
+          "ubisoft": {
+            "achievements": "# J'ai constamment dépassé le quota de bugs, glitches et artefacts signalés, me classant n°1 des rapporteurs pendant 5 mois solides sur les 6 travaillés. # Découverte et signalement de défauts de code majeurs allant des conditions de concurrence aux défauts d'allocation de ressources mémoire. # Augmentation de l'efficacité des rapports quotidiens en exploitant les capacités de filtrage SQL et JQL.",
+            "company": "Ubisoft",
+            "description": "J'ai travaillé sur Avatar: Frontiers of Pandora™, un jeu d'action-aventure à la première personne construit avec la dernière version du moteur Snowdrop (C++) par Massive Entertainment - un studio UBISOFT, et testé par UBISOFT Roumanie.",
+            "location": "Hybride (Bucarest, Roumanie)",
+            "period": "2020 - 2021",
+            "responsibilites": "# Gestion des tests de régression, d'intégration et unitaires avec des logiciels tels que XRAY, TestRail, Bugzilla. # Création de suites de tests et de plans de tests de haute qualité utilisant les produits Atlassian (JIRA / Confluence). # Assurer des communications stables et claires entre les équipes de production et de test.",
+            "techAndSkills": "# Tests Unitaires # Tests d'Intégration # Tests A/B # Tests de Performance # Tests Automatiques # Tests E2E",
+            "title": "Ingénieur QA/QC"
+          }
+        },
+        "perspectives": {
+          "perspectiveFromX": {
+            "author": "Anonyme",
+            "avatar": " ",
+            "company": "Microsoft",
+            "position": "Ingénieur Logiciel Senior",
+            "quote": "Ce que j'apprécie beaucoup chez vous, c'est votre recherche incessante de l'amélioration et votre volonté de remettre en question le statu quo. Votre engagement envers le développement personnel continu est évident dans la façon dont vous abordez chaque tâche avec un état d'esprit orienté vers l'innovation et l'excellence. Votre capacité à questionner les méthodes existantes et à proposer de meilleures alternatives a été déterminante pour faire avancer nos projets. Cette attitude proactive améliore non seulement la qualité de notre travail mais inspire également l'équipe à viser des standards plus élevés. Je suis heureux d'avoir travaillé avec vous et j'espère que nos chemins se croiseront à nouveau à l'avenir."
+          },
+          "perspectiveFromXX": {
+            "author": "Anonyme",
+            "avatar": " ",
+            "company": "Microsoft",
+            "position": "Senior Software Engineering Manager",
+            "quote": "Alex est un ingénieur intelligent dont les capacités ont brillé durant notre collaboration sur nos projets. Il démontre constamment son empressement à aider l'équipe avec toute demande, montrant son dévouement au succès collectif. Son approche proactive de la résolution de problèmes et son dévouement à la stabilité du système bénéficient grandement au flux de travail de notre équipe. De plus, la disponibilité d'Alex et sa volonté de soutenir les autres pendant notre flux de release soulignent sa valeur en tant que collègue qui priorise le travail d'équipe et la collaboration."
+          },
+          "perspectiveFromXY": {
+            "author": "Anonyme",
+            "avatar": " ",
+            "company": "Microsoft",
+            "position": "Ingénieur d'Escalade Senior",
+            "quote": "Alex, si je devais choisir une chose que j'apprécie le plus dans le travail avec vous, ce serait votre état d'esprit - car il englobe plusieurs aspects. Travailler avec vous est authentique, amusant, sage et pertinent en même temps. Il est facile de remarquer que vos moteurs quotidiens sont l'engagement, le raisonnement et l'apprentissage continu. J'admire votre approche, votre désir sincère d'aider, de construire sur le succès des autres et de soutenir chacun dans sa croissance, ce qui est une valeur si rare. En plus de cela, j'apprécie votre patience, ainsi que la grande quantité de connaissances que vous apportez dans nos interactions. La façon dont vous gérez les situations stressantes et votre approche globale ont le pouvoir de façonner un résultat positif pour toute question ou sujet."
+          },
+          "perspectiveFromXZ": {
+            "author": "Anonyme",
+            "avatar": " ",
+            "company": "Microsoft",
+            "position": "Ingénieur Logiciel Senior",
+            "quote": "J'ai été constamment impressionné par votre production de travail. Vous livrez toujours un travail de haute qualité, en accordant une attention particulière aux détails et en vous assurant que tout est fait au mieux de vos capacités. De plus, vous avez une compréhension approfondie des aspects techniques de notre travail, ce qui a été un atout précieux pour l'équipe. Votre volonté de partager vos connaissances et votre expérience avec les autres a été inestimable et il est clair que vous êtes fier de mentorer les autres et de les aider à grandir."
+          },
+          "perspectiveFromY": {
+            "author": "Anonyme",
+            "avatar": " ",
+            "company": "Microsoft",
+            "position": "Ingénieur Logiciel II",
+            "quote": "J'apprécie vraiment votre approche proactive et votre esprit collaboratif, et votre soutien et style de communication amical ont été très positifs pour mon expérience d'intégration et pour apprendre les tenants et aboutissants de notre projet. Votre capacité à communiquer efficacement et à tenir tout le monde informé est quelque chose que j'admire, vous avez de l'expérience dans les relations avec les équipes transversales, en particulier avec nos équipes partenaires, en apprenant leurs besoins et en résolvant leurs problèmes. Vos compétences techniques sont impressionnantes et votre attention aux détails est louable."
+          },
+          "perspectiveFromYX": {
+            "author": "Anonyme",
+            "avatar": " ",
+            "company": "Microsoft",
+            "position": "Chef de Produit Senior",
+            "quote": "La profondeur de caractère d'Alexandru est évidente dans sa passion et son engagement à aider les autres à réussir et nulle part cela n'est plus clair que dans son mentorat. Je tiens Alexandru en haute estime - j'ai peut-être quelques années de plus que lui, mais il ne devrait pas hésiter à me défier s'il croit qu'il y a une meilleure façon d'aborder un problème."
+          },
+          "perspectiveFromYY": {
+            "author": "Anonyme",
+            "avatar": " ",
+            "company": "Microsoft",
+            "position": "Ingénieur Logiciel Staff",
+            "quote": "J'aime votre attitude et votre ouverture d'esprit, je trouve facile de travailler et de parler avec vous. Je n'ai pas grand-chose à vous dire pour exploiter davantage ces forces : restez vous-même et vous faites déjà un excellent travail !"
+          },
+          "perspectiveFromYZ": {
+            "author": "Anonyme",
+            "avatar": " ",
+            "company": "Microsoft",
+            "position": "Ingénieur Logiciel Staff",
+            "quote": "Alexandru est un excellent ingénieur logiciel. Il est incroyablement vif et je le classerais dans le top 1% pour son âge - à 25 ans, la plupart des gens ont du mal à trouver un emploi, tandis qu'Alexandru délivre un impact qui se traduit en millions de dollars. Il est extrêmement talentueux."
+          },
+          "perspectiveFromZ": {
+            "author": "Anonyme",
+            "avatar": " ",
+            "company": "Microsoft",
+            "position": "Ingénieur Logiciel Senior",
+            "quote": "Vous êtes toujours prêt à aider, partageant généreusement votre temps, même lorsque vous avez vos propres tâches urgentes. Vos réponses rapides et utiles à toutes les questions sont grandement appréciées. Vous adoptez une approche priorisée et méticuleuse, fournissant des solutions instantanées qui non seulement nous débloquent à court terme mais décrivent également les corrections à long terme et leurs calendriers de mise en œuvre. Votre état d'esprit orienté solutions est un véritable atout pour notre équipe. Votre expertise, votre volonté d'aider et votre personnalité agréable font de vous un excellent collègue. Continuez votre excellent travail !"
+          },
+          "subtitle": "Perspectives de collègues qui ont travaillé avec ou aux côtés d'Alexandru.",
+          "title": "Perspectives"
+        },
+        "subtitle": "Alexandru-Razvan Olariu est l'auteur de la plateforme que vous consultez actuellement.",
+        "title": "Rencontrez l'auteur."
       },
-      "whatYouCanDoTitle": "Ce que vous pouvez faire",
-      "whatYouCanDo": {
-        "0": "Recevez des alertes sur les allergènes des produits alimentaires",
-        "1": "Partagez des factures avec votre famille ou vos collègues",
-        "2": "Exportez des statistiques et des rapports de dépenses",
-        "3": "Accédez à vos données depuis n'importe quel appareil"
-      },
-      "body": "Prêt à commencer ? Téléversez votre premier reçu et regardez la magie opérer. Le processus prend moins d'une minute.",
-      "feedbackPrompt": "Des questions ou des commentaires ? Nous serions ravis de vous entendre à <email></email>.",
-      "signOff": {
-        "line1": "Cordialement,",
-        "line2": "L'équipe {brand}"
-      },
-      "ctaPrimary": "Téléversez votre premier reçu",
-      "ctaSecondary": "Explorez le tableau de bord"
-    },
-    "firstInvoiceUploaded": {
-      "subject": "Votre première facture est arrivée !",
-      "badge": "Étape importante",
-      "heading": "Votre première facture est arrivée !",
-      "preview": "Félicitations, {name} ! Votre première facture est arrivée.",
-      "greeting": "Bonjour {name},",
-      "intro": "Félicitations pour le téléchargement de votre première facture ! Vous avez fait le premier pas vers un suivi organisé et perspicace des dépenses. Voici ce que nous avons jusqu'à présent :",
-      "invoiceSummaryTitle": "Votre Première Facture",
-      "invoiceSummary": {
-        "invoiceName": "Nom de la facture",
-        "uploaded": "Téléchargé",
-        "status": "Statut"
-      },
-      "statusValue": "Prêt pour l'analyse",
-      "untitledFallback": "Sans titre",
-      "whatHappensNextTitle": "Ce qui va suivre",
-      "whatHappensNext": {
-        "0": "Nous analysons votre reçu — notre IA extrait les articles, les prix et les informations sur le commerçant",
-        "1": "Vous examinez les résultats — vérifiez l'analyse et corrigez tout ce qui semble incorrect",
-        "2": "Votre tableau de bord se met à jour — graphiques de dépenses, répartitions par catégorie et tendances commencent à se construire"
-      },
-      "featuresToExploreTitle": "Fonctionnalités à explorer",
-      "featuresToExplore": {
-        "0": "Partagez des factures avec votre famille ou vos collègues pour un suivi des dépenses conjoint",
-        "1": "Consultez les suggestions de recettes générées par l'IA à partir de vos articles d'épicerie",
-        "2": "Vérifiez les avertissements sur les allergènes pour les produits alimentaires détectés",
-        "3": "Suivez les modèles de dépenses par commerçant, catégorie et période"
-      },
-      "body": "Plus vous téléchargez de factures, plus vos informations sur les dépenses deviennent riches. Essayez de télécharger quelques reçus cette semaine pour voir votre tableau de bord prendre vie.",
-      "feedbackPrompt": "Besoin d'aide ou avez-vous des commentaires ? Contactez-nous à <email></email>.",
-      "signOff": {
-        "line1": "Cordialement,",
-        "line2": "L'équipe {brand}"
-      },
-      "ctaPrimary": "Voir votre facture",
-      "ctaSecondary": "Télécharger un autre reçu"
-    },
-    "invoiceAnalyzed": {
-      "subject": "Votre facture a été analysée",
-      "badge": "Factures • Analyse Terminée",
-      "heading": "L'analyse de votre facture est prête",
-      "preview": "Votre facture est prête, {name}. Analyse terminée !",
-      "greeting": "Bonjour {name},",
-      "intro": "Bonne nouvelle ! Notre IA a terminé l'analyse de votre facture. Nous avons extrait toutes les informations clés, catégorisé vos articles et généré des aperçus de dépenses pour vous aider à suivre vos finances.",
-      "summaryTitle": "Résumé de la facture",
-      "summary": {
-        "invoiceName": "Nom de la facture",
-        "merchantId": "ID Commerçant",
-        "itemsDetected": "Articles détectés",
-        "totalAmount": "Montant total",
-        "notIdentified": "Pas encore identifié"
-      },
-      "whatWasAnalyzedTitle": "Ce qui a été analysé",
-      "whatWasAnalyzed": {
-        "0": "Identification et catégorisation du commerçant",
-        "1": "Extraction ligne par ligne des articles avec les prix",
-        "2": "Catégorisation automatique des produits (épicerie, boissons, articles ménagers, etc.)",
-        "3": "Détection de la devise et validation du montant",
-        "4": "Extraction de la date et de l'heure lorsque disponible"
-      },
-      "body": "Cliquez sur le bouton ci-dessus pour voir l'analyse complète. Si quelque chose ne va pas—peut-être qu'un produit a été mal catégorisé ou qu'un prix n'a pas été détecté correctement—vous pouvez modifier la facture directement dans votre tableau de bord et les aperçus se mettront à jour automatiquement.",
-      "feedbackPrompt": "Vous avez des questions sur votre analyse ou besoin d'aide ? Contactez-nous à <email></email>.",
-      "signOff": {
-        "line1": "Cordialement,",
-        "line2": "L'équipe {brand}"
-      },
-      "ctaPrimary": "Voir l'analyse complète"
-    },
-    "invoiceDeleted": {
-      "subject": "Votre facture a été supprimée",
-      "badge": "Factures • Supprimé",
-      "heading": "Facture retirée de votre compte",
-      "preview": "La facture {invoiceLabel} a été retirée de votre compte.",
-      "greeting": "Bonjour {name},",
-      "intro": "Cet email confirme qu'une facture a été retirée de votre compte {brand}. La suppression a été traitée avec succès.",
-      "detailsTitle": "Détails de la suppression",
-      "details": {
-        "invoice": "Facture",
-        "invoiceId": "ID facture",
-        "status": "Statut"
-      },
-      "statusValue": "Supprimé (suppression douce)",
-      "placeholder": "—",
-      "whatYouShouldKnowTitle": "Ce que vous devez savoir",
-      "whatYouShouldKnow": {
-        "0": "Il s'agit d'une suppression douce—les données de la facture peuvent être conservées pendant 30 jours à des fins de récupération.",
-        "1": "Tout accès partagé à cette facture a été automatiquement révoqué.",
-        "2": "Les statistiques et informations seront recalculées pour exclure cette facture.",
-        "3": "Si vous devez récupérer cette facture, contactez le support dans les 30 jours."
-      },
-      "body": "Si vous n'avez pas initié cette suppression ou si vous devez récupérer la facture, veuillez nous contacter immédiatement à <email></email>. Nous sommes là pour vous aider.",
-      "signOff": {
-        "line1": "Cordialement,",
-        "line2": "L'équipe {brand}"
-      },
-      "ctaPrimary": "Voir vos factures"
-    },
-    "invoiceMadePublic": {
-      "subject": "Votre facture est maintenant publique",
-      "badge": "Factures • Lien Public",
-      "heading": "Votre facture est maintenant publique",
-      "preview": "Votre facture \"{invoiceName}\" est désormais publique et partageable.",
-      "greeting": "Bonjour {name},",
-      "intro": "Vous avez réussi à rendre votre facture publique. Toute personne possédant le lien ou le code QR ci-dessous peut désormais consulter cette facture—sans connexion requise. C'est parfait pour partager des reçus avec des collègues, des comptables ou pour les rapports de dépenses.",
-      "detailsTitle": "Détails de la facture",
-      "details": {
-        "invoiceName": "Nom de la facture",
-        "invoiceId": "ID facture",
-        "merchant": "Commerçant",
-        "total": "Total",
-        "created": "Créé",
-        "access": "Accès"
-      },
-      "accessValue": "Public (n'importe qui avec le lien)",
-      "qrTitle": "Code QR d'Accès Rapide",
-      "qrSubText": "Scannez avec l'appareil photo de votre téléphone pour un accès instantané.",
-      "qrAlt": "Code QR pour l'accès à la facture",
-      "howToShareTitle": "Comment partager",
-      "howToShare": {
-        "0": "Copiez le lien direct ci-dessous et envoyez par email ou message",
-        "1": "Imprimez ou capturez le code QR pour un partage en personne",
-        "2": "Incluez dans les rapports de dépenses ou les demandes de remboursement"
-      },
-      "privacyNoticeTitle": "Avis de Confidentialité",
-      "privacyNoticeBody": "Les factures publiques peuvent être consultées par toute personne possédant l'URL ou le code QR. Pour rendre cette facture privée à nouveau, mettez à jour les paramètres de partage depuis votre page de facture à tout moment.",
-      "directLinkLabel": "Lien direct :",
-      "feedbackPrompt": "Des questions sur le partage ou les paramètres de confidentialité ? Contactez-nous à <email></email>.",
-      "signOff": {
-        "line1": "Cordialement,",
-        "line2": "L'équipe {brand}"
-      },
-      "ctaPrimary": "Ouvrir la facture publique"
-    },
-    "invoiceShared": {
-      "subject": "{fromName} a partagé une facture avec vous",
-      "badge": "Factures • Partagées",
-      "heading": "Une facture a été partagée avec vous",
-      "preview": "{fromName} a partagé une facture avec vous.",
-      "greeting": "Bonjour {toName},",
-      "intro": "Bonne nouvelle ! <from></from> a partagé une facture avec vous sur {brand}. Cela vous donne accès à tous les détails de la facture, y compris les produits détaillés, les informations sur le commerçant et les analyses.",
-      "detailsTitle": "Détails du partage",
-      "details": {
-        "sharedBy": "Partagé par",
-        "invoiceId": "ID Facture"
-      },
-      "whatYouCanDoTitle": "Ce que vous pouvez faire",
-      "whatYouCanDo": {
-        "0": "Voir les détails complets de la facture et la ventilation par article",
-        "1": "Consulter les analyses et les catégories de dépenses",
-        "2": "Télécharger ou imprimer la facture pour vos archives"
-      },
-      "body": "Cliquez sur le bouton ci-dessus pour accéder à la facture partagée. Ce lien restera actif tant que les autorisations de partage seront en place.",
-      "feedbackPrompt": "Vous avez des questions sur ce partage ou besoin d'aide ? Contactez-nous à <email></email>.",
-      "signOff": {
-        "line1": "Cordialement,",
-        "line2": "L'équipe {brand}"
-      },
-      "ctaPrimary": "Voir la facture partagée"
-    },
-    "invoiceUnshared": {
-      "subject": "L'accès à une facture partagée a été révoqué",
-      "badge": "Factures • Accès Révoqué",
-      "heading": "Votre accès à une facture a été révoqué",
-      "preview": "{fromName} a révoqué votre accès à une facture partagée.",
-      "greeting": "Bonjour {toName},",
-      "intro": "Nous vous écrivons pour vous informer que <from></from> a révoqué votre accès à une facture qui avait été partagée avec vous auparavant. Cela signifie que vous ne pourrez plus consulter cette facture.",
-      "detailsTitle": "Détails de la révocation",
-      "details": {
-        "revokedBy": "Révoqué par",
-        "invoiceId": "ID Facture",
-        "revokedAt": "Révoqué le",
-        "yourAccess": "Votre accès",
-        "accessRevoked": "Révoqué",
-        "notProvided": "—"
-      },
-      "whatThisMeansTitle": "Ce que cela signifie",
-      "whatThisMeans": {
-        "0": "Tous les liens enregistrés vers cette facture ne fonctionneront plus pour vous.",
-        "1": "Cette facture n'apparaîtra plus dans votre liste de factures partagées.",
-        "2": "Si vous avez besoin d'un nouvel accès, contactez directement le propriétaire de la facture."
-      },
-      "body": "Si vous pensez que ce changement a été effectué par erreur, veuillez contacter <from></from> ou notre équipe d'assistance. Les révocations d'accès sont parfois accidentelles et nous sommes heureux de faciliter la communication si nécessaire.",
-      "feedbackPrompt": "Besoin d'aide ? Envoyez-nous un email à <email></email>.",
-      "signOff": {
-        "line1": "Cordialement,",
-        "line2": "L'équipe {brand}"
-      },
-      "ctaPrimary": "Voir vos factures",
-      "ctaSecondary": "Contacter le support"
-    },
-    "spendingAlert": {
-      "subject": "Alerte de seuil de dépenses",
-      "badge": "Alerte Dépenses • {percent}%",
-      "heading": "{percent, select, 80 {Attention : vous approchez de la limite de votre budget} 90 {Presque terminé : 90% de votre budget utilisé} 100 {Budget atteint : vous avez atteint votre limite de dépenses} other {Alerte de dépenses}}",
-      "preview": "{name}, vous avez utilisé {percent}% de votre budget {category} pour {period}.",
-      "greeting": "Bonjour {name},",
-      "intro": "{state, select, over {Vous avez atteint votre limite de dépenses pour {category} en {period}. Voici un résumé de votre situation.} other {Vous avez utilisé {percent}% de votre budget {category} pour {period}. Voici un résumé rapide pour vous aider à planifier le reste de la période.}}",
-      "overBudgetWarning": "Vos dépenses ont atteint ou dépassé le budget que vous avez défini. Examinez vos achats récents pour rester sur la bonne voie.",
-      "metricsLabels": {
-        "budgetLimit": "Limite du budget",
-        "currentSpending": "Dépenses actuelles",
-        "remaining": "Restant",
-        "threshold": "Seuil"
-      },
-      "overBudgetValue": "Au-dessus du budget",
-      "detailsTitle": "Détails du Budget",
-      "detailsLabels": {
-        "category": "Catégorie",
-        "period": "Période",
-        "budget": "Budget",
-        "spent": "Dépensé"
-      },
-      "chartTitle": "Dépenses par catégorie",
-      "chartAlt": "Répartition des dépenses par catégorie pour {period}",
-      "tipsTitle": "{state, select, over {Ce que vous pouvez faire} other {Conseils pour rester sur la bonne voie}}",
-      "tipsOverBudget": {
-        "0": "Examinez les achats récents pour identifier les dépenses non essentielles",
-        "1": "Envisagez d'ajuster votre budget s'il ne reflète plus la réalité",
-        "2": "Définissez un seuil plus strict (par exemple 80%) pour des avertissements plus précoces"
-      },
-      "tipsOnTrack": {
-        "0": "Vérifiez vos achats récents pour voir où va la majeure partie",
-        "1": "Priorisez les dépenses essentielles pour le reste de la période",
-        "2": "Envisagez de cuisiner davantage à la maison si les restaurants augmentent les coûts"
-      },
-      "notificationsParagraph": "Vous pouvez ajuster vos seuils de budget et vos préférences de notification dans vos <settings></settings>.",
-      "notificationsLink": "paramètres de notification",
-      "feedbackPrompt": "Des questions ? Contactez-nous à <email></email>.",
-      "ctaPrimary": "Voir le tableau de bord",
-      "signOff": {
-        "line1": "Cordialement",
-        "line2": "L'équipe {brand}"
+      "platform": {
+        "architecture": {
+          "badge": "Architecture Technique",
+          "description": "Une architecture cloud-native moderne suivant les principes de conception pilotée par le domaine, la méthodologie The Standard et les meilleures pratiques de l'industrie.",
+          "layers": {
+            "ai": {
+              "description": "Traitement intelligent de documents et compréhension du langage naturel",
+              "name": "Services IA",
+              "technologies": "Azure OpenAI,Document Intelligence,Computer Vision"
+            },
+            "api": {
+              "description": "APIs RESTful avec documentation OpenAPI et limitation de débit",
+              "name": "Passerelle API",
+              "technologies": ".NET 10,Minimal APIs,OpenAPI,GraphQL"
+            },
+            "auth": {
+              "description": "Authentification de niveau entreprise avec plusieurs fournisseurs",
+              "name": "Identité et Sécurité",
+              "technologies": "Azure AD B2C,OAuth 2.0,OIDC,MFA"
+            },
+            "cdn": {
+              "description": "Distribution de contenu mondiale avec mise en cache edge et optimisation",
+              "name": "Edge et CDN",
+              "technologies": "Azure CDN,Vercel Edge,Static Assets"
+            },
+            "client": {
+              "description": "Frontends modernes basés sur React avec capacités SSR et SSG",
+              "name": "Couche Client",
+              "technologies": "Next.js 16,React 19,TypeScript,Modules SCSS"
+            },
+            "data": {
+              "description": "Stratégie de base de données multi-modèle pour des performances optimales",
+              "name": "Couche Données",
+              "technologies": "CosmosDB,Azure SQL,Redis Cache,Blob Storage"
+            },
+            "infra": {
+              "description": "Infrastructure Azure entièrement gérée avec déploiement IaC",
+              "name": "Infrastructure Cloud",
+              "technologies": "Azure,Bicep IaC,Container Apps,Key Vault"
+            },
+            "services": {
+              "description": "Conception pilotée par le domaine avec contextes délimités et architecture propre",
+              "name": "Microservices",
+              "technologies": "DDD,CQRS,Event Sourcing,The Standard"
+            }
+          },
+          "principles": {
+            "appRouter": {
+              "description": "Routage basé sur les fichiers avec layouts, états de chargement et limites d'erreur",
+              "title": "Architecture App Router"
+            },
+            "cloudNative": {
+              "description": "Microservices conteneurisés avec auto-scaling et capacités d'auto-réparation",
+              "title": "Conception Cloud Native"
+            },
+            "rsc": {
+              "description": "Exploitation des RSC pour des performances optimales avec rendu côté serveur et streaming",
+              "title": "React Server Components"
+            }
+          },
+          "title": "Conçue pour",
+          "titleHighlight": "l'évolutivité et la fiabilité"
+        },
+        "callToAction": {
+          "cta": {
+            "createAccount": "Créer un Compte",
+            "exploreApplications": "Explorer les Applications"
+          },
+          "description": "Explorez la plateforme, essayez les fonctionnalités et rejoignez la communauté. Que vous soyez ici pour gérer des factures, découvrir des recettes ou simplement explorer, il y a quelque chose pour tout le monde.",
+          "footer": "Construit avec passion par",
+          "footerRole": ", un ingénieur logiciel chez Microsoft.",
+          "links": {
+            "getInTouch": "Nous Contacter",
+            "meetAuthor": "Rencontrer l'Auteur",
+            "viewSource": "Voir le Code Source"
+          },
+          "title": "Prêt à",
+          "titleHighlight": "commencer",
+          "trust": {
+            "freeToUse": {
+              "description": "Pas de frais cachés ni d'abonnements",
+              "title": "Gratuit"
+            },
+            "openSource": {
+              "description": "100% open source avec licence MIT",
+              "title": "Open Source"
+            },
+            "privacyFirst": {
+              "description": "Vos données restent les vôtres, toujours",
+              "title": "Confidentialité d'Abord"
+            }
+          }
+        },
+        "features": {
+          "badge": "Fonctionnalités de la Plateforme",
+          "description": "Une suite complète d'outils conçus pour la gestion moderne des finances personnelles, l'organisation des recettes et plus encore. Construite avec des technologies de pointe et un accent sur l'expérience utilisateur.",
+          "items": {
+            "ai": {
+              "description": "Automatisation intelligente à portée de main",
+              "longDescription": "Alimenté par Azure OpenAI, notre assistant IA aide à la compréhension de documents, l'extraction de données, la catégorisation intelligente et les requêtes en langage naturel sur vos données.",
+              "tags": "GPT-4,Azure AI,NLP",
+              "title": "Assistant IA"
+            },
+            "analytics": {
+              "description": "Aperçus approfondis de vos dépenses",
+              "longDescription": "Tableau de bord analytique complet avec les tendances de dépenses, les répartitions par catégorie, les comparaisons mensuelles et les aperçus prédictifs alimentés par des algorithmes d'apprentissage automatique.",
+              "tags": "Graphiques,Tendances,Rapports",
+              "title": "Analytique des Dépenses"
+            },
+            "auth": {
+              "description": "Options de connexion flexibles et sécurisées",
+              "longDescription": "Connectez-vous avec Microsoft, Google, GitHub ou email. Azure AD B2C fournit une gestion d'identité de niveau entreprise avec support MFA et une expérience SSO transparente.",
+              "tags": "OAuth,MFA,SSO",
+              "title": "Authentification Sécurisée"
+            },
+            "budgets": {
+              "description": "Suivi intelligent du budget et alertes",
+              "longDescription": "Définissez des budgets par catégorie et recevez des alertes intelligentes à l'approche des limites. Visualisez vos dépenses avec des graphiques interactifs et identifiez les domaines à optimiser.",
+              "tags": "Budgets,Alertes,Planification",
+              "title": "Gestion du Budget"
+            },
+            "i18n": {
+              "description": "Expérience entièrement internationalisée",
+              "longDescription": "La plateforme prend en charge plusieurs langues avec un support RTL complet. Actuellement disponible en anglais et en roumain, avec d'autres langues prévues pour les versions futures.",
+              "tags": "i18n,Anglais,Roumain",
+              "title": "Multi-Langue"
+            },
+            "invoices": {
+              "description": "Analyse et gestion des factures alimentées par l'IA",
+              "longDescription": "Téléchargez des photos de reçus et laissez l'IA extraire les détails du commerçant, les articles, les prix et plus encore. La catégorisation automatique, le suivi des dépenses et les analyses détaillées vous aident à comprendre vos habitudes de consommation.",
+              "tags": "IA,OCR,Analytique",
+              "title": "Traitement des Factures"
+            },
+            "merchants": {
+              "description": "Détection automatique des commerçants et aperçus",
+              "longDescription": "Notre IA identifie les commerçants à partir des données de reçus, construisant une base de données complète de vos habitudes d'achat. Obtenez des aperçus sur vos lieux d'achat, les tendances de dépenses et les comparaisons de commerçants.",
+              "tags": "ML,Aperçus,Suivi",
+              "title": "Intelligence Commerçants"
+            },
+            "recipes": {
+              "description": "Organisez et découvrez des créations culinaires",
+              "longDescription": "Stockez vos recettes préférées, découvrez-en de nouvelles et planifiez vos repas efficacement. Suggestions alimentées par l'IA basées sur les ingrédients, les préférences alimentaires et l'historique de cuisine.",
+              "tags": "Cuisine,Planification Repas,IA",
+              "title": "Gestion des Recettes"
+            },
+            "security": {
+              "description": "Sécurité de niveau bancaire pour vos données",
+              "longDescription": "Vos données sont protégées par un chiffrement de niveau entreprise, une authentification sécurisée via Azure AD B2C et la conformité au RGPD. Nous ne vendons ni ne partageons jamais vos informations personnelles.",
+              "tags": "Chiffrement,RGPD,SSO",
+              "title": "Sécurité Entreprise"
+            }
+          },
+          "modal": {
+            "close": "Fermer",
+            "exploreFeature": "Explorer la Fonctionnalité"
+          },
+          "title": "Tout ce dont vous avez besoin,",
+          "titleHighlight": "magnifiquement conçu"
+        },
+        "hero": {
+          "cta": {
+            "exploreFeatures": "Explorer les Fonctionnalités",
+            "viewSource": "Voir le Code Source"
+          },
+          "description": "Une plateforme full-stack complète combinant Next.js, .NET et les services cloud Azure. Construite avec une architecture de niveau entreprise, une conception pilotée par le domaine et un accent sur l'expérience développeur.",
+          "scrollIndicator": "Faites défiler pour explorer",
+          "stats": {
+            "countries": "Pays",
+            "linesOfCode": "Lignes de Code",
+            "projects": "Projets",
+            "techStack": "Stack Technologique"
+          },
+          "statusBadge": "Plateforme Technologique Open Source",
+          "subtitle": "Moderne • Évolutive • Open Source",
+          "title": "Bienvenue sur",
+          "trust": {
+            "freeForever": "Gratuit pour Toujours",
+            "openSource": "Open Source",
+            "privacyFirst": "Confidentialité d'Abord"
+          }
+        },
+        "statistics": {
+          "badge": "Statistiques de la Plateforme",
+          "description": "Un aperçu de l'échelle et de l'impact de la plateforme arolariu.ro, des lignes de code à la portée mondiale.",
+          "items": {
+            "apis": {
+              "description": "Microservices",
+              "label": "APIs",
+              "suffix": "+",
+              "value": "8"
+            },
+            "commits": {
+              "description": "Contributions de code",
+              "label": "Commits",
+              "suffix": "+",
+              "value": "2500"
+            },
+            "contributors": {
+              "description": "Open source",
+              "label": "Contributeurs",
+              "suffix": "+",
+              "value": "5"
+            },
+            "countries": {
+              "description": "Portée mondiale",
+              "label": "Pays",
+              "suffix": "+",
+              "value": "25"
+            },
+            "linesOfCode": {
+              "description": "Sur tous les projets",
+              "label": "Lignes de Code",
+              "suffix": "K+",
+              "value": "150"
+            },
+            "projects": {
+              "description": "Dépôts actifs",
+              "label": "Projets",
+              "suffix": "+",
+              "value": "15"
+            },
+            "stars": {
+              "description": "Étoiles GitHub",
+              "label": "Étoiles",
+              "suffix": "+",
+              "value": "50"
+            },
+            "users": {
+              "description": "Actifs mensuellement",
+              "label": "Utilisateurs",
+              "suffix": "+",
+              "value": "1000"
+            }
+          },
+          "title": "Des chiffres qui",
+          "titleHighlight": "parlent d'eux-mêmes"
+        },
+        "techStack": {
+          "badge": "Stack Technologique",
+          "categories": {
+            "backend": {
+              "description": "Technologies côté serveur évolutives et APIs",
+              "name": "Backend"
+            },
+            "cloud": {
+              "description": "Infrastructure et automatisation du déploiement",
+              "name": "Cloud et DevOps"
+            },
+            "frontend": {
+              "description": "Technologies web modernes pour des expériences utilisateur ultra-rapides",
+              "name": "Frontend"
+            },
+            "tooling": {
+              "description": "Outils et frameworks pour l'excellence en développement",
+              "name": "Outils de Développement"
+            }
+          },
+          "description": "Un stack technologique soigneusement sélectionné pour la performance, l'expérience développeur et la maintenabilité à long terme.",
+          "stats": {
+            "coverage": {
+              "description": "Tests unitaires et E2E",
+              "label": "Couverture de Tests",
+              "value": "90%+"
+            },
+            "security": {
+              "description": "Meilleures pratiques",
+              "label": "Note de Sécurité",
+              "value": "A+"
+            },
+            "technologies": {
+              "description": "Dans notre stack",
+              "label": "Technologies",
+              "value": "24+"
+            },
+            "typescript": {
+              "description": "Typage complet",
+              "label": "TypeScript",
+              "value": "100%"
+            }
+          },
+          "technologies": {
+            "aspnet": {
+              "description": "APIs web haute performance",
+              "name": "ASP.NET Core"
+            },
+            "azure": {
+              "description": "Fournisseur cloud principal",
+              "name": "Azure"
+            },
+            "azureDevops": {
+              "description": "Gestion de projet et pipelines",
+              "name": "Azure DevOps"
+            },
+            "azuresql": {
+              "description": "Base de données relationnelle gérée",
+              "name": "Azure SQL"
+            },
+            "bicep": {
+              "description": "Infrastructure as Code",
+              "name": "Bicep"
+            },
+            "cosmosdb": {
+              "description": "Base de données NoSQL distribuée globalement",
+              "name": "CosmosDB"
+            },
+            "docker": {
+              "description": "Plateforme de conteneurisation",
+              "name": "Docker"
+            },
+            "dotnet": {
+              "description": "Framework backend principal",
+              "name": ".NET"
+            },
+            "eslint": {
+              "description": "Linting JavaScript avec plus de 20 plugins",
+              "name": "ESLint"
+            },
+            "git": {
+              "description": "Système de contrôle de version",
+              "name": "Git"
+            },
+            "githubActions": {
+              "description": "Automatisation CI/CD",
+              "name": "GitHub Actions"
+            },
+            "motion": {
+              "description": "Animations prêtes pour la production",
+              "name": "Motion"
+            },
+            "nextjs": {
+              "description": "Framework React full-stack avec SSR/SSG",
+              "name": "Next.js"
+            },
+            "nodejs": {
+              "description": "BFF et fonctions serverless",
+              "name": "Node.js"
+            },
+            "playwright": {
+              "description": "Framework de tests E2E",
+              "name": "Playwright"
+            },
+            "pnpm": {
+              "description": "Gestion des paquets",
+              "name": "pnpm/npm"
+            },
+            "prettier": {
+              "description": "Formatage de code",
+              "name": "Prettier"
+            },
+            "react": {
+              "description": "Bibliothèque UI pour construire des interfaces interactives",
+              "name": "React"
+            },
+            "redis": {
+              "description": "Cache en mémoire pour la performance",
+              "name": "Redis"
+            },
+            "scss": {
+              "description": "Feuilles de style à portée de composant avec CSS Modules",
+              "name": "Modules SCSS"
+            },
+            "typescript": {
+              "description": "JavaScript typé pour un code robuste",
+              "name": "TypeScript"
+            },
+            "vercel": {
+              "description": "Plateforme de déploiement frontend",
+              "name": "Vercel"
+            },
+            "vitest": {
+              "description": "Framework de tests unitaires",
+              "name": "Vitest"
+            },
+            "zustand": {
+              "description": "Gestion d'état légère",
+              "name": "Zustand"
+            }
+          },
+          "title": "Alimentée par",
+          "titleHighlight": "des technologies modernes"
+        },
+        "timeline": {
+          "badge": "Parcours de Développement",
+          "collapseHint": "Cliquez pour réduire",
+          "description": "Le parcours d'arolariu.ro d'une simple idée à une plateforme complète, avec les jalons clés en chemin.",
+          "events": {
+            "ai": {
+              "date": "Juin 2024",
+              "description": "Intégration profonde avec Azure OpenAI pour le traitement intelligent de documents et les requêtes en langage naturel.",
+              "details": "Intégration Azure OpenAI GPT-4,Requêtes de factures en langage naturel,Algorithmes de catégorisation intelligente,Fonctionnalités d'analytique prédictive",
+              "tags": "GPT-4,Azure AI,NLP",
+              "title": "Intégration IA"
+            },
+            "backend": {
+              "date": "Septembre 2022",
+              "description": "Refonte complète du backend avec implémentation de .NET et architecture cloud-native.",
+              "details": "Développement API .NET 6,Configuration de l'infrastructure cloud Azure,Conception de base de données avec CosmosDB,Implémentation du pipeline CI/CD",
+              "tags": ".NET,Azure,API",
+              "title": "Infrastructure Backend"
+            },
+            "expansion": {
+              "date": "Janvier 2023",
+              "description": "Ajouts majeurs de fonctionnalités incluant le traitement des factures et les capacités d'analyse alimentées par l'IA.",
+              "details": "Téléchargement de factures et intégration OCR,Intégration Azure Document Intelligence,Algorithmes de détection de commerçants,Fonctionnalités de suivi de budget",
+              "tags": "IA,OCR,Factures",
+              "title": "Expansion de la Plateforme"
+            },
+            "inception": {
+              "date": "Mars 2022",
+              "description": "La plateforme arolariu.ro a été conçue comme un projet d'apprentissage personnel pour explorer le développement web moderne.",
+              "details": "Phase initiale de concept et planification,Recherche sur les technologies web modernes,Premier dépôt créé sur GitHub,Prototype HTML/CSS de base développé",
+              "tags": "Planification,Recherche",
+              "title": "Lancement du Projet"
+            },
+            "launch": {
+              "date": "Juin 2023",
+              "description": "Lancement public officiel avec un ensemble complet de fonctionnalités et une infrastructure prête pour la production.",
+              "details": "Déploiement en production sur Azure,Configuration de domaine personnalisé,Implémentation de la sécurité SSL/TLS,Optimisation des performances",
+              "tags": "Lancement,Production",
+              "title": "Lancement Public"
+            },
+            "nextjs": {
+              "date": "Décembre 2023",
+              "description": "Réécriture complète du frontend vers Next.js App Router avec React Server Components.",
+              "details": "Migration vers Next.js 14+,Adoption des React Server Components,SEO amélioré avec génération statique,Métriques de performance améliorées",
+              "tags": "Next.js,RSC,Migration",
+              "title": "Migration Next.js"
+            },
+            "present": {
+              "date": "Présent",
+              "description": "Développement en cours avec de nouvelles fonctionnalités, optimisations et contributions de la communauté.",
+              "details": "Mises à jour régulières des fonctionnalités,Améliorations de performance,Intégration des retours de la communauté,Planification de la feuille de route future",
+              "tags": "Actif,En croissance",
+              "title": "Évolution Continue"
+            },
+            "prototype": {
+              "date": "Juin 2022",
+              "description": "Le premier prototype fonctionnel de la plateforme a été développé en utilisant React et des services backend de base.",
+              "details": "Implémentation du frontend React,Flux d'authentification de base,Design UI/UX initial,Configuration de l'environnement de développement local",
+              "tags": "React,Frontend",
+              "title": "Premier Prototype"
+            }
+          },
+          "expandHint": "Cliquez pour développer",
+          "futureIndicator": "Le voyage continue...",
+          "keyAchievements": "Réalisations clés :",
+          "title": "De l'idée à",
+          "titleHighlight": "la réalité"
+        }
       }
     },
-    "newsletterSubscribed": {
-      "subject": "Vous êtes abonné !",
-      "badge": "Newsletter",
-      "heading": "Vous êtes inscrit — bienvenue à bord",
-      "preview": "Bienvenue, {name} — vous êtes abonné.",
-      "greeting": "Bonjour {name},",
-      "intro": "Merci de vous être abonné à la newsletter <brand>{brandName}</brand>. Je suis sincèrement ravi de vous avoir ici. Je garderai les communications légères, significatives et dignes de votre temps.",
-      "whatToExpectTitle": "À quoi s'attendre",
-      "whatToExpect": {
-        "0": "Mises à jour de produits et nouvelles fonctionnalités au fur et à mesure de leur lancement",
-        "1": "Nouveaux articles et écrits sur la technologie, la productivité et les finances personnelles",
-        "2": "Points forts occasionnels et ressources sélectionnées (1 à 2 emails par trimestre)"
-      },
-      "body": "Votre boîte de réception est sacrée—je respecte cela. Chaque email est conçu pour apporter une véritable valeur, que ce soit un conseil qui vous fait gagner des heures ou une perspective qui change votre vision des finances personnelles.",
-      "feedbackPrompt": "Des questions, des commentaires ou juste envie de dire bonjour ? Répondez à cet email ou contactez-moi directement à <email></email>.",
-      "ctaPrimary": "Visiter arolariu.ro",
-      "signOff": {
-        "line1": "Cordialement",
-        "line2": "L'équipe {brand}"
-      }
-    },
-    "newsletterUnsubscribed": {
-      "subject": "Vous avez été désabonné",
-      "badge": "Newsletter",
-      "heading": "Vous avez été désabonné",
-      "preview": "Bonjour {name} — vous avez été désabonné.",
-      "greeting": "Bonjour {name},",
-      "intro": "Cet email confirme que vous avez été retiré de la liste de newsletter <brand>{brandName}</brand>. Je suis désolé de vous voir partir.",
-      "whatHappensNextTitle": "Ce qui se passe ensuite",
-      "whatHappensNext": {
-        "0": "Vous ne recevrez plus de newsletters de notre part à l'avenir.",
-        "1": "Vous pourriez toujours recevoir des emails essentiels de compte et de service si vous utilisez le produit.",
-        "2": "Vous avez changé d'avis ? Vous pouvez vous réabonner à tout moment en utilisant le bouton ci-dessus."
-      },
-      "body": "J'apprécie le temps que vous avez passé avec nous. Si vous avez des commentaires sur les raisons de votre départ ou sur la façon dont je peux m'améliorer, j'aimerais sincèrement les entendre—répondez simplement à cet email.",
-      "feedbackPrompt": "Si vous n'avez pas demandé cette désinscription, ou si vous avez besoin d'aide, veuillez contacter <email></email>.",
-      "ctaPrimary": "Revoir les préférences",
-      "ctaSecondary": "Se réabonner",
-      "signOff": {
-        "line1": "Cordialement",
-        "line2": "L'équipe {brand}"
-      }
-    },
-    "accountInactivity": {
-      "subject": "Vous nous manquez chez {brand}",
-      "badge": "Compte",
-      "heading": "Avis d'inactivité du compte",
-      "preview": "Bonjour {name} — votre compte est inactif depuis {inactiveDays} jours.",
-      "greeting": "Bonjour {name},",
-      "intro": "Ceci est un avertissement que votre compte est inactif depuis <count>{inactiveDays}</count> jours.",
-      "whatThisMeans": {
-        "title": "Ce que cela signifie",
-        "bullet1": "Se connecter gardera votre compte actif.",
-        "bullet2": "S'il n'y a aucune activité pendant les prochains {daysUntilClosure} jours, le compte pourrait être programmé pour fermeture.",
-        "bullet3": "Si vous souhaitez conserver vos données, veuillez agir avant la date limite."
-      },
+    "invoices": {
       "timeline": {
-        "title": "Chronologie",
-        "inactiveFor": "Inactif depuis",
-        "timeRemaining": "Temps restant",
-        "daysValue": "{days} jours"
-      },
-      "supportPrompt": "Si vous pensez avoir reçu ce message par erreur ou si vous avez besoin d'aide, veuillez contacter <link>{supportEmail}</link>.",
-      "signOff": {
-        "line1": "Cordialement,",
-        "line2": "L'équipe {brand}"
-      },
-      "footnote": "Note : Cet avis est informatif et destiné à vous aider à éviter de perdre l'accès. Les politiques réelles de rétention des comptes peuvent varier selon la région et le produit.",
-      "cta": {
-        "primary": "Se connecter",
-        "secondary": "Contacter le support"
+        "item": {
+          "aria": {
+            "moreInfo": "Plus d’infos sur {title}"
+          },
+          "confidence": "Confiance : {value}%",
+          "events": {
+            "aiAnalysis": {
+              "description": "{count, plural, one {# article détecté et catégorisé} other {# articles détectés et catégorisés}}",
+              "title": "Analyse IA terminée"
+            },
+            "categorized": {
+              "description": "Catégorisation automatique selon les articles",
+              "title": "Catégorie attribuée"
+            },
+            "created": {
+              "description": "Scannée et numérisée depuis le reçu",
+              "title": "Facture créée"
+            },
+            "edited": {
+              "title": "Facture mise à jour"
+            },
+            "exported": {
+              "title": "Facture exportée"
+            },
+            "markedImportant": {
+              "description": "Signalée pour un suivi prioritaire",
+              "title": "Marquée importante"
+            },
+            "recipesGenerated": {
+              "description": "{count, plural, one {# recette suggérée} other {# recettes suggérées}}",
+              "title": "Recettes générées"
+            },
+            "shared": {
+              "description": "Partagée avec {count, plural, one {# personne} other {# personnes}}",
+              "title": "Partagée avec d’autres"
+            }
+          },
+          "fallbacks": {
+            "ocr": "OCR",
+            "pdf": "PDF"
+          },
+          "relativeTime": {
+            "now": "À l’instant"
+          },
+          "tooltips": {
+            "aiAnalysis": "L’IA a traité cette facture en {duration} et analysé {count, plural, one {# article} other {# articles}}.",
+            "categorized": "La facture a reçu une catégorie pour une meilleure organisation.",
+            "created": "La facture a été scannée et numérisée avec {method}.",
+            "edited": "Des modifications manuelles ont été apportées à la facture.",
+            "exported": "La facture a été exportée au format {format}.",
+            "markedImportant": "La facture a été marquée importante pour un accès rapide.",
+            "recipesGenerated": "D’après les ingrédients achetés, {count, plural, one {# recette a été générée} other {# recettes ont été générées}}.",
+            "shared": "La facture a été partagée avec {count, plural, one {# utilisateur} other {# utilisateurs}}.",
+            "unavailable": "Détails de l’événement indisponibles"
+          }
+        }
       }
     },
-    "invoiceInactivity": {
-      "subject": "Cela fait {daysWithoutUpload} jours depuis votre dernière facture",
-      "badge": {
-        "3": "Inactivité • 3 jours",
-        "7": "Inactivité • 7 jours",
-        "14": "Inactivité • 14 jours",
-        "30": "Inactivité • 30 jours"
+    "legal": {
+      "acknowledgements": {
+        "contributors": {
+          "items": {
+            "c1": {
+              "description": "Instrumentation d'observabilité",
+              "name": "OpenTelemetry Authors",
+              "packages": "12"
+            },
+            "c2": {
+              "description": "SDKs Azure et outils",
+              "name": "Microsoft Corporation",
+              "packages": "5"
+            },
+            "c3": {
+              "description": "Solutions d'authentification",
+              "name": "Clerk",
+              "packages": "2"
+            },
+            "c4": {
+              "description": "Utilitaires de test",
+              "name": "Kent C. Dodds",
+              "packages": "3"
+            }
+          },
+          "packages": "{count, plural, one {# paquet} other {# paquets}}",
+          "subtitle": "Organisations et individus dont nous dépendons le plus",
+          "title": "Principaux Contributeurs"
+        },
+        "hero": {
+          "badge": "Open Source",
+          "lastUpdate": "Dernière mise à jour : {date}",
+          "subtitle": "Cette plateforme est construite sur les épaules de projets open-source incroyables. Nous sommes reconnaissants envers les mainteneurs et contributeurs qui rendent leur travail librement disponible.",
+          "title": "Remerciements"
+        },
+        "lastUpdate": "Dernière mise à jour le : {date}",
+        "licenses": {
+          "apache": "Apache 2.0",
+          "apacheDescription": "Licence open-source adaptée aux entreprises",
+          "gpl": "Licence GPL",
+          "gplDescription": "Licence copyleft garantissant que le code reste libre",
+          "mit": "Licence MIT",
+          "mitDescription": "Licence permissive permettant une utilisation large",
+          "other": "Autres Licences",
+          "otherDescription": "Licences personnalisées ou diverses licences open-source",
+          "packages": "{count, plural, one {# paquet} other {# paquets}}",
+          "title": "Distribution des Licences"
+        },
+        "packages": {
+          "subtitle": "Ce site web n'aurait pas été possible sans les packages tiers suivants. Je tiens à remercier les auteurs de ces packages pour leur travail acharné et leur dévouement à la communauté open-source.",
+          "title": "Packages tiers"
+        },
+        "packagesScreen": {
+          "badge": {
+            "development": "Développement",
+            "production": "Production"
+          },
+          "card": {
+            "dependencies": "Dépendances :",
+            "license": "Licence :",
+            "viewDependencies": "Voir les Dépendances",
+            "website": "Site Web"
+          },
+          "dialog": {
+            "dependencies": "Dépendances de {name}",
+            "dependenciesCount": "Ce package a {count} dépendances."
+          },
+          "emptyState": {
+            "subtitle": "Essayez d'ajuster les filtres ci-dessus.",
+            "title": "Aucun package trouvé."
+          },
+          "filters": {
+            "allPackages": "Tous les Packages",
+            "ascending": "Croissant",
+            "dependenciesCount": "Nombre de Dépendances",
+            "descending": "Décroissant",
+            "developmentOnly": "Développement Uniquement",
+            "filterByType": "Filtrer par type",
+            "name": "Nom",
+            "packageType": "Type de Package",
+            "productionOnly": "Production Uniquement",
+            "sortBy": "Trier par",
+            "sortDirection": "Direction du tri"
+          },
+          "openSource": {
+            "description": "Ce projet repose sur les épaules de géants. Nous sommes reconnaissants envers la communauté open-source et tous les développeurs qui ont contribué à ces packages.",
+            "title": "L'Open Source Compte"
+          },
+          "search": {
+            "placeholder": "Rechercher..."
+          },
+          "table": {
+            "dependencies": "Dépendances",
+            "description": "Description",
+            "license": "Licence",
+            "package": "Paquet",
+            "type": "Type",
+            "version": "Version",
+            "website": "Site Web"
+          },
+          "views": {
+            "gridView": "Vue Grille",
+            "tableView": "Vue Tableau"
+          }
+        },
+        "stats": {
+          "development": {
+            "description": "Outils de build",
+            "label": "Développement",
+            "value": "{count}"
+          },
+          "mitLicense": {
+            "description": "Licence la plus courante",
+            "label": "Licence MIT",
+            "value": "{count}"
+          },
+          "production": {
+            "description": "Dépendances d'exécution",
+            "label": "Production",
+            "value": "{count}"
+          },
+          "subtitle": "Un aperçu de l'écosystème open-source qui alimente cette plateforme",
+          "title": "Aperçu des Dépendances",
+          "total": {
+            "description": "Dépendances utilisées",
+            "label": "Total des Packages",
+            "value": "{count}"
+          }
+        },
+        "title": "Remerciements"
       },
-      "heading": {
-        "3": "Vérification rapide",
-        "7": "Un rappel doux",
-        "14": "Reprenons le fil",
-        "30": "Cela fait un moment"
+      "privacyPolicy": {
+        "contactInformation": {
+          "content": "Si vous avez des questions concernant notre Politique de Confidentialité, veuillez nous contacter à admin@arolariu.ro",
+          "title": "Informations de Contact"
+        },
+        "lastUpdated": "Dernière mise à jour : 2024-01-01",
+        "terms": {
+          "childrenPrivacy": {
+            "content": "Notre site web n'est pas destiné aux enfants de moins de 13 ans. Nous ne collectons pas sciemment de données personnelles auprès d'enfants de moins de 13 ans. Si vous êtes un parent ou un tuteur et que vous savez que votre enfant nous a fourni des données personnelles, veuillez nous contacter. Si nous apprenons que nous avons collecté des données personnelles d'enfants sans vérification du consentement parental, nous prendrons des mesures pour supprimer ces informations de nos serveurs.",
+            "title": "Confidentialité des Enfants"
+          },
+          "cookiesDefinition": {
+            "content": "Les cookies sont de petits fichiers de données stockés sur votre appareil (ordinateur ou appareil mobile). Les cookies sont utilisés pour améliorer votre expérience sur notre site web et pour vous fournir un contenu pertinent. Pour plus d'informations sur les cookies, veuillez visiter https://www.allaboutcookies.org/ <br></br><br></br><br></br> Nous utilisons des cookies pour collecter des informations sur votre appareil et votre utilisation de notre site web. Notre fournisseur d'analyses de site web utilise des cookies pour générer des informations statistiques et autres sur l'utilisation du site web au moyen de cookies. <br></br><br></br><br></br> Vous pouvez refuser les cookies en utilisant les paramètres de votre navigateur. Veuillez noter que si vous désactivez les cookies, vous ne pourrez peut-être pas utiliser toutes les fonctionnalités de notre site web. <br></br><br></br><br></br> Nous ne conserverons vos données personnelles que le temps nécessaire à la finalité pour laquelle ces données ont été collectées et dans la mesure requise par la loi applicable. Lorsque nous n'avons plus besoin de données personnelles, nous les supprimons de nos systèmes et/ou prenons des mesures pour les anonymiser.",
+            "title": "Que sont les Cookies ?"
+          },
+          "dataCollectionTerms": {
+            "content": "a) Lorsque vous effectuez un achat ou tentez d'effectuer un achat, nous collectons les types de données personnelles suivants : <ul> <li> Informations de paiement telles que votre adresse de facturation, numéro de téléphone, carte de crédit, carte de débit et/ou autres informations de méthode de paiement ; </li><li> Informations de compte telles que votre nom, nom d'utilisateur, adresse e-mail ; </li><li> Informations d'achat spécifiquement si personnalisées ou uniques ;</li> <li>Données démographiques ;</li> <li>Données de localisation.</li> </ul> <br></br><br></br> b) Lorsque vous visitez et utilisez notre site web, nous collectons automatiquement les types de données personnelles suivants : <ul> <li> Informations de paiement telles que votre adresse de facturation, numéro de téléphone, carte de crédit, carte de débit et/ou autres informations de méthode de paiement ; </li> <li>Données d'appareil, telles que votre ordinateur, téléphone, tablette ou autre appareil que vous utilisez pour accéder à notre site web ;</li> <li>Données de communication, telles que vos préférences pour recevoir des communications de notre part ;</li> <li>Commentaires, tels que le support client, les avis sur les produits, les sondages et/ou autres commentaires ;</li> <li>Données de contenu, telles que le contenu que vous nous soumettez : publications, documents, audio, images, etc. ;</li> <li>Données d'utilisation, telles que la façon dont vous utilisez notre site web, produits et services ;</li> <li>Informations de compte telles que votre nom, nom d'utilisateur, adresse e-mail ;</li> <li>Informations d'achat spécifiquement si personnalisées ou uniques ;</li> <li>Données démographiques ;</li> <li>Données de localisation ;</li></ul>",
+            "title": "Quelles Données Personnelles Nous Collectons"
+          },
+          "dataTransferTerms": {
+            "content": "Dans la mesure du possible, nous stockons et traitons les données sur des serveurs situés dans la région géographique générale où vous résidez (remarque : cela peut ne pas être dans le pays dans lequel vous résidez). <span> Plus précisément, pour les utilisateurs, entreprises et clients basés en Europe, nous avons des serveurs dans l'Espace économique européen (EEE). </span> Vos données personnelles peuvent également être transférées vers des serveurs situés en dehors de votre état, province, pays ou autre juridiction gouvernementale où les lois sur les données peuvent différer de celles de votre juridiction, et y être conservées. Nous prendrons les mesures appropriées pour garantir que vos données personnelles sont traitées de manière sécurisée et conformément à cette politique ainsi qu'à la législation applicable en matière de protection des données. Les données peuvent être conservées dans d'autres pays considérés comme adéquats en vertu de vos lois. <br></br><br></br><br></br><br></br> Plus d'informations sur ces clauses peuvent être trouvées ici : https://eur-lex.europa.eu/legal-content/en/TXT/?uri=CELEX:32021D0914",
+            "title": "Transfert et Stockage International des Données"
+          },
+          "deviceUsageTerms": {
+            "content": "Lorsque vous visitez un site web <code>AROLARIU.RO</code> et/ou une application mobile, nous collectons et stockons automatiquement des informations sur votre visite en utilisant des cookies de navigateur (fichiers que nous envoyons à votre ordinateur), ou des technologies similaires. Vous pouvez configurer votre navigateur pour refuser tous les cookies ou pour indiquer quand un cookie est envoyé. La fonction `Aide` de la plupart des navigateurs fournira des informations sur la façon d'accepter les cookies, de désactiver les cookies ou de vous notifier lors de la réception d'un nouveau cookie. Si vous n'acceptez pas les cookies, vous ne pourrez peut-être pas utiliser certaines fonctionnalités de notre Service et nous vous recommandons de les laisser activés. <br></br><br></br><br></br> Nous traitons également des informations lorsque vous utilisez nos services et produits. Ces informations peuvent inclure : <ul> <li>   Des informations sur vos interactions avec nos services, y compris l'heure et la date de vos interactions,   et vos interactions avec nos e-mails ; </li> <li>   Des informations sur votre utilisation de nos services, y compris le type de navigateur que vous utilisez, les heures d'accès, les pages   consultées, votre adresse IP ; </li> <li>   Des informations sur vos achats, y compris les articles que vous achetez, la date d'achat et la méthode de paiement   que vous utilisez ; </li> <li>   Des informations sur votre appareil, y compris le type d'appareil, son système d'exploitation et les informations sur le réseau   mobile ; </li> <li>   D'autres informations que vous nous fournissez, y compris vos commentaires, remarques et autres informations que vous nous fournissez ; </li> <li>Des informations sur votre localisation, y compris votre localisation générale basée sur votre adresse IP ;</li> <li>D'autres informations que nous collectons avec votre consentement ou comme permis ou requis par la loi ;</li> <li>Des informations sur vos préférences, y compris vos préférences linguistiques.</li> </ul>",
+            "title": "Données d'Appareil et d'Utilisation"
+          },
+          "exerciseRights": {
+            "content": "Pour exercer vos droits, veuillez nous contacter en utilisant les coordonnées fournies dans la section « Nous Contacter » ci-dessous. Nous répondrons à votre demande dans un délai raisonnable et conformément à la loi applicable. <br></br><br></br> Pour votre propre sécurité, nous pouvons avoir besoin de vérifier votre identité avant de répondre à votre demande. Nous ferons des efforts raisonnables pour vérifier votre identité en demandant des informations que nous avons dans nos dossiers à votre sujet.",
+            "title": "Comment Exercer Vos Droits"
+          },
+          "howWeCollectDataTerms": {
+            "content": "Nous collectons des données personnelles de la manière suivante : <br></br><br></br> <span>1. Directement de vous.</span> <br></br> Nous collectons des données personnelles de votre part lorsque vous nous les fournissez directement ou indirectement, en utilisant notre site web, nos produits ou nos services. Cela inclut : <br></br> <ul> <li>Lorsque vous créez un compte ou achetez des produits sur notre site web ;</li> <li>Lorsque vous téléchargez des logiciels et/ou notre application mobile ;</li> <li>Lorsque vous participez à nos sondages, concours ou promotions ;</li> <li>Lorsque vous créez du contenu à travers nos produits et services ;</li> <li>Lorsque vous nous contactez avec une demande ou pour signaler un problème ;</li> <li>Lorsque vous exprimez un intérêt pour nos produits et services ;</li> <li>Lorsque vous utilisez notre site web, nos produits ou nos services ;</li> <li>Lorsque vous interagissez avec nous sur les réseaux sociaux ;</li> <li>Lorsque vous vous abonnez à notre newsletter ;</li> <li>Lorsque vous nous les fournissez directement ;</li> <li>Lorsque vous communiquez avec nous.</li> </ul> <br></br><br></br><br></br><br></br> <span>2. Technologies automatisées ou interactions.</span> <br></br> <br></br> Lorsque vous interagissez avec notre site web, nous pouvons automatiquement collecter les types de données suivants (tous décrits ci-dessus) : Données d'appareil concernant votre équipement, Données d'utilisation concernant vos actions et modèles de navigation, et Données de contact lorsque des tâches effectuées via notre site web restent inachevées, comme des commandes incomplètes ou des paniers abandonnés. Nous collectons ces données en utilisant des cookies, des journaux de serveur et d'autres technologies similaires. Veuillez consulter notre section Cookies (ci-dessous) pour plus de détails. <br></br><br></br><br></br><br></br> <span>3. Tiers ou sources accessibles au public.</span> <br></br><br></br> Nous pouvons recevoir des données personnelles vous concernant de divers tiers, notamment : <ul> <li>   Informations de compte et données de paiement de tiers, y compris des organisations (telles que les forces de l'ordre),   des associations et des groupes, qui partagent des données à des fins de prévention et de détection de la fraude et   de réduction du risque de crédit </li> <li>Données de contact, financières et de transaction des fournisseurs de services techniques, de paiement et de livraison</li> <li>Données techniques des fournisseurs d'analyses tels que Google Analytics</li> <li>Données d'identité et de contact des courtiers ou agrégateurs de données</li> <li>Données d'identité et de contact provenant de sources accessibles au public</li> </ul> <br></br><br></br><br></br><br></br><span> Si vous nous fournissez, ou fournissez à nos prestataires de services, des données personnelles relatives à d'autres personnes, vous déclarez avoir l'autorité de le faire et reconnaissez qu'elles seront utilisées conformément à cette politique. Si vous pensez que vos données personnelles nous ont été fournies de manière inappropriée, ou pour exercer autrement vos droits relatifs à vos données personnelles, veuillez nous contacter en utilisant les informations indiquées dans la section « Nous Contacter » ci-dessous.</span>",
+            "title": "Comment Nous Collectons les Données Personnelles"
+          },
+          "legalTerms": {
+            "content": "Nous pouvons utiliser ou divulguer vos données personnelles afin de nous conformer à une obligation légale, en relation avec une demande d'une autorité publique ou gouvernementale, ou en relation avec des procédures judiciaires ou tribunales, pour prévenir la perte de vie ou les blessures, ou pour protéger nos droits ou notre propriété. Dans la mesure du possible et pratique, nous vous informerons à l'avance d'une telle divulgation.",
+            "title": "Exigences Légales"
+          },
+          "personalDataRights": {
+            "content": "Vous avez le droit d'accéder, de corriger, de mettre à jour ou de supprimer vos données personnelles. Vous avez également le droit de vous opposer au traitement de vos données personnelles, de nous demander de restreindre le traitement de vos données personnelles ou de demander la portabilité de vos données personnelles. Vous pouvez exercer ces droits en nous contactant en utilisant les coordonnées fournies dans la section « Nous Contacter » ci-dessous. <br></br><br></br><br></br> Selon votre situation géographique et votre citoyenneté, vos droits sont soumis aux réglementations locales sur la confidentialité des données. Ces droits peuvent inclure : <ul> <li>   Droit à l'oubli (droit à l'effacement) (RGPD Article 17, CCPA/CPRA, CPA, VCDPA, CTDPA, UCPA, LGPD,   POPIA) </li> <li>Droit d'accès (PIPEDA, RGPD Article 15, CCPA/CPRA, CPA, VCDPA, CTDPA, UCPA, LGPD, POPIA)</li> <li>Droit de rectification (PIPEDA, RGPD Article 16, CPRA, CPA, VCDPA, CTDPA, LGPD, POPIA)</li> <li>Non-discrimination et non-représailles (CCPA/CPRA, CPA, VCDPA, CTDPA, UCPA)</li> <li>Droit à la limitation du traitement (RGPD Article 18, LGPD)</li> <li>Droit de retrait (CPRA, CPA, VCDPA, CTDPA, UCPA)</li> <li>Droit à la portabilité (PIPEDA, RGPD Article 20, LGPD)</li> <li>Droit d'opposition (RGPD Article 21, LGPD, POPIA)</li> </ul> <br></br><br></br><br></br> Si vous souhaitez faire appel ou déposer une plainte concernant la façon dont nous traitons vos données personnelles, vous pouvez nous contacter en utilisant les coordonnées fournies dans la section « Nous Contacter » ci-dessous. Vous avez également le droit de déposer une plainte auprès de l'autorité de protection des données de votre juridiction. <br></br> Dans le cas où vous nous avez contactés et que vous n'êtes pas satisfait de notre réponse, vous avez le droit de faire appel auprès du procureur général situé ici : <ul> <li>   Si vous êtes basé dans l'EEE, veuillez visiter le site https://edpb.europa.eu/about-edpb/about-edpb/members_en pour une liste des autorités locales de protection des données. </li> <li>   Si vous êtes basé dans le Connecticut, veuillez visiter le site https://portal.ct.gov/AG/Common/Complaint-Form-Landing-page pour déposer une plainte. </li> <li> Si vous êtes basé dans le Colorado, veuillez visiter le site https://complaints.coag.gov/s/contact-us pour déposer une plainte. </li> <li> Si vous êtes basé en Virginie, veuillez visiter le site https://www.oag.state.va.us/consumer-protection/index.php/file-a-complaint pour déposer une plainte. </li></ul>",
+            "title": "Vos Droits Concernant Vos Données Personnelles"
+          },
+          "policyChanges": {
+            "content": "Nous pouvons mettre à jour cette politique de temps à autre. Si nous apportons des modifications importantes, nous vous en informerons, mais veuillez vérifier régulièrement cette politique pour vous assurer que vous êtes au courant de la version la plus récente.",
+            "title": "Modifications de Cette Politique"
+          },
+          "processingDataTerms": {
+            "content": "Nous collectons et utilisons vos données personnelles avec votre consentement pour fournir, maintenir et développer nos produits et services et comprendre comment les améliorer davantage. <br></br><br></br><br></br> Ces finalités incluent : <ul> <li>Construire un environnement sûr et sécurisé pour nos utilisateurs et notre communauté ;</li> <li>Mener des recherches et des analyses pour améliorer nos produits et services ;</li> <li>Communiquer avec vous concernant votre compte, vos achats ou vos demandes ;</li> <li>Enquêter et prévenir les incidents de sécurité et autres activités illégales ;</li> <li>Personnaliser votre expérience avec nos produits et services ;</li> <li>Fournir, maintenir et améliorer nos produits et services ;</li> <li>Vous fournir les produits et services que vous demandez ;</li> <li>Vous fournir des communications marketing ;</li> <li>Vous fournir un support client ;</li> <li>Protéger nos produits et services ;</li> <li>Autres finalités avec votre consentement ;</li> <li>Se conformer aux obligations légales.</li> </ul> <br></br><br></br><br></br><br></br> Lorsque nous traitons vos données personnelles pour fournir un produit ou un service, nous le faisons parce que c'est nécessaire pour exécuter des obligations contractuelles. Tout le traitement ci-dessus est nécessaire dans nos intérêts légitimes pour fournir des produits et services et pour maintenir notre relation avec vous et pour protéger notre entreprise par exemple contre la fraude. Le consentement sera requis pour initier les services avec vous. Un nouveau consentement sera requis si des modifications sont apportées au type de données collectées. Dans le cadre de notre contrat, si vous ne fournissez pas votre consentement, certains services peuvent ne pas vous être disponibles.",
+            "title": "Finalité et Base Légale du Traitement des Données Personnelles"
+          },
+          "processingTerms": {
+            "content": "Cette politique s'applique lorsque vous visitez notre site web, utilisez nos produits ou services, ou interagissez avec nous. <br></br> De plus, cette politique s'applique lorsque vous : <ul> <li> Utilisez notre application et nos services en tant qu'utilisateur autorisé ;</li> <li>Visitez l'un de nos sites web liés à cette Politique de Confidentialité ;</li> <li>Recevez toute communication de notre part, y compris les e-mails.</li></ul>",
+            "title": "Activités de Traitement"
+          },
+          "safeDataTerms": {
+            "content": "Nous avons mis en place des mesures de sécurité techniques et organisationnelles appropriées conçues pour protéger la sécurité de toute donnée personnelle que nous traitons. Cependant, veuillez également vous rappeler que nous ne pouvons pas garantir que l'internet lui-même est 100% sécurisé. Bien que nous fassions de notre mieux pour protéger vos données personnelles, la transmission de données personnelles vers et depuis notre site web se fait à vos propres risques. Vous ne devez accéder aux services que dans un environnement sécurisé. <br></br><br></br><br></br> Nous avons mis en place des garanties organisationnelles et des mesures de sécurité appropriées pour protéger vos données personnelles contre la perte accidentelle, l'utilisation ou l'accès non autorisé, la modification ou la divulgation. <br></br><br></br><br></br> La communication entre votre navigateur et notre site web utilise une connexion chiffrée sécurisée partout où vos données personnelles sont impliquées. <br></br><br></br><br></br> Nous exigeons que tout tiers contracté pour traiter vos données personnelles en notre nom ait des mesures de sécurité en place pour protéger vos données et traiter ces données conformément à la loi. <br></br><br></br><br></br> Dans le cas malheureux d'une violation de données personnelles, nous vous informerons ainsi que tout régulateur applicable lorsque nous sommes légalement tenus de le faire.",
+            "title": "Comment Nous Gardons Vos Données en Sécurité"
+          },
+          "scopeTerms": {
+            "content": "Cette politique s'applique au site web <code> AROLARIU.RO </code>, aux produits et aux services. Elle s'applique également à l'utilisation de notre site web, de nos produits et de nos services par nos clients, partenaires et visiteurs. <br></br><br></br> Cette politique ne s'applique pas aux applications, sites web, produits, services ou plateformes tiers qui peuvent être accessibles via des liens (non-<code>AROLARIU.RO</code>) que nous pouvons vous fournir. Ces sites sont détenus et exploités indépendamment de nous, et ils ont leurs propres pratiques distinctes en matière de confidentialité et de collecte de données. Toute donnée personnelle que vous fournissez à ces sites web sera régie par la propre politique de confidentialité du tiers. Nous ne pouvons pas accepter de responsabilité pour les actions ou les politiques de ces sites indépendants, et nous ne sommes pas responsables du contenu ou des pratiques de confidentialité de ces sites.",
+            "title": "Portée de la Politique"
+          },
+          "serviceProviderTerms": {
+            "content": "Nous pouvons utiliser des prestataires de services tiers, des entrepreneurs indépendants, des agences ou des consultants pour fournir et nous aider à améliorer nos produits et services. Nous pouvons partager vos données personnelles avec des agences de marketing, des fournisseurs de services de bases de données, des fournisseurs de services de sauvegarde et de reprise après sinistre, des fournisseurs de services de messagerie et d'autres, mais uniquement pour maintenir et améliorer nos produits et services. <br></br><br></br> Pour plus d'informations sur les destinataires de vos données personnelles, veuillez nous contacter en utilisant les informations de la section « Nous Contacter » ci-dessous.",
+            "title": "Prestataires de Services et Autres Tiers"
+          },
+          "sharingAndDisclosureTerms": {
+            "content": "Nous partagerons vos données personnelles avec des tiers uniquement de la manière indiquée dans cette politique ou au moment où les données personnelles sont collectées. <br></br><br></br><br></br> Nous utilisons également Google Analytics pour nous aider à comprendre comment nos clients utilisent le site. Vous pouvez en savoir plus sur la façon dont Google utilise vos données personnelles ici : https://www.google.com/intl/en/policies/privacy/ <br></br><br></br><br></br> Vous pouvez également vous désinscrire de Google Analytics ici : https://tools.google.com/dlpage/gaoptout <br></br><br></br><br></br> Nous pouvons également partager vos données personnelles avec des tiers lorsque la loi l'exige, lorsqu'il est nécessaire d'administrer la relation entre nous ou lorsque nous avons un autre intérêt légitime à le faire. Nous pouvons également partager vos données personnelles avec des tiers à qui nous pouvons choisir de vendre, transférer ou fusionner des parties de notre entreprise ou de nos actifs. Alternativement, nous pouvons chercher à acquérir d'autres entreprises ou à fusionner avec elles. <br></br><br></br><br></br> Pour plus d'informations sur le fonctionnement de la publicité ciblée, vous pouvez visiter la page éducative de la Network Advertising Initiative (NAI) à : https://www.networkadvertising.org/understanding-online-advertising/how-does-it-work <br></br><br></br><br></br> De plus, vous pouvez vous désinscrire de certains de ces services en visitant la page de désinscription de la Digital Advertising Alliance : https: //optout.aboutads.info/",
+            "title": "Partage et Divulgation des Données Personnelles"
+          },
+          "thirdPartyData": {
+            "content": "Nous pouvons recevoir vos données personnelles de tiers tels que des entreprises abonnées aux services <code>AROLARIU.RO</code>, des partenaires et d'autres sources. Ces données personnelles ne sont pas collectées par nous mais par un tiers et sont soumises aux politiques distinctes de confidentialité et de collecte de données de ce tiers. Nous n'avons aucun contrôle ou influence sur la façon dont vos données personnelles sont traitées par des tiers. Comme toujours, vous avez le droit de consulter et de rectifier ces informations. Si vous avez des questions, vous devez d'abord contacter le tiers concerné pour plus d'informations sur vos données personnelles. Lorsque ce tiers ne répond pas à vos droits, vous pouvez contacter le Délégué à la Protection des Données chez <code> AROLARIU.RO </code> (coordonnées ci-dessous). <br></br><br></br><br></br> Nos sites web et services peuvent contenir des liens vers d'autres sites web, applications et services maintenus par des tiers. Les pratiques d'information de ces autres services, ou des réseaux de médias sociaux qui hébergent nos pages de médias sociaux de marque, sont régies par les déclarations de confidentialité de ces tiers, que vous devriez consulter pour mieux comprendre les pratiques de confidentialité de ces tiers.",
+            "title": "Données que nous collectons auprès de tiers"
+          },
+          "whatIsTerms": {
+            "content": "Chez <code> AROLARIU.RO </code> (« nous », « notre » ou la « Société »), nous accordons de l'importance à votre vie privée et à l'importance de protéger vos données. Cette Politique de Confidentialité (la « Politique ») décrit nos pratiques de confidentialité pour les activités décrites ci-dessous. <br></br> <br></br> Conformément à vos droits, nous vous informons de la manière dont nous collectons, stockons, accédons et traitons autrement les informations relatives aux individus. Dans cette Politique, les données personnelles (« Données Personnelles ») désignent toute information qui, seule ou en combinaison avec d'autres informations disponibles, peut identifier un individu. <br></br> <br></br> Nous nous engageons à protéger votre vie privée conformément au plus haut niveau de réglementation en matière de confidentialité. En tant que tel, nous respectons les obligations des réglementations suivantes : <ul> <li> Le California Consumer Privacy Act (CCPA) / California Privacy Rights Act (CPRA) et le California Online Privacy Protection Act (CalOPPA) </li> <li> Le Personal Information Protection and Electronic Documents Act (PIPEDA) du Canada et les législations provinciales applicables </li> <li> Le Règlement Général sur la Protection des Données (RGPD) de l'Union Européenne </li> <li> Le Protection of Personal Information Act (POPIA) d'Afrique du Sud </li> <li> Le Virginia Consumer Data Protection Act (VCDPA) </li> <li> La législation brésilienne sur la protection des données (LGPD) </li> <li> Le Connecticut Data Privacy Act (CTDPA) </li> <li> Le Utah Consumer Privacy Act (UCPA) et le Colorado Privacy Act (CPA) </li> </ul>",
+            "title": "Qu'est-ce que AROLARIU.RO ?"
+          },
+          "withdrawingConsent": {
+            "content": "Si vous avez donné votre consentement au traitement de vos données personnelles, vous avez le droit de retirer votre consentement à tout moment. Pour retirer votre consentement, veuillez nous contacter en utilisant les coordonnées fournies dans la section « Nous Contacter » ci-dessous.",
+            "title": "Retrait du Consentement"
+          }
+        },
+        "title": "Politique de Confidentialité"
       },
-      "preview": "Bonjour {name} — {days} jours depuis votre dernier téléchargement.",
-      "greeting": "Bonjour {name},",
-      "intro": {
-        "3": "Nous avons remarqué que vous n'avez téléchargé aucune facture récemment.",
-        "7": "Il semble qu'une semaine se soit écoulée depuis votre dernier téléchargement de facture.",
-        "14": "Deux semaines sans téléchargements — besoin d'un petit coup de pouce pour reprendre l'habitude?",
-        "30": "Cela fait environ un mois depuis votre dernier téléchargement — nous pouvons vous aider à reprendre là où vous en étiez."
-      },
-      "whyWorthIt": {
-        "title": "Pourquoi c'est utile",
-        "bullet1": "Gardez votre chronologie de dépenses précise.",
-        "bullet2": "Obtenez des totaux plus propres par commerçant et catégorie.",
-        "bullet3": "Trouvez les reçus plus rapidement quand vous en avez besoin."
-      },
-      "status": {
-        "title": "Statut",
-        "daysWithoutUpload": "Jours sans téléchargement",
-        "lastUpload": "Dernier téléchargement"
-      },
-      "tip": {
-        "title": "Astuce (30 secondes)",
-        "message": "Téléchargez une facture récente aujourd'hui — une petite constance vaut mieux qu'un gros rattrapage."
-      },
-      "important": {
-        "title": "Important",
-        "message": "Si vous êtes bloqué ou si quelque chose ne fonctionne pas, répondez à cet email ou contactez le support — nous vous aiderons."
-      },
-      "helpPrompt": "Besoin d'aide ou avez des questions? Envoyez un email à <link>{supportEmail}</link>.",
-      "signOff": {
-        "line1": "Cordialement",
-        "line2": "L'équipe {brand}"
-      },
-      "cta": {
-        "primary": "Télécharger une facture",
-        "secondary": "Voir les factures"
+      "termsOfService": {
+        "contactInformation": {
+          "content": "Si vous avez des questions concernant nos Conditions de Service, veuillez nous contacter à admin@arolariu.ro",
+          "title": "Informations de Contact"
+        },
+        "lastUpdated": "Dernière mise à jour : 2024-01-01",
+        "terms": {
+          "amendmentsTerms": {
+            "content": "Nous nous réservons le droit de modifier, compléter ou remplacer les termes de l'Accord, prenant effet dès la publication sur www.arolariu.ro ou en vous en informant autrement. Si vous ne souhaitez pas accepter les modifications de l'Accord, vous pouvez résilier l'Accord à tout moment conformément aux termes des présentes. Si une révision est importante, nous fournirons un préavis d'au moins 30 jours avant l'entrée en vigueur de nouveaux termes. Ce qui constitue un changement important sera déterminé à notre seule discrétion. En continuant à accéder ou à utiliser notre service après que les révisions deviennent effectives, vous acceptez d'être lié par les termes révisés. Si vous n'acceptez pas les nouveaux termes, vous n'êtes plus autorisé à utiliser notre service.",
+            "title": "Modifications de l'Accord"
+          },
+          "arbitrateTerms": {
+            "content": "Cet Accord et tout litige ou réclamation découlant de, ou lié à, celui-ci, son interprétation, ou la violation, résiliation ou validité de celui-ci, les relations qui résultent de cet Accord, y compris l'exécution, la violation ou la validité de cet Accord, seront régis par les lois de la Roumanie. La juridiction et le lieu exclusifs pour toute action en vertu de cet Accord seront les tribunaux situés en Roumanie et vous vous soumettez par les présentes à la juridiction personnelle de ces tribunaux. Vous renoncez par les présentes à tout droit à un procès devant jury dans toute procédure découlant de ou liée à cet Accord. La Convention des Nations Unies sur les Contrats de Vente Internationale de Marchandises ne s'applique pas à cet Accord. Le terme « litige » désigne tout litige, action ou autre controverse entre vous et nous concernant les Services ou cet accord, que ce soit en matière de contrat, garantie, délit, loi, règlement, ordonnance ou toute autre base légale ou équitable. « Litige » aura le sens le plus large possible autorisé par la loi.",
+            "title": "Arbitrage"
+          },
+          "changesToTos": {
+            "content": "AROLARIU.RO se réserve le droit de modifier ces Conditions de Service à tout moment. Nous vous recommandons cependant de lire cette page régulièrement pour vous assurer que vous êtes au courant de tout changement. Votre utilisation continue du site web suite à la publication de modifications signifiera que vous acceptez et êtes d'accord avec les modifications. Vous reconnaissez et acceptez que nous pouvons arrêter (de façon permanente ou temporaire) de fournir le Service (ou toute fonctionnalité au sein du Service) à vous ou aux utilisateurs en général à notre seule discrétion, sans préavis. Vous pouvez cesser d'utiliser le Service à tout moment. Vous n'avez pas besoin de nous informer spécifiquement lorsque vous cessez d'utiliser le Service. Vous reconnaissez et acceptez que si nous désactivons l'accès à votre compte, vous pouvez être empêché d'accéder au Service, aux détails de votre compte ou à tout fichier ou autre matériel contenu dans votre compte",
+            "title": "Modifications des Conditions de Service"
+          },
+          "consentTerms": {
+            "content": "Nous avons mis à jour nos Termes et Conditions pour vous fournir une transparence complète sur ce qui est défini lorsque vous visitez notre site et comment il est utilisé. En utilisant notre site web, vous consentez par les présentes à nos Conditions de Service et acceptez les Termes et Conditions.",
+            "title": "Votre Consentement"
+          },
+          "cookiesTerms": {
+            "content": "Nous utilisons des 'Cookies' pour identifier les zones de notre site web que vous avez visitées. Un Cookie est un petit fichier de données stocké sur votre ordinateur ou appareil mobile par votre navigateur web. Nous utilisons des Cookies pour améliorer les performances et la fonctionnalité de notre service mais ils ne sont pas essentiels à leur utilisation. Cependant, sans ces cookies, certaines fonctionnalités comme les vidéos peuvent devenir indisponibles ou vous seriez obligé de saisir vos identifiants de connexion chaque fois que vous visitez notre plateforme car nous ne pourrions pas nous souvenir que vous vous étiez connecté précédemment. La plupart des navigateurs web peuvent être configurés pour désactiver l'utilisation des Cookies. Cependant, si vous désactivez les Cookies, vous pourriez ne pas être en mesure d'accéder correctement ou pas du tout aux fonctionnalités de notre site web. Nous ne plaçons jamais d'informations personnellement identifiables dans les Cookies.",
+            "title": "Cookies"
+          },
+          "copyrightTerms": {
+            "content": "Si vous êtes titulaire de droits d'auteur ou l'agent de ce titulaire et que vous croyez qu'un matériel de notre part constitue une violation de vos droits d'auteur, veuillez nous contacter en fournissant les informations suivantes : (a) une signature physique ou électronique du titulaire des droits d'auteur ou d'une personne autorisée à agir en son nom ; (b) l'identification du matériel présumé contrefaisant ; (c) vos coordonnées, y compris votre adresse, numéro de téléphone et email ; (d) une déclaration de votre part indiquant que vous croyez de bonne foi que l'utilisation du matériel n'est pas autorisée par les titulaires des droits d'auteur ; et (e) une déclaration que les informations dans la notification sont exactes, et, sous peine de parjure, que vous êtes autorisé à agir au nom du titulaire.",
+            "title": "Protection des Droits d'Auteur"
+          },
+          "definitionTerms": {
+            "content": "Les termes 'nous' ou 'notre' font référence à AROLARIU.RO, le propriétaire du site web. Un client est la personne ou l'organisation qui achète ou accepte d'acheter le produit. Notre 'produit' fait référence au site web, aux produits ou aux services proposés à la vente sur notre site web. Un 'utilisateur' est une personne qui utilise notre site web ou nos services. Le terme 'vous' fait référence à l'utilisateur ou au visiteur de notre site web.",
+            "title": "Définitions"
+          },
+          "disclaimerTerms": {
+            "content": "Dans la mesure maximale permise par la loi applicable, nous excluons toutes les déclarations, garanties et conditions relatives à notre site web et à l'utilisation de ce site web. Nous ne serons pas responsables des dommages résultant de l'utilisation ou de l'incapacité d'utiliser les matériaux sur le site web d'AROLARIU.RO, même si AROLARIU.RO ou un représentant autorisé d'AROLARIU.RO a été informé, oralement ou par écrit, de la possibilité de tels dommages. Parce que certaines juridictions n'autorisent pas les limitations sur les garanties implicites, ou les limitations de responsabilité pour les dommages consécutifs ou accessoires, ces limitations peuvent ne pas s'appliquer à vous. Nous ne sommes pas responsables du contenu, du code ou de toute autre imprécision. Nous ne fournissons pas de garanties. En aucun cas, nous ne serons responsables de dommages spéciaux, directs, indirects, consécutifs ou accessoires ou de tout dommage quel qu'il soit, que ce soit dans une action contractuelle, par négligence ou autre délit, découlant de ou en relation avec l'utilisation du Service ou du contenu du Service. Nous nous réservons le droit d'effectuer des ajouts, des suppressions ou des modifications au contenu du Service à tout moment sans préavis. Notre Service et son contenu sont fournis 'EN L'ÉTAT' et 'SELON DISPONIBILITÉ' sans aucune garantie ou représentation d'aucune sorte, qu'elle soit expresse ou implicite. Nous sommes un distributeur et non un éditeur du contenu fourni par des tiers ; en tant que tel, nous n'exerçons aucun contrôle éditorial sur ce contenu et ne faisons aucune garantie ou représentation quant à l'exactitude, la fiabilité ou l'actualité de toute information, contenu, service ou marchandise fourni par ou accessible via notre Service. Sans limiter ce qui précède, nous déclinons spécifiquement toutes les garanties et représentations dans tout contenu transmis sur ou en relation avec notre Service ou sur des sites qui peuvent apparaître comme des liens sur notre Service, ou dans les produits fournis dans le cadre de, ou autrement en relation avec, notre Service, y compris sans limitation toute garantie de qualité marchande, d'adéquation à un usage particulier ou de non-violation des droits de tiers. Aucun conseil oral ou information écrite donnée par nous ou par l'un de ses affiliés, employés, dirigeants, directeurs, agents, ou similaires ne créera une garantie. Les informations sur les prix et la disponibilité sont sujettes à modification sans préavis. Sans limiter ce qui précède, nous ne garantissons pas que notre Service sera ininterrompu, non corrompu, opportun ou sans erreur.",
+            "title": "Avertissement"
+          },
+          "disputeNoticeTerms": {
+            "content": "En cas de litige, vous ou AROLARIU.RO devez donner à l'autre un Avis de Litige, qui est une déclaration écrite indiquant le nom, l'adresse et les coordonnées de la partie qui le donne, les faits donnant lieu au litige et le recours demandé. Vous devez envoyer tout Avis de Litige par email à : admin@arolariu.ro. AROLARIU.RO vous enverra tout Avis de Litige par courrier à votre adresse si nous l'avons, ou sinon à votre adresse email. Vous et AROLARIU.RO tenterez de résoudre tout litige par négociation informelle dans les soixante (60) jours à compter de la date d'envoi de l'Avis de Litige. Après soixante (60) jours, vous ou AROLARIU.RO pouvez engager un arbitrage.",
+            "title": "Avis de Litige"
+          },
+          "entireAgreementTerms": {
+            "content": "Les Conditions de Service constituent l'intégralité de l'accord entre vous et AROLARIU.RO concernant votre utilisation du service et remplacent tous les accords écrits ou oraux antérieurs et contemporains entre vous et AROLARIU.RO. Vous pouvez être soumis à des termes et conditions supplémentaires qui s'appliquent lorsque vous utilisez ou achetez d'autres services d'AROLARIU.RO, qu'AROLARIU.RO vous fournira au moment d'une telle utilisation ou d'un tel achat.",
+            "title": "Accord Intégral"
+          },
+          "generalTerms": {
+            "content": "En accédant et en passant une commande auprès d'AROLARIU.RO, vous confirmez que vous êtes en accord avec et lié par les conditions de service contenues dans les Termes et Conditions décrits ci-dessous. Ces termes s'appliquent à l'ensemble du site web et à tout email ou autre type de communication entre vous et AROLARIU.RO. En aucun cas l'équipe AROLARIU.RO ne sera responsable de dommages directs, indirects, spéciaux, accessoires ou consécutifs, y compris, mais sans s'y limiter, la perte de données ou de profit, découlant de l'utilisation, ou de l'incapacité d'utiliser, les matériaux sur ce site, même si l'équipe AROLARIU.RO ou un représentant autorisé a été informé de la possibilité de tels dommages. Si votre utilisation des matériaux de ce site entraîne le besoin d'entretien, de réparation ou de correction d'équipement ou de données, vous assumez tous les coûts y afférents. AROLARIU.RO ne sera pas responsable de tout résultat qui pourrait survenir au cours de l'utilisation de nos ressources. Nous nous réservons le droit de modifier les prix et de réviser la politique d'utilisation des ressources à tout moment.",
+            "title": "Conditions Générales"
+          },
+          "liabilityTerms": {
+            "content": "Dans la mesure la plus complète permise par la loi applicable, en aucun cas AROLARIU.RO ne sera responsable envers vous sur quelque théorie juridique que ce soit pour tout dommage accessoire, direct, indirect, punitif, réel, consécutif, spécial, exemplaire ou autre, y compris sans limitation, la perte de revenus ou de bénéfices, les profits perdus, la douleur et la souffrance, la détresse émotionnelle, le coût des biens ou services de substitution, ou des dommages similaires subis ou encourus par vous ou tout tiers qui surviennent en relation avec le service (ou sa résiliation pour quelque raison que ce soit), même si AROLARIU.RO a été informé de la possibilité de tels dommages. AROLARIU.RO ne sera pas responsable de tout dommage, responsabilité ou perte découlant de : (i) votre utilisation ou votre confiance dans le service ou votre incapacité à accéder ou à utiliser le service ; ou (ii) toute transaction ou relation entre vous et tout fournisseur tiers, même si AROLARIU.RO a été informé de la possibilité de tels dommages. AROLARIU.RO ne sera pas responsable de tout retard ou défaut d'exécution résultant de causes échappant au contrôle raisonnable d'AROLARIU.RO. Vous reconnaissez que le service peut être soumis à des limitations, des retards et d'autres problèmes inhérents à l'utilisation d'internet et des communications électroniques. AROLARIU.RO n'est pas responsable des retards, des échecs de livraison ou d'autres dommages résultant de tels problèmes. Dans la mesure maximale permise par la loi applicable, en aucun cas nous ou nos fournisseurs ne serons responsables de dommages spéciaux, accessoires, indirects ou consécutifs quels qu'ils soient (y compris, mais sans s'y limiter, les dommages pour perte de profits, pour perte de données ou d'autres informations, pour interruption d'activité, pour blessure personnelle, pour perte de vie privée découlant de ou de quelque manière que ce soit liée à l'utilisation ou à l'incapacité d'utiliser le service, les logiciels tiers et/ou le matériel tiers utilisé avec le service, ou autrement en relation avec toute disposition du présent Accord), même si nous ou tout fournisseur avons été informés de la possibilité de tels dommages et même si le recours échoue dans son objectif essentiel. Certains états/juridictions n'autorisent pas l'exclusion ou la limitation des dommages accessoires ou consécutifs, de sorte que la limitation ou l'exclusion ci-dessus peut ne pas s'appliquer à vous.",
+            "title": "Limitation de Responsabilité"
+          },
+          "licenseTerms": {
+            "content": "En achetant un produit d'AROLARIU.RO, vous recevez une licence non exclusive et non transférable pour accéder au produit. Le produit est destiné à un usage personnel et commercial. Vous êtes autorisé à installer le produit sur plus d'un ordinateur ou appareil, mais vous n'êtes pas autorisé à partager le produit avec d'autres personnes. Vous ne pouvez pas modifier, adapter, traduire, rétro-concevoir, décompiler, désassembler ou créer des œuvres dérivées basées sur le produit sans le consentement écrit préalable d'AROLARIU.RO. Vous ne pouvez pas vendre, louer, donner en location ou sous-licencier le produit. Vous ne pouvez pas rendre le produit disponible sur un réseau où il pourrait être utilisé par plusieurs appareils en même temps. Vous ne pouvez pas utiliser le produit pour enfreindre tout droit d'auteur ou marque de commerce. Vous ne pouvez pas utiliser le produit pour créer tout matériel qui est illégal, nuisible, menaçant, abusif, harcelant, délictueux, diffamatoire, vulgaire, obscène, calomnieux, envahissant la vie privée d'autrui, haineux, ou racialement, ethniquement ou autrement répréhensible.",
+            "title": "Conditions de Licence"
+          },
+          "linksToOtherSitesTerms": {
+            "content": "Notre service peut contenir des liens vers d'autres sites web qui ne sont pas exploités par nous. Si vous cliquez sur un lien tiers, vous serez dirigé vers le site de ce tiers. Nous vous conseillons fortement de consulter les Termes et Conditions de chaque site que vous visitez. Nous n'avons aucun contrôle sur et n'assumons aucune responsabilité pour le contenu, les Termes et Conditions ou les pratiques de tout site ou service tiers.",
+            "title": "Liens vers d'Autres Sites Web"
+          },
+          "miscellaneousTerms": {
+            "content": "Si, pour quelque raison que ce soit, un tribunal compétent juge qu'une disposition ou une partie de ces Termes et Conditions est inapplicable, le reste de ces Termes et Conditions continuera de s'appliquer pleinement. Toute renonciation à une disposition de ces Termes et Conditions ne sera effective que si elle est écrite et signée par un représentant autorisé de notre part. Nous aurons droit à une injonction ou à une autre réparation équitable (sans obligation de fournir une caution ou une garantie) en cas de violation ou de violation anticipée de votre part. Nous exploitons et contrôlons notre Service depuis nos bureaux en Roumanie. Le Service n'est pas destiné à être distribué ou utilisé par toute personne ou entité dans une juridiction ou un pays où une telle distribution ou utilisation serait contraire à la loi ou à la réglementation. En conséquence, les personnes qui choisissent d'accéder à notre Service depuis d'autres emplacements le font de leur propre initiative et sont seules responsables de la conformité aux lois locales, si et dans la mesure où les lois locales sont applicables. Ces Termes et Conditions (qui incluent et incorporent notre Politique de Confidentialité) contiennent l'intégralité de l'accord, et remplacent tous les accords antérieurs, entre vous et nous concernant son objet, et ne peuvent pas être modifiés par vous. Les titres de section utilisés dans cet Accord sont à des fins de commodité uniquement et n'auront aucune portée juridique. Le fait qu'une partie n'exerce pas à quelque égard que ce soit tout droit prévu aux présentes ne sera pas considéré comme une renonciation à d'autres droits en vertu des présentes. AROLARIU.RO ne sera pas responsable de tout manquement à l'exécution de ses obligations en vertu des présentes lorsqu'un tel manquement résulte d'une cause",
+            "title": "Divers"
+          },
+          "noWarrantiesTerms": {
+            "content": "Ce site web est fourni 'tel quel', avec tous ses défauts, et AROLARIU.RO ne fait aucune déclaration ou garantie expresse ou implicite, de quelque nature que ce soit, liée à ce site web ou aux matériaux contenus sur ce site web. De plus, rien de ce qui est contenu sur ce site web ne doit être interprété comme vous fournissant des conseils ou un avis. Le service vous est fourni 'EN L'ÉTAT' et 'SELON DISPONIBILITÉ' et avec tous les défauts et imperfections sans garantie d'aucune sorte. Dans la mesure maximale permise par la loi applicable, nous, en notre propre nom et au nom de nos affiliés et de nos concédants de licence et prestataires de services respectifs, déclinons expressément toutes les garanties, qu'elles soient expresses, implicites, statutaires ou autres, concernant le service, y compris toutes les garanties implicites de qualité marchande, d'adéquation à un usage particulier, de titre et de non-contrefaçon, et les garanties qui peuvent découler des usages commerciaux, de l'exécution, de l'utilisation ou de la pratique commerciale. Sans limitation de ce qui précède, nous ne fournissons aucune garantie ou engagement, et ne faisons aucune déclaration d'aucune sorte que le service répondra à vos exigences, atteindra les résultats prévus, sera compatible ou fonctionnera avec tout autre logiciel, site web, système ou service, fonctionnera sans interruption, répondra à toute norme de performance ou de fiabilité ou sera exempt d'erreurs ou que toute erreur ou défaut puisse ou sera corrigé. Sans limiter ce qui précède, ni nous ni aucun fournisseur ne faisons de déclaration ou de garantie d'aucune sorte, expresse ou implicite : (i) quant au fonctionnement ou à la disponibilité du service, ou aux informations, contenus et matériaux ou produits qui y sont inclus ; (ii) que le service sera ininterrompu ou sans erreur ; (iii) quant à l'exactitude, la fiabilité ou l'actualité de toute information ou contenu fourni par le service ; ou (iv) que le service, ses serveurs, le contenu ou les e-mails envoyés par nous ou en notre nom sont exempts de virus, scripts, chevaux de Troie, vers, logiciels malveillants, bombes à retardement ou autres composants nuisibles. Certaines juridictions n'autorisent pas l'exclusion ou les limitations sur les garanties implicites ou les limitations sur les droits statutaires applicables d'un consommateur, de sorte que certaines ou toutes les exclusions et limitations ci-dessus peuvent ne pas s'appliquer à vous.",
+            "title": "Absence de Garanties"
+          },
+          "promotionTerms": {
+            "content": "Nous pouvons, de temps à autre, inclure des concours, des promotions, des tirages au sort ou d'autres activités (« Promotions ») qui vous obligent à soumettre du matériel ou des informations vous concernant. Veuillez noter que toutes les Promotions peuvent être régies par des règles distinctes qui peuvent contenir certaines conditions d'éligibilité, telles que des restrictions d'âge et de situation géographique. Vous êtes responsable de lire toutes les règles des Promotions pour déterminer si vous êtes éligible ou non à participer. Si vous participez à une Promotion, vous acceptez de respecter et de vous conformer à toutes les Règles des Promotions. Des termes et conditions supplémentaires peuvent s'appliquer aux achats de biens ou de services sur ou via les Services, ces termes et conditions faisant partie intégrante du présent Accord par cette référence. Toute promotion rendue disponible via le service peut être régie par des règles distinctes de ces Termes. Si vous participez à des promotions, veuillez consulter les règles applicables ainsi que notre Politique de Confidentialité. Si les règles d'une promotion entrent en conflit avec ces Termes, les règles de la promotion s'appliqueront.",
+            "title": "Promotions"
+          },
+          "restrictionTerms": {
+            "content": "Il vous est spécifiquement interdit de publier, vendre, sous-licencier ou autrement commercialiser tout matériel du site web ; d'utiliser ce site web de toute manière qui est ou pourrait être préjudiciable à ce site web ; d'utiliser ce site web de toute manière qui affecte l'accès des utilisateurs à ce site web ; d'utiliser ce site web contrairement aux lois et réglementations applicables, ou de toute manière susceptible de causer un préjudice au site web, ou à toute personne ou entité commerciale ; de s'engager dans toute exploration de données, récolte de données, extraction de données ou toute autre activité similaire en relation avec ce site web ; d'utiliser ce site web pour s'engager dans toute publicité ou marketing.",
+            "title": "Restrictions"
+          },
+          "severabilityTerms": {
+            "content": "Si une disposition de ces Termes est jugée inapplicable ou invalide, cette disposition sera modifiée et interprétée pour accomplir les objectifs de cette disposition dans la mesure la plus large possible en vertu de la loi applicable et les dispositions restantes continueront de s'appliquer pleinement. Cet Accord, avec la Politique de Confidentialité et tout autre avis juridique publié par nous sur les Services, constituera l'intégralité de l'accord entre vous et nous concernant les Services. Si une disposition du présent Accord est jugée invalide par un tribunal compétent, l'invalidité de cette disposition n'affectera pas la validité des dispositions restantes du présent Accord, qui resteront pleinement en vigueur. Aucune renonciation à un terme de cet Accord ne sera considérée comme une renonciation supplémentaire ou continue à ce terme ou à tout autre terme, et notre défaut de faire valoir tout droit ou disposition en vertu du présent Accord ne constituera pas une renonciation à ce droit ou à cette disposition. VOUS ET NOUS CONVENONS QUE TOUTE CAUSE D'ACTION DÉCOULANT DE OU LIÉE AUX SERVICES DOIT COMMENCER DANS L'ANNÉE (1) SUIVANT L'ACCUMULATION DE LA CAUSE D'ACTION. SINON, UNE TELLE CAUSE D'ACTION EST DÉFINITIVEMENT IRRECEVABLE.",
+            "title": "Divisibilité"
+          },
+          "submissionsAndPrivacyTerms": {
+            "content": "Lorsque vous visitez le site web ou nous envoyez des e-mails, vous communiquez avec nous électroniquement. Vous consentez à recevoir des communications de notre part par voie électronique. Nous communiquerons avec vous par e-mail ou en publiant des avis sur le site web. Vous acceptez que tous les accords, avis, divulgations et autres communications que nous fournissons électroniquement satisfont toute exigence légale que ces communications soient par écrit. AROLARIU.RO peut, mais n'est pas obligé de, surveiller, examiner ou modifier le Contenu Utilisateur. Dans tous les cas, AROLARIU.RO se réserve le droit de supprimer ou de désactiver l'accès à tout Contenu Utilisateur pour quelque raison que ce soit ou sans raison, y compris, mais sans s'y limiter, le Contenu Utilisateur qui, à la seule discrétion d'AROLARIU.RO, viole les Accords. AROLARIU.RO peut prendre ces mesures sans notification préalable à vous ou à un tiers. La suppression ou la désactivation de l'accès au Contenu Utilisateur sera à notre seule discrétion, et nous ne promettons pas de supprimer ou de désactiver l'accès à tout Contenu Utilisateur spécifique. Dans le cas où vous soumettez ou publiez des idées, suggestions créatives, designs, photographies, informations, publicités, données ou propositions, y compris des idées pour des produits, services, fonctionnalités, technologies ou promotions nouveaux ou améliorés, vous acceptez expressément que ces soumissions seront automatiquement traitées comme non confidentielles et non propriétaires et deviendront notre propriété exclusive sans aucune compensation ni crédit à vous. Nous et nos affiliés n'aurons aucune obligation concernant ces soumissions ou publications et pourrons utiliser les idées contenues dans ces soumissions ou publications à toutes fins dans tout média à perpétuité, y compris, mais sans s'y limiter, le développement, la fabrication et la commercialisation de produits et services utilisant ces idées.",
+            "title": "Soumissions et Confidentialité"
+          },
+          "terminationTerms": {
+            "content": "Nous pouvons résilier ou suspendre votre compte et interdire l'accès au service immédiatement, sans préavis ni responsabilité, à notre seule discrétion, pour quelque raison que ce soit et sans limitation, y compris, mais sans s'y limiter, une violation des Termes. Si vous souhaitez résilier votre compte, vous pouvez simplement cesser d'utiliser le service. Toutes les dispositions des Termes qui par leur nature devraient survivre à la résiliation survivront à la résiliation, y compris, sans limitation, les dispositions relatives à la propriété, les exclusions de garantie, l'indemnisation et les limitations de responsabilité.",
+            "title": "Résiliation"
+          },
+          "thirdPartyTerms": {
+            "content": "En utilisant le service, vous pouvez utiliser des services, produits, logiciels, intégrations ou applications tiers développés par un tiers ('Services Tiers'). Toute utilisation d'un Service Tiers est à vos propres risques, et nous ne serons pas responsables envers quiconque pour les sites web ou Services Tiers. Vous reconnaissez et acceptez que nous ne serons pas responsables de tout dommage ou perte causé ou prétendument causé par ou en relation avec l'utilisation de tout contenu, bien ou service disponible sur ou via de tels sites web ou services. Nous n'assumons et n'aurons aucune responsabilité envers vous ou toute autre personne ou entité pour tout Service Tiers. Les Services Tiers et les liens sont donc fournis uniquement pour votre commodité et vous y accédez et les utilisez entièrement à vos propres risques et sous réserve des termes et conditions de ces tiers.",
+            "title": "Services Tiers"
+          },
+          "typographyErrorsTerms": {
+            "content": "Dans le cas où un produit AROLARIU.RO est par erreur affiché à un prix incorrect, AROLARIU.RO se réserve le droit de refuser ou d'annuler toute commande passée pour le produit affiché au prix incorrect. AROLARIU.RO se réserve le droit de refuser ou d'annuler toute commande de ce type, que la commande ait été confirmée ou non et que votre carte de crédit ait été débitée ou non. Si votre carte de crédit a déjà été débitée pour l'achat et que votre commande est annulée, AROLARIU.RO émettra un crédit sur votre compte de carte de crédit du montant du prix incorrect.",
+            "title": "Erreurs Typographiques"
+          },
+          "updateOfServicesTerms": {
+            "content": "AROLARIU.RO met constamment à jour ses services, ce qui signifie que nous pouvons ajouter ou supprimer des fonctionnalités, des produits ou des fonctionnalités, et nous pouvons également suspendre ou arrêter complètement le service. Nous pouvons prendre n'importe laquelle de ces mesures à tout moment, et lorsque nous le faisons, nous pouvons ne pas vous fournir de préavis. Vous reconnaissez qu'AROLARIU.RO peut établir des pratiques générales et des limites concernant l'utilisation du service, y compris sans limitation la période maximale pendant laquelle les données ou autres contenus seront conservés par le service et l'espace de stockage maximal qui sera alloué sur les serveurs d'AROLARIU.RO en votre nom. Vous acceptez qu'AROLARIU.RO n'a aucune responsabilité pour la suppression ou l'échec de stockage de toute donnée ou autre contenu maintenu ou téléchargé par le service. Vous reconnaissez qu'AROLARIU.RO se réserve le droit de résilier les comptes inactifs pendant une période prolongée. Vous acceptez que nous n'avons aucune obligation de (i) fournir des Mises à jour, ou (ii) continuer à fournir ou activer des fonctionnalités et/ou fonctionnalités particulières du service pour vous. Vous acceptez en outre que toutes les Mises à jour seront (i) considérées comme faisant partie intégrante du service, et (ii) soumises aux termes et conditions du présent Accord.",
+            "title": "Mises à Jour du Service"
+          },
+          "waiverTerms": {
+            "content": "Sauf disposition contraire des présentes, le fait de ne pas exercer un droit ou d'exiger l'exécution d'une obligation en vertu du présent Accord n'affectera pas la capacité d'une partie à exercer ce droit ou à exiger cette exécution à tout moment par la suite, et la renonciation à une violation ne constituera pas une renonciation à toute violation ultérieure. Aucun manquement à exercer, et aucun retard dans l'exercice, de la part de l'une ou l'autre partie, de tout droit ou pouvoir en vertu du présent Accord ne fonctionnera comme une renonciation à ce droit ou pouvoir. L'exercice unique ou partiel d'un droit ou d'un pouvoir en vertu du présent Accord n'empêchera pas non plus l'exercice ultérieur de ce droit ou de tout autre droit accordé aux présentes. En cas de conflit entre le présent Accord et tout achat applicable ou d'autres conditions, les termes du présent Accord prévaudront.",
+            "title": "Renonciation"
+          }
+        },
+        "title": "Conditions de Service"
       }
+    }
+  },
+  "shared": {
+    "accessibility": {
+      "logoAlt": "logo arolariu.ro",
+      "toggleTheme": "Basculer le thème"
     },
-    "incompleteInvoice": {
-      "subject": "Vous avez des factures incomplètes",
-      "badge": "Rappel",
-      "heading": "Votre facture nécessite une mise à jour rapide",
-      "preview": "{name}, votre facture \"{invoiceName}\" nécessite une attention.",
-      "greeting": "Bonjour {name},",
-      "intro": "Nous avons analysé votre facture {invoiceName}, mais n'avons pas pu tout extraire. Quelques détails manquent, et les compléter vous donnera de meilleures informations sur vos dépenses et des tableaux de bord plus précis.",
-      "invoiceDetailsTitle": "Détails de la facture",
-      "invoiceLabel": "Facture",
-      "analyzedOnLabel": "Analysée le",
-      "missingFieldsLabel": "Champs manquants",
-      "whatsMissingTitle": "Ce qui manque",
-      "missingFields": {
-        "merchant": {
-          "label": "Commerçant",
-          "suggestion": "Ajoutez manuellement le nom du magasin dans la vue d'édition"
+    "invoices": {
+      "commandPalette": {
+        "actions": {
+          "createInvoice": "Créer une facture",
+          "uploadScans": "Télécharger des numérisations",
+          "viewAll": "Voir toutes les factures",
+          "viewStatistics": "Voir les statistiques"
         },
-        "items": {
-          "label": "Articles ligne par ligne",
-          "suggestion": "Essayez de télécharger à nouveau une photo plus claire, ou ajoutez les articles manuellement"
+        "groups": {
+          "quickActions": "Actions rapides",
+          "recentInvoices": "Factures récentes",
+          "searchResults": "Résultats de recherche"
         },
-        "payment": {
-          "label": "Informations de paiement",
-          "suggestion": "Entrez le montant total et le mode de paiement dans la vue d'édition"
+        "noResults": "Aucun résultat trouvé",
+        "placeholder": "Rechercher des factures, commerçants, articles..."
+      },
+      "invoiceHeader": {
+        "buttons": {
+          "analyzeWithAi": "Analyser avec l'IA",
+          "delete": "Supprimer",
+          "discard": "Annuler",
+          "edit": "Modifier",
+          "export": "Exporter",
+          "print": "Imprimer",
+          "save": "Enregistrer",
+          "saving": "Enregistrement..."
         },
-        "category": {
-          "label": "Catégorie de facture",
-          "suggestion": "Sélectionnez une catégorie (épicerie, restauration rapide, ménage, etc.)"
-        },
-        "unknown": {
-          "label": "{field}",
-          "suggestion": "Veuillez réviser et mettre à jour ces informations"
+        "id": "ID : {id}",
+        "tooltips": {
+          "analyzeSpendingPatterns": "Analyser les habitudes de dépenses de cette facture",
+          "delete": "Supprimer définitivement cette facture",
+          "deleteInvoicePermanently": "Supprimer cette facture définitivement",
+          "discardAllPendingChanges": "Annuler toutes les modifications en attente",
+          "edit": "Modifier cette facture",
+          "export": "Exporter les données de la facture dans différents formats",
+          "importantInvoice": "Facture importante",
+          "print": "Imprimer cette facture",
+          "printInvoiceWithAllDetails": "Imprimer cette facture avec tous les détails",
+          "saveAllPendingChanges": "Enregistrer toutes les modifications en attente"
         }
       },
-      "tipsTitle": "Conseils pour une meilleure analyse",
-      "tips": {
-        "0": "Utilisez une surface bien éclairée et plate lors de la photographie des reçus",
-        "1": "Assurez-vous que le reçu entier est visible et net",
-        "2": "Les reçus PDF des commandes en ligne ont tendance à être mieux analysés",
-        "3": "Vous pouvez toujours ajouter ou corriger les détails manuellement après l'analyse"
+      "invoicesNotFound": {
+        "cta": "Téléverser une facture ici.",
+        "description": "Il semble que vous n’ayez aucune facture associée à votre compte. Veuillez téléverser des factures puis revenir plus tard.",
+        "title": "Il manque quelque chose ici..."
       },
-      "bodyText": "Compléter ces détails prend moins d'une minute et garantit que vos rapports de dépenses restent précis.",
-      "feedback": "Bloqué ou besoin d’aide ? Contactez-nous à <link>{supportEmail}</link>.",
-      "signOff": {
-        "line1": "Cordialement,",
-        "line2": "L'équipe {brand}"
+      "loadingInvoices": {
+        "description": "Chargement factures...",
+        "title": "Chargement factures"
       },
-      "primaryCta": "Compléter votre facture",
-      "secondaryCta": "Réanalyser"
-    },
-    "unanalyzedInvoices": {
-      "subject": "Vous avez des factures non analysées",
-      "badge": "Rappel",
-      "heading": "{count, plural, =1 {1 facture en attente d'analyse} other {# factures en attente d'analyse}}",
-      "preview": "{name}, vous avez {count, plural, =1 {1 facture} other {# factures}} en attente d'analyse AI.",
-      "greeting": "Bonjour {name},",
-      "intro": "{count, plural, =1 {Vous avez 1 facture qui n'a pas encore été analysée. L'exécution de notre analyse AI débloque toute la valeur de vos reçus téléchargés.} other {Vous avez # factures qui n'ont pas encore été analysées. L'exécution de notre analyse AI débloque toute la valeur de vos reçus téléchargés.}}",
-      "invoicesAwaitingTitle": "Factures en attente d'analyse",
-      "uploadedDate": "Téléchargée le {date}",
-      "andMore": "…et {remaining} de plus. Voir tout dans votre <dashboard></dashboard>.",
-      "analysisProvidedTitle": "Ce que l'analyse fournit",
-      "analysisProvides": {
-        "0": "Extraction ligne par ligne des articles avec prix et catégories",
-        "1": "Identification et catégorisation des commerçants",
-        "2": "Détection des allergènes sur les produits alimentaires",
-        "3": "Suggestions de recettes basées sur vos articles d'épicerie",
-        "4": "Catégorisation automatique des dépenses pour les informations du tableau de bord"
-      },
-      "bodyText": "L'analyse prend généralement moins d'une minute par facture. Une fois terminée, vous recevrez une notification avec les résultats.",
-      "feedback": "Besoin d’aide ? Contactez-nous à <link>{supportEmail}</link>.",
-      "signOff": {
-        "line1": "Cordialement,",
-        "line2": "L'équipe {brand}"
-      },
-      "primaryCta": "Voir les factures"
-    },
-    "weeklyUploadReminder": {
-      "subject": "Votre rappel hebdomadaire de téléchargement",
-      "badge": "Rappel Hebdomadaire",
-      "heading": "Votre contrôle hebdomadaire des reçus",
-      "preview": "Bonjour {name} — voici votre contrôle hebdomadaire des reçus.",
-      "greeting": "Bonjour {name},",
-      "intro": "Voici un aperçu rapide de votre activité de suivi des reçus. Un téléchargement régulier vous donne les informations les plus précises sur vos dépenses.",
-      "metricsLabels": {
-        "thisWeek": "Cette semaine",
-        "lastWeek": "La semaine dernière",
-        "totalInvoices": "Total factures",
-        "totalTracked": "Total suivi"
-      },
-      "quickTipsTitle": "Conseils rapides",
-      "quickTips": {
-        "0": "Téléchargez les reçus juste après les achats — cela prend moins de 30 secondes",
-        "1": "Téléchargez par lot en fin de journée si vous préférez",
-        "2": "Même les petits achats aident à construire une image complète des dépenses"
-      },
-      "bodyText": "Chaque reçu que vous suivez rend vos informations de dépenses plus précises et vos tableaux de bord plus utiles.",
-      "feedback": "Questions ou retours ? Contactez-nous à <link>{supportEmail}</link>.",
-      "signOff": {
-        "line1": "Cordialement,",
-        "line2": "L'équipe {brand}"
-      },
-      "primaryCta": "Télécharger les reçus de cette semaine",
-      "secondaryCta": "Voir le tableau de bord"
-    },
-    "invoiceStats": {
-      "subject": "Vos statistiques {frequency, select, daily {quotidiennes} weekly {hebdomadaires} monthly {mensuelles} yearly {annuelles} other {périodiques}} de factures",
-      "frequencyLabel": "{frequency, select, daily {Quotidienne} weekly {Hebdomadaire} monthly {Mensuelle} yearly {Annuelle} other {Périodique}}",
-      "title": "Statistiques de factures {frequencyLabel}",
-      "badge": "Factures",
-      "heading": "Statistiques {frequencyLabel} de factures",
-      "preview": "Statistiques {frequencyLabel} pour {name} — {totalSpend} au total.",
-      "greeting": "Bonjour {name},",
-      "intro": "Voici votre résumé d'activité et de dépenses pour la période <start></start> → <end></end>.",
-      "metrics": {
+      "mobileNav": {
+        "ariaLabel": "Navigation mobile",
+        "home": "Accueil",
         "invoices": "Factures",
-        "scans": "Analyses",
-        "totalSpend": "Dépenses totales",
-        "averagePerInvoice": "Moy. / facture"
+        "profile": "Profil",
+        "scan": "Numériser"
       },
-      "reportDetailsTitle": "Détails du rapport",
-      "reportDetails": {
-        "period": "Période",
-        "currency": "Devise"
+      "notifications": {
+        "markAllRead": "Tout marquer comme lu",
+        "noNotifications": "Aucune notification pour le moment",
+        "timeAgo": {
+          "days": "{count, plural, one {il y a # jour} other {il y a # jours}}",
+          "hours": "{count, plural, one {il y a # heure} other {il y a # heures}}",
+          "minutes": "{count, plural, one {il y a # minute} other {il y a # minutes}}",
+          "now": "À l'instant"
+        },
+        "title": "Notifications",
+        "types": {
+          "analysisComplete": "Analyse IA terminée",
+          "invoiceCreated": "Facture créée",
+          "monthlyReport": "Rapport mensuel prêt"
+        }
       },
-      "topMerchantsTitle": "Top commerçants",
-      "topCategoriesTitle": "Top catégories",
-      "noDataFallback": "Pas encore de données — téléchargez quelques factures pour débloquer les statistiques.",
-      "breakdownCardTitle": "Répartition des dépenses (par catégorie)",
-      "donutChartTitle": "Distribution des dépenses par catégorie",
-      "donutChartAlt": "Graphique en anneau montrant la répartition des dépenses par catégorie.",
-      "breakdownTableTitle": "Répartition",
-      "breakdownNote": "Remarque : Ce graphique utilise les données de classement par catégorie disponibles pour la période.",
-      "body": "Pour une répartition complète de vos dépenses, visitez votre liste de factures pour consulter les tendances, les commerçants, les catégories et les totaux au fil du temps. Ces informations peuvent vous aider à identifier les habitudes de dépenses et à prendre des décisions financières plus éclairées.",
-      "feedbackPrompt": "Des questions ou quelque chose ne semble pas correct ? Écrivez-nous à <email></email>.",
-      "signOff": {
-        "line1": "Cordialement,",
-        "line2": "L'équipe {brand}"
+      "onboarding": {
+        "back": "Retour",
+        "dontShowAgain": "Ne plus afficher",
+        "getStarted": "Commencer",
+        "next": "Suivant",
+        "skip": "Passer",
+        "stepOf": "Étape {current} sur {total}",
+        "steps": {
+          "analyze": {
+            "description": "Notre système alimenté par l'IA extrait automatiquement les noms des commerçants, les dates, les montants et les articles de vos reçus avec une grande précision.",
+            "title": "L'IA extrait les détails"
+          },
+          "track": {
+            "description": "Consultez des analyses détaillées et des informations sur vos habitudes de dépenses. Comprenez où va votre argent grâce à des graphiques et rapports interactifs.",
+            "title": "Suivez vos dépenses"
+          },
+          "upload": {
+            "description": "Prenez une photo ou téléchargez un PDF de votre reçu. Notre système prend en charge plusieurs formats et peut traiter des lots de reçus en même temps.",
+            "title": "Téléchargez vos reçus"
+          }
+        }
       },
-      "ctaPrimary": "Voir les factures",
-      "ctaSecondary": "Télécharger une nouvelle facture"
+      "preferences": {
+        "currency": "Devise",
+        "defaultView": "Vue par défaut",
+        "pageSize": "Éléments par page",
+        "save": "Enregistrer les préférences",
+        "saved": "Préférences enregistrées avec succès",
+        "showStats": "Afficher les statistiques sur l'accueil",
+        "sortBy": "Trier par",
+        "sortOptions": {
+          "amountAsc": "Montant (croissant)",
+          "amountDesc": "Montant (décroissant)",
+          "dateAsc": "Date (plus ancienne)",
+          "dateDesc": "Date (plus récente)",
+          "nameAsc": "Nom (A à Z)"
+        },
+        "title": "Préférences de facturation",
+        "views": {
+          "grid": "Vue grille",
+          "table": "Vue tableau"
+        }
+      },
+      "shortcuts": {
+        "close": "Fermer",
+        "closeDialog": "Fermer la boîte de dialogue",
+        "description": "Accès rapide aux actions courantes via votre clavier",
+        "newInvoice": "Nouvelle facture",
+        "openSearch": "Ouvrir la recherche",
+        "showHelp": "Afficher cette aide",
+        "title": "Raccourcis clavier",
+        "uploadScan": "Télécharger une numérisation"
+      },
+      "statesLoading": {
+        "description": "Chargement de la facture avec l'identifiant {invoiceIdentifier}.",
+        "title": "Chargement de la Facture"
+      },
+      "statesNotFound": {
+        "description": "La facture avec l'identifiant {invoiceIdentifier} n'a pas été trouvée.",
+        "title": "Facture Non Trouvée"
+      },
+      "unknownMerchant": "Commerçant inconnu",
+      "workflowProgress": {
+        "create": "Créer",
+        "review": "Vérifier",
+        "upload": "Télécharger"
+      }
+    },
+    "legacy": {
+      "about": {
+        "cards": {
+          "author": {
+            "cta": "En savoir plus sur l'auteur...",
+            "subtitle": "arolariu est l'alias/pseudo de l'auteur : Alexandru-Razvan Olariu. Alexandru est un ingénieur logiciel expérimenté, architecte de solutions et apprenant perpétuel. Pour en savoir plus sur Alexandru, cliquez sur le bouton ci-dessous.",
+            "title": "Qui est arolariu ?"
+          },
+          "platform": {
+            "cta": "En savoir plus sur la plateforme...",
+            "subtitle": "La plateforme arolariu.ro est une collection d'applications hébergées sous le domaine arolariu.ro. La plateforme a été construite dans le but de fournir une expérience unifiée pour toutes les applications et projets OSS sur lesquels l'auteur (Alexandru-Razvan Olariu) travaille. Pour en savoir plus sur les technologies utilisées et comment elles interagissent entre elles, cliquez sur le bouton ci-dessous.",
+            "title": "Qu'est-ce que arolariu.ro ?"
+          }
+        },
+        "footer": "Merci !",
+        "metadata": {
+          "description": "En savoir plus sur l'auteur et la plateforme.",
+          "title": "À propos de nous"
+        },
+        "subtitle": " L'histoire d'arolariu.ro a commencé en 2022, lorsque l'auteur - Alexandru-Razvan Olariu, voulait comprendre comment fonctionnent les sites web. Toute la plateforme et les intégrations sous-jacentes ont été développées uniquement par l'auteur, à partir de ce qu'il a appris au fil des années. Alexandru travaille actuellement comme ingénieur logiciel chez Microsoft. Pour en savoir plus sur lui, consultez la section de droite de cette page. La plateforme est construite en utilisant les dernières technologies de pointe. Pour en savoir plus, consultez la section de gauche de cette page.",
+        "title": "À propos de nous"
+      },
+      "common": {
+        "states": {
+          "forbidden": {
+            "callToAction": "Rejoignez le domaine arolariu.ro.",
+            "description": "Malheureusement, cette fonctionnalité nécessite que vous ayez un compte sur notre domaine. En créant un compte sur notre plateforme ou en vous connectant avec un compte existant, vous pourrez accéder à tout notre arsenal de services, y compris celui-ci.",
+            "title": "Vous manquez quelque chose d'amusant !"
+          }
+        }
+      }
+    }
+  },
+  "toasts": {
+    "invoices": {
+      "useInvoiceDelete": {
+        "bulkDeleteError": "Échec de la suppression de {count} factures.",
+        "bulkDeletePartial": "Supprimées : {successCount} ; échouées : {failureCount}.",
+        "bulkDeleteSuccess": "{count} factures supprimées.",
+        "deleteError": "Impossible de supprimer la facture : {error}",
+        "deleteSuccess": "Facture supprimée."
+      },
+      "useInvoiceShare": {
+        "emailError": "Impossible d'envoyer l'e-mail à {email} : {error}",
+        "emailSending": "Envoi de l'e-mail à {email}…",
+        "emailSuccess": "E-mail envoyé à {email}.",
+        "revokeError": "Impossible de révoquer l'accès.",
+        "toggleError": "Impossible de modifier la visibilité de la facture."
+      },
+      "useRecipeAdd": {
+        "error": "Impossible d'ajouter la recette."
+      },
+      "useRecipeDelete": {
+        "error": "Impossible de supprimer la recette."
+      },
+      "useRecipeUpdate": {
+        "error": "Impossible de mettre à jour la recette."
+      },
+      "useScanAdd": {
+        "addError": "Échec de l’ajout du scan",
+        "addSuccess": "Scan ajouté",
+        "uploadFailed": "Échec du téléversement (statut {status})"
+      }
     }
   }
 }

--- a/sites/arolariu.ro/messages/fr.json
+++ b/sites/arolariu.ro/messages/fr.json
@@ -826,12 +826,19 @@
           "upload": "Téléverser le scan",
           "uploading": "Téléversement..."
         },
+        "console": {
+          "uploadError": "Erreur lors du téléversement du scan :"
+        },
         "description": "Téléversez une nouvelle image ou un nouveau document de reçu à joindre à cette facture.",
         "dropzone": {
           "dragAndDrop": "Glissez-déposez un fichier ici",
           "dropHere": "Déposez le fichier ici...",
           "formats": "JPEG, PNG, PDF (max 10 Mo)",
           "orClickBrowse": "ou cliquez pour parcourir"
+        },
+        "errors": {
+          "unknown": "Une erreur inconnue est survenue",
+          "uploadStorageFailed": "Échec du téléversement du scan dans le stockage"
         },
         "scanType": {
           "jpeg": "Image JPEG",
@@ -844,7 +851,10 @@
         "title": "Ajouter un nouveau scan",
         "toasts": {
           "fileTooLargeDescription": "La taille maximale du fichier est de 10 Mo",
-          "fileTooLargeTitle": "Fichier trop volumineux"
+          "fileTooLargeTitle": "Fichier trop volumineux",
+          "scanAddedDescription": "Le scan a été joint à la facture",
+          "scanAddedTitle": "Scan ajouté avec succès",
+          "scanFailedTitle": "Échec de l’ajout du scan"
         }
       },
       "allergenDialog": {

--- a/sites/arolariu.ro/messages/ro.json
+++ b/sites/arolariu.ro/messages/ro.json
@@ -826,12 +826,19 @@
           "upload": "Încarcă scan",
           "uploading": "Se încarcă..."
         },
+        "console": {
+          "uploadError": "Eroare la încărcarea scanării:"
+        },
         "description": "Încarcă o imagine nouă a bonului sau un document nou pentru a-l atașa la această factură.",
         "dropzone": {
           "dragAndDrop": "Trage și plasează un fișier aici",
           "dropHere": "Plasează fișierul aici...",
           "formats": "JPEG, PNG, PDF (max 10MB)",
           "orClickBrowse": "sau apasă pentru a răsfoi"
+        },
+        "errors": {
+          "unknown": "A apărut o eroare necunoscută",
+          "uploadStorageFailed": "Încărcarea scanării în spațiul de stocare a eșuat"
         },
         "scanType": {
           "jpeg": "Imagine JPEG",
@@ -844,7 +851,10 @@
         "title": "Adaugă o scanare nouă",
         "toasts": {
           "fileTooLargeDescription": "Dimensiunea maximă a fișierului este 10MB",
-          "fileTooLargeTitle": "Fișier prea mare"
+          "fileTooLargeTitle": "Fișier prea mare",
+          "scanAddedDescription": "Scanarea a fost atașată la factură",
+          "scanAddedTitle": "Scan adăugat cu succes",
+          "scanFailedTitle": "Adăugarea scanării a eșuat"
         }
       },
       "allergenDialog": {

--- a/sites/arolariu.ro/messages/ro.json
+++ b/sites/arolariu.ro/messages/ro.json
@@ -1,2033 +1,2183 @@
 {
-  "About": {
-    "Author": {
-      "Biography": {
-        "FifthPoint": "Alexandru este deschis colaborării în proiecte care implică oricare dintre domeniile Internet of Things, Software Engineering și Network Engineering. El are o experiență dovedită în furnizarea de soluții de înaltă calitate la probleme complexe și este mereu în căutarea de noi provocări.",
-        "FirstPoint": "Alexandru are {age} ani și este inginer software și arhitect de soluții. În prezent lucrează la Microsoft ca inginer software în cadrul organizației E+D MSAI FAST, construind soluții care sunt utilizate de milioane de utilizatori din întreaga lume.",
-        "FourthPoint": "Lui Alexandru îi place să citească cărți tehnice și să se joace cu noile tehnologii. A construit această platformă ca un \"banc de testare\" pentru noile tehnologii și ca o modalitate de a învăța lucruri noi. De asemenea, este un mare fan al mișcării \"open-source\" și a contribuit la depozitele OSS ale Microsoft (dotnet/core, dotnet/docs, azure/docs).",
-        "SecondPoint": "Alexandru s-a născut pe 8 ianuarie 2000 într-un orășel numit Curtea de Argeș din România. A primit primul său computer când avea doar 5 ani - un Pentium 4 E2200 2.2Ghz Dual-Core cu 512 MB de RAM. De atunci, a rulat diferite versiuni de Windows (a început cu Windows 98!), a bricolat calculatorul personal și și-a dezvoltat abilitățile informatice jucând jocuri video. De asemenea, a învățat o bună parte din limba engleză și a fost capabil să citească, să scrie și să vorbească fluent în limba engleză până la vârsta de 12 ani!",
-        "ThirdPoint": "Alexandru este un pasionat de jocuri video. A fost jucător profesionist, clasându-se pe locul 70 în România pentru jocul video numit „DotA 2”. Îi place să joace jocuri de strategie care pun accentul pe mecanică și pe un cadru tehnic, cum ar fi Age of Empires, Age of Mythology, etc. De asemenea, îi place să joace jocuri precum Red Alert, StarCraft și alte jocuri RTS.",
-        "title": "Despre Alexandru"
+  "app": {
+    "commander": {
+      "groups": {
+        "accessibility": "Accesibilitate",
+        "fun": "Distracție",
+        "language": "Limbă",
+        "links": "Linkuri",
+        "navigation": "Navigare",
+        "theme": "Temă"
       },
-      "Certifications": {
-        "certificates": {
-          "ab730": {
-            "code": "AB-730",
-            "coreSkills": "# Strategie AI # Adopție AI # AI Responsabil # Valoare de business AI # Identificarea cazurilor de utilizare AI",
-            "description": "Validează cunoștințele orientate pe business privind AI pentru profesioniștii care conduc sau influențează inițiative AI în cadrul organizației. Este destinată factorilor de decizie, product owner-ilor și consultanților care modelează strategia AI mai degrabă decât o implementează.",
-            "issuer": "Microsoft",
-            "issuerDate": "2026",
-            "link": "https://learn.microsoft.com/en-us/credentials/certifications/ai-business-professional/",
-            "name": "Certificat Microsoft: AI Business Professional"
-          },
-          "ab731": {
-            "code": "AB-731",
-            "coreSkills": "# Transformare AI la nivel de întreprindere # Strategie AI # Managementul schimbării # Guvernanță AI # Leadership executiv",
-            "description": "Validează capacitatea de a conduce inițiative de transformare AI la nivel de întreprindere — definirea strategiei, conducerea schimbării organizaționale și stabilirea guvernanței pentru operaționalizarea AI în întreaga afacere.",
-            "issuer": "Microsoft",
-            "issuerDate": "2026",
-            "link": "https://learn.microsoft.com/en-us/credentials/certifications/ai-transformation-leader/",
-            "name": "Certificat Microsoft: AI Transformation Leader"
-          },
-          "ai900": {
-            "code": "AI-900",
-            "coreSkills": "# Machine Learning # Computer Vision # Natural Language Processing # Conversational AI # Responsible AI",
-            "description": "Demonstrează cunoașterea volumelor de lucru comune de AI și machine learning și a modului de implementare a acestora pe Azure. Această certificare se adresează candidaților cu pregătire atât tehnică, cât și non-tehnică.",
-            "issuer": "Microsoft",
-            "issuerDate": "2023",
-            "link": "https://learn.microsoft.com/en-us/certifications/azure-ai-fundamentals/",
-            "name": "Certificat Microsoft: Azure AI Fundamentals"
-          },
-          "az900": {
-            "code": "AZ-900",
-            "coreSkills": "# Concepte cloud # Servicii Azure de bază # Securitate, confidențialitate, conformitate și încredere # Prețuri, SLA și ciclul de viață Azure",
-            "description": "Validează cunoștințele de bază privind serviciile cloud și modul în care aceste servicii sunt furnizate cu Microsoft Azure. Certificarea este destinată candidaților care abia încep să lucreze cu soluții și servicii bazate pe cloud.",
-            "issuer": "Microsoft",
-            "issuerDate": "2023",
-            "link": "https://learn.microsoft.com/en-us/certifications/azure-fundamentals/",
-            "name": "Certificat Microsoft: Azure Fundamentals"
-          },
-          "gh100": {
-            "code": "GH-100",
-            "coreSkills": "# Autentificare # Gestionarea utilizatorilor și echipelor # Politici de repository # Configurare Enterprise # Securitate și conformitate",
-            "description": "Validează abilitățile necesare pentru a administra organizațiile GitHub Enterprise — gestionarea utilizatorilor, echipelor, repositoriilor, politicilor și integrărilor la scară.",
-            "issuer": "GitHub",
-            "issuerDate": "2026",
-            "link": "https://learn.microsoft.com/en-us/credentials/certifications/github-administration/",
-            "name": "Certificat GitHub: Administration"
-          },
-          "gh200": {
-            "code": "GH-200",
-            "coreSkills": "# Crearea workflow-urilor # Runner-e self-hosted # Securitatea workflow-urilor # Workflow-uri reutilizabile # Pipeline-uri CI/CD",
-            "description": "Validează expertiza în crearea, configurarea și menținerea workflow-urilor GitHub Actions pentru automatizarea build, test și deployment de-a lungul întregului ciclu de viață software.",
-            "issuer": "GitHub",
-            "issuerDate": "2026",
-            "link": "https://learn.microsoft.com/en-us/credentials/certifications/github-actions/",
-            "name": "Certificat GitHub: Actions"
-          },
-          "gh300": {
-            "code": "GH-300",
-            "coreSkills": "# Planuri și funcționalități Copilot # Sugestii de cod # Prompt Engineering # Utilizare AI responsabilă # Copilot Chat",
-            "description": "Validează abilitățile necesare pentru a folosi GitHub Copilot eficient în dezvoltarea software asistată de AI — acoperind funcționalitățile, personalizarea, prompt engineering-ul și utilizarea responsabilă.",
-            "issuer": "GitHub",
-            "issuerDate": "2026",
-            "link": "https://learn.microsoft.com/en-us/credentials/certifications/github-copilot/",
-            "name": "Certificat GitHub: Copilot"
-          },
-          "gh900": {
-            "code": "GH-900",
-            "coreSkills": "# Bazele GitHub # Repository-uri # Colaborare # Produsele GitHub # Issues, Pull Request-uri și workflow-uri",
-            "description": "Validează cunoștințele de bază despre GitHub — acoperind repository-urile, funcționalitățile de colaborare, familia de produse GitHub și workflow-urile esențiale ale dezvoltatorilor.",
-            "issuer": "GitHub",
-            "issuerDate": "2026",
-            "link": "https://learn.microsoft.com/en-us/credentials/certifications/github-foundations/",
-            "name": "Certificat GitHub: Foundations"
-          },
-          "sc900": {
-            "code": "SC-900",
-            "coreSkills": "# Concepte de securitate # Principii de identitate # Microsoft Entra # Soluții de conformitate # Confidențialitate și protecția informațiilor",
-            "description": "Validează cunoștințele de bază privind securitatea, conformitatea și identitatea, împreună cu soluțiile Microsoft cloud aferente — Entra, Defender și Purview.",
-            "issuer": "Microsoft",
-            "issuerDate": "2023",
-            "link": "https://learn.microsoft.com/en-us/credentials/certifications/security-compliance-and-identity-fundamentals/",
-            "name": "Certificat Microsoft: Security, Compliance & Identity Fundamentals"
-          }
-        },
-        "coreSkillsLabel": "Competențe Demonstrate:",
-        "subtitle": "Certificări și acreditări profesionale pe care Alexandru le-a obținut de-a lungul carierei sale.",
-        "title": "Certificări",
-        "viewCertification": "Vezi certificarea"
-      },
-      "Competencies": {
-        "competences": {
-          "agileMethodologies": {
-            "description": "Alexandru a învățat despre munca agile și metodologiile agile încă de când era student la licență. El urmează manifestul agile și este un mare fan al tehnicii Kanban de planificare.",
-            "title": "Metodologii Agile"
-          },
-          "algorithmicSkills": {
-            "description": "Alexandru a finalizat multe provocări Hacker Rank, Hacker Earth și Leet Code publicate din 2019 până în 2021. El are o gândire algoritmică puternică și este capabil să construiască algoritmi complecși cu ușurință.",
-            "title": "Competențe Algoritmice"
-          },
-          "customerCentric": {
-            "description": "Alexandru lucrează cu clienții de mulți ani, în perioada în care a lucrat la Microsoft. A acumulat multe cunoștințe și este capabil să se pună în locul clientului. Este capabil să înțeleagă nevoile clientului și să ofere soluții care sunt exact adaptate nevoilor acestuia.",
-            "title": "Centrat pe client"
-          },
-          "domainDrivenDesign": {
-            "description": "Alexandru urmează cu strictețe principiile de proiectare bazate pe domeniu. El este capabil să combine DDD cu TDD pentru a crea soluții complexe care sunt ușor de întreținut și extins. El este, de asemenea, un mare fan al abordărilor „arhitectură în ceapă” și „arhitectură curată”.",
-            "title": "Proiectarea bazată pe domeniu (DDD)"
-          },
-          "engineeringExcellence": {
-            "description": "Alexandru este pasionat de furnizarea celor mai bune soluții pentru problemă și pentru client. El se străduiește mereu să livreze cel mai bun software și să urmeze practicile de excelență în inginerie înțelese. O soluție perfectă este o soluție care este ușor de întreținut, extins și înțeles, nu cea care este cea mai complexă.",
-            "title": "Excelență în domeniul ingineriei"
-          },
-          "testDrivenDevelopment": {
-            "description": "Alexandru este un adept convins al dezvoltării bazate pe teste. Aplică constant această abordare în proiectele sale și încearcă mereu să își îmbunătățească abilitățile de testare. De asemenea, este un mare fan al abordării „red-green-refactor”.",
-            "title": "Dezvoltare bazată pe teste (TDD)"
-          }
-        },
-        "subtitle": "O vitrină a abilităților tehnice și a competențelor profesionale ale lui Alexandru.",
-        "title": "Competențele lui Alexandru"
-      },
-      "Contact": {
-        "collaborate": {
-          "discipline1": "Inginerie Software",
-          "discipline2": "Internetul obiectelor (Internet of Things)",
-          "discipline3": "Aplicații native în cloud",
-          "discipline4": "Inginerie de rețea",
-          "footer": " Dacă aveți un proiect interesant sau o oportunitate care se aliniază cu expertiza lui Alexandru, nu ezitați să îl contactați. El este întotdeauna dornic să exploreze noi provocări și colaborări.",
-          "subtitle": "Alexandru este deschis pentru colaborare în proiecte care implică oricare dintre următoarele domenii:",
-          "title": "Să colaborăm!"
-        },
-        "footer": "Mulțumesc.",
-        "socials": {
-          "footer": "Pentru a ajunge la el, utilizați una dintre metodele de contact de mai sus.",
-          "subtitle": "Simțiți-vă liber să vă adresați pentru colaborări, întrebări sau doar să ne cunoastem!",
-          "title": "Luați legătura"
-        },
-        "subtitle": "Dacă doriți să luați legătura cu Alexandru, vă rugăm să utilizați modalitățile de contact de mai jos.",
-        "title": "Conectați-vă cu Alexandru"
-      },
-      "Education": {
-        "subtitle": "Trecutul academic al lui Alexandru și călătoria sa de învățare.",
-        "title": "Educaţie",
-        "university": {
-          "aseBucharest": {
-            "aboutTheProgram_cta": "Vezi mai multe detalii",
-            "aboutTheProgram_description": "Licența în Informatică la Universitatea din București este un program riguros care oferă studenților o bază solidă în informatică teoretică și dezvoltare practică de software. Curriculum-ul pune accentul pe abilitățile de rezolvare a problemelor, gândirea algoritmică și principiile ingineriei software.",
-            "aboutTheProgram_learnings": "# Proiectarea și analiza algoritmilor și a structurilor de date # Dezvoltarea de software folosind diverse paradigme de programare # Implementarea sistemelor de baze de date și gestionarea datelor # Înțelegerea rețelelor de calculatoare și a sistemelor distribuite # Aplicarea principiilor ingineriei software la probleme din lumea reală",
-            "aboutTheProgram_learnings_title": "Rezultatele cheie ale învățării",
-            "aboutTheProgram_title": "Despre program",
-            "degree": "BSC. \nInformatică",
-            "description": "Diplomă de licență în Informatică și Economie la Universitatea de Studii Economice din București, România. A terminat în top 1% conform statisticilor de evaluare a tezelor.",
-            "institution": "Academia de Studii Economice",
-            "keyCourses": "# Inginerie software # Rețele de calculatoare # Sisteme de operare # Algoritmi și structuri de date # Sisteme de gestionare a bazelor de date # Dezvoltare web # Dezvoltare mobilă",
-            "keyCourses_title": "Cursuri cheie",
-            "location": "București, România",
-            "period": "2019 - 2022",
-            "status": "Completat"
-          },
-          "malmoSweden": {
-            "aboutTheProgram_cta": "Vezi mai multe detalii",
-            "aboutTheProgram_description": "MSc în Internet of Things la Universitatea Malmö este un program de ultimă oră care pregătește studenții pentru provocările și oportunitățile revoluției IoT. Planul de învățământ pune accentul pe învățarea practică, colaborarea interdisciplinară și aplicațiile din lumea reală.",
-            "aboutTheProgram_learnings": "# Proiectați și implementați sisteme IoT utilizând diverse platforme hardware și software # Analizați și gestionați datele generate de dispozitivele IoT # Aplicați tehnici de învățare automată și inteligență artificială pentru aplicațiile IoT # Înțelegeți implicațiile sistemelor IoT în materie de securitate și confidențialitate # Colaborați cu parteneri din industrie la proiecte reale",
-            "aboutTheProgram_learnings_title": "Rezultatele cheie ale învățării",
-            "aboutTheProgram_title": "Despre program",
-            "degree": "MSC. \nInternetul lucrurilor",
-            "description": "Înscris anterior în programul MSc. Internet of Things la Universitatea Malmö, Suedia. Întrerupt din cauza unor circumstanțe personale și neprevăzute în 2024.",
-            "institution": "Universitatea Malmö",
-            "keyCourses": "# Internet of Things # Cloud Computing # Data Science # Machine Learning # Inteligență artificială # Computer Vision # Robotică",
-            "keyCourses_title": "Cursuri cheie",
-            "location": "Malmö, Suedia",
-            "period": "2023 - 2024",
-            "status": "Întrerupt"
-          }
-        }
-      },
-      "Experiences": {
-        "achievementsLabel": "Realizări",
-        "intel": {
-          "achievements": "# Am dezvoltat convertoare de spațiu de culoare (CSC) în C și Assembly x8086 (YUV->RGB, Grayscale).# Am creat peste 10 tipuri de filtre de imagine, cum ar fi Fish Eye, Sobel, Edge Detection, Box Blur, etc.# Am refăcut codul .ASM pentru a funcționa mai bine pe dispozitivele IoT și Embedded Systems.",
-          "company": "Intel",
-          "description": "Site-ul din Timișoara abordează mai multe domenii de interes în care se dezvoltă în mod activ software pentru diverse componente hardware, algoritmi de procesare a imaginilor și implementări de nivel scăzut și înalt ale părților componente ale rețelelor neuronale.",
-          "location": "Remote (România - Timisoara)",
-          "period": "2021 (6 luni)",
-          "responsibilites": "#Stăpânirea abilităților în lumea procesării imaginilor. #Înțelegerea domeniului învățării automate (ML). #Practicarea cunoștințelor dobândite prin dezvoltarea unor convertoare diferite de spațiu de culoare.",
-          "techAndSkills": "# C # C++ #Intel x8086 Assembly # Color Space Converters # Python # Embedded Compute # Internet of Things",
-          "title": "Inginer Embedded"
-        },
-        "microsoft1": {
-          "achievements": "# (Excelență Inginerească) M-am impus constant pentru a obține cel mai bun feedback din partea clienților. (Punctaj actual: 4.94 / 5.00) # (Interacțiuni proactive) Am oferit feedback continuu Grupului de Produs pentru produsul Azure Virtual Desktop (AVD), cu privire la implementarea unor caracteristici și servicii specifice. # (Experiența Clientului) Am dezvoltat documentația existentă privind caracteristicile serviciilor Azure Core, precum Azure Virtual Desktop, Azure Virtual Machines, Azure Networks. # Am lucrat exclusiv cu clienți TOP 100 și Fortune 500 și cu profesioniști de top din industrie.",
-          "company": "Microsoft",
-          "description": "Cu peste 12.000 de angajați în întreaga lume, organizația Microsoft Customer Experience & Success (CE&S) este responsabilă pentru strategia, proiectarea și implementarea experienței clienților Microsoft de la un capăt la altul.",
-          "location": "România",
-          "period": "03/2021 – 03/2023",
-          "responsibilites": "# Oferirea de schimb de cunoștințe, coaching tehnic și mentorat colegilor; # Rezolvarea problemelor prin depanare profundă, debugging, analiză de log-uri, testare A/B; # Identificarea și răspunsul la problemele critice de afaceri ale clienților, specifice serviciilor Azure precum Azure Virtual Desktop; # Lucrul exclusiv cu clienți Fortune 500 pentru a înțelege nevoile lor tehnice și pentru a defini un plan de acțiune pentru a le îndeplini, colaborând regulat cu colegi sau alte echipe.",
-          "techAndSkills": "# Network Traffic Analysis # Azure # Customer-centric Approach # Business Relationships # Incident Manager",
-          "title": "Inginer Tehnic Azure"
-        },
-        "microsoft2": {
-          "achievements": "# (Observabilitate-as-a-Service) Am orchestrat și implementat complet cei trei piloni ai observabilității în arhitectura noastră de microservicii folosind standardele Open Telemetry; am construit, de asemenea, declanșatoare automate de monitorizare și alertare bazate pe statistici p95/p99 pentru trafic real și sintetic. # (Cercetare & Dezvoltare) Am contribuit major la dezvoltarea unei biblioteci .NET interne care implementează protocolul de consum de date ODataV4 pentru motoare de baze de date NoSQL precum Azure Data Explorer (ADX), folosind practici Domain-Driven Design (DDD) (de ex. aggregator roots) (brevet în curs de obținere). # (Experiența de Dezvoltare) Am preluat conducerea a două domenii cheie pentru DX: documentația și straturile de consum. Am construit o documentație remarcabilă și am folosit instrumente de generare a site-urilor statice (DocFX) pentru a genera automat documentația API din cod; am oferit straturi de consum API sub formă de UI-uri frontend, tooling CLI și fișiere de specificație OpenAPI. # (Creștere) Am asistat și am participat la interviuri de angajare pentru pozițiile SWE II și Senior SWE.",
-          "company": "Microsoft",
-          "description": "Pe măsură ce guvernele de astăzi se uită la inovația tehnologică, există nevoia de a răspunde cerințelor în evoluție rapidă ale cetățenilor lor, protejând în același timp cele mai sensibile date și respectând promisiunile de încredere și securitate.",
-          "location": "EMEA",
-          "period": "03/2023 – 12/2024",
-          "responsibilites": "# Furnizarea unei platforme de date E+C capabilă să funcționeze pe mai multe cloud-uri și cu mai mulți chiriași în medii suverane și în scenarii air-gapped. # Gestionarea și asigurarea bunăstării operațiunilor platformei de date RISE (Runtime in Sovereign Environments). # Construirea unei noi arhitecturi de întreprindere de tip data mesh utilizând concepte de inginerie a datelor, instrumente precum Azure Data Factory și alte noțiuni de depozit de date.",
-          "techAndSkills": "# .NET # Azure # Microservicii # Cloud-Native Applications # Agile Methodologies # DevOps # Domain-Driven Design # Test-Driven Development # Project Management",
-          "title": "E + D Inginer Software II - Cloud-uri Suverane"
-        },
-        "microsoft3": {
-          "achievements": " ",
-          "company": "Microsoft",
-          "description": "Alexandru lucrează în prezent la Microsoft ca inginer software în cadrul organizației E+D MSAI (M365 AI Experiences).",
-          "location": "Remote (Norvegia)",
-          "period": "11/2024 - prezent",
-          "responsibilites": " ",
-          "techAndSkills": "# React # GraphQL # Dezvoltare la scară largă # Aplicații Cloud-Native # Metodologii Agile # Excelență în inginerie # Leadership",
-          "title": "E + D Inginer Software Fullstack II - M365 AI"
-        },
-        "responsibilitiesLabel": "Responsabilități",
-        "subtitle": "O călătorie prin cariera profesională a lui Alexandru și prin companiile cu care a lucrat.",
-        "techSkillsLabel": "Tehnologii și Competențe",
-        "title": "Experiență profesională",
-        "ubisoft": {
-          "achievements": "# Am depășit constant cota de bug-uri, glitch-uri și artefacte raportate, clasându-mă pe locul #1 ca raportor timp de 5 luni solide din cele 6 lucrate. # Am descoperit și raportat defecte majore de cod, de la race conditions până la defecte de alocare a resurselor de memorie. # Am crescut eficiența raportării zilnice prin valorificarea capacităților de filtrare SQL și JQL.",
-          "company": "Ubisoft",
-          "description": "Am lucrat la Avatar: Frontiers of Pandora™, un joc construit folosind cea mai recentă iterație a motorului Snowdrop (C++) de Massive Entertainment - un studio Ubisoft și testat de Ubisoft România.",
-          "location": "Hibrid (București, România)",
-          "period": "2020 - 2021",
-          "responsibilites": " # Gestionarea regresiei, integrării și testării unităților cu software precum XRAY, TestRail, Bugzilla. # Crearea de suite de teste și planuri de teste de înaltă calitate folosind produsele Atlassian (JIRA / Confluence). # Asigurarea unor comunicații stabile și clare între echipele de producție și cele de testare.",
-          "techAndSkills": "# Testare unitară # Testare de integrare # Testare A/B # Testare de performanță # Testare automată # Testare E2E",
-          "title": "Inginer QA/QC"
-        }
-      },
-      "metadata": {
-        "description": "Aflați mai multe despre autor, Alexandru-Razvan Olariu.",
-        "title": "Alexandru-Razvan Olariu"
-      },
-      "Perspectives": {
-        "perspectiveFromX": {
-          "author": "Anonim",
-          "avatar": " ",
-          "company": "Microsoft",
-          "position": "Inginer software senior",
-          "quote": "Lucrul pe care îl apreciez foarte mult la dvs. este căutarea neîncetată a îmbunătățirii și dorința dvs. de a contesta status quo-ul. Angajamentul tău față de autodezvoltare continuă este evident în modul în care abordezi fiecare sarcină cu o mentalitate orientată spre inovare și excelență. Capacitatea dumneavoastră de a pune în discuție metodele existente și de a propune alternative mai bune a fost esențială pentru progresul proiectelor noastre. Această atitudine proactivă nu numai că îmbunătățește calitatea muncii noastre, dar și inspiră echipa să depună eforturi pentru a atinge standarde mai înalte. Mă bucur că am lucrat cu dvs. și sper că drumurile noastre se vor intersecta din nou în viitor."
-        },
-        "perspectiveFromXX": {
-          "author": "Anonim",
-          "avatar": " ",
-          "company": "Microsoft",
-          "position": "Manager Senior Inginerie Software",
-          "quote": "Alex este un inginer inteligent ale cărui capacități au strălucit în timpul colaborării noastre la proiectele noastre. El demonstrează în mod constant dorința de a ajuta echipa cu orice solicitare, demonstrând dedicarea sa pentru succesul colectiv. Abordarea sa proactivă în ceea ce privește rezolvarea problemelor și dedicarea față de stabilitatea sistemului aduc beneficii majore fluxului de lucru al echipei noastre. În plus, disponibilitatea și dorința lui Alex de a sprijini pe alții în timpul fluxului nostru de lansare evidențiază valoarea sa ca coleg care acordă prioritate muncii în echipă și colaborării."
-        },
-        "perspectiveFromXY": {
-          "author": "Anonim",
-          "avatar": " ",
-          "company": "Microsoft",
-          "position": "Inginer senior de escaladare",
-          "quote": "Alex, dacă ar fi să aleg un lucru pe care îl apreciez cel mai mult la colaborarea cu tine, ar trebui să fie modul tău de gândire - deoarece acesta include mai multe aspecte. Lucrul cu tine este autentic, amuzant, înțelept și relevant în același timp. Este ușor de observat că motivațiile tale zilnice sunt angajamentul, raționamentul și învățarea continuă. Îți admir abordarea, dorința sinceră de a ajuta, de a te baza pe succesul altora și de a-i sprijini pe toți în dezvoltarea lor, ceea ce este o valoare atât de rară. Pe lângă acestea, apreciez răbdarea dumneavoastră, precum și cantitatea mare de cunoștințe pe care o aduceți în interacțiunile noastre. Modul în care gestionați situațiile stresante și abordarea dvs. generală au puterea de a modela un rezultat pozitiv pentru orice problemă sau subiect."
-        },
-        "perspectiveFromXZ": {
-          "author": "Anonim",
-          "avatar": " ",
-          "company": "Microsoft",
-          "position": "Inginer software senior",
-          "quote": "Am fost impresionat în mod constant de rezultatele muncii dvs. Întotdeauna livrați o muncă de înaltă calitate, acordând o atenție deosebită detaliilor și asigurându-vă că totul este făcut la cel mai bun nivel al abilităților dumneavoastră. În plus, aveți o înțelegere profundă a aspectelor tehnice ale muncii noastre, ceea ce a reprezentat un avantaj valoros pentru echipă. Dorința dvs. de a împărtăși cunoștințele și experiența dvs. cu alții a fost de neprețuit și este clar că sunteți mândru să îi îndrumați pe alții și să îi ajutați să se dezvolte."
-        },
-        "perspectiveFromY": {
-          "author": "Anonim",
-          "avatar": " ",
-          "company": "Microsoft",
-          "position": "Software Engineer II",
-          "quote": "Apreciez cu adevărat abordarea dvs. proactivă și spiritul de colaborare, iar sprijinul dvs. și stilul dvs. prietenos de comunicare au fost foarte pozitive pentru experiența mea de integrare și pentru învățarea intrărilor și ieșirilor proiectului nostru. Capacitatea dvs. de a comunica eficient și de a ține pe toată lumea la curent este un lucru pe care îl admir, aveți experiență în relaționarea cu echipele interfuncționale, în special cu echipele noastre partenere, în cunoașterea nevoilor lor și în rezolvarea problemelor lor. Aptitudinile dvs. tehnice sunt impresionante, iar atenția dvs. la detalii este lăudabilă."
-        },
-        "perspectiveFromYX": {
-          "author": "",
-          "avatar": "",
-          "company": "",
-          "position": "",
-          "quote": ""
-        },
-        "perspectiveFromYY": {
-          "author": "",
-          "avatar": "",
-          "company": "",
-          "position": "",
-          "quote": ""
-        },
-        "perspectiveFromYZ": {
-          "author": "",
-          "avatar": "",
-          "company": "",
-          "position": "",
-          "quote": ""
-        },
-        "perspectiveFromZ": {
-          "author": "Anonim",
-          "avatar": " ",
-          "company": "Microsoft",
-          "position": "Inginer software senior",
-          "quote": "Întotdeauna sunteți gata să ajutați, împărțindu-vă timpul cu generozitate, chiar și atunci când aveți propriile dvs. sarcini urgente. Răspunsurile tale rapide și utile la orice întrebare sunt foarte apreciate. Aveți o abordare prioritară și meticuloasă, oferind soluții instantanee care nu numai că ne deblochează pe termen scurt, ci și schițează soluții pe termen lung și termenele lor de implementare. Mentalitatea dvs. orientată spre soluții este un adevărat avantaj pentru echipa noastră. Expertiza ta, dorința de a ajuta și personalitatea ta plăcută fac din tine un coleg excelent. Continuați munca excelentă!"
-        },
-        "subtitle": "Perspective de la colegii care au lucrat cu sau alături de Alexandru.",
-        "title": "Perspective"
-      },
-      "subtitle": "Alexandru-Razvan Olariu este autorul platformei pe care o navigați în prezent.",
-      "title": "Faceți cunoștință cu autorul."
-    },
-    "cards": {
-      "author": {
-        "cta": "Aflați mai multe despre autor ...",
-        "subtitle": "arolariu este pseudonimul/nickname-ul autorului: Alexandru-Răzvan Olariu. Alexandru este un inginer software cu vechime, arhitect de soluții și învățător pe tot parcursul vieții. Pentru a afla mai multe despre Alexandru, faceți clic pe butonul de mai jos.",
-        "title": "Cine este arolariu?"
-      },
-      "platform": {
-        "cta": "Aflați mai multe despre platformă ...",
-        "subtitle": "Platforma arolariu.ro este o colecție de aplicații care sunt găzduite sub domeniul arolariu.ro. Platforma a fost construită cu scopul de a oferi o experiență unificată pentru toate aplicațiile și proiectele OSS la care lucrează autorul (Alexandru-Răzvan Olariu). Pentru a afla mai multe despre tehnologiile care sunt folosite în acest proces și modul în care acestea interacționează între ele, dați click pe butonul de mai jos.",
-        "title": "Ce este arolariu.ro?"
-      }
-    },
-    "footer": "Vă mulțumesc!",
-    "Hub": {
-      "cta": {
-        "footer": "Construit cu pasiune în România",
-        "primary": "Vezi pe GitHub",
-        "secondary": "Ia legătura",
-        "subtitle": "Începe-ți călătoria prin platformă sau conectează-te cu autorul.",
-        "title": "Gata de explorare?"
-      },
-      "faq": {
-        "questions": {
-          "q1": {
-            "answer": "arolariu.ro este o platformă full-stack cuprinzătoare care servește atât ca portofoliu personal, cât și ca vitrină tehnologică. Demonstrează practici moderne de dezvoltare web folosind Next.js, .NET și servicii cloud Azure.",
-            "question": "Ce este arolariu.ro?"
-          },
-          "q2": {
-            "answer": "Da! Întreaga platformă este open source și disponibilă pe GitHub. Poți explora codul sursă, să înveți din el sau chiar să contribui la dezvoltarea lui.",
-            "question": "Este această platformă open source?"
-          },
-          "q3": {
-            "answer": "Platforma folosește Next.js 16 cu React 19 pentru frontend, .NET 10 cu ASP.NET Core pentru backend și Azure pentru infrastructura cloud. Include și o bibliotecă de componente cuprinzătoare și testare extensivă.",
-            "question": "Ce tehnologii sunt folosite?"
-          },
-          "q4": {
-            "answer": "Absolut! Platforma este proiectată să prezinte cele mai bune practici în ingineria software. Simte-te liber să o folosești ca referință pentru arhitectură, modele și detalii de implementare.",
-            "question": "Pot folosi aceasta ca referință pentru propriile mele proiecte?"
-          }
-        },
-        "subtitle": "Întrebări comune despre platformă și scopul ei",
-        "title": "Întrebări frecvente"
-      },
-      "hero": {
-        "badge": "Despre noi",
-        "ctaPrimary": "Explorează platforma",
-        "ctaSecondary": "Cunoaște autorul",
-        "subtitle": "O platformă full-stack modernă construită cu pasiune, proiectată pentru inovație și creată cu atenție la detalii.",
-        "title": "Descoperă arolariu.ro"
-      },
-      "mission": {
-        "description": "arolariu.ro este mai mult decât un simplu site web - este un teren de joacă pentru tehnologii moderne, o vitrină de bune practici și o platformă care demonstrează ce este posibil atunci când excelența în inginerie întâlnește viziunea creativă.",
-        "pillars": {
-          "innovation": {
-            "description": "Adoptăm tehnologii de ultimă oră și modele arhitecturale moderne",
-            "title": "Inovație"
-          },
-          "openness": {
-            "description": "Open source, transparent și orientat spre comunitate",
-            "title": "Deschidere"
-          },
-          "quality": {
-            "description": "Menținem standarde înalte cu acoperire de teste de peste 90%",
-            "title": "Calitate"
-          }
-        },
-        "statement": "Să construim software care face diferența.",
-        "title": "Misiunea noastră"
-      },
-      "navigation": {
-        "author": {
-          "cta": "Cunoaște-l pe Alexandru",
-          "features": {
-            "0": "Inginer Microsoft",
-            "1": "Arhitect de soluții",
-            "2": "Entuziast tehnologie"
-          },
-          "subtitle": "Cunoaște-l pe Alexandru-Răzvan Olariu, inginerul software din spatele acestei platforme.",
-          "title": "Autorul"
-        },
-        "platform": {
-          "cta": "Explorează platforma",
-          "features": {
-            "0": "Frontend Next.js 16",
-            "1": "Backend .NET 10",
-            "2": "Infrastructură Azure Cloud"
-          },
-          "subtitle": "Descoperă arhitectura, stack-ul tehnologic și funcționalitățile care alimentează arolariu.ro.",
-          "title": "Platforma"
-        },
-        "subtitle": "Aprofundează ce face arolariu.ro unic",
-        "title": "Explorează mai departe"
-      },
-      "stats": {
-        "items": {
-          "linesOfCode": {
-            "description": "Între frontend și backend",
-            "label": "Linii de cod",
-            "value": "50K+"
-          },
-          "technologies": {
-            "description": "Stack tehnologic modern",
-            "label": "Tehnologii",
-            "value": "25+"
-          },
-          "testCoverage": {
-            "description": "Standard de asigurare a calității",
-            "label": "Acoperire teste",
-            "value": "90%"
-          },
-          "yearsActive": {
-            "description": "În continuă evoluție din 2022",
-            "label": "Ani activi",
-            "value": "3+"
-          }
-        },
-        "subtitle": "Metrici cheie care demonstrează angajamentul nostru față de calitate",
-        "title": "În cifre"
-      },
-      "values": {
-        "items": {
-          "accessibility": {
-            "description": "Construit pentru toți, cu navigare prin tastatură și suport pentru cititoare de ecran.",
-            "title": "Design accesibil"
-          },
-          "community": {
-            "description": "Open source din suflet, contribuind înapoi la comunitatea de dezvoltatori.",
-            "title": "Comunitatea pe primul loc"
-          },
-          "engineering": {
-            "description": "Fiecare funcționalitate este construită cu arhitectură curată, testare adecvată și mentenabilitate în minte.",
-            "title": "Excelență în inginerie"
-          },
-          "learning": {
-            "description": "Această platformă servește ca teren de testare pentru noi tehnologii și abordări.",
-            "title": "Învățare continuă"
-          },
-          "performance": {
-            "description": "Optimizat pentru viteză cu randare pe server și implementări pe edge.",
-            "title": "Orientat spre performanță"
-          },
-          "privacy": {
-            "description": "Protecția datelor utilizatorilor și confidențialitatea sunt fundamentale, nu gânduri secundare.",
-            "title": "Axat pe confidențialitate"
-          }
-        },
-        "subtitle": "Principiile care ghidează fiecare linie de cod",
-        "title": "Valori fundamentale"
-      }
-    },
-    "metadata": {
-      "description": "Aflați mai multe despre autor și platformă.",
-      "title": "Despre noi"
-    },
-    "Platform": {
-      "architecture": {
-        "badge": "Arhitectură tehnică",
-        "description": "O arhitectură modernă nativă cloud care urmează principiile de design bazat pe domeniu, metodologia The Standard și cele mai bune practici din industrie.",
-        "layers": {
-          "ai": {
-            "description": "Procesare inteligentă a documentelor și înțelegere a limbajului natural",
-            "name": "Servicii AI",
-            "technologies": "Azure OpenAI,Document Intelligence,Computer Vision"
-          },
-          "api": {
-            "description": "API-uri RESTful cu documentație OpenAPI și limitare a ratei",
-            "name": "Gateway API",
-            "technologies": ".NET 10,Minimal APIs,OpenAPI,GraphQL"
-          },
-          "auth": {
-            "description": "Autentificare de nivel enterprise cu furnizori multipli",
-            "name": "Identitate și securitate",
-            "technologies": "Azure AD B2C,OAuth 2.0,OIDC,MFA"
-          },
-          "cdn": {
-            "description": "Livrare globală de conținut cu cache la margine și optimizare",
-            "name": "Edge și CDN",
-            "technologies": "Azure CDN,Vercel Edge,Active statice"
-          },
-          "client": {
-            "description": "Frontend-uri moderne bazate pe React cu capacități SSR și SSG",
-            "name": "Nivelul client",
-            "technologies": "Next.js 16,React 19,TypeScript,Module SCSS"
-          },
-          "data": {
-            "description": "Strategie de baze de date multi-model pentru performanță optimă",
-            "name": "Nivelul de date",
-            "technologies": "CosmosDB,Azure SQL,Redis Cache,Blob Storage"
-          },
-          "infra": {
-            "description": "Infrastructură Azure complet gestionată cu implementare IaC",
-            "name": "Infrastructură cloud",
-            "technologies": "Azure,Bicep IaC,Container Apps,Key Vault"
-          },
-          "services": {
-            "description": "Design bazat pe domeniu cu contexte delimitate și arhitectură curată",
-            "name": "Microservicii",
-            "technologies": "DDD,CQRS,Event Sourcing,The Standard"
-          }
-        },
-        "principles": {
-          "appRouter": {
-            "description": "Rutare bazată pe fișiere cu layout-uri, stări de încărcare și limite de erori",
-            "title": "Arhitectură App Router"
-          },
-          "cloudNative": {
-            "description": "Microservicii containerizate cu auto-scalare și capacități de auto-vindecare",
-            "title": "Design nativ cloud"
-          },
-          "rsc": {
-            "description": "Utilizarea RSC pentru performanță optimă cu randare server-side și streaming",
-            "title": "React Server Components"
-          }
-        },
-        "title": "Construit pentru",
-        "titleHighlight": "scalabilitate și fiabilitate"
-      },
-      "callToAction": {
-        "cta": {
-          "createAccount": "Creează cont",
-          "exploreApplications": "Explorează aplicațiile"
-        },
-        "description": "Explorează platforma, încearcă funcționalitățile și alătură-te comunității. Fie că ești aici să gestionezi facturi, să descoperi rețete sau doar să explorezi, există ceva pentru toată lumea.",
-        "footer": "Construit cu pasiune de",
-        "footerRole": ", un inginer software la Microsoft.",
-        "links": {
-          "getInTouch": "Ia legătura",
-          "meetAuthor": "Cunoaște autorul",
-          "viewSource": "Vezi codul sursă"
-        },
-        "title": "Gata să",
-        "titleHighlight": "începi",
-        "trust": {
-          "freeToUse": {
-            "description": "Fără taxe ascunse sau abonamente",
-            "title": "Gratuit de folosit"
-          },
-          "openSource": {
-            "description": "100% open source cu licență MIT",
-            "title": "Sursă Deschisă"
-          },
-          "privacyFirst": {
-            "description": "Datele tale rămân ale tale, mereu",
-            "title": "Confidențialitate în prim-plan"
-          }
-        }
-      },
-      "features": {
-        "badge": "Funcționalități ale platformei",
-        "description": "O suită completă de instrumente concepute pentru gestionarea modernă a finanțelor personale, organizarea rețetelor și multe altele. Construite cu tehnologii de ultimă generație și un accent pe experiența utilizatorului.",
-        "items": {
-          "ai": {
-            "description": "Automatizare inteligentă la îndemână",
-            "longDescription": "Alimentat de Azure OpenAI, asistentul nostru AI ajută la înțelegerea documentelor, extragerea datelor, categorizarea inteligentă și interogări în limbaj natural despre datele dvs.",
-            "tags": "GPT-4,Azure AI,NLP",
-            "title": "Asistent AI"
-          },
-          "analytics": {
-            "description": "Perspective profunde în cheltuielile dvs.",
-            "longDescription": "Tablou de bord analitic complet cu tendințe de cheltuieli, defalcări pe categorii, comparații lunare și perspective predictive alimentate de algoritmi de învățare automată.",
-            "tags": "Grafice,Tendințe,Rapoarte",
-            "title": "Analize cheltuieli"
-          },
-          "auth": {
-            "description": "Opțiuni de conectare flexibile și sigure",
-            "longDescription": "Conectați-vă cu Microsoft, Google, GitHub sau email. Azure AD B2C oferă gestionarea identității de nivel enterprise cu suport MFA și experiență SSO fără întreruperi.",
-            "tags": "OAuth,MFA,SSO",
-            "title": "Autentificare securizată"
-          },
-          "budgets": {
-            "description": "Urmărire inteligentă a bugetului și alerte",
-            "longDescription": "Setați bugete pe categorii și primiți alerte inteligente când vă apropiați de limite. Vizualizați cheltuielile cu grafice interactive și identificați zonele pentru optimizare.",
-            "tags": "Bugete,Alerte,Planificare",
-            "title": "Gestionare buget"
-          },
-          "i18n": {
-            "description": "Experiență complet internaționalizată",
-            "longDescription": "Platforma suportă mai multe limbi cu suport RTL complet. Disponibilă în prezent în engleză și română, cu mai multe limbi planificate pentru versiunile viitoare.",
-            "tags": "i18n,Engleză,Română",
-            "title": "Multi-limbă"
-          },
-          "invoices": {
-            "description": "Analiză și gestionare a facturilor cu ajutorul AI",
-            "longDescription": "Încărcați fotografii cu bonuri și lăsați AI să extragă detaliile comerciantului, articolele, prețurile și multe altele. Categorizarea automată, urmărirea cheltuielilor și analizele detaliate vă ajută să vă înțelegeți tiparele de cheltuieli.",
-            "tags": "AI,OCR,Analize",
-            "title": "Procesare facturi"
-          },
-          "merchants": {
-            "description": "Detectare automată a comercianților și perspective",
-            "longDescription": "AI-ul nostru identifică comercianții din datele bonurilor, construind o bază de date completă a tiparelor dvs. de cumpărături. Obțineți informații despre unde faceți cumpărături, tendințele cheltuielilor și comparații între comercianți.",
-            "tags": "ML,Perspective,Urmărire",
-            "title": "Inteligență comercianți"
-          },
-          "recipes": {
-            "description": "Organizați și descoperiți creații culinare",
-            "longDescription": "Stocați rețetele preferate, descoperiți unele noi și planificați mesele eficient. Sugestii bazate pe AI în funcție de ingrediente, preferințe dietetice și istoricul de gătit.",
-            "tags": "Gătit,Planificare mese,AI",
-            "title": "Gestionare rețete"
-          },
-          "security": {
-            "description": "Securitate de nivel bancar pentru datele dvs.",
-            "longDescription": "Datele dvs. sunt protejate cu criptare de nivel enterprise, autentificare securizată prin Azure AD B2C și conformitate cu GDPR. Nu vindem și nu împărtășim niciodată informațiile dvs. personale.",
-            "tags": "Criptare,GDPR,SSO",
-            "title": "Securitate enterprise"
-          }
-        },
-        "modal": {
-          "close": "Închide",
-          "exploreFeature": "Explorează funcționalitatea"
-        },
-        "title": "Tot ce ai nevoie,",
-        "titleHighlight": "frumos realizat"
-      },
-      "hero": {
-        "cta": {
-          "exploreFeatures": "Explorează funcționalități",
-          "viewSource": "Vezi codul sursă"
-        },
-        "description": "O platformă full-stack completă care combină Next.js, .NET și servicii cloud Azure. Construită cu arhitectură de nivel enterprise, design bazat pe domeniu și un accent pe experiența dezvoltatorului.",
-        "scrollIndicator": "Derulează pentru a explora",
-        "stats": {
-          "countries": "Țări",
-          "linesOfCode": "Linii de cod",
-          "projects": "Proiecte",
-          "techStack": "Stack tehnologic"
-        },
-        "statusBadge": "Platformă Open Source",
-        "subtitle": "Modern • Scalabil • Open Source",
-        "title": "Bine ai venit pe",
-        "trust": {
-          "freeForever": "Gratuit pentru totdeauna",
-          "openSource": "Sursă Deschisă",
-          "privacyFirst": "Confidențialitate în prim-plan"
-        }
-      },
-      "metadata": {
-        "description": "Aflați mai multe despre platformă, Arolariu.ro.",
-        "title": "Platforma"
-      },
-      "statistics": {
-        "badge": "Statistici ale platformei",
-        "description": "O privire asupra dimensiunii și impactului platformei arolariu.ro, de la linii de cod la acoperire globală.",
-        "items": {
-          "apis": {
-            "description": "Microservicii",
-            "label": "API-uri",
-            "suffix": "+",
-            "value": "8"
-          },
-          "commits": {
-            "description": "Contribuții de cod",
-            "label": "Commit-uri",
-            "suffix": "+",
-            "value": "2500"
-          },
-          "contributors": {
-            "description": "Sursă deschisă",
-            "label": "Contribuitori",
-            "suffix": "+",
-            "value": "5"
-          },
-          "countries": {
-            "description": "Acoperire globală",
-            "label": "Țări",
-            "suffix": "+",
-            "value": "25"
-          },
-          "linesOfCode": {
-            "description": "În toate proiectele",
-            "label": "Linii de cod",
-            "suffix": "K+",
-            "value": "150"
-          },
-          "projects": {
-            "description": "Repozitorii active",
-            "label": "Proiecte",
-            "suffix": "+",
-            "value": "15"
-          },
-          "stars": {
-            "description": "Stele GitHub",
-            "label": "Stele",
-            "suffix": "+",
-            "value": "50"
-          },
-          "users": {
-            "description": "Activi lunar",
-            "label": "Utilizatori",
-            "suffix": "+",
-            "value": "1000"
-          }
-        },
-        "title": "Numere care",
-        "titleHighlight": "vorbesc de la sine"
-      },
-      "techStack": {
-        "badge": "Stack tehnologic",
-        "categories": {
-          "backend": {
-            "description": "Tehnologii server-side scalabile și API-uri",
-            "name": "Backend"
-          },
-          "cloud": {
-            "description": "Automatizarea infrastructurii și implementării",
-            "name": "Cloud și DevOps"
-          },
-          "frontend": {
-            "description": "Tehnologii web moderne pentru experiențe de utilizator ultra-rapide",
-            "name": "Frontend"
-          },
-          "tooling": {
-            "description": "Unelte și framework-uri pentru excelență în dezvoltare",
-            "name": "Unelte pentru dezvoltatori"
-          }
-        },
-        "description": "Un stack tehnologic atent ales pentru performanță, experiența dezvoltatorului și mentenabilitate pe termen lung.",
-        "stats": {
-          "coverage": {
-            "description": "Teste unitare și E2E",
-            "label": "Acoperire teste",
-            "value": "90%+"
-          },
-          "security": {
-            "description": "Cele mai bune practici",
-            "label": "Grad de securitate",
-            "value": "A+"
-          },
-          "technologies": {
-            "description": "În stack-ul nostru",
-            "label": "Tehnologii",
-            "value": "24+"
-          },
-          "typescript": {
-            "description": "Siguranță completă a tipurilor",
-            "label": "TypeScript",
-            "value": "100%"
-          }
-        },
-        "technologies": {
-          "aspnet": {
-            "description": "API-uri web de înaltă performanță",
-            "name": "ASP.NET Core"
-          },
-          "azure": {
-            "description": "Furnizor cloud principal",
-            "name": "Azure"
-          },
-          "azureDevops": {
-            "description": "Gestionare proiecte și pipeline-uri",
-            "name": "Azure DevOps"
-          },
-          "azuresql": {
-            "description": "Bază de date relațională gestionată",
-            "name": "Azure SQL"
-          },
-          "bicep": {
-            "description": "Infrastructură ca și cod",
-            "name": "Bicep"
-          },
-          "cosmosdb": {
-            "description": "Bază de date NoSQL distribuită global",
-            "name": "CosmosDB"
-          },
-          "docker": {
-            "description": "Platformă de containerizare",
-            "name": "Docker"
-          },
-          "dotnet": {
-            "description": "Framework backend principal",
-            "name": ".NET"
-          },
-          "eslint": {
-            "description": "Linting JavaScript cu 20+ plugin-uri",
-            "name": "ESLint"
-          },
-          "git": {
-            "description": "Sistem de control al versiunilor",
-            "name": "Git"
-          },
-          "githubActions": {
-            "description": "Automatizare CI/CD",
-            "name": "GitHub Actions"
-          },
-          "motion": {
-            "description": "Animații gata de producție",
-            "name": "Motion"
-          },
-          "nextjs": {
-            "description": "Framework React full-stack cu SSR/SSG",
-            "name": "Next.js"
-          },
-          "nodejs": {
-            "description": "BFF și funcții serverless",
-            "name": "Node.js"
-          },
-          "playwright": {
-            "description": "Framework de testare E2E",
-            "name": "Playwright"
-          },
-          "pnpm": {
-            "description": "Gestionare pachete",
-            "name": "pnpm/npm"
-          },
-          "prettier": {
-            "description": "Formatare cod",
-            "name": "Prettier"
-          },
-          "react": {
-            "description": "Bibliotecă UI pentru construirea de interfețe interactive",
-            "name": "React"
-          },
-          "redis": {
-            "description": "Cache în memorie pentru performanță",
-            "name": "Redis"
-          },
-          "scss": {
-            "description": "Foi de stil cu domeniu de aplicare la nivel de component folosind CSS Modules",
-            "name": "Module SCSS"
-          },
-          "typescript": {
-            "description": "JavaScript cu tipuri pentru cod robust",
-            "name": "TypeScript"
-          },
-          "vercel": {
-            "description": "Platformă de implementare frontend",
-            "name": "Vercel"
-          },
-          "vitest": {
-            "description": "Framework de testare unitară",
-            "name": "Vitest"
-          },
-          "zustand": {
-            "description": "Gestionare ușoară a stării",
-            "name": "Zustand"
-          }
-        },
-        "title": "Alimentat de",
-        "titleHighlight": "tehnologii moderne"
-      },
-      "timeline": {
-        "badge": "Călătoria de dezvoltare",
-        "collapseHint": "Click pentru a restrânge",
-        "description": "Călătoria arolariu.ro de la o simplă idee la o platformă completă, cu etape cheie pe parcurs.",
-        "events": {
-          "ai": {
-            "date": "Iunie 2024",
-            "description": "Integrare profundă cu Azure OpenAI pentru procesarea inteligentă a documentelor și interogări în limbaj natural.",
-            "details": "Integrare Azure OpenAI GPT-4,Interogări facturi în limbaj natural,Algoritmi de categorizare inteligentă,Funcționalități de analiză predictivă",
-            "tags": "GPT-4,Azure AI,NLP",
-            "title": "Integrare AI"
-          },
-          "backend": {
-            "date": "Septembrie 2022",
-            "description": "Refacerea completă a backend-ului cu .NET și implementarea arhitecturii native cloud.",
-            "details": "Dezvoltare API .NET 6,Configurare infrastructură cloud Azure,Design bază de date cu CosmosDB,Implementare pipeline CI/CD",
-            "tags": ".NET,Azure,API",
-            "title": "Infrastructură backend"
-          },
-          "expansion": {
-            "date": "Ianuarie 2023",
-            "description": "Adăugări majore de funcționalități incluzând procesarea facturilor și capabilități de analiză alimentate de AI.",
-            "details": "Încărcare facturi și integrare OCR,Integrare Azure Document Intelligence,Algoritmi de detectare a comercianților,Funcționalități de urmărire a bugetului",
-            "tags": "AI,OCR,Facturi",
-            "title": "Extinderea platformei"
-          },
-          "inception": {
-            "date": "Martie 2022",
-            "description": "Platforma arolariu.ro a fost concepută ca un proiect personal de învățare pentru a explora dezvoltarea web modernă.",
-            "details": "Faza inițială de concept și planificare,Cercetare în tehnologii web moderne,Primul repozitoriu creat pe GitHub,Prototip HTML/CSS de bază dezvoltat",
-            "tags": "Planificare,Cercetare",
-            "title": "Începutul proiectului"
-          },
-          "launch": {
-            "date": "Iunie 2023",
-            "description": "Lansare publică oficială cu un set complet de funcționalități și infrastructură gata de producție.",
-            "details": "Implementare în producție pe Azure,Configurare domeniu personalizat,Implementare securitate SSL/TLS,Optimizare performanță",
-            "tags": "Lansare,Producție",
-            "title": "Lansare publică"
-          },
-          "nextjs": {
-            "date": "Decembrie 2023",
-            "description": "Rescrierea completă a frontend-ului la Next.js App Router cu React Server Components.",
-            "details": "Migrare la Next.js 14+,Adoptarea React Server Components,SEO îmbunătățit cu generare statică,Metrici de performanță îmbunătățite",
-            "tags": "Next.js,RSC,Migrare",
-            "title": "Migrare la Next.js"
-          },
-          "present": {
-            "date": "Prezent",
-            "description": "Dezvoltare continuă cu funcționalități noi, optimizări și contribuții din comunitate.",
-            "details": "Actualizări regulate de funcționalități,Îmbunătățiri de performanță,Integrare feedback din comunitate,Planificare roadmap viitor",
-            "tags": "Activ,În creștere",
-            "title": "Evoluție continuă"
-          },
-          "prototype": {
-            "date": "Iunie 2022",
-            "description": "Primul prototip funcțional al platformei a fost dezvoltat folosind React și servicii backend de bază.",
-            "details": "Implementare frontend React,Flux de autentificare de bază,Design UI/UX inițial,Configurare mediu de dezvoltare locală",
-            "tags": "React,Frontend",
-            "title": "Primul prototip"
-          }
-        },
-        "expandHint": "Click pentru a extinde",
-        "futureIndicator": "Călătoria continuă...",
-        "keyAchievements": "Realizări cheie:",
-        "title": "De la idee la",
-        "titleHighlight": "realitate"
-      }
-    },
-    "subtitle": " Povestea arolariu.ro a început în 2022, când autorul - Alexandru-Răzvan Olariu, a vrut să înțeleagă cum funcționează site-urile. Întreaga platformă și integrările subiacente au fost dezvoltate exclusiv de autor, din ceea ce a învățat de-a lungul anilor. Alexandru lucrează în prezent ca inginer software la Microsoft. Pentru a afla mai multe despre el, consultați secțiunea din dreapta a acestei pagini. Platforma este construită folosind cele mai noi tehnologii de ultimă oră. Pentru a afla mai multe despre el, consultați secțiunea din stânga a acestei pagini.",
-    "title": "Despre noi"
-  },
-  "Acknowledgements": {
-    "contributors": {
       "items": {
-        "c1": {
-          "description": "Instrumentație pentru observabilitate",
-          "name": "OpenTelemetry Authors",
-          "packages": "12"
+        "dark": "Întunecat",
+        "disco": "Mod disco",
+        "english": "English",
+        "fontDyslexic": "Font pentru dislexie",
+        "fontNormal": "Font standard",
+        "french": "Français",
+        "github": "GitHub",
+        "homepage": "Pagina principală",
+        "light": "Luminos",
+        "matrix": "Mod Matrix",
+        "rainbow": "Mod curcubeu",
+        "romanian": "Română",
+        "system": "Sistem"
+      },
+      "noResults": "Niciun rezultat găsit.",
+      "placeholder": "Tastați o comandă sau căutați..."
+    },
+    "errors": {
+      "globalError": {
+        "actions": {
+          "step1": "Încearcă să reîmprospătezi pagina folosind butonul de mai jos.",
+          "step2": "Revino la pagina principală și începe din nou.",
+          "step3": "Contactează suportul dacă problema persistă.",
+          "whatCanYouDoTitle": "Ce puteți face?"
         },
-        "c2": {
-          "description": "SDK-uri Azure și unelte",
-          "name": "Microsoft Corporation",
-          "packages": "5"
+        "buttons": {
+          "copied": "Copiat!",
+          "copyErrorId": "Copiază ID-ul erorii",
+          "copyErrorIdTitle": "Copiază ID-ul erorii",
+          "returnHome": "Înapoi la pagina principală",
+          "tryAgain": "Încearcă din nou"
         },
-        "c3": {
-          "description": "Soluții de autentificare",
-          "name": "Clerk",
-          "packages": "2"
+        "copyErrorConsoleMessage": "Copierea ID-ului erorii a eșuat:",
+        "details": {
+          "errorIdLabel": "ID eroare:",
+          "genericDescription": "A apărut o eroare în timpul procesării cererii tale.",
+          "title": "Detalii eroare",
+          "unknownError": "A apărut o eroare necunoscută.",
+          "whatHappenedTitle": "Ce s-a întâmplat?"
         },
-        "c4": {
-          "description": "Utilități pentru testare",
-          "name": "Kent C. Dodds",
-          "packages": "3"
+        "diagnostics": {
+          "loading": "Se încarcă informațiile de diagnostic...",
+          "scanLabel": "Scanați pentru informații de diagnostic:",
+          "stackTraceLabel": "Trasă de stivă:",
+          "technicalSummary": "Informații tehnice (pentru dezvoltatori)"
+        },
+        "hero": {
+          "subtitle": "A apărut o eroare neașteptată. Echipa noastră a fost notificată automat.",
+          "title": "Ceva nu a mers bine"
+        },
+        "metadata": {
+          "title": "Eroare aplicație - AROLARIU.RO"
+        },
+        "support": {
+          "contactPrefix": "Dacă această problemă continuă, contactează-ne la",
+          "includeErrorId": "și include ID-ul erorii:"
         }
       },
-      "packages": "{count, plural, one {# pachet} few {# pachete} other {# de pachete}}",
-      "subtitle": "Organizații și indivizi pe ale căror pachete ne bazăm cel mai mult",
-      "title": "Contributori Principali"
-    },
-    "hero": {
-      "badge": "Sursă Deschisă",
-      "lastUpdate": "Ultima actualizare: {date}",
-      "subtitle": "Această platformă este construită pe umerii unor proiecte open-source incredibile. Suntem recunoscători întreținătorilor și contributorilor care își fac munca disponibilă gratuit.",
-      "title": "Mulțumiri"
-    },
-    "lastUpdate": "Ultima actualizare pe: {date}",
-    "licenses": {
-      "apache": "Apache 2.0",
-      "apacheDescription": "Licență open-source prietenoasă pentru întreprinderi",
-      "gpl": "Licență GPL",
-      "gplDescription": "Licență copyleft care asigură că codul rămâne liber",
-      "mit": "Licență MIT",
-      "mitDescription": "Licență permisivă care permite utilizare largă",
-      "other": "Alte Licențe",
-      "otherDescription": "Licențe custom sau diverse alte licențe open-source",
-      "packages": "{count, plural, one {# pachet} few {# pachete} other {# de pachete}}",
-      "title": "Distribuția Licențelor"
-    },
-    "metadata": {
-      "description": "Pagina de mulțumire pentru pachetele terțe utilizate în acest proiect și colaboratori.",
-      "title": "Mulțumiri"
-    },
-    "packages": {
-      "subtitle": "Acest site web nu ar fi putut fi posibil fără următoarele pachete terțe. \nAș dori să le mulțumesc autorilor acestor pachete pentru munca grea și dăruirea lor pentru comunitatea open-source.",
-      "title": "Pachete terțe"
-    },
-    "packagesScreen": {
-      "badge": {
-        "development": "Dezvoltare",
-        "production": "Producție"
-      },
-      "card": {
-        "dependencies": "Dependențe:",
-        "license": "Licență:",
-        "viewDependencies": "Vezi dependențele",
-        "website": "Site web"
-      },
-      "dialog": {
-        "dependencies": "Dependențele {name}",
-        "dependenciesCount": "Acest pachet are {count} dependențe."
-      },
-      "emptyState": {
-        "subtitle": "Încercați să ajustați filtrele de mai sus.",
-        "title": "Nu s-au găsit pachete."
-      },
-      "filters": {
-        "allPackages": "Toate pachetele",
-        "ascending": "Crescător",
-        "dependenciesCount": "Număr dependențe",
-        "descending": "Descrescător",
-        "developmentOnly": "Doar dezvoltare",
-        "filterByType": "Filtrează după tip",
-        "name": "Nume",
-        "packageType": "Tip pachet",
-        "productionOnly": "Doar producție",
-        "sortBy": "Sortează după",
-        "sortDirection": "Direcție sortare"
-      },
-      "openSource": {
-        "description": "Acest proiect stă pe umerii unor giganți. Suntem recunoscători comunității open-source și tuturor dezvoltatorilor care au contribuit la aceste pachete.",
-        "title": "Open Source contează"
-      },
-      "search": {
-        "placeholder": "Caută..."
-      },
-      "table": {
-        "dependencies": "Dependențe",
-        "description": "Descriere",
-        "license": "Licență",
-        "package": "Pachet",
-        "type": "Tip",
-        "version": "Versiune",
-        "website": "Site web"
-      },
-      "views": {
-        "gridView": "Vizualizare grilă",
-        "tableView": "Vizualizare tabel"
-      }
-    },
-    "stats": {
-      "development": {
-        "description": "Instrumente de build",
-        "label": "Dezvoltare",
-        "value": "{count}"
-      },
-      "mitLicense": {
-        "description": "Cea mai comună licență",
-        "label": "Licență MIT",
-        "value": "{count}"
-      },
-      "production": {
-        "description": "Dependențe runtime",
-        "label": "Producție",
-        "value": "{count}"
-      },
-      "subtitle": "O privire asupra ecosistemului open-source care alimentează această platformă",
-      "title": "Prezentare Generală a Dependențelor",
-      "total": {
-        "description": "Dependențe utilizate",
-        "label": "Total Pachete",
-        "value": "{count}"
-      }
-    },
-    "title": "Mulțumiri"
-  },
-  "Auth": {
-    "Button": {
-      "login": "Conectare",
-      "logout": "Deconectare"
-    },
-    "Island": {
-      "callToAction": "Efectuați procesul de autentificare",
-      "description": "Conectați-vă utilizând serverul nostru securizat de autentificare OAuth 2.0. \nProfilul dvs. va fi menținut sincronizat în timpul acestei sesiuni de browser. \nPuteți folosi conturile de rețele sociale pentru a vă conecta.",
-      "footer": "Puteți schimba furnizorii oricând. Autentificarea este gestionată de furnizorul nostru de identitate de încredere.",
-      "hero": {
-        "badge": "Autentificare Securizată",
-        "subtitle": "Alegeți o variantă și continuați cu furnizorul preferat. Totul rămâne rapid, sigur și localizat.",
-        "title": "Bun venit la punctul de intrare securizat"
-      },
-      "signIn": {
-        "bullets": {
-          "first": "Continuați cu furnizorul de identitate pe care îl folosiți deja.",
-          "second": "Reluați de unde ați rămas pe orice dispozitiv.",
-          "third": "Sesiunea rămâne sincronizată în timpul navigării."
+      "notFound": {
+        "additionalInfo": "Informații suplimentare:",
+        "buttons": {
+          "returnButton": "Reveniți la pagina de pornire.",
+          "submitErrorButton": "Trimiteți eroare falsă."
         },
-        "cta": "Conectare",
-        "description": "Accesați contul și păstrați sesiunea sincronizată în timpul acestei sesiuni de browser.",
-        "illustrationAlt": "Ilustrație pentru conectare",
-        "secondaryAction": "Creați unul",
-        "secondaryPrompt": "Nu aveți cont?",
-        "title": "Conectare"
-      },
-      "signUp": {
-        "bullets": {
-          "first": "Creați un cont în câteva secunde cu furnizori OAuth.",
-          "second": "Fără parole de reținut.",
-          "third": "Începeți să folosiți platforma imediat."
-        },
-        "cta": "Creați un cont",
-        "description": "Alăturați-vă platformei și deblocați experiențe dedicate membrilor în spațiul de domeniu.",
-        "illustrationAlt": "Ilustrație pentru înregistrare",
-        "secondaryAction": "Conectați-vă",
-        "secondaryPrompt": "Aveți deja cont?",
-        "title": "Înregistrare"
-      },
-      "step1": "Pasul 1",
-      "step2": "Pasul 2",
-      "title": "Autentificați-vă cu serverul nostru securizat de autentificare OAuth 2.0.",
-      "trust": {
-        "oauth": "OAuth 2.0",
-        "privacy": "Confidențialitate",
-        "session": "Sesiune sincronizată"
+        "falsePositive": "Dacă credeți că această pagină ar trebui să existe și vă confruntați cu o eroare, vă rugăm să raportați acest lucru administratorului site-ului.",
+        "subtitle": "Se pare că pagina pe care ați ajuns nu este prezentă pe site. Dacă această pagină ar trebui să existe, vă rugăm să raportați acest lucru administratorului site-ului.",
+        "title": "404 - Pagina nu a fost găsită."
       }
     },
-    "metadata": {
-      "description": "Pagina de autorizare pentru platforma Arolariu.ro.",
-      "title": "Autorizare"
+    "footer": {
+      "accessibility": {
+        "brandTitle": "AROLARIU.RO",
+        "goHome": "Pagina principală",
+        "logoAlt": "Logo-ul arolariu.ro."
+      },
+      "builtOn": "Construit pe ",
+      "commitSha": "Commit SHA:",
+      "copyright": "Drepturi de autor",
+      "navigation": {
+        "about": "Despre",
+        "acknowledgements": "Mulțumiri",
+        "privacyPolicy": "Politica de confidențialitate",
+        "subdomains": "Subdomenii",
+        "termsOfService": "Termeni și condiții",
+        "what": "Ce este asta?"
+      },
+      "socialLinks": {
+        "github": "Selectați acest link pentru a naviga la pagina GitHub a autorului.",
+        "linkedin": "Selectați acest link pentru a naviga la pagina LinkedIn a autorului."
+      },
+      "sourceCode": "Codul sursă este disponibil ",
+      "sourceCodeAnchor": "aici (GitHub)",
+      "subtitle": "Platforma este construită folosind cele mai recente tehnologii stabile, de ultimă generație și cu experiență de nivel enterprise. \n<br></br> <br></br> Sperăm că aveți o experiență grozavă când explorați această platformă."
     },
-    "SignIn": {
-      "bullets": {
-        "first": "Conectare rapidă cu furnizori de încredere.",
-        "second": "Sesiunea rămâne consecventă în întreaga aplicație.",
-        "third": "Optimizat pentru mobil și desktop."
-      },
-      "footer": "Protejat prin securitate de nivel enterprise.",
-      "form": {
-        "kicker": "Conectați-vă cu furnizorul preferat",
-        "secondaryAction": "Creați un cont",
-        "secondaryPrompt": "Sunteți nou aici?"
-      },
-      "hero": {
-        "subtitle": "Folosiți furnizorul în care aveți încredere și continuați instant.",
-        "title": "Bun venit înapoi"
-      },
-      "illustrationAlt": "Ilustrație pentru pagina de conectare",
-      "metadata": {
-        "description": "Conectați-vă pentru a continua sesiunea pe arolariu.ro.",
-        "title": "Conectare"
-      }
-    },
-    "SignUp": {
-      "bullets": {
-        "first": "Înregistrare rapidă cu furnizori OAuth.",
-        "second": "Nu este necesar niciun card.",
-        "third": "Începeți să explorați platforma imediat."
-      },
-      "footer": "Înregistrare rapidă și sigură.",
-      "form": {
-        "kicker": "Creați contul cu furnizorul preferat",
-        "secondaryAction": "Conectare",
-        "secondaryPrompt": "Aveți deja cont?"
-      },
-      "hero": {
-        "subtitle": "Creați-vă contul în câteva secunde și începeți.",
-        "title": "Alăturați-vă astăzi"
-      },
-      "illustrationAlt": "Ilustrație pentru pagina de înregistrare",
-      "metadata": {
-        "description": "Creați un cont și începeți să folosiți arolariu.ro.",
-        "title": "Înregistrare"
-      }
-    }
-  },
-  "Commander": {
-    "groups": {
-      "accessibility": "Accesibilitate",
-      "fun": "Distracție",
-      "language": "Limbă",
-      "links": "Linkuri",
-      "navigation": "Navigare",
-      "theme": "Temă"
-    },
-    "items": {
-      "dark": "Întunecat",
-      "disco": "Mod disco",
-      "english": "English",
-      "fontDyslexic": "Font pentru dislexie",
-      "fontNormal": "Font standard",
-      "french": "Français",
-      "github": "GitHub",
-      "homepage": "Pagina principală",
-      "light": "Luminos",
-      "matrix": "Mod Matrix",
-      "rainbow": "Mod curcubeu",
-      "romanian": "Română",
-      "system": "Sistem"
-    },
-    "noResults": "Niciun rezultat găsit.",
-    "placeholder": "Tastați o comandă sau căutați..."
-  },
-  "Common": {
-    "accessibility": {
-      "logoAlt": "logo arolariu.ro",
-      "toggleTheme": "Comută tema"
-    },
-    "states": {
-      "forbidden": {
-        "callToAction": "Alatura-te domeniului arolariu.ro.",
-        "description": "Din păcate, această funcționalitate necesită să aveți un cont pe domeniul nostru. \nPrin crearea unui cont pe platforma noastră sau conectarea cu un cont existent, veți putea accesa întregul nostru arsenal de servicii, inclusiv acesta.",
-        "title": "Pierzi distracția!"
-      }
-    }
-  },
-  "Domains": {
-    "metadata": {
-      "description": "Serviciile de spațiu din domeniu sunt servicii care sunt oferite vizitatorilor și membrilor spațiului de domeniu `arolariu.ro`",
-      "title": "Servicii spațiului de domeniu"
-    },
-    "services": {
-      "callToAction": "Vizitați acest serviciu de domeniu",
-      "invoices": {
-        "card": {
-          "description": "Acest serviciu de domeniu ajută la transformarea digitală a chitanțelor fizice. \nPermite utilizatorilor să încarce chitanțe și să obțină informații bine elaborate despre obiceiurile lor de cheltuieli.",
-          "imageAlt": "Ilustrație a Sistemului de Management al Facturilor care prezintă digitalizarea chitanțelor",
-          "title": "Sistem de management al bonurilor fiscale"
-        }
-      }
-    },
-    "subtitle": "Platforma <code>arolariu.ro</code> oferă o gamă largă de servicii sub umbrela sa. <br></br> Majoritatea serviciilor necesită să aveți un cont creat pe această platformă, astfel încât datele dumneavoastră să poată fi sincronizate în siguranță între toate serviciile domeniului. <br></br> <br></br> Aici puteți vedea o prezentare a tuturor serviciilor de domeniu disponibile pentru explorare.",
-    "title": "Servicii disponibile"
-  },
-  "Errors": {
-    "globalError": {
-      "actions": {
-        "step1": "Încearcă să reîmprospătezi pagina folosind butonul de mai jos.",
-        "step2": "Revino la pagina principală și începe din nou.",
-        "step3": "Contactează suportul dacă problema persistă.",
-        "whatCanYouDoTitle": "Ce puteți face?"
-      },
-      "buttons": {
-        "copied": "Copiat!",
-        "copyErrorId": "Copiază ID-ul erorii",
-        "copyErrorIdTitle": "Copiază ID-ul erorii",
-        "returnHome": "Înapoi la pagina principală",
-        "tryAgain": "Încearcă din nou"
-      },
-      "copyErrorConsoleMessage": "Copierea ID-ului erorii a eșuat:",
-      "details": {
-        "errorIdLabel": "ID eroare:",
-        "genericDescription": "A apărut o eroare în timpul procesării cererii tale.",
-        "title": "Detalii eroare",
-        "unknownError": "A apărut o eroare necunoscută.",
-        "whatHappenedTitle": "Ce s-a întâmplat?"
-      },
-      "diagnostics": {
-        "loading": "Se încarcă informațiile de diagnostic...",
-        "scanLabel": "Scanați pentru informații de diagnostic:",
-        "stackTraceLabel": "Trasă de stivă:",
-        "technicalSummary": "Informații tehnice (pentru dezvoltatori)"
-      },
-      "hero": {
-        "subtitle": "A apărut o eroare neașteptată. Echipa noastră a fost notificată automat.",
-        "title": "Ceva nu a mers bine"
-      },
-      "metadata": {
-        "title": "Eroare aplicație - AROLARIU.RO"
-      },
-      "support": {
-        "contactPrefix": "Dacă această problemă continuă, contactează-ne la",
-        "includeErrorId": "și include ID-ul erorii:"
-      }
-    },
-    "notFound": {
-      "additionalInfo": "Informații suplimentare:",
-      "buttons": {
-        "returnButton": "Reveniți la pagina de pornire.",
-        "submitErrorButton": "Trimiteți eroare falsă."
-      },
-      "falsePositive": "Dacă credeți că această pagină ar trebui să existe și vă confruntați cu o eroare, vă rugăm să raportați acest lucru administratorului site-ului.",
-      "subtitle": "Se pare că pagina pe care ați ajuns nu este prezentă pe site. Dacă această pagină ar trebui să existe, vă rugăm să raportați acest lucru administratorului site-ului.",
-      "title": "404 - Pagina nu a fost găsită."
-    }
-  },
-  "EULA": {
-    "accept": "Accept acest acord",
-    "content": "Acest acord de licență pentru utilizatorul final („EULA”) reprezintă un acord între dvs. și AROLARIU.RO și reglementează utilizarea acestui software. Vă rugăm să citiți cu atenție următoarele documente înainte de a utiliza site-ul web:",
-    "cookiesPolicy": {
-      "cookies": {
-        "analytics": {
-          "checkbox": "Activarea cookie-urilor de analiză ne ajută să ne îmbunătățim site-ul.",
-          "description": "Aceste cookie-uri ne permit să numărăm vizitele și sursele de trafic, astfel încât să putem măsura și îmbunătăți performanța site-ului nostru.  Ne ajută să știm care pagini sunt cele mai și mai puțin populare și să vedem cum se deplasează vizitatorii pe site. Toate informațiile colectate de aceste cookie-uri sunt agregate și, prin urmare, pot fi considerate anonime.",
-          "title": "Cookie-uri de analiză"
-        },
-        "cta": "Salvează preferințele cookie-urilor",
-        "essential": {
-          "checkbox": "Aceste cookie-uri sunt necesare pentru ca site-ul să funcționeze corect.",
-          "description": "Cookie-urile esențiale sunt necesare pentru ca site-ul să funcționeze corect. Această categorie include numai cookie-uri care asigură funcționalitățile de bază și caracteristicile de securitate ale site-ului web.",
-          "title": "Cookie-uri esențiale"
-        }
-      },
-      "subtitle": "Acest site folosește cookie-uri pentru a vă îmbunătăți experiența.",
-      "title": "Politica de cookie-uri"
-    },
-    "language": "Limbă",
-    "privacyPolicy": {
-      "cta": "Vizualizați politica",
-      "subtitle": "Politica noastră de confidențialitate explică modul în care colectăm, folosim și protejăm informațiile dvs. personale atunci când utilizați serviciile noastre.",
-      "title": "Politica de confidențialitate"
-    },
-    "subtitle": "Vă rugăm să examinați termenii și condițiile noastre înainte de a utiliza site-ul.",
-    "termsOfService": {
-      "cta": "Vizualizați termenii",
-      "subtitle": "Termenii noștri de serviciu conturează regulile și liniile directoare pentru utilizarea platformei noastre, inclusiv responsabilitățile utilizatorului și obligațiile noastre.",
-      "title": "Termeni de serviciu"
-    },
-    "title": "Acord de licență pentru utilizatorul final"
-  },
-  "Footer": {
-    "accessibility": {
-      "brandTitle": "AROLARIU.RO",
-      "goHome": "Pagina principală",
-      "logoAlt": "Logo-ul arolariu.ro."
-    },
-    "builtOn": "Construit pe ",
-    "commitSha": "Commit SHA:",
-    "copyright": "Drepturi de autor",
     "navigation": {
       "about": "Despre",
-      "acknowledgements": "Mulțumiri",
-      "privacyPolicy": "Politica de confidențialitate",
-      "subdomains": "Subdomenii",
-      "termsOfService": "Termeni și condiții",
-      "what": "Ce este asta?"
-    },
-    "socialLinks": {
-      "github": "Selectați acest link pentru a naviga la pagina GitHub a autorului.",
-      "linkedin": "Selectați acest link pentru a naviga la pagina LinkedIn a autorului."
-    },
-    "sourceCode": "Codul sursă este disponibil ",
-    "sourceCodeAnchor": "aici (GitHub)",
-    "subtitle": "Platforma este construită folosind cele mai recente tehnologii stabile, de ultimă generație și cu experiență de nivel enterprise. \n<br></br> <br></br> Sperăm că aveți o experiență grozavă când explorați această platformă."
+      "domains": "Domenii",
+      "invoices": "Facturi",
+      "mobile": {
+        "closeNavigation": "Închide navigarea",
+        "openNavigation": "Deschide navigarea",
+        "title": "Navigare"
+      },
+      "myInvoices": "Facturile mele",
+      "myProfile": "Profilul meu",
+      "theAuthor": "Autorul",
+      "thePlatform": "Platforma",
+      "uploadScans": "Încarcă scanări",
+      "viewScans": "Vezi scanările"
+    }
   },
-  "Home": {
-    "appreciation": "MULȚUMESC PENTRU TIMPUL PETRECUT PE SITE.",
-    "cta": "Începeți să explorați",
-    "featuresTab": {
-      "azure": {
-        "description": "Cloud-ul Microsoft Azure este utilizat pentru a găzdui platforma și toate serviciile sale. Acest lucru asigură faptul că platforma este întotdeauna disponibilă și că poate fi extinsă la cerere.",
-        "title": "Microsoft Azure"
+  "cards": {
+    "invoices": {
+      "budgetImpactCard": {
+        "dailyAllowance": "Alocație zilnică",
+        "dailyAllowanceValue": "{amount} / zi",
+        "daysLeft": "Zile rămase",
+        "inMonth": "în {month}",
+        "invoiceUsed": "Această factură a folosit",
+        "monthlyBudget": "Buget lunar",
+        "ofMonthlyBudget": "din bugetul tău lunar",
+        "overBudget": "Peste buget",
+        "remaining": "Rămas",
+        "spent": "{amount} cheltuiți",
+        "title": "Impact bugetar {month}"
       },
-      "csharp": {
-        "description": "Platforma este construită folosind .NET 8 LTS - cea mai recentă versiune stabilă a .NET. Acest lucru asigură faptul că platforma este rapidă, fiabilă și ușor de utilizat. Platforma este construită folosind C# și F#.",
-        "title": ".NET 8 LTS"
+      "categorySuggestionCard": {
+        "description": "Nu am putut categoriza automat această factură. Selectează categoria corectă pentru a debloca analize:",
+        "gamification": "Categorisește {goal} facturi pentru a debloca analize detaliate!",
+        "moreCategories": "Mai multe categorii:",
+        "title": "Ajută-ne să categorisim această factură"
       },
-      "description": "Platforma `arolariu.ro` este construita folosind cele mai noi tehnologii stabile.",
-      "githubActions": {
-        "description": "Experiența DevOps este alimentată de acțiuni Github. \n(CI/CD, testare etc.)",
-        "title": "GitHub Actions"
+      "comparisonStatsCard": {
+        "avgValue": "Medie: {amount} {currency}",
+        "itemCount": "Articol Count",
+        "itemCountComparison": "{current} vs medie {average}",
+        "maxValue": "Maxim: {amount}",
+        "minValue": "Minim: {amount}",
+        "positionInRange": "Poziția ta în intervalul de cheltuieli",
+        "sameStore": "Același magazin",
+        "sameStoreComparison": "vs medie {average} {currency}",
+        "subtitle": "Comparativ cu ultimele tale {count} facturi",
+        "thisValue": "Aceasta: {amount} {currency}",
+        "title": "Cum te compari",
+        "vsAverage": "vs medie"
       },
-      "learnMoreBtn": "Interesant? \nFaceți clic aici pentru a afla mai multe ...",
-      "nextJs": {
-        "description": "Platforma este construită folosind NextJS - cel mai popular cadru React pentru producție.  Este proiectat pentru aplicații React de nivel de producție. NextJS este cel mai popular cadru React pentru un motiv: este rapid, fiabil și ușor de utilizat.",
-        "title": "Next.JS 15"
+      "diningCard": {
+        "challenge": {
+          "descriptionPrefix": "Evită fast-food-ul timp de 7 zile și salvează",
+          "descriptionSuffix": "",
+          "title": "Provocare săptămânală"
+        },
+        "estimatedNutrition": {
+          "calories": "Calorii",
+          "caloriesValue": "~{value} kcal",
+          "carbs": "Carbohidrați",
+          "carbsValue": "~{value}g",
+          "protein": "Proteine",
+          "proteinValue": "~{value}g",
+          "sodium": "Sodiu",
+          "title": "Nutriție estimată"
+        },
+        "habits": {
+          "avgSpend": "Cheltuială medie",
+          "favorite": "Favorit",
+          "frequency": "Frecvență",
+          "frequencyDiff": "+1 vs medie",
+          "frequencyValue": "{count}x/lună",
+          "title": "Obiceiurile tale de fast-food",
+          "visits": "{count} vizite"
+        },
+        "sodium": {
+          "high": "Ridicat",
+          "low": "Scăzut",
+          "medium": "Mediu"
+        },
+        "swaps": {
+          "caloriesSaved": "-{count} kcal",
+          "grilled": "La grătar în loc de prăjit",
+          "moneySaved": ", economisești {amount}",
+          "salad": "Salată garnitură în loc de cartofi prăjiți",
+          "title": "Alternative mai sănătoase",
+          "water": "Apă în loc de suc"
+        },
+        "title": "Informații despre mese"
       },
-      "otel": {
-        "description": "Observabilitate completă cu metrici, urme și jurnale integrate. Totul este instrumentat utilizând OpenTelemetry. Acest lucru permite o experiență de telemetrie unificată pe toată linia. (3PO: metrici, jurnale, urme)",
-        "title": "Open Telemetry"
+      "generalExpenseCard": {
+        "aria": {
+          "changeCategory": "Change detected categorie",
+          "confirmCategory": "Confirmă că categoria detectată este corectă",
+          "export": "Exportă datele cheltuielii",
+          "organize": "Organizează această cheltuială în categorii"
+        },
+        "budgetCategories": {
+          "electronics": "Electronice",
+          "entertainment": "Divertisment",
+          "shopping": "Cumpărături"
+        },
+        "buttons": {
+          "change": "Schimbă",
+          "correct": "Corect",
+          "export": "Exportă",
+          "organize": "Organizează"
+        },
+        "confidence": "Încredere: {value}%",
+        "detectedCategory": "Electronice / Tehnologie",
+        "nearLimitAlert": "{name}: {percent}% utilizat (10 zile rămase în lună)",
+        "options": {
+          "businessExpense": "Marchează drept cheltuială de business",
+          "insuranceInventory": "Adaugă în inventarul de asigurare",
+          "trackWarranty": "Urmărește garanția (standard 24 luni)"
+        },
+        "sections": {
+          "autoDetectedCategory": "Auto-detected categorie",
+          "budgetImpact": "Impact bugetar",
+          "similarPurchases": "Achiziții similare anterioare",
+          "taxBusiness": "Opțiuni fiscale și de business"
+        },
+        "title": "Analiză cheltuieli",
+        "vatReclaimable": "TVA recuperabil"
       },
-      "svelte": {
-        "description": "Folosim Svelte pentru componente UI reactive, rapide, reactive. \nPlatforma `cv.arolariu.ro` este construită doar folosind Svelte și SvelteKit (v5)",
-        "title": "Svelte"
+      "homeInventoryCard": {
+        "bulk": {
+          "description": "Detergent 5L față de 2L economisește 18% ({amount}/an)",
+          "title": "Economii la cumpărături în vrac"
+        },
+        "eco": {
+          "productsWithEcoLabels": "{count} produse cu etichete ecologice",
+          "recyclablePackaging": "{count} produs cu ambalaj reciclabil",
+          "tip": "Tip: Eco alternatives salvează 2kg plastic/year",
+          "title": "Scor ecologic"
+        },
+        "stockLevels": {
+          "daysRemaining": "~{count} zile",
+          "title": "Niveluri stoc consumabile (estimate)"
+        },
+        "supplyNames": {
+          "dishSoap": "Detergent vase",
+          "floorCleaner": "Soluție pentru podea",
+          "laundryDetergent": "Detergent rufe",
+          "paperProducts": "Produse din hârtie"
+        },
+        "title": "Inventar casă și consumabile"
       },
-      "title": "Caracteristici cheie"
-    },
-    "subtitle": "Această platformă a fost construită de Alexandru-Răzvan Olariu ca loc de joacă pentru noile tehnologii. Platforma este construită folosind tehnologii de ultimă oră, de nivel enterprise. <br> </br> <br> </br> Sunteți binevenit să explorați toate aplicațiile și serviciile care sunt găzduite pe acest spațiu de domeniu.",
-    "technologyTab": {
-      "badgeTitle": "Arhitectură modernă",
-      "description": "Această platformă utilizează cele mai recente tehnologii web, combinând Next.js pentru frontend cu .NET pentru servicii backend robuste, toate implementate pe Microsoft Azure.",
-      "learnMoreBtn": "Explorați arhitectura",
-      "points": {
-        "point1": "Arhitectură fără server pentru o scalare și performanță optimă",
-        "point2": "TypeScript full-stack pentru siguranța tipurilor în întreaga aplicație",
-        "point3": "Telemetrie și monitorizare cuprinzătoare cu OpenTelemetry"
+      "imageCard": {
+        "aria": {
+          "expandImage": "Apasă pentru a extinde imaginea"
+        },
+        "buttons": {
+          "addScan": "Adaugă scan",
+          "expand": "Extinde imaginea",
+          "next": "Următor",
+          "previous": "Anterior",
+          "remove": "Elimină"
+        },
+        "dialogTitle": "Imagine bon",
+        "dialogTitleWithIndex": "Imagine bon ({current}/{total})",
+        "scanAlt": "Scanare bon {index}",
+        "scanAltFullSize": "Scanare bon {index} - dimensiune completă",
+        "title": "Scanare bon",
+        "titleWithIndex": "Scanare bon ({current}/{total})",
+        "tooltips": {
+          "addScan": "Încarcă și atașează o scanare nouă a bonului",
+          "expand": "Vezi imaginea bonului la dimensiune completă",
+          "next": "Vezi următoarea scanare a bonului",
+          "previous": "Vezi scanarea anterioară a bonului",
+          "remove": "Elimină scanarea curentă a bonului"
+        }
       },
-      "title": "Construit pentru viitor."
-    },
-    "title": "Bine ai venit pe arolariu.ro"
+      "invoiceCard": {
+        "descriptionPlaceholder": "Introdu descrierea facturii...",
+        "fromMerchant": "De la {merchant}",
+        "importantBadge": "IMPORTANT",
+        "labels": {
+          "category": "Categorie",
+          "dateUtc": "Dată (UTC)",
+          "hours": "Ore",
+          "minutes": "Minute",
+          "paymentMethod": "Metodă de plată",
+          "totalAmount": "Sumă totală",
+          "utc": "UTC"
+        },
+        "markImportant": "Marchează ca important",
+        "placeholders": {
+          "selectCategory": "Selectează categorie",
+          "selectPaymentType": "Selectează tipul de plată"
+        },
+        "title": "Detalii factură",
+        "tooltips": {
+          "markFavorite": "Apasă pentru a marca drept favorit",
+          "unmarkFavorite": "Apasă pentru a scoate din favorite"
+        }
+      },
+      "invoiceDetailsCard": {
+        "itemsTitle": "Articole ({count})",
+        "labels": {
+          "category": "Categorie",
+          "countryRegion": "Țară/Regiune",
+          "dateUtc": "Dată (UTC)",
+          "payment": "Plată",
+          "receiptType": "Tip bon",
+          "ronEquivalent": "Echivalent RON",
+          "subtotal": "Subtotal",
+          "tip": "Bacșiș",
+          "totalAmount": "Suma totală"
+        },
+        "pagination": {
+          "next": "Următor",
+          "pageOf": "Pagina {current} din {total}",
+          "previous": "Anterior"
+        },
+        "sections": {
+          "paymentMethods": "Metode de plată",
+          "taxBreakdown": "Detalii taxe"
+        },
+        "table": {
+          "grandTotal": "Total general",
+          "item": "Articol",
+          "price": "Preț",
+          "qty": "Cant.",
+          "total": "Total general",
+          "unit": "Unitate"
+        },
+        "taxLabels": {
+          "net": "Net",
+          "tax": "Taxă"
+        },
+        "title": "Detalii factură",
+        "tooltips": {
+          "exchangeRate": "1 {fromCurrency} = {rate} RON (medie {year})"
+        }
+      },
+      "merchantCard": {
+        "addressLabel": "Adresă: {address}",
+        "buttons": {
+          "viewAllReceipts": "Vezi toate bonurile",
+          "viewMerchantDetails": "Vezi detalii comerciant"
+        },
+        "noMerchantLinked": "Niciun comerciant asociat acestei facturi",
+        "title": "Comerciant",
+        "tooltips": {
+          "viewAllReceipts": "Vezi toate bonurile de la acest comerciant",
+          "viewMerchantDetails": "Vezi informații detaliate despre acest comerciant"
+        }
+      },
+      "merchantInfoCard": {
+        "categoryDistribution": "Distribuție categorii",
+        "noMerchantLinked": "Niciun comerciant asociat acestei facturi",
+        "spendingHistory": "Istoric cheltuieli",
+        "stats": {
+          "avgSpend": "Cheltuială medie",
+          "daysAgo": "zile în urmă",
+          "visits": "vizite"
+        },
+        "title": "Informații comerciant",
+        "viewAllInvoices": "Vezi toate facturile",
+        "viewAllReceipts": "Vezi toate bonurile",
+        "viewOnMap": "Vezi pe hartă"
+      },
+      "nutritionCard": {
+        "allergens": {
+          "foundInItems": "Găsit în {count} articol(e)",
+          "title": "Alergeni detectați"
+        },
+        "composition": {
+          "dairyOther": "Lactate/Altele",
+          "processed": "Procesate",
+          "title": "Compoziția coșului tău",
+          "wholeFoods": "Alimente integrale"
+        },
+        "foodGroups": {
+          "fruits": "Fructe",
+          "grains": "Cereale",
+          "itemsCount": "{count} articol(s)",
+          "protein": "Proteine",
+          "vegetables": "Legume"
+        },
+        "score": {
+          "excellent": "Excelent",
+          "fair": "Acceptabil",
+          "good": "Bun",
+          "needsWork": "Necesită îmbunătățiri",
+          "title": "Scor echilibru alimentar"
+        },
+        "suggestions": {
+          "addFruits": "Adăugarea unor fructe ar îmbunătăți echilibrul nutrițional",
+          "addFruitsAndVegetables": "Adaugă mai multe fructe și legume pentru a-ți echilibra coșul",
+          "addVegetables": "Ia în calcul adăugarea de legume pentru o alimentație mai echilibrată",
+          "greatBalance": "Cumpărături foarte bine echilibrate!",
+          "swapProcessed": "Încearcă să înlocuiești unele produse procesate cu alimente integrale"
+        },
+        "title": "Privire generală nutriție"
+      },
+      "receiptScanCard": {
+        "buttons": {
+          "expand": "Extinde imaginea",
+          "nextScan": "Scanarea următoare",
+          "previousScan": "Scanarea anterioară"
+        },
+        "controls": {
+          "download": "Descarcă",
+          "fullScreen": "Ecran complet",
+          "reset": "Resetează zoom",
+          "rotate": "Rotește",
+          "toggleZoom": "Clic pentru a comuta zoom-ul",
+          "zoomIn": "Mărește",
+          "zoomOut": "Micșorează"
+        },
+        "dialogTitle": "Imagine bon",
+        "dialogTitleWithIndex": "Imagine bon ({current}/{total})",
+        "navigation": {
+          "next": "Următor",
+          "of": "din",
+          "previous": "Anterior"
+        },
+        "scanAlt": "Scanare bon {index}",
+        "scanAltFullSize": "Scanare bon {index} - dimensiune completă",
+        "title": "Scanare bon",
+        "titleWithIndex": "Scanare bon ({current}/{total})",
+        "tooltips": {
+          "expand": "Vezi imaginea bonului la dimensiune completă",
+          "nextScan": "Vezi următoarea scanare a bonului",
+          "previousScan": "Vezi scanarea anterioară a bonului"
+        }
+      },
+      "recipeCard": {
+        "buttons": {
+          "viewRecipe": "Vezi rețeta",
+          "visitReference": "Vizitează referința"
+        },
+        "complexity": {
+          "easy": "Ușor",
+          "hard": "Greu",
+          "normal": "Normal",
+          "unknown": "Necunoscut"
+        },
+        "dropdown": {
+          "delete": "Șterge",
+          "edit": "Editează",
+          "markAsFavorite": "Marchează ca favorit",
+          "share": "Distribuie",
+          "view": "Vezi"
+        },
+        "ingredients": {
+          "additionalLabel": "Ingrediente suplimentare:",
+          "label": "Ingrediente:",
+          "more": "+{count} în plus"
+        },
+        "timing": {
+          "cookLabel": "Gătire: {minutes}′",
+          "cookTooltip": "Timpul de gătire este de {minutes} minute.",
+          "prepLabel": "Pregătire: {minutes}′",
+          "prepTooltip": "Timpul de pregătire este de {minutes} minute."
+        }
+      },
+      "seasonalInsightsCard": {
+        "insights": {
+          "holidaySeason": {
+            "description": "Cheltuielile din decembrie sunt de obicei cu 35% mai mari",
+            "title": "Sezonul sărbătorilor"
+          },
+          "insufficientData": {
+            "description": "Adaugă mai multe facturi pentru a vedea informații sezoniere și modele de cheltuieli",
+            "title": "Construim profilul tău de cheltuieli"
+          },
+          "normalPattern": {
+            "description": "Cheltuielile tale sunt în intervalul obișnuit",
+            "title": "Model normal de cumpărături"
+          },
+          "spike": {
+            "description": "+{percent}% vs media ta",
+            "title": "Creștere {category}"
+          },
+          "stockUpTip": {
+            "description": "Prețurile cresc cu ~15% după 15 decembrie",
+            "title": "Sfat de aprovizionare"
+          }
+        },
+        "month": {
+          "spendingSoFar": "{month} până acum",
+          "vsAverage": "vs media pe {month}: {amount}"
+        },
+        "title": "Insight sezonier"
+      },
+      "sharingCard": {
+        "buttons": {
+          "manageSharing": "Gestionează Partajare",
+          "markAsPrivate": "Marchează ca privată",
+          "revokingAccess": "Se revocă accesul...",
+          "shareInvoice": "Partajează Factură"
+        },
+        "emptyShared": {
+          "private": "Nu este partajată",
+          "public": "Niciun utilizator suplimentar nu are acces direct"
+        },
+        "owner": "Proprietar",
+        "ownerAvatarAlt": "Utilizator",
+        "publicInvoice": {
+          "description": "Această factură este accesibilă public. Oricine are linkul o poate vedea.",
+          "title": "Factură publică"
+        },
+        "sharedWith": "Partajată cu",
+        "title": "Partajare",
+        "toasts": {
+          "removeAccessComingSoon": {
+            "description": "Această funcționalitate este în curs de dezvoltare.",
+            "title": "Funcția de eliminare a accesului va fi disponibilă în curând"
+          },
+          "revoke": {
+            "error": "Marcarea ca privată a eșuat: {message}",
+            "loading": "Se revocă accesul public...",
+            "success": "Factura este acum privată. Linkurile existente nu vor mai funcționa."
+          }
+        },
+        "tooltips": {
+          "manageSharing": "Gestionează setările de partajare pentru această factură",
+          "markAsPrivate": "Marchează factura ca privată",
+          "removeAccess": "Elimină accesul",
+          "shareInvoice": "Partajează această factură cu alți utilizatori"
+        },
+        "userWithId": "Utilizator {id}"
+      },
+      "shoppingCalendarCard": {
+        "insights": {
+          "days": "{count} zile",
+          "mostActiveOn": "Cel mai activ în",
+          "onAverage": "în medie",
+          "perTrip": " per cumpărătură",
+          "shopEveryPrefix": "Faci cumpărături la fiecare",
+          "spendingPrefix": ", cheltuind",
+          "weekdayLabel": "{weekday}"
+        },
+        "legend": {
+          "less": "Mai puțin",
+          "more": "Mai mult"
+        },
+        "stats": {
+          "monthTotal": "Total lună",
+          "shoppingDays": "Zile de cumpărături"
+        },
+        "title": "Calendar cumpărături",
+        "tooltip": {
+          "basedOnCachedInvoices": "Bazat pe {count} facturi din cache",
+          "currentInvoice": "Factura curentă",
+          "currentInvoiceOnly": "Se afișează doar factura curentă",
+          "invoiceCount": "{count} factură(s)",
+          "more": "+{count} în plus",
+          "vsAverage": "vs medie ({years} ani de date)"
+        }
+      },
+      "statistics": {
+        "allergenSummary": {
+          "ariaLabel": "Rezumat frecvență alergeni",
+          "description": "Expunerea la alergeni în produse",
+          "empty": "Niciun alergen detectat în achizițiile tale",
+          "stats": {
+            "ofTotal": "din total",
+            "products": "produse"
+          },
+          "title": "Rezumat Alergeni"
+        },
+        "calendarHeatmap": {
+          "aria": {
+            "calendarGrid": "Calendar cheltuieli zilnice"
+          },
+          "days": {
+            "fri": "Vin",
+            "mon": "Lun",
+            "sat": "Sâm",
+            "sun": "Dum",
+            "thu": "Joi",
+            "tue": "Mar",
+            "wed": "Mie"
+          },
+          "description": "Intensitatea cheltuielilor zilnice în timp",
+          "legend": {
+            "less": "Mai puțin",
+            "more": "Mai mult"
+          },
+          "navigation": {
+            "next": "Luna următoare",
+            "previous": "Luna anterioară"
+          },
+          "title": "Calendar Cheltuieli",
+          "tooltip": {
+            "amount": "Cheltuit",
+            "invoices": "{count} facturi",
+            "noSpending": "Fără cheltuieli"
+          }
+        },
+        "categoryBreakdown": {
+          "description": "Distribuție pe categorii",
+          "title": "Cheltuieli pe categorii",
+          "tooltip": {
+            "invoiceCount": "{count} facturi"
+          },
+          "totalLabel": "Cheltuieli totale"
+        },
+        "comparison": {
+          "decrease": "scădere",
+          "description": "Comparație cu luna anterioară",
+          "discovered": "descoperiți",
+          "increase": "creștere",
+          "invoiceCount": "Număr de facturi",
+          "newMerchants": "Comercianți noi",
+          "none": "niciunul",
+          "spendingDelta": "Variația cheltuielilor",
+          "title": "Lună de lună"
+        },
+        "currencyDistribution": {
+          "description": "Defalcarea cheltuielilor pe valute cu conversie în RON",
+          "invoiceCount": "Facturi",
+          "originalAmount": "Original",
+          "ronEquivalent": "Echivalent RON",
+          "showOriginal": "Arată Original",
+          "showRON": "Arată RON",
+          "singleCurrency": "Toate facturile în {currency} ({symbol})",
+          "title": "Distribuție Valutară",
+          "toggleLabel": "Comutați vizualizarea valutei",
+          "totalAmount": "Sumă Totală",
+          "totalCurrencies": "Total Valute",
+          "totalSpending": "Cheltuieli Totale"
+        },
+        "empty": {
+          "cta": "Încarcă bon",
+          "subtitle": "Încărcați bonuri pentru a vedea statisticile",
+          "title": "Nicio statistică încă"
+        },
+        "kpi": {
+          "acrossInvoices": "din {count} facturi",
+          "averageItems": "Med. produse",
+          "avgPerInvoice": "medie {amount} per factură",
+          "invoiceCount": "Număr de facturi",
+          "noneYet": "Niciun rezultat încă",
+          "topMerchant": "Comerciant principal",
+          "totalSpending": "Cheltuieli totale",
+          "visits": "{count} vizite",
+          "vsLastMonth": "{delta}% față de luna trecută"
+        },
+        "merchantLeaderboard": {
+          "description": "Unde cheltuiești cel mai mult",
+          "empty": "Nu sunt date disponibile despre comercianți",
+          "labels": {
+            "totalSpent": "Total Cheltuit"
+          },
+          "title": "Comercianți de Top",
+          "tooltip": {
+            "invoiceCount": "{count} facturi"
+          },
+          "unknownMerchant": "Comerciant necunoscut"
+        },
+        "merchantTrends": {
+          "aria": {
+            "sparkline": "Tendință cheltuieli pentru {merchant}"
+          },
+          "description": "Modele lunare de cheltuieli pentru comercianții de top",
+          "empty": "Nu există date despre comercianți încă",
+          "labels": {
+            "merchant": "Comerciant",
+            "totalSpend": "Total Cheltuit",
+            "trend": "Tendință (Ultimele 6 Luni)"
+          },
+          "title": "Tendințe Cheltuieli Comercianți"
+        },
+        "merchantVisit": {
+          "description": "Frecvența cumpărăturilor și informații despre coș",
+          "empty": "Nu există date de vizite încă",
+          "metrics": {
+            "avgSpend": "Cheltuială Medie/Vizită",
+            "basketSize": "Coș Mediu",
+            "preferredDay": "Zi Preferată",
+            "totalVisits": "Total Vizite",
+            "visitsPerMonth": "Vizite/Lună"
+          },
+          "title": "Modele de Vizitare Comercianți"
+        },
+        "priceDistribution": {
+          "description": "Distribuția prețurilor produselor",
+          "labels": {
+            "itemCount": "Număr de produse"
+          },
+          "title": "Distribuția prețurilor",
+          "tooltip": {
+            "itemCount": "{count} produse"
+          }
+        },
+        "productAnalytics": {
+          "subtitle": "Detalii despre articolele achiziționate",
+          "title": "Analiză Produse"
+        },
+        "productCategory": {
+          "description": "Defalcare cheltuieli după tip de produs",
+          "empty": "Niciun produs de analizat încă",
+          "title": "Cheltuieli pe Categorii de Produse",
+          "tooltip": {
+            "productCount": "{count} produse"
+          }
+        },
+        "spendingOverTime": {
+          "description": "Urmăriți tendințele cheltuielilor",
+          "labels": {
+            "amount": "Sumă"
+          },
+          "title": "Cheltuieli în Timp",
+          "tooltip": {
+            "andMore": "și încă {count}...",
+            "invoiceCount": "{count} facturi"
+          }
+        },
+        "subtitle": "Gestionează bonurile și urmărește obiceiurile tale de cheltuieli",
+        "timeOfDay": {
+          "description": "Când faceți cumpărături",
+          "labels": {
+            "invoiceCount": "Număr de facturi"
+          },
+          "title": "Obiceiuri de cumpărare",
+          "tooltip": {
+            "invoiceCount": "{count} facturi"
+          }
+        },
+        "title": "Statistici facturi",
+        "topProducts": {
+          "ariaLabel": "Clasament produse preferate",
+          "description": "Cele mai cumpărate articole",
+          "empty": "Niciun produs cumpărat încă",
+          "headers": {
+            "avgPrice": "Preț Mediu",
+            "product": "Produs",
+            "purchases": "Achiziții",
+            "quantity": "Cant",
+            "rank": "#",
+            "totalSpent": "Total"
+          },
+          "title": "Produse Preferate"
+        }
+      },
+      "summaryStatsCard": {
+        "description": "Statistici cheie dintr-o privire",
+        "extremes": {
+          "highest": "Cel mai mare",
+          "lowest": "Cel mai mic"
+        },
+        "stats": {
+          "averagePrice": {
+            "description": "{currency} per articol",
+            "label": "Preț mediu"
+          },
+          "categories": {
+            "description": "Categorii unice",
+            "label": "Categorii"
+          },
+          "taxRate": {
+            "description": "{amount} {currency}",
+            "label": "Rată taxă"
+          },
+          "totalItems": {
+            "description": "Produse cumpărate",
+            "label": "Total articole"
+          }
+        },
+        "title": "Rezumat factură"
+      },
+      "vehicleCard": {
+        "buttons": {
+          "addVehicle": "Adaugă Vehicul",
+          "fullReport": "Raport complet"
+        },
+        "chart": {
+          "amount": "Sumă",
+          "title": "Cheltuieli lunare cu combustibilul"
+        },
+        "details": {
+          "liters": "Litri",
+          "notSet": "Nesetat",
+          "pricePerLiter": "Preț/L",
+          "station": "Stație",
+          "vehicle": "Vehicul"
+        },
+        "expenseType": "Tip cheltuială: Combustibil",
+        "maintenance": {
+          "title": "Mementouri întreținere"
+        },
+        "months": {
+          "dec": "dec.",
+          "nov": "nov.",
+          "oct": "oct.",
+          "sep": "sept."
+        },
+        "reminders": {
+          "oilChange": "Schimb de ulei în ~1.200 km",
+          "tireRotation": "Se recomandă rotația anvelopelor"
+        },
+        "stats": {
+          "costPerKm": "Cost pe km",
+          "estimated": "estimat",
+          "fillUps": "{count} alimentări",
+          "fuelPrice": "Fuel Preț",
+          "thisMonth": "Luna aceasta",
+          "thisMonthSuffix": "luna aceasta"
+        },
+        "tip": {
+          "perLiter": "L",
+          "title": "Cel mai ieftin în apropiere"
+        },
+        "title": "Analiza cheltuielilor vehiculului"
+      }
+    }
   },
-  "IMS--Cards": {
-    "budgetImpactCard": {
-      "dailyAllowance": "Alocație zilnică",
-      "dailyAllowanceValue": "{amount} / zi",
-      "daysLeft": "Zile rămase",
-      "inMonth": "în {month}",
-      "invoiceUsed": "Această factură a folosit",
-      "monthlyBudget": "Buget lunar",
-      "ofMonthlyBudget": "din bugetul tău lunar",
-      "overBudget": "Peste buget",
-      "remaining": "Rămas",
-      "spent": "{amount} cheltuiți",
-      "title": "Impact bugetar {month}"
-    },
-    "categorySuggestionCard": {
-      "description": "Nu am putut categoriza automat această factură. Selectează categoria corectă pentru a debloca analize:",
-      "gamification": "Categorisește {goal} facturi pentru a debloca analize detaliate!",
-      "moreCategories": "Mai multe categorii:",
-      "title": "Ajută-ne să categorisim această factură"
-    },
-    "comparisonStatsCard": {
-      "avgValue": "Medie: {amount} {currency}",
-      "itemCount": "Articol Count",
-      "itemCountComparison": "{current} vs medie {average}",
-      "maxValue": "Maxim: {amount}",
-      "minValue": "Minim: {amount}",
-      "positionInRange": "Poziția ta în intervalul de cheltuieli",
-      "sameStore": "Același magazin",
-      "sameStoreComparison": "vs medie {average} {currency}",
-      "subtitle": "Comparativ cu ultimele tale {count} facturi",
-      "thisValue": "Aceasta: {amount} {currency}",
-      "title": "Cum te compari",
-      "vsAverage": "vs medie"
-    },
-    "diningCard": {
-      "challenge": {
-        "descriptionPrefix": "Evită fast-food-ul timp de 7 zile și salvează",
-        "descriptionSuffix": "",
-        "title": "Provocare săptămânală"
+  "dialogs": {
+    "invoices": {
+      "addScanDialog": {
+        "buttons": {
+          "cancel": "Anulează",
+          "upload": "Încarcă scan",
+          "uploading": "Se încarcă..."
+        },
+        "description": "Încarcă o imagine nouă a bonului sau un document nou pentru a-l atașa la această factură.",
+        "dropzone": {
+          "dragAndDrop": "Trage și plasează un fișier aici",
+          "dropHere": "Plasează fișierul aici...",
+          "formats": "JPEG, PNG, PDF (max 10MB)",
+          "orClickBrowse": "sau apasă pentru a răsfoi"
+        },
+        "scanType": {
+          "jpeg": "Imagine JPEG",
+          "label": "Tip scanare",
+          "other": "Altele",
+          "pdf": "Document PDF",
+          "placeholder": "Selectează tipul de scanare",
+          "png": "Imagine PNG"
+        },
+        "title": "Adaugă o scanare nouă",
+        "toasts": {
+          "fileTooLargeDescription": "Dimensiunea maximă a fișierului este 10MB",
+          "fileTooLargeTitle": "Fișier prea mare"
+        }
       },
-      "estimatedNutrition": {
-        "calories": "Calorii",
-        "caloriesValue": "~{value} kcal",
-        "carbs": "Carbohidrați",
-        "carbsValue": "~{value}g",
-        "protein": "Proteine",
-        "proteinValue": "~{value}g",
-        "sodium": "Sodiu",
-        "title": "Nutriție estimată"
+      "allergenDialog": {
+        "aria": {
+          "removeAllergen": "Elimină alergenul {name}"
+        },
+        "buttons": {
+          "add": "Adaugă",
+          "cancel": "Anulează",
+          "save": "Salvează Modificările",
+          "saving": "Se salvează..."
+        },
+        "defaultDescription": "Conține {name}",
+        "description": "Gestionează alergenii pentru {productName}",
+        "empty": {
+          "noAllergens": "Niciun alergen detectat"
+        },
+        "errors": {
+          "duplicate": "Alergenul {name} este deja adăugat",
+          "emptyName": "Numele alergenului nu poate fi gol",
+          "missingData": "Datele produsului lipsesc",
+          "saveFailed": "Eroare la salvarea alergenilor"
+        },
+        "labels": {
+          "currentAllergens": "Alergeni Actuali",
+          "customAllergen": "Adaugă Alergen Personalizat",
+          "quickAdd": "Adaugă Rapid Alergeni Comuni"
+        },
+        "placeholders": {
+          "customAllergen": "Introdu numele alergenului..."
+        },
+        "success": {
+          "added": "Alergen adăugat: {name}",
+          "removed": "Alergen eliminat: {name}",
+          "saved": "Alergenii au fost actualizați cu succes"
+        },
+        "title": "Editează Alergeni"
       },
-      "habits": {
-        "avgSpend": "Cheltuială medie",
-        "favorite": "Favorit",
-        "frequency": "Frecvență",
-        "frequencyDiff": "+1 vs medie",
-        "frequencyValue": "{count}x/lună",
-        "title": "Obiceiurile tale de fast-food",
-        "visits": "{count} vizite"
+      "analyzeDialog": {
+        "analysisSteps": {
+          "analyzingWithAi": "Se analizează cu IA...",
+          "categorizingItems": "Se categorisesc articolele...",
+          "finalizingResults": "Se finalizează rezultatele...",
+          "preparingDocument": "Se pregătește documentul...",
+          "processing": "Se procesează...",
+          "runningOcrExtraction": "Se rulează extracția OCR..."
+        },
+        "analyzing": {
+          "progressComplete": "{progress}% complet",
+          "title": "Se analizează factura"
+        },
+        "badges": {
+          "recommended": "Recomandat"
+        },
+        "buttons": {
+          "analyzing": "Se analizează...",
+          "cancel": "Anulează",
+          "startAnalysis": "Pornește analiza"
+        },
+        "enhancements": {
+          "priceComparison": {
+            "description": "Compară prețurile cu date istorice",
+            "label": "Comparare prețuri"
+          },
+          "quickExtract": {
+            "description": "Prioritizează viteza în locul acurateței",
+            "label": "Mod de extragere rapidă"
+          },
+          "savingsTips": {
+            "description": "Primește recomandări de economisire cu IA",
+            "label": "Sugestii de economisire"
+          }
+        },
+        "header": {
+          "description": "Configurează o analiză cu IA pentru factura",
+          "title": "Analizează factura"
+        },
+        "options": {
+          "completeAnalysis": {
+            "description": "Analiză completă cu IA ce include toate datele facturii, articolele și informațiile comerciantului.",
+            "estimatedTime": "2-3 min",
+            "features": {
+              "itemCategorization": "Categorisirea articolelor",
+              "merchantIdentification": "Identificarea comerciantului",
+              "ocrExtraction": "Extracție OCR",
+              "priceAnalysis": "Analiza prețurilor",
+              "receiptValidation": "Validarea bonului"
+            },
+            "title": "Analiză completă"
+          },
+          "invoiceOnly": {
+            "description": "Analizează informațiile de bază ale facturii precum totaluri, date și detalii de plată.",
+            "estimatedTime": "30-60 sec",
+            "features": {
+              "dateParsing": "Interpretarea datelor",
+              "paymentMethodDetection": "Detectarea metodei de plată",
+              "totalExtraction": "Extracția totalului"
+            },
+            "title": "Doar datele facturii"
+          },
+          "itemsOnly": {
+            "description": "Se concentrează pe extragerea și categorisirea articolelor individuale din factură.",
+            "estimatedTime": "1-2 min",
+            "features": {
+              "categoryAssignment": "Atribuirea categoriilor",
+              "itemExtraction": "Extracția articolelor",
+              "pricePerItem": "Preț per articol",
+              "quantityDetection": "Detectarea cantității"
+            },
+            "title": "Analiza articolelor"
+          },
+          "merchantOnly": {
+            "description": "Identifică și analizează informațiile comerciantului, inclusiv locația și categoria.",
+            "estimatedTime": "30-45 sec",
+            "features": {
+              "businessCategory": "Categoria afacerii",
+              "contactInfo": "Informații de contact",
+              "locationExtraction": "Extracția locației",
+              "merchantIdentification": "Identificarea comerciantului"
+            },
+            "title": "Analiza comerciantului"
+          }
+        },
+        "sections": {
+          "analysisType": "Tip analiză",
+          "enhancementsOptional": "Îmbunătățiri (opțional)",
+          "includedFeatures": "Funcționalități incluse"
+        },
+        "summary": {
+          "enhancementsSelected": "+ {count} îmbunătățire(i)",
+          "estimatedTime": "Durată estimată",
+          "noEnhancementsSelected": "Nicio îmbunătățire selectată"
+        },
+        "toasts": {
+          "analysisComplete": {
+            "description": "Factura ta a fost analizată cu succes.",
+            "title": "Analiză finalizată"
+          },
+          "analysisFailed": {
+            "description": "Nu am putut analiza factura ta. Te rugăm să încerci din nou.",
+            "title": "Analiza a eșuat"
+          }
+        }
       },
-      "sodium": {
-        "high": "Ridicat",
-        "low": "Scăzut",
-        "medium": "Mediu"
+      "bulkCategoryDialog": {
+        "buttons": {
+          "cancel": "Anulează",
+          "save": "Aplică Tuturor",
+          "saving": "Se salvează..."
+        },
+        "description": "{count, plural, one {Schimbă categoria pentru # produs} other {Schimbă categoria pentru # produse}}",
+        "errors": {
+          "allFailed": "Toate produsele nu au putut fi actualizate",
+          "missingData": "Date lipsă",
+          "noProducts": "Niciun produs selectat",
+          "saveFailed": "Eroare la actualizarea categoriilor"
+        },
+        "labels": {
+          "andMore": "...și încă {count}",
+          "newCategory": "Categorie Nouă",
+          "progress": "Progres",
+          "selectedProducts": "Produse Selectate"
+        },
+        "placeholders": {
+          "selectCategory": "Selectează o categorie"
+        },
+        "progress": {
+          "updating": "Se actualizeaza {current} din {total}..."
+        },
+        "success": {
+          "partialSuccess": "{success} produse actualizate, {failed} esuate",
+          "saved": "{count, plural, one {Categoria actualizată pentru # produs} other {Categoria actualizată pentru # produse}}"
+        },
+        "title": "Schimbă Categoria"
       },
-      "swaps": {
-        "caloriesSaved": "-{count} kcal",
-        "grilled": "La grătar în loc de prăjit",
-        "moneySaved": ", economisești {amount}",
-        "salad": "Salată garnitură în loc de cartofi prăjiți",
-        "title": "Alternative mai sănătoase",
-        "water": "Apă în loc de suc"
+      "createInvoiceDialog": {
+        "batchMode": {
+          "description": "Creează 1 factură cu toate cele {count} scanări atașate. Ideal pentru chitanțe cu mai multe pagini.",
+          "title": "Combinați într-o singură factură"
+        },
+        "buttons": {
+          "cancel": "Anulare",
+          "close": "Închide",
+          "createMultiple": "Pornește analiza pentru {count} scanări",
+          "createSingle": "Pornește analiza"
+        },
+        "chooseMode": "Alegeți Modul de Creare",
+        "complete": {
+          "description": "Factura dvs. este gata pentru vizualizare și editare.",
+          "descriptionPlural": "Facturile dvs. sunt gata pentru vizualizare și editare.",
+          "errorsLabel": "Scanări Eșuate:",
+          "failureDescription": "Nu am putut crea nicio factură. Vă rugăm să revedeți erorile de mai jos și să încercați din nou.",
+          "failureTitle": "Creare Eșuată",
+          "nextSteps": "Pași următori:",
+          "nextStepsDescription": "Revizuiți factura, verificați datele extrase și faceți orice modificări necesare. Puteți solicita și analiza AI pentru informații despre cheltuieli.",
+          "nextStepsDescriptionPlural": "Revizuiți facturile, verificați datele extrase și faceți orice modificări necesare. Puteți solicita și analiza AI pentru informații despre cheltuieli.",
+          "partialDescription": "Unele scanări nu au putut fi procesate. Facturile create cu succes sunt gata pentru vizualizare.",
+          "partialTitle": "{created} din {total} Facturi Create",
+          "retryButton": "Încearcă Din Nou",
+          "title": "{count} Factură Creată!",
+          "titlePlural": "{count} Facturi Create!",
+          "viewButton": "Vizualizați Factura",
+          "viewButtonPlural": "Vizualizați Facturile"
+        },
+        "creating": {
+          "processing": "Se procesează {count} scanare...",
+          "processingPlural": "Se procesează {count} scanări...",
+          "step1Description": "Se trimit scanările către serverele noastre",
+          "step1Title": "Se încarcă scanările",
+          "step2Description": "Se configurează structurile de date ale facturilor",
+          "step2Title": "Se creează înregistrările facturilor",
+          "step3Description": "Se pregătesc facturile pentru vizualizare",
+          "step3Title": "Finalizare",
+          "title": "Se creează Factura",
+          "titlePlural": "Se creează Facturile"
+        },
+        "description": "Transformă scanările în date structurate de factură.",
+        "errors": {
+          "createFailed": "Nu s-au putut crea facturile: {message}",
+          "partialFail": "Nu s-au putut crea {count} facturi",
+          "unknown": "Eroare necunoscută"
+        },
+        "selectedScans": "Scanări Selectate",
+        "singleMode": {
+          "description": "Creează {count} facturi separate. Ideal când fiecare scanare este o chitanță diferită.",
+          "title": "O factură per scanare"
+        },
+        "singleScanInfo": {
+          "description": "AI-ul nostru va analiza scanarea dvs. și va extrage automat detaliile comerciantului, articolele, prețurile și totalurile. Puteți revizui și edita rezultatele ulterior.",
+          "title": "Ce se întâmplă în continuare?"
+        },
+        "title": "Pornește analiza AI",
+        "titlePlural": "Pornește analiza AI",
+        "totalSize": "total"
       },
-      "title": "Informații despre mese"
-    },
-    "generalExpenseCard": {
-      "aria": {
-        "changeCategory": "Change detected categorie",
-        "confirmCategory": "Confirmă că categoria detectată este corectă",
-        "export": "Exportă datele cheltuielii",
-        "organize": "Organizează această cheltuială în categorii"
+      "deleteInvoiceDialog": {
+        "buttons": {
+          "cancel": "Anulează",
+          "deletePermanently": "Șterge permanent",
+          "deleting": "Se șterge..."
+        },
+        "confirmation": {
+          "typeToConfirm": "Tastează <highlight>{name}</highlight> pentru confirmare:",
+          "understoodDescription": "Această factură și toate datele ei vor fi șterse definitiv și nu vor putea fi recuperate.",
+          "understoodLabel": "Înțeleg că această acțiune este permanentă"
+        },
+        "console": {
+          "deleteError": "Eroare ștergere factură:"
+        },
+        "deleting": {
+          "description": "Te rugăm să aștepți cât timp ștergem toate datele asociate.",
+          "title": "Ștergere factură..."
+        },
+        "description": "Această acțiune nu poate fi anulată. Te rugăm să verifici atent înainte de a continua.",
+        "impact": {
+          "intro": "Următoarele date vor fi șterse definitiv:",
+          "invoiceRecord": "Înregistrarea facturii și metadatele",
+          "lineItems": "{count} line articol(s)",
+          "sharedAccess": "Acces partajat pentru {count} utilizator(i)",
+          "title": "Ștergere permanentă",
+          "uploadedScans": "{count} scanare(i) încărcată(e)"
+        },
+        "title": "Șterge factură",
+        "toasts": {
+          "deletedDescription": "Factura a fost ștearsă cu succes.",
+          "deletedTitle": "Factură ștearsă",
+          "deleteFailedDescription": "Nu am putut șterge această factură. Te rugăm să încerci din nou.",
+          "deleteFailedTitle": "Șterge eșuat"
+        }
       },
-      "budgetCategories": {
-        "electronics": "Electronice",
-        "entertainment": "Divertisment",
-        "shopping": "Cumpărături"
+      "exportDialog": {
+        "buttons": {
+          "cancel": "Anulează",
+          "copied": "Copiat!",
+          "copy": "Copiază în Clipboard",
+          "export": "Exportă"
+        },
+        "description": "Exportă {count} facturi în formatul preferat.",
+        "estimate": {
+          "label": "Dimensiune estimată fișier:"
+        },
+        "filename": {
+          "hint": "Fișierul va fi salvat cu extensia bazată pe format",
+          "label": "Nume fișier"
+        },
+        "format": {
+          "descriptions": {
+            "csv": "Format de foaie de calcul, compatibil cu Excel",
+            "json": "Format de date structurate",
+            "pdf": "Format document imprimabil"
+          },
+          "labels": {
+            "csv": "CSV",
+            "json": "JSON",
+            "pdf": "PDF"
+          },
+          "title": "Format de export"
+        },
+        "options": {
+          "csv": {
+            "delimiterLabel": "Suprascriere delimitator CSV (opțional):",
+            "delimiterPlaceholder": ",",
+            "includeHeaders": "Include antetele CSV"
+          },
+          "includeMerchant": "Include comerciantul",
+          "includeMetadata": "Include metadatele",
+          "includeProducts": "Include produsele",
+          "json": {
+            "prettyPrint": "Afișare formatată (2 spații)"
+          },
+          "title": "Opțiuni"
+        },
+        "title": "Exportă facturi"
       },
-      "buttons": {
-        "change": "Schimbă",
-        "correct": "Corect",
-        "export": "Exportă",
-        "organize": "Organizează"
+      "feedbackDialog": {
+        "buttons": {
+          "cancel": "Anulează",
+          "submit": "Trimite feedback"
+        },
+        "commentsPlaceholder": "Împărtășește-ne părerea ta despre analize...",
+        "description": "Ajută-ne să îmbunătățim analizele pentru {merchant} împărtășindu-ne opinia ta",
+        "features": {
+          "categoryBreakdown": "Categorie Breakdown",
+          "merchantAnalysis": "Merchant Analiză",
+          "priceComparisons": "Preț Comparisons",
+          "savingsTips": "Sfaturi de economisire",
+          "spendingTrends": "Tendințe de cheltuieli",
+          "visualCharts": "Grafice vizuale"
+        },
+        "sections": {
+          "comments": "Comentarii suplimentare (opțional)",
+          "features": "Care funcționalități au fost cele mai utile? (Selectează toate opțiunile aplicabile)",
+          "rating": "Cum ai evalua analizele?"
+        },
+        "title": "Oferă feedback",
+        "toasts": {
+          "error": {
+            "description": "Te rugăm să încerci din nou mai târziu.",
+            "title": "A apărut o eroare la trimiterea feedback-ului"
+          },
+          "ratingRequired": {
+            "description": "Te rugăm să oferi un calificativ cu stele înainte de trimitere",
+            "title": "Evaluare necesară"
+          },
+          "sending": {
+            "description": "Te rugăm să aștepți cât timp trimitem feedback-ul.",
+            "title": "Se trimite feedback-ul..."
+          },
+          "success": {
+            "description": "Feedback trimis cu succes",
+            "title": "Feedback trimis!"
+          }
+        }
       },
-      "confidence": "Încredere: {value}%",
-      "detectedCategory": "Electronice / Tehnologie",
-      "nearLimitAlert": "{name}: {percent}% utilizat (10 zile rămase în lună)",
-      "options": {
-        "businessExpense": "Marchează drept cheltuială de business",
-        "insuranceInventory": "Adaugă în inventarul de asigurare",
-        "trackWarranty": "Urmărește garanția (standard 24 luni)"
+      "imageDialog": {
+        "imageAlt": "Fotografie a bonului",
+        "title": "Imagine ({image})"
       },
-      "sections": {
-        "autoDetectedCategory": "Auto-detected categorie",
-        "budgetImpact": "Impact bugetar",
-        "similarPurchases": "Achiziții similare anterioare",
-        "taxBusiness": "Opțiuni fiscale și de business"
+      "importDialog": {
+        "buttons": {
+          "cancel": "Anulează",
+          "import": "Importă",
+          "importWithCount": "Importă ({count})"
+        },
+        "description": "Încarcă fișierele de facturi pentru a le importa în sistem.",
+        "dropzone": {
+          "acceptsCsv": "Acceptă fișiere .csv (max 10MB)",
+          "acceptsPdf": "Acceptă fișiere .pdf (max 10MB)",
+          "acceptsXlsx": "Acceptă fișiere .xlsx și .xls (max. 10MB)",
+          "dragAndDrop": "Trage și plasează fișierele aici",
+          "dropHere": "Plasează fișierele aici...",
+          "orClickBrowse": "sau apasă pentru a răsfoi fișierele"
+        },
+        "remove": "Elimină",
+        "selectedFiles": "Fișiere selectate",
+        "status": {
+          "error": "A apărut o eroare la importul fișierelor. Te rugăm să încerci din nou.",
+          "success": "Fișiere importate cu succes!"
+        },
+        "tabs": {
+          "csv": "CSV",
+          "pdf": "PDF",
+          "xlsx": "Excel"
+        },
+        "title": "Importă facturi"
       },
-      "title": "Analiză cheltuieli",
-      "vatReclaimable": "TVA recuperabil"
-    },
-    "homeInventoryCard": {
-      "bulk": {
-        "description": "Detergent 5L față de 2L economisește 18% ({amount}/an)",
-        "title": "Economii la cumpărături în vrac"
+      "itemsDialog": {
+        "aria": {
+          "addItem": "Adaugă un articol nou în factură",
+          "cancel": "Anulează editarea și închide dialogul",
+          "deleteItem": "Șterge articol: {name}",
+          "nextPage": "Mergi la pagina următoare (pagina {page})",
+          "previousPage": "Mergi la pagina anterioară (pagina {page})",
+          "save": "Salvează modificările articolelor facturii",
+          "unnamedItem": "unnamed articol"
+        },
+        "buttons": {
+          "addItem": "Adaugă articol",
+          "cancel": "Anulează",
+          "next": "Următor",
+          "previous": "Anterior",
+          "saveChanges": "Salvează changes"
+        },
+        "description": "Actualizează cantitățile, prețurile sau adaugă articole noi în această factură",
+        "footer": {
+          "itemsFound": "{total} articole găsite (se afișează {shown})",
+          "itemsTotal": "{count, plural, one {# articol în total} few {# articole în total} other {# de articole în total}}",
+          "page": "Pagina {current} din {total}"
+        },
+        "table": {
+          "actions": "Acțiuni",
+          "item": "Articol",
+          "price": "Preț",
+          "quantity": "Cantitate",
+          "total": "Total general",
+          "unit": "Unitate"
+        },
+        "title": "Editează articolele facturii"
       },
-      "eco": {
-        "productsWithEcoLabels": "{count} produse cu etichete ecologice",
-        "recyclablePackaging": "{count} produs cu ambalaj reciclabil",
-        "tip": "Tip: Eco alternatives salvează 2kg plastic/year",
-        "title": "Scor ecologic"
+      "merchantDialog": {
+        "buttons": {
+          "openInMaps": "Deschide în Maps"
+        },
+        "description": "Informații despre {merchantName}",
+        "fields": {
+          "address": "Adresă",
+          "parentCompany": "Companie mamă",
+          "phone": "Telefon"
+        },
+        "noMerchantLinked": "Niciun comerciant asociat acestei facturi",
+        "title": "Detalii comerciant"
       },
-      "stockLevels": {
-        "daysRemaining": "~{count} zile",
-        "title": "Niveluri stoc consumabile (estimate)"
+      "merchantReceiptsDialog": {
+        "buttons": {
+          "next": "Următor",
+          "previous": "Anterior"
+        },
+        "dateOptions": {
+          "allTime": "Toată perioada",
+          "last30Days": "Ultimele 30 de zile",
+          "last90Days": "Ultimele 90 de zile",
+          "thisYear": "Anul acesta"
+        },
+        "description": "Vezi și filtrează toate bonurile tale de la acest comerciant",
+        "filters": {
+          "date": "Dată",
+          "sort": "Sortare"
+        },
+        "footer": {
+          "page": "Pagina {current} din {total}",
+          "receiptsFound": "{count} bonuri găsite (afișate {showing})"
+        },
+        "searchPlaceholder": "Caută receipts...",
+        "sortOptions": {
+          "newest": "Cele mai noi primele",
+          "oldest": "Cele mai vechi primele"
+        },
+        "table": {
+          "actions": "Acțiuni",
+          "date": "Dată",
+          "itemsCount": "Articole #",
+          "receipt": "Bon",
+          "view": "Vede"
+        },
+        "title": "Toate bonurile de la {merchant}"
       },
-      "supplyNames": {
-        "dishSoap": "Detergent vase",
-        "floorCleaner": "Soluție pentru podea",
-        "laundryDetergent": "Detergent rufe",
-        "paperProducts": "Produse din hârtie"
+      "metadataDialog": {
+        "add": {
+          "description": "Adaugă informații suplimentare la această factură",
+          "title": "Adaugă metadate"
+        },
+        "buttons": {
+          "cancel": "Anulează",
+          "delete": "Șterge",
+          "save": "Salvează"
+        },
+        "delete": {
+          "description": "Sigur vrei să ștergi aceste metadate?",
+          "title": "Șterge metadatele"
+        },
+        "edit": {
+          "description": "Actualizează valoarea acestui câmp de metadate",
+          "fieldLabel": "Câmp metadate",
+          "title": "Editează metadatele"
+        },
+        "fields": {
+          "keyLabel": "Cheie metadate",
+          "keyPlaceholder": "Introdu cheia",
+          "valueLabel": "Valoare metadate",
+          "valuePlaceholder": "Introdu valoarea"
+        }
       },
-      "title": "Inventar casă și consumabile"
-    },
-    "imageCard": {
-      "aria": {
-        "expandImage": "Apasă pentru a extinde imaginea"
+      "recipeDialog": {
+        "actions": {
+          "enhanceInstructions": "Îmbunătățește instrucțiunile",
+          "generateName": "Generează nume",
+          "unavailable": "Această acțiune asistată pentru rețete nu este disponibilă încă"
+        },
+        "buttons": {
+          "add": "Adaugă",
+          "cancel": "Anulează",
+          "close": "Închide",
+          "delete": "Șterge",
+          "deleting": "Se șterge...",
+          "save": "Salvează",
+          "saving": "Se salvează..."
+        },
+        "create": {
+          "description": "Completează detaliile pentru a crea o rețetă.",
+          "error": "Nu s-a putut crea rețeta",
+          "success": "Rețeta a fost creată cu succes",
+          "title": "Adaugă o rețetă nouă"
+        },
+        "delete": {
+          "description": "Această acțiune nu poate fi anulată. Va șterge definitiv rețeta <strong>{name}</strong> și toate datele asociate.",
+          "error": "Nu s-a putut șterge rețeta",
+          "missingRecipe": "Detaliile rețetei nu sunt disponibile.",
+          "success": "Rețeta a fost ștearsă cu succes",
+          "title": "Ești sigur?"
+        },
+        "difficulty": {
+          "easy": "Ușor",
+          "hard": "Greu",
+          "medium": "Mediu"
+        },
+        "fields": {
+          "complexity": "Nivel de complexitate",
+          "cookTime": "Timp de gătire",
+          "description": "Descriere",
+          "difficulty": "Nivel de dificultate",
+          "ingredients": "Ingrediente",
+          "instructions": "Instrucțiuni",
+          "prepTime": "Timp de pregătire",
+          "recipeName": "Nume rețetă",
+          "totalDuration": "Durata Totală"
+        },
+        "minutes": "minute",
+        "placeholders": {
+          "cookTime": "ex. 30 minute",
+          "description": "Introdu o descriere scurtă a rețetei",
+          "instructions": "Introdu instrucțiunile de gătire",
+          "prepTime": "ex. 15 minute",
+          "recipeName": "Introdu numele rețetei",
+          "selectDifficulty": "Selectează dificultatea"
+        },
+        "read": {
+          "description": "Detalii despre rețetă și instrucțiuni de preparare",
+          "missingRecipe": "Detaliile rețetei nu sunt disponibile.",
+          "noDescription": "Nu a fost furnizată nicio descriere.",
+          "notSpecified": "Nespecificat"
+        },
+        "share": {
+          "copied": "Linkul rețetei a fost copiat",
+          "copy": "Copiază linkul",
+          "copyFailed": "Nu s-a putut copia linkul rețetei",
+          "description": "Partajează linkul de referință al rețetei când este disponibil.",
+          "missingRecipe": "Detaliile rețetei nu sunt disponibile.",
+          "title": "Partajează rețeta",
+          "unavailable": "Partajarea rețetei nu este disponibilă încă pentru această rețetă."
+        },
+        "tooltips": {
+          "enhanceInstructions": "Folosește AI pentru a-ți îmbunătăți instrucțiunile cu mai multe detalii",
+          "generateName": "Generează un nume de rețetă pe baza ingredientelor și a nivelului de dificultate folosind AI"
+        },
+        "update": {
+          "description": "Actualizează detaliile rețetei.",
+          "error": "Nu s-a putut actualiza rețeta",
+          "missingRecipe": "Detaliile rețetei nu sunt disponibile.",
+          "success": "Rețeta a fost actualizată cu succes",
+          "title": "Actualizează rețeta"
+        }
       },
-      "buttons": {
-        "addScan": "Adaugă scan",
-        "expand": "Extinde imaginea",
-        "next": "Următor",
-        "previous": "Anterior",
-        "remove": "Elimină"
+      "removeScanDialog": {
+        "buttons": {
+          "cancel": "Anulează",
+          "remove": "Elimină scan",
+          "removing": "Se elimină..."
+        },
+        "console": {
+          "deleteError": "Eroare ștergere scan:"
+        },
+        "description": "Sigur vrei să elimini scanarea {current} din {total}?",
+        "descriptionLastScan": "Aceasta este singura scanare atașată la această factură. Nu o poți elimina.",
+        "errors": {
+          "unknown": "A apărut o eroare necunoscută"
+        },
+        "scanAlt": "Scanare {index}",
+        "scanCaption": "Scanare {index}",
+        "title": "Elimină scan",
+        "toasts": {
+          "cannotDeleteLastDescription": "O factură trebuie să aibă cel puțin o scanare atașată",
+          "cannotDeleteLastTitle": "Nu poți șterge ultima scanare",
+          "removedDescription": "Scanarea a fost eliminată din factură",
+          "removedTitle": "Scan eliminat cu succes",
+          "removeFailedTitle": "Eliminarea scanării a eșuat"
+        },
+        "warning": {
+          "description": "Fiecare factură trebuie să aibă cel puțin o scanare atașată. Adaugă o altă scanare înainte să o elimini pe aceasta.",
+          "title": "Nu poți elimina ultima scanare"
+        }
       },
-      "dialogTitle": "Imagine bon",
-      "dialogTitleWithIndex": "Imagine bon ({current}/{total})",
-      "scanAlt": "Scanare bon {index}",
-      "scanAltFullSize": "Scanare bon {index} - dimensiune completă",
-      "title": "Scanare bon",
-      "titleWithIndex": "Scanare bon ({current}/{total})",
-      "tooltips": {
-        "addScan": "Încarcă și atașează o scanare nouă a bonului",
-        "expand": "Vezi imaginea bonului la dimensiune completă",
-        "next": "Vezi următoarea scanare a bonului",
-        "previous": "Vezi scanarea anterioară a bonului",
-        "remove": "Elimină scanarea curentă a bonului"
+      "shareAnalyticsDialog": {
+        "description": "Partajează analizele tale de cheltuieli pentru {merchant} cu alte persoane.",
+        "email": {
+          "description": "Trimite analizele la o adresă de email.",
+          "label": "Adresă email",
+          "placeholder": "name@example.com",
+          "send": "Trimite email"
+        },
+        "image": {
+          "copyToClipboard": "Copiază graficul în clipboard",
+          "description": "Descarcă sau copiază graficul de analiză ca imagine PNG, pe care o poți partaja sau salva.",
+          "download": "Descarcă graficul",
+          "previewPlaceholder": "Previzualizare analize"
+        },
+        "tabs": {
+          "email": "email",
+          "image": "Imagine"
+        },
+        "title": "Partajează Analytics",
+        "toasts": {
+          "emailSent": {
+            "description": "Raportul de analiză a fost trimis la {email}",
+            "title": "Email trimis!"
+          },
+          "imageCopied": {
+            "description": "Imaginea analizelor a fost copiată în clipboard",
+            "title": "Imagine copiată!"
+          },
+          "imageSaved": {
+            "description": "Analizele de cheltuieli pentru {merchant} au fost descărcate ca PNG",
+            "title": "Imagine salvată!"
+          }
+        }
+      },
+      "shareInvoiceDialog": {
+        "dialogDescription": {
+          "currentlyPublic": "\"{invoiceName}\" este publică în acest moment",
+          "private": "Trimite \"{invoiceName}\" în privat",
+          "public": "Partajează \"{invoiceName}\" public",
+          "selection": "Alege cum să partajezi „{invoiceName}”"
+        },
+        "errors": {
+          "qrNotFound": "Elementul codului QR nu a fost găsit"
+        },
+        "selection": {
+          "description": "Alege cum vrei să partajezi această factură. Opțiunea aleasă influențează cine poate avea acces.",
+          "privacyNoticeDescription": "Linkurile publice pot fi accesate de oricine are URL-ul. Partajarea privată limitează accesul la destinatarul specificat.",
+          "privacyNoticeTitle": "Notă de confidențialitate",
+          "privateDescription": "Trimite o invitație pe email unei <strong>persoane specifice</strong>. Doar acea persoană va avea acces.",
+          "privateTitle": "Privat sharing",
+          "publicDescription": "Generează un link sau un cod QR pe care <strong>oricine</strong> îl poate folosi pentru a vedea această factură.",
+          "publicTitle": "Partajare publică"
+        },
+        "title": "Partajează factură",
+        "toasts": {
+          "copyLink": {
+            "error": "Eșuat: {message}",
+            "loadingMakePublic": "Factura devine publică...",
+            "loadingPublic": "Se copiază linkul...",
+            "successMadePublic": "Factura este acum publică! Link copiat în clipboard.",
+            "successPublic": "Link copiat în clipboard!"
+          },
+          "copyQr": {
+            "error": "Eșuat: {message}",
+            "loadingMakePublic": "Factura devine publică...",
+            "loadingPublic": "Se copiază codul QR...",
+            "successMadePublic": "Factura este acum publică! Cod QR copiat în clipboard.",
+            "successPublic": "Cod QR copiat în clipboard!"
+          },
+          "revoke": {
+            "error": "Revocarea accesului a eșuat: {message}",
+            "loading": "Se trimite cererea de revocare către server...",
+            "success": "Factura este acum privată. Linkurile existente nu vor mai funcționa."
+          },
+          "sendEmail": {
+            "comingSoon": "Partajarea prin email va fi disponibilă în curând",
+            "error": "Eșuat: {message}",
+            "loading": "Se trimite invitația către {email}...",
+            "success": "Invitație trimisă către {email}!"
+          }
+        }
+      },
+      "shareInvoiceDialogPrivate": {
+        "backToOptions": "Înapoi la opțiuni",
+        "comingSoonTooltip": "Funcția de partajare prin email va fi disponibilă în curând",
+        "description": "Invitația va fi trimisă direct la adresa de email pe care o specifici. Doar acest destinatar va primi acces pentru a vedea factura.",
+        "emailHint": "O invitație pe email va fi trimisă la această adresă cu un link privat pentru a vedea factura.",
+        "emailLabel": "Adresa de email a destinatarului",
+        "emailPlaceholder": "name@example.com",
+        "sending": "Se trimite invitația...",
+        "sendInvitation": "Trimite invitație privată",
+        "title": "Privat sharing"
+      },
+      "shareInvoiceDialogPublic": {
+        "alreadyPublic": {
+          "description": "Această factură este accesibilă public. <strong>Oricine are linkul o poate vedea</strong>, inclusiv toate detaliile facturii, articolele și sumele. Poți revoca accesul public oricând pentru a o face din nou privată.",
+          "revoke": "Revocă accesul public",
+          "revokeHint": "Factura va deveni privată. Linkurile existente nu vor mai funcționa.",
+          "revoking": "Se revocă accesul...",
+          "title": "Această factură este publică în acest moment"
+        },
+        "backToOptions": "Înapoi la opțiuni",
+        "copyQrImage": "Copiază codul QR ca imagine",
+        "hints": {
+          "link": "Copiază acest link și partajează-l. Oricine îl primește va putea vedea factura.",
+          "qr": "Oricine scanează acest cod QR va fi redirecționat pentru a vedea factura."
+        },
+        "tabs": {
+          "directLink": "Link direct",
+          "qrCode": "Cod QR"
+        },
+        "warning": {
+          "description": "Prin partajarea publică a acestei facturi, <strong>oricine are linkul o va putea vedea</strong>. Asta include toate detaliile facturii, articolele și sumele. Continuă doar dacă vrei ca această factură să fie accesibilă publicului.",
+          "title": "Avertisment privind accesul public"
+        }
+      }
+    }
+  },
+  "emails": {
+    "accountInactivity": {
+      "badge": "Cont",
+      "cta": {
+        "primary": "Autentifică-te",
+        "secondary": "Contactează asistența"
+      },
+      "footnote": "Notă: Această notificare este informativă și are scopul de a te ajuta să eviți pierderea accesului. Politicile reale de retenție a conturilor pot varia în funcție de regiune și produs.",
+      "greeting": "Bună {name},",
+      "heading": "Notificare de inactivitate a contului",
+      "intro": "Acesta este un atenționare că contul tău a fost inactiv de <count>{inactiveDays}</count> zile.",
+      "preview": "Bună {name} — contul tău a fost inactiv de {inactiveDays} zile.",
+      "signOff": {
+        "line1": "Cu respect,",
+        "line2": "Echipa {brand}"
+      },
+      "subject": "Ne lipsești la {brand}",
+      "supportPrompt": "Dacă crezi că ai primit acest mesaj din greșeală sau ai nevoie de asistență, te rugăm să contactezi <link>{supportEmail}</link>.",
+      "timeline": {
+        "daysValue": "{days} zile",
+        "inactiveFor": "Inactiv de",
+        "timeRemaining": "Timp rămas",
+        "title": "Cronologie"
+      },
+      "whatThisMeans": {
+        "bullet1": "Autentificarea va menține contul tău activ.",
+        "bullet2": "Dacă nu există activitate în următoarele {daysUntilClosure} zile, contul poate fi programat pentru închidere.",
+        "bullet3": "Dacă dorești să îți păstrezi datele, te rugăm să acționezi înainte de termen.",
+        "title": "Ce înseamnă asta"
       }
     },
-    "invoiceCard": {
-      "descriptionPlaceholder": "Introdu descrierea facturii...",
-      "fromMerchant": "De la {merchant}",
-      "importantBadge": "IMPORTANT",
-      "labels": {
-        "category": "Categorie",
-        "dateUtc": "Dată (UTC)",
-        "hours": "Ore",
-        "minutes": "Minute",
-        "paymentMethod": "Metodă de plată",
-        "totalAmount": "Sumă totală",
-        "utc": "UTC"
+    "firstInvoiceUploaded": {
+      "badge": "Milestone",
+      "body": "Cu cât încarci mai multe facturi, cu atât informațiile despre cheltuieli devin mai bogate. Încearcă să încarci câteva chitanțe în această săptămână pentru a vedea tabloul tău de bord prinde viață.",
+      "ctaPrimary": "Vezi factura ta",
+      "ctaSecondary": "Încarcă altă chitanță",
+      "featuresToExplore": {
+        "item0": "Partajează facturi cu familia sau colegii pentru urmărirea cheltuielilor comune",
+        "item1": "Vezi sugestii de rețete generate de AI din articolele tale de cumpărături",
+        "item2": "Verifică avertismente despre alergeni pentru produsele alimentare detectate",
+        "item3": "Urmărește tiparele de cheltuieli pe comercianți, categorii și perioade de timp"
       },
-      "markImportant": "Marchează ca important",
-      "placeholders": {
-        "selectCategory": "Selectează categorie",
-        "selectPaymentType": "Selectează tipul de plată"
+      "featuresToExploreTitle": "Funcții de explorat",
+      "feedbackPrompt": "Ai nevoie de ajutor sau ai feedback? Contactează-ne la <email></email>.",
+      "greeting": "Salut {name},",
+      "heading": "Prima ta factură a fost încărcată!",
+      "intro": "Felicitări pentru încărcarea primei tale facturi! Ai făcut primul pas către urmărirea organizată și perspicace a cheltuielilor. Iată ce avem până acum:",
+      "invoiceSummary": {
+        "invoiceName": "Nume factură",
+        "status": "Status",
+        "uploaded": "Încărcat"
       },
-      "title": "Detalii factură",
-      "tooltips": {
-        "markFavorite": "Apasă pentru a marca drept favorit",
-        "unmarkFavorite": "Apasă pentru a scoate din favorite"
-      }
+      "invoiceSummaryTitle": "Prima Ta Factură",
+      "preview": "Felicitări, {name}! Prima ta factură a fost încărcată.",
+      "signOff": {
+        "line1": "Cu drag",
+        "line2": "Echipa {brand}"
+      },
+      "statusValue": "Gata pentru analiză",
+      "subject": "Prima ta factură a sosit!",
+      "untitledFallback": "Fără titlu",
+      "whatHappensNext": {
+        "item0": "Analizăm chitanța ta — AI-ul nostru extrage articole, prețuri și informații despre comerciant",
+        "item1": "Revizuiești rezultatele — verifică analiza și corectează orice pare greșit",
+        "item2": "Tabloul tău de bord se actualizează — grafice de cheltuieli, defalcări pe categorii și tendințe încep să se construiască"
+      },
+      "whatHappensNextTitle": "Ce urmează"
     },
-    "invoiceDetailsCard": {
-      "itemsTitle": "Articole ({count})",
-      "labels": {
-        "category": "Categorie",
-        "countryRegion": "Țară/Regiune",
-        "dateUtc": "Dată (UTC)",
-        "payment": "Plată",
-        "receiptType": "Tip bon",
-        "ronEquivalent": "Echivalent RON",
-        "subtotal": "Subtotal",
-        "tip": "Bacșiș",
+    "incompleteInvoice": {
+      "analyzedOnLabel": "Analizată la",
+      "badge": "Memento",
+      "bodyText": "Completarea acestor detalii durează mai puțin de un minut și asigură acuratețea rapoartelor tale de cheltuieli.",
+      "feedback": "Întâmpini probleme sau ai nevoie de ajutor? Scrie-ne la <link>{supportEmail}</link>.",
+      "greeting": "Bună, {name}!",
+      "heading": "Factura ta necesită o actualizare rapidă",
+      "intro": "Am analizat factura ta {invoiceName}, dar nu am putut extrage totul. Câteva detalii lipsesc, iar completarea lor îți va oferi o perspectivă mai bună asupra cheltuielilor și rapoarte mai precise.",
+      "invoiceDetailsTitle": "Detalii factură",
+      "invoiceLabel": "Factură",
+      "missingFields": {
+        "category": {
+          "label": "Categorie factură",
+          "suggestion": "Selectează o categorie (produse alimentare, fast food, gospodărie, etc.)"
+        },
+        "items": {
+          "label": "Articole pe rânduri",
+          "suggestion": "Încearcă să reîncarci o fotografie mai clară sau adaugă articolele manual"
+        },
+        "merchant": {
+          "label": "Comerciant",
+          "suggestion": "Adaugă manual numele magazinului în vizualizarea de editare"
+        },
+        "payment": {
+          "label": "Informații de plată",
+          "suggestion": "Introdu suma totală și metoda de plată în vizualizarea de editare"
+        },
+        "unknown": {
+          "label": "{field}",
+          "suggestion": "Te rugăm să revizuiești și să actualizezi aceste informații"
+        }
+      },
+      "missingFieldsLabel": "Câmpuri lipsă",
+      "preview": "{name}, factura ta \"{invoiceName}\" necesită atenție.",
+      "primaryCta": "Completează factura",
+      "secondaryCta": "Reanalizeză",
+      "signOff": {
+        "line1": "Cu stimă,",
+        "line2": "Echipa {brand}"
+      },
+      "subject": "Ai facturi incomplete",
+      "tips": {
+        "item0": "Folosește o suprafață bine iluminată și plată când fotografiezi bonuri",
+        "item1": "Asigură-te că întregul bon este vizibil și în focus",
+        "item2": "Bonurile PDF de la comenzile online tind să fie analizate cel mai bine",
+        "item3": "Poți întotdeauna să adaugi sau să corectezi detaliile manual după analiză"
+      },
+      "tipsTitle": "Sfaturi pentru o analiză mai bună",
+      "whatsMissingTitle": "Ce lipsește"
+    },
+    "invoiceAnalyzed": {
+      "badge": "Facturi • Analiză Completă",
+      "body": "Apasă butonul de mai sus pentru a vizualiza analiza completă. Dacă ceva nu arată bine—poate un produs a fost categorizat greșit sau un preț nu a fost detectat corect—poți edita factura direct în tabloul tău de bord și perspectivele se vor actualiza automat.",
+      "ctaPrimary": "Vizualizează analiza completă",
+      "feedbackPrompt": "Ai întrebări despre analiză sau ai nevoie de ajutor? Contactează-ne la <email></email>.",
+      "greeting": "Bună {name},",
+      "heading": "Analiza facturii tale este gata",
+      "intro": "Vești bune! AI-ul nostru a terminat de analizat factura ta. Am extras toate informațiile cheie, am categorisit articolele și am generat perspective asupra cheltuielilor pentru a te ajuta să îți urmărești finanțele.",
+      "preview": "Factura ta este gata, {name}. Analiză completă!",
+      "signOff": {
+        "line1": "Cu stimă,",
+        "line2": "Echipa {brand}"
+      },
+      "subject": "Factura ta a fost analizată",
+      "summary": {
+        "invoiceName": "Nume factură",
+        "itemsDetected": "Articole detectate",
+        "merchantId": "ID Comerciant",
+        "notIdentified": "Neidentificat încă",
         "totalAmount": "Suma totală"
       },
-      "pagination": {
-        "next": "Următor",
-        "pageOf": "Pagina {current} din {total}",
-        "previous": "Anterior"
+      "summaryTitle": "Rezumat factură",
+      "whatWasAnalyzed": {
+        "item0": "Identificarea și categorizarea comerciantului",
+        "item1": "Extragerea linie cu linie a articolelor cu prețuri",
+        "item2": "Categorizare automată a produselor (produse alimentare, băuturi, articole casnice etc.)",
+        "item3": "Detectarea monedei și validarea sumei",
+        "item4": "Extragerea datei și orei când este disponibilă"
       },
-      "sections": {
-        "paymentMethods": "Metode de plată",
-        "taxBreakdown": "Detalii taxe"
-      },
-      "table": {
-        "grandTotal": "Total general",
-        "item": "Articol",
-        "price": "Preț",
-        "qty": "Cant.",
-        "total": "Total general",
-        "unit": "Unitate"
-      },
-      "taxLabels": {
-        "net": "Net",
-        "tax": "Taxă"
-      },
-      "title": "Detalii factură",
-      "tooltips": {
-        "exchangeRate": "1 {fromCurrency} = {rate} RON (medie {year})"
-      }
+      "whatWasAnalyzedTitle": "Ce a fost analizat"
     },
-    "merchantCard": {
-      "addressLabel": "Adresă: {address}",
-      "buttons": {
-        "viewAllReceipts": "Vezi toate bonurile",
-        "viewMerchantDetails": "Vezi detalii comerciant"
-      },
-      "noMerchantLinked": "Niciun comerciant asociat acestei facturi",
-      "title": "Comerciant",
-      "tooltips": {
-        "viewAllReceipts": "Vezi toate bonurile de la acest comerciant",
-        "viewMerchantDetails": "Vezi informații detaliate despre acest comerciant"
-      }
-    },
-    "merchantInfoCard": {
-      "categoryDistribution": "Distribuție categorii",
-      "noMerchantLinked": "Niciun comerciant asociat acestei facturi",
-      "spendingHistory": "Istoric cheltuieli",
-      "stats": {
-        "avgSpend": "Cheltuială medie",
-        "daysAgo": "zile în urmă",
-        "visits": "vizite"
-      },
-      "title": "Informații comerciant",
-      "viewAllInvoices": "Vezi toate facturile",
-      "viewAllReceipts": "Vezi toate bonurile",
-      "viewOnMap": "Vezi pe hartă"
-    },
-    "nutritionCard": {
-      "allergens": {
-        "foundInItems": "Găsit în {count} articol(e)",
-        "title": "Alergeni detectați"
-      },
-      "composition": {
-        "dairyOther": "Lactate/Altele",
-        "processed": "Procesate",
-        "title": "Compoziția coșului tău",
-        "wholeFoods": "Alimente integrale"
-      },
-      "foodGroups": {
-        "fruits": "Fructe",
-        "grains": "Cereale",
-        "itemsCount": "{count} articol(s)",
-        "protein": "Proteine",
-        "vegetables": "Legume"
-      },
-      "score": {
-        "excellent": "Excelent",
-        "fair": "Acceptabil",
-        "good": "Bun",
-        "needsWork": "Necesită îmbunătățiri",
-        "title": "Scor echilibru alimentar"
-      },
-      "suggestions": {
-        "addFruits": "Adăugarea unor fructe ar îmbunătăți echilibrul nutrițional",
-        "addFruitsAndVegetables": "Adaugă mai multe fructe și legume pentru a-ți echilibra coșul",
-        "addVegetables": "Ia în calcul adăugarea de legume pentru o alimentație mai echilibrată",
-        "greatBalance": "Cumpărături foarte bine echilibrate!",
-        "swapProcessed": "Încearcă să înlocuiești unele produse procesate cu alimente integrale"
-      },
-      "title": "Privire generală nutriție"
-    },
-    "receiptScanCard": {
-      "buttons": {
-        "expand": "Extinde imaginea",
-        "nextScan": "Scanarea următoare",
-        "previousScan": "Scanarea anterioară"
-      },
-      "controls": {
-        "download": "Descarcă",
-        "fullScreen": "Ecran complet",
-        "reset": "Resetează zoom",
-        "rotate": "Rotește",
-        "toggleZoom": "Clic pentru a comuta zoom-ul",
-        "zoomIn": "Mărește",
-        "zoomOut": "Micșorează"
-      },
-      "dialogTitle": "Imagine bon",
-      "dialogTitleWithIndex": "Imagine bon ({current}/{total})",
-      "navigation": {
-        "next": "Următor",
-        "of": "din",
-        "previous": "Anterior"
-      },
-      "scanAlt": "Scanare bon {index}",
-      "scanAltFullSize": "Scanare bon {index} - dimensiune completă",
-      "title": "Scanare bon",
-      "titleWithIndex": "Scanare bon ({current}/{total})",
-      "tooltips": {
-        "expand": "Vezi imaginea bonului la dimensiune completă",
-        "nextScan": "Vezi următoarea scanare a bonului",
-        "previousScan": "Vezi scanarea anterioară a bonului"
-      }
-    },
-    "recipeCard": {
-      "buttons": {
-        "viewRecipe": "Vezi rețeta",
-        "visitReference": "Vizitează referința"
-      },
-      "complexity": {
-        "easy": "Ușor",
-        "hard": "Greu",
-        "normal": "Normal",
-        "unknown": "Necunoscut"
-      },
-      "dropdown": {
-        "delete": "Șterge",
-        "edit": "Editează",
-        "markAsFavorite": "Marchează ca favorit",
-        "share": "Distribuie",
-        "view": "Vezi"
-      },
-      "ingredients": {
-        "additionalLabel": "Ingrediente suplimentare:",
-        "label": "Ingrediente:",
-        "more": "+{count} în plus"
-      },
-      "timing": {
-        "cookLabel": "Gătire: {minutes}′",
-        "cookTooltip": "Timpul de gătire este de {minutes} minute.",
-        "prepLabel": "Pregătire: {minutes}′",
-        "prepTooltip": "Timpul de pregătire este de {minutes} minute."
-      }
-    },
-    "seasonalInsightsCard": {
-      "insights": {
-        "holidaySeason": {
-          "description": "Cheltuielile din decembrie sunt de obicei cu 35% mai mari",
-          "title": "Sezonul sărbătorilor"
-        },
-        "insufficientData": {
-          "description": "Adaugă mai multe facturi pentru a vedea informații sezoniere și modele de cheltuieli",
-          "title": "Construim profilul tău de cheltuieli"
-        },
-        "normalPattern": {
-          "description": "Cheltuielile tale sunt în intervalul obișnuit",
-          "title": "Model normal de cumpărături"
-        },
-        "spike": {
-          "description": "+{percent}% vs media ta",
-          "title": "Creștere {category}"
-        },
-        "stockUpTip": {
-          "description": "Prețurile cresc cu ~15% după 15 decembrie",
-          "title": "Sfat de aprovizionare"
-        }
-      },
-      "month": {
-        "spendingSoFar": "{month} până acum",
-        "vsAverage": "vs media pe {month}: {amount}"
-      },
-      "title": "Insight sezonier"
-    },
-    "sharingCard": {
-      "buttons": {
-        "manageSharing": "Gestionează Partajare",
-        "markAsPrivate": "Marchează ca privată",
-        "revokingAccess": "Se revocă accesul...",
-        "shareInvoice": "Partajează Factură"
-      },
-      "emptyShared": {
-        "private": "Nu este partajată",
-        "public": "Niciun utilizator suplimentar nu are acces direct"
-      },
-      "owner": "Proprietar",
-      "ownerAvatarAlt": "Utilizator",
-      "publicInvoice": {
-        "description": "Această factură este accesibilă public. Oricine are linkul o poate vedea.",
-        "title": "Factură publică"
-      },
-      "sharedWith": "Partajată cu",
-      "title": "Partajare",
-      "toasts": {
-        "removeAccessComingSoon": {
-          "description": "Această funcționalitate este în curs de dezvoltare.",
-          "title": "Funcția de eliminare a accesului va fi disponibilă în curând"
-        },
-        "revoke": {
-          "error": "Marcarea ca privată a eșuat: {message}",
-          "loading": "Se revocă accesul public...",
-          "success": "Factura este acum privată. Linkurile existente nu vor mai funcționa."
-        }
-      },
-      "tooltips": {
-        "manageSharing": "Gestionează setările de partajare pentru această factură",
-        "markAsPrivate": "Marchează factura ca privată",
-        "removeAccess": "Elimină accesul",
-        "shareInvoice": "Partajează această factură cu alți utilizatori"
-      },
-      "userWithId": "Utilizator {id}"
-    },
-    "shoppingCalendarCard": {
-      "insights": {
-        "days": "{count} zile",
-        "mostActiveOn": "Cel mai activ în",
-        "onAverage": "în medie",
-        "perTrip": " per cumpărătură",
-        "shopEveryPrefix": "Faci cumpărături la fiecare",
-        "spendingPrefix": ", cheltuind",
-        "weekdayLabel": "{weekday}"
-      },
-      "legend": {
-        "less": "Mai puțin",
-        "more": "Mai mult"
-      },
-      "stats": {
-        "monthTotal": "Total lună",
-        "shoppingDays": "Zile de cumpărături"
-      },
-      "title": "Calendar cumpărături",
-      "tooltip": {
-        "basedOnCachedInvoices": "Bazat pe {count} facturi din cache",
-        "currentInvoice": "Factura curentă",
-        "currentInvoiceOnly": "Se afișează doar factura curentă",
-        "invoiceCount": "{count} factură(s)",
-        "more": "+{count} în plus",
-        "vsAverage": "vs medie ({years} ani de date)"
-      }
-    },
-    "summaryStatsCard": {
-      "description": "Statistici cheie dintr-o privire",
-      "extremes": {
-        "highest": "Cel mai mare",
-        "lowest": "Cel mai mic"
-      },
-      "stats": {
-        "averagePrice": {
-          "description": "{currency} per articol",
-          "label": "Preț mediu"
-        },
-        "categories": {
-          "description": "Categorii unice",
-          "label": "Categorii"
-        },
-        "taxRate": {
-          "description": "{amount} {currency}",
-          "label": "Rată taxă"
-        },
-        "totalItems": {
-          "description": "Produse cumpărate",
-          "label": "Total articole"
-        }
-      },
-      "title": "Rezumat factură"
-    },
-    "vehicleCard": {
-      "buttons": {
-        "addVehicle": "Adaugă Vehicul",
-        "fullReport": "Raport complet"
-      },
-      "chart": {
-        "amount": "Sumă",
-        "title": "Cheltuieli lunare cu combustibilul"
-      },
+    "invoiceDeleted": {
+      "badge": "Facturi • Șters",
+      "body": "Dacă nu ai inițiat această ștergere sau dacă trebuie să recuperezi factura, te rugăm să ne contactezi imediat la <email></email>. Suntem aici să te ajutăm.",
+      "ctaPrimary": "Vezi facturile tale",
       "details": {
-        "liters": "Litri",
-        "notSet": "Nesetat",
-        "pricePerLiter": "Preț/L",
-        "station": "Stație",
-        "vehicle": "Vehicul"
+        "invoice": "Factură",
+        "invoiceId": "ID factură",
+        "status": "Status"
       },
-      "expenseType": "Tip cheltuială: Combustibil",
-      "maintenance": {
-        "title": "Mementouri întreținere"
+      "detailsTitle": "Detalii ștergere",
+      "greeting": "Salut {name},",
+      "heading": "Factură eliminată din contul tău",
+      "intro": "Acest email confirmă că o factură a fost eliminată din contul tău {brand}. Ștergerea a fost procesată cu succes.",
+      "placeholder": "—",
+      "preview": "Factura {invoiceLabel} a fost eliminată din contul tău.",
+      "signOff": {
+        "line1": "Cu drag,",
+        "line2": "Echipa {brand}"
       },
-      "months": {
-        "dec": "dec.",
-        "nov": "nov.",
-        "oct": "oct.",
-        "sep": "sept."
+      "statusValue": "Șters (ștergere soft)",
+      "subject": "Factura ta a fost ștearsă",
+      "whatYouShouldKnow": {
+        "item0": "Aceasta este o ștergere soft—datele facturii pot fi păstrate timp de 30 de zile pentru recuperare.",
+        "item1": "Orice acces partajat la această factură a fost revocat automat.",
+        "item2": "Statisticile și informațiile vor fi recalculate pentru a exclude această factură.",
+        "item3": "Dacă trebuie să recuperezi această factură, contactează suportul în 30 de zile."
       },
-      "reminders": {
-        "oilChange": "Schimb de ulei în ~1.200 km",
-        "tireRotation": "Se recomandă rotația anvelopelor"
+      "whatYouShouldKnowTitle": "Ce trebuie să știi"
+    },
+    "invoiceInactivity": {
+      "badge": {
+        "item14": "Inactivitate • 14 zile",
+        "item3": "Inactivitate • 3 zile",
+        "item30": "Inactivitate • 30 zile",
+        "item7": "Inactivitate • 7 zile"
       },
-      "stats": {
-        "costPerKm": "Cost pe km",
-        "estimated": "estimat",
-        "fillUps": "{count} alimentări",
-        "fuelPrice": "Fuel Preț",
-        "thisMonth": "Luna aceasta",
-        "thisMonthSuffix": "luna aceasta"
+      "cta": {
+        "primary": "Încarcă o factură",
+        "secondary": "Vezi facturile"
       },
+      "greeting": "Bună {name},",
+      "heading": {
+        "item14": "Hai să te aducem înapoi pe drumul cel bun",
+        "item3": "Verificare rapidă",
+        "item30": "A trecut ceva timp",
+        "item7": "O reamintire blândă"
+      },
+      "helpPrompt": "Ai nevoie de ajutor sau ai întrebări? Email <link>{supportEmail}</link>.",
+      "important": {
+        "message": "Dacă ești blocat sau ceva nu funcționează, răspunde la acest email sau contactează suportul — te vom ajuta.",
+        "title": "Important"
+      },
+      "intro": {
+        "item14": "Două săptămâni fără încărcări — vrei o îmboldire rapidă pentru a relua obiceiul?",
+        "item3": "Am observat că nu ai încărcat nicio factură recent.",
+        "item30": "A trecut aproximativ o lună de la ultima încărcare — te putem ajuta să reia de unde ai rămas.",
+        "item7": "Se pare că a trecut o săptămână de la ultima ta încărcare de factură."
+      },
+      "preview": "Bună {name} — {days} zile de la ultima încărcare.",
+      "signOff": {
+        "line1": "Cu stimă",
+        "line2": "Echipa {brand}"
+      },
+      "status": {
+        "daysWithoutUpload": "Zile fără încărcare",
+        "lastUpload": "Ultima încărcare",
+        "title": "Stare"
+      },
+      "subject": "Au trecut {daysWithoutUpload} de zile de la ultima ta factură",
       "tip": {
-        "perLiter": "L",
-        "title": "Cel mai ieftin în apropiere"
+        "message": "Încarcă o factură recentă astăzi — consistența mică bate recuperarea mare.",
+        "title": "Sfat (30 secunde)"
       },
-      "title": "Analiza cheltuielilor vehiculului"
+      "whyWorthIt": {
+        "bullet1": "Păstrează cronologia cheltuielilor tale exactă.",
+        "bullet2": "Obține totaluri mai clare pe comerciant și categorie.",
+        "bullet3": "Găsește chitanțe mai repede când ai nevoie.",
+        "title": "De ce merită"
+      }
+    },
+    "invoiceMadePublic": {
+      "accessValue": "Public (oricine cu linkul)",
+      "badge": "Facturi • Link Public",
+      "ctaPrimary": "Deschide factura publică",
+      "details": {
+        "access": "Acces",
+        "created": "Creat",
+        "invoiceId": "ID factură",
+        "invoiceName": "Nume factură",
+        "merchant": "Comerciant",
+        "total": "Total"
+      },
+      "detailsTitle": "Detalii factură",
+      "directLinkLabel": "Link direct:",
+      "feedbackPrompt": "Întrebări despre partajare sau setări de confidențialitate? Contactează-ne la <email></email>.",
+      "greeting": "Salut {name},",
+      "heading": "Factura ta este acum publică",
+      "howToShare": {
+        "item0": "Copiază linkul direct de mai jos și trimite prin email sau mesaj",
+        "item1": "Printează sau fă screenshot codului QR pentru partajare în persoană",
+        "item2": "Include în rapoarte de cheltuieli sau cereri de rambursare"
+      },
+      "howToShareTitle": "Cum să partajezi",
+      "intro": "Ai făcut cu succes factura publică. Oricine are linkul sau codul QR de mai jos poate vedea această factură—fără autentificare. Acest lucru este perfect pentru partajarea chitanțelor cu colegi, contabili sau pentru rapoarte de cheltuieli.",
+      "preview": "Factura ta \"{invoiceName}\" este acum publică și partajabilă.",
+      "privacyNoticeBody": "Facturile publice pot fi accesate de oricine are URL-ul sau codul QR. Pentru a face această factură privată din nou, actualizează setările de partajare din pagina facturii în orice moment.",
+      "privacyNoticeTitle": "Notificare Confidențialitate",
+      "qrAlt": "Cod QR pentru acces factură",
+      "qrSubText": "Scanează cu camera telefonului pentru acces instant.",
+      "qrTitle": "Cod QR Acces Rapid",
+      "signOff": {
+        "line1": "Cu drag,",
+        "line2": "Echipa {brand}"
+      },
+      "subject": "Factura ta este acum publică"
+    },
+    "invoiceShared": {
+      "badge": "Facturi • Distribuite",
+      "body": "Apasă butonul de mai sus pentru a accesa factura distribuită. Acest link va rămâne activ atât timp cât permisiunile de distribuire sunt în vigoare.",
+      "ctaPrimary": "Vizualizează factura distribuită",
+      "details": {
+        "invoiceId": "ID Factură",
+        "sharedBy": "Distribuit de"
+      },
+      "detailsTitle": "Detalii distribuire",
+      "feedbackPrompt": "Ai întrebări despre această distribuire sau ai nevoie de ajutor? Contactează-ne la <email></email>.",
+      "greeting": "Bună {toName},",
+      "heading": "O factură a fost distribuită cu tine",
+      "intro": "Vești bune! <from></from> a distribuit o factură cu tine pe {brand}. Aceasta îți oferă acces pentru a vizualiza toate detaliile facturii, inclusiv produsele detaliate, informațiile despre comerciant și analizele.",
+      "preview": "{fromName} a distribuit o factură cu tine.",
+      "signOff": {
+        "line1": "Cu stimă,",
+        "line2": "Echipa {brand}"
+      },
+      "subject": "{fromName} a distribuit o factură cu tine",
+      "whatYouCanDo": {
+        "item0": "Vizualizează detaliile complete ale facturii și descompunerea pe articole",
+        "item1": "Vezi analizele și categoriile de cheltuieli",
+        "item2": "Descarcă sau printează factura pentru evidențele tale"
+      },
+      "whatYouCanDoTitle": "Ce poți face"
+    },
+    "invoiceStats": {
+      "badge": "Facturi",
+      "body": "Pentru o detaliere completă a cheltuielilor tale, vizitează lista de facturi pentru a analiza trendurile, comercianții, categoriile și totalurile în timp. Aceste statistici te pot ajuta să identifici modele de cheltuire și să iei decizii financiare mai informate.",
+      "breakdownCardTitle": "Detaliere cheltuieli (pe categorie)",
+      "breakdownNote": "Notă: Acest grafic folosește datele de clasare pe categorii disponibile pentru perioadă.",
+      "breakdownTableTitle": "Detaliere",
+      "ctaPrimary": "Vezi facturile",
+      "ctaSecondary": "Încarcă o factură nouă",
+      "donutChartAlt": "Grafic inelar arătând distribuția cheltuielilor pe categorii.",
+      "donutChartTitle": "Distribuția cheltuielilor pe categorii",
+      "feedbackPrompt": "Întrebări sau ceva nu pare corect? Scrie-ne la <email></email>.",
+      "frequencyLabel": "{frequency, select, daily {Zilnică} weekly {Săptămânală} monthly {Lunară} yearly {Anuală} other {Periodică}}",
+      "greeting": "Salut {name},",
+      "heading": "Statistici {frequencyLabel} de factură",
+      "intro": "Acesta este rezumatul activității tale pe facturi și cheltuieli pentru <start></start> → <end></end>.",
+      "metrics": {
+        "averagePerInvoice": "Medie / factură",
+        "invoices": "Facturi",
+        "scans": "Scanări",
+        "totalSpend": "Cheltuieli totale"
+      },
+      "noDataFallback": "Încă nu există date — încarcă câteva facturi pentru a debloca statistici.",
+      "preview": "Statistici {frequencyLabel} pentru {name} — {totalSpend} total.",
+      "reportDetails": {
+        "currency": "Monedă",
+        "period": "Perioadă"
+      },
+      "reportDetailsTitle": "Detalii raport",
+      "signOff": {
+        "line1": "La revedere,",
+        "line2": "Echipa {brand}"
+      },
+      "subject": "Statisticile tale {frequency, select, daily {zilnice} weekly {săptămânale} monthly {lunare} yearly {anuale} other {periodice}} de facturi",
+      "title": "Statistici factură {frequencyLabel}",
+      "topCategoriesTitle": "Top categorii",
+      "topMerchantsTitle": "Top comercianți"
+    },
+    "invoiceUnshared": {
+      "badge": "Facturi • Acces Revocat",
+      "body": "Dacă crezi că această schimbare a fost făcută din greșeală, te rugăm să contactezi pe <from></from> sau echipa noastră de suport. Revocările de acces sunt uneori accidentale și suntem bucuroși să ajutăm la facilitarea comunicării dacă este necesar.",
+      "ctaPrimary": "Vizualizează facturile tale",
+      "ctaSecondary": "Contactează suportul",
+      "details": {
+        "accessRevoked": "Revocat",
+        "invoiceId": "ID Factură",
+        "notProvided": "—",
+        "revokedAt": "Revocat la",
+        "revokedBy": "Revocat de",
+        "yourAccess": "Accesul tău"
+      },
+      "detailsTitle": "Detalii revocare",
+      "feedbackPrompt": "Ai nevoie de asistență? Trimite-ne un email la <email></email>.",
+      "greeting": "Bună {toName},",
+      "heading": "Accesul tău la o factură a fost revocat",
+      "intro": "Îți scriem pentru a te informa că <from></from> a revocat accesul tău la o factură care îți fusese distribuită anterior. Aceasta înseamnă că nu vei mai putea vizualiza această factură.",
+      "preview": "{fromName} a revocat accesul tău la o factură distribuită.",
+      "signOff": {
+        "line1": "Cu stimă,",
+        "line2": "Echipa {brand}"
+      },
+      "subject": "Accesul la o factură distribuită a fost revocat",
+      "whatThisMeans": {
+        "item0": "Orice link salvat la această factură nu va mai funcționa pentru tine.",
+        "item1": "Această factură nu va mai apărea în lista ta de facturi distribuite.",
+        "item2": "Dacă ai nevoie din nou de acces, contactează direct proprietarul facturii."
+      },
+      "whatThisMeansTitle": "Ce înseamnă asta"
+    },
+    "layout": {
+      "allRightsReserved": "© 2022-{year} {brand}. Toate drepturile rezervate.",
+      "buttonFallback": "Dacă butonul nu funcționează, deschide acest link:",
+      "managePreferences": "Administrează preferințele de email",
+      "secondaryFallback": "Sau:",
+      "tagline": "Instrumente practice. Informații clare. Gândit pentru cheltuielile de zi cu zi.",
+      "unsubscribe": "Dezabonează-te"
+    },
+    "newsletterSubscribed": {
+      "badge": "Newsletter",
+      "body": "Inbox-ul tău este sacru—respect asta. Fiecare email este creat pentru a oferi valoare genuină, fie că este un sfat care îți economisește ore sau o perspectivă care îți schimbă viziunea asupra finanțelor personale.",
+      "ctaPrimary": "Vizitează arolariu.ro",
+      "feedbackPrompt": "Întrebări, feedback sau doar vrei să saluti? Răspunde la acest email sau contactează-mă direct la <email></email>.",
+      "greeting": "Salut {name},",
+      "heading": "Bine ai venit — te-ai abonat",
+      "intro": "Mulțumesc că te-ai abonat la newsletter-ul <brand>{brandName}</brand>. Mă bucur sincer să te am aici. Voi păstra comunicările ușoare, semnificative și merită timpul tău.",
+      "preview": "Bun venit, {name} — te-ai abonat.",
+      "signOff": {
+        "line1": "Cu respect",
+        "line2": "Echipa {brand}"
+      },
+      "subject": "Te-ai abonat cu succes!",
+      "whatToExpect": {
+        "item0": "Actualizări de produs și funcționalități noi pe măsură ce sunt lansate",
+        "item1": "Articole și materiale noi despre tehnologie, productivitate și finanțe personale",
+        "item2": "Evidențieri ocazionale și resurse curatate (1–2 emailuri pe trimestru)"
+      },
+      "whatToExpectTitle": "La ce să te aștepți"
+    },
+    "newsletterUnsubscribed": {
+      "badge": "Newsletter",
+      "body": "Apreciez timpul pe care l-ai petrecut cu noi. Dacă ai feedback despre motivul pentru care ai plecat sau despre cum mă pot îmbunătăți, aș fi cu adevărat bucuros să-l aud—doar răspunde la acest email.",
+      "ctaPrimary": "Verifică preferințele",
+      "ctaSecondary": "Reabonează-te",
+      "feedbackPrompt": "Dacă nu ai solicitat această dezabonare sau ai nevoie de ajutor cu ceva, te rugăm să contactezi <email></email>.",
+      "greeting": "Salut {name},",
+      "heading": "Te-ai dezabonat",
+      "intro": "Acest email confirmă că ai fost eliminat din lista de newsletter <brand>{brandName}</brand>. Îmi pare rău să te văd plecând.",
+      "preview": "Salut {name} — te-ai dezabonat.",
+      "signOff": {
+        "line1": "Cu respect",
+        "line2": "Echipa {brand}"
+      },
+      "subject": "Te-ai dezabonat",
+      "whatHappensNext": {
+        "item0": "Nu vei mai primi actualizări de newsletter de la noi în viitor.",
+        "item1": "Este posibil să primești în continuare emailuri esențiale de cont și serviciu dacă folosești produsul.",
+        "item2": "Ți-ai schimbat părerea? Te poți reabona oricând folosind butonul de mai sus."
+      },
+      "whatHappensNextTitle": "Ce urmează"
+    },
+    "spendingAlert": {
+      "badge": "Alertă Cheltuieli • {percent}%",
+      "chartAlt": "Defalcare cheltuieli pe categorii pentru {period}",
+      "chartTitle": "Cheltuieli pe categorii",
+      "ctaPrimary": "Vezi tabloul de bord",
+      "detailsLabels": {
+        "budget": "Buget",
+        "category": "Categorie",
+        "period": "Perioadă",
+        "spent": "Cheltuit"
+      },
+      "detailsTitle": "Detalii Buget",
+      "feedbackPrompt": "Întrebări? Contactează-ne la <email></email>.",
+      "greeting": "Salut {name},",
+      "heading": "{percent, select, 80 {Atenție: te apropii de limita bugetului} 90 {Aproape gata: ai folosit 90% din buget} 100 {Buget atins: ai atins limita de cheltuieli} other {Alertă de cheltuieli}}",
+      "intro": "{state, select, over {Ai atins limita de cheltuieli pentru {category} în {period}. Iată un rezumat al situației tale.} other {Ai folosit {percent}% din bugetul tău de {category} pentru {period}. Iată un rezumat rapid pentru a planifica restul perioadei.}}",
+      "metricsLabels": {
+        "budgetLimit": "Limită buget",
+        "currentSpending": "Cheltuieli curente",
+        "remaining": "Rămas",
+        "threshold": "Prag"
+      },
+      "notificationsLink": "setările de notificări",
+      "notificationsParagraph": "Poți ajusta pragurile bugetului și preferințele de notificare în <settings></settings>.",
+      "overBudgetValue": "Peste buget",
+      "overBudgetWarning": "Cheltuielile tale au atins sau depășit bugetul stabilit. Verifică achizițiile recente pentru a rămâne pe drumul cel bun.",
+      "preview": "{name}, ai folosit {percent}% din bugetul tău de {category} pentru {period}.",
+      "signOff": {
+        "line1": "Cu respect",
+        "line2": "Echipa {brand}"
+      },
+      "subject": "Alertă prag de cheltuieli",
+      "tipsOnTrack": {
+        "item0": "Verifică achizițiile recente pentru a vedea unde merg cea mai mare parte",
+        "item1": "Prioritizează cheltuielile esențiale pentru restul perioadei",
+        "item2": "Consideră să găătești mai mult acasă dacă mesele la restaurant cresc costurile"
+      },
+      "tipsOverBudget": {
+        "item0": "Verifică achizițiile recente pentru a identifica cheltuielile neesențiale",
+        "item1": "Consideră ajustarea bugetului dacă nu mai reflectă realitatea",
+        "item2": "Stabilește un prag mai strict (de ex. 80%) pentru avertismente mai timpurii"
+      },
+      "tipsTitle": "{state, select, over {Ce poți face} other {Sfaturi pentru a rămâne pe drumul cel bun}}"
+    },
+    "unanalyzedInvoices": {
+      "analysisProvidedTitle": "Ce oferă analiza",
+      "analysisProvides": {
+        "item0": "Extracția rând cu rând a articolelor cu prețuri și categorii",
+        "item1": "Identificarea și categorizarea comercianților",
+        "item2": "Detectarea alergenilor pe produsele alimentare",
+        "item3": "Sugestii de rețete bazate pe articolele din coșul de cumpărături",
+        "item4": "Categorizare automată a cheltuielilor pentru informații de pe tablou"
+      },
+      "andMore": "…și încă {remaining}. Vezi toate în <dashboard></dashboard>.",
+      "badge": "Memento",
+      "bodyText": "Analiza durează de obicei mai puțin de un minut per factură. Odată completă, vei primi o notificare cu rezultatele.",
+      "feedback": "Ai nevoie de ajutor? Contactează-ne la <link>{supportEmail}</link>.",
+      "greeting": "Bună, {name}!",
+      "heading": "{count, plural, =1 {1 factură în așteptarea analizei} other {# facturi în așteptarea analizei}}",
+      "intro": "{count, plural, =1 {Ai 1 factură care nu a fost încă analizată. Rularea analizei noastre AI deblochează întreaga valoare a bonurilor încărcate.} other {Ai # facturi care nu au fost încă analizate. Rularea analizei noastre AI deblochează întreaga valoare a bonurilor încărcate.}}",
+      "invoicesAwaitingTitle": "Facturi în așteptarea analizei",
+      "preview": "{name}, ai {count, plural, =1 {1 factură} other {# facturi}} care așteaptă analiza AI.",
+      "primaryCta": "Vezi facturile",
+      "signOff": {
+        "line1": "Cu stimă,",
+        "line2": "Echipa {brand}"
+      },
+      "subject": "Ai facturi neanalizate",
+      "uploadedDate": "Încărcată la {date}"
+    },
+    "weeklyUploadReminder": {
+      "badge": "Memento Săptămânal",
+      "bodyText": "Fiecare bon pe care îl urmărești face ca informațiile despre cheltuieli să fie mai precise și tablourile mai utile.",
+      "feedback": "Întrebări sau feedback? Scrie-ne la <link>{supportEmail}</link>.",
+      "greeting": "Bună, {name}!",
+      "heading": "Verificarea săptămânală a bonurilor",
+      "intro": "Iată o privire rapidă asupra activității tale de urmărire a bonurilor. Încărcarea constantă îți oferă cele mai precise informații despre cheltuieli.",
+      "metricsLabels": {
+        "lastWeek": "Săptămâna trecută",
+        "thisWeek": "Săptămâna aceasta",
+        "totalInvoices": "Total facturi",
+        "totalTracked": "Total urmărit"
+      },
+      "preview": "Bună, {name} — iată verificarea săptămânală a bonurilor tale.",
+      "primaryCta": "Încarcă bonurile din această săptămână",
+      "quickTips": {
+        "item0": "Încarcă bonurile imediat după cumpărături — durează mai puțin de 30 de secunde",
+        "item1": "Încarcă în lot la sfârșitul zilei dacă preferi",
+        "item2": "Chiar și achizițiile mici ajută la construirea unei imagini complete a cheltuielilor"
+      },
+      "quickTipsTitle": "Sfaturi rapide",
+      "secondaryCta": "Vezi tabloul de bord",
+      "signOff": {
+        "line1": "Cu stimă,",
+        "line2": "Echipa {brand}"
+      },
+      "subject": "Mementoultău săptămânal pentru încărcări"
+    },
+    "welcome": {
+      "badge": "Bun venit",
+      "body": "Gata să începi? Încarcă primul tău bon și privește magia în acțiune. Întregul proces durează mai puțin de un minut.",
+      "ctaPrimary": "Încarcă primul tău bon",
+      "ctaSecondary": "Explorează panoul",
+      "feedbackPrompt": "Întrebări sau feedback? Ne-ar plăcea să auzim de la tine la <email></email>.",
+      "greeting": "Salut {name},",
+      "heading": "Bun venit la {brand}",
+      "howItWorks": {
+        "item0": "Încarcă — fă o fotografie sau încarcă un PDF al oricărui bon",
+        "item1": "Analizează — AI-ul nostru extrage produsele, prețurile, comercianții și chiar sugerează rețete din bonurile de băcănie",
+        "item2": "Urmărește — vizualizează panouri de cheltuieli pe comerciant, categorie, lună sau an"
+      },
+      "howItWorksTitle": "Cum funcționează",
+      "intro": "Mulțumim că ni te-ai alăturat la {brand}. Ne bucurăm că ești aici. Platforma noastră te ajută să transformi bonurile zilnice în informații financiare organizate — cu ajutorul analizei AI.",
+      "preview": "Bun venit la {brand}, {name}! Hai să începem.",
+      "signOff": {
+        "line1": "Cu drag,",
+        "line2": "Echipa {brand}"
+      },
+      "subject": "Bun venit la {brand}",
+      "whatYouCanDo": {
+        "item0": "Primește alerte despre alergeni pentru produsele alimentare",
+        "item1": "Partajează facturi cu membrii familiei sau colegii",
+        "item2": "Exportă statistici și rapoarte de cheltuieli",
+        "item3": "Accesează-ți datele de pe orice dispozitiv"
+      },
+      "whatYouCanDoTitle": "Ce poți face"
     }
   },
-  "IMS--Common": {
-    "commandPalette": {
-      "actions": {
-        "createInvoice": "Crează Factură",
-        "uploadScans": "Încarcă Scanări",
-        "viewAll": "Vezi Toate Facturile",
-        "viewStatistics": "Vezi Statistici"
-      },
-      "groups": {
-        "quickActions": "Acțiuni Rapide",
-        "recentInvoices": "Facturi Recente",
-        "searchResults": "Rezultate Căutare"
-      },
-      "noResults": "Nu s-au găsit rezultate",
-      "placeholder": "Caută facturi, comercianți, articole..."
-    },
-    "invoiceHeader": {
-      "buttons": {
-        "analyzeWithAi": "Analizează cu IA",
-        "delete": "Șterge",
-        "discard": "Renunță",
-        "edit": "Editează",
-        "export": "Exportă",
-        "print": "Printează",
-        "save": "Salvează",
-        "saving": "Se salvează..."
-      },
-      "id": "Identificator: {id}",
-      "tooltips": {
-        "analyzeSpendingPatterns": "Analizează tiparele de cheltuieli pentru această factură",
-        "delete": "Șterge definitiv această factură",
-        "deleteInvoicePermanently": "Șterge permanent această factură",
-        "discardAllPendingChanges": "Renunță la toate modificările în așteptare",
-        "edit": "Editează această factură",
-        "export": "Exportă datele facturii în diverse formate",
-        "importantInvoice": "Factură importantă",
-        "print": "Printează această factură",
-        "printInvoiceWithAllDetails": "Tipărește această factură cu toate detaliile",
-        "saveAllPendingChanges": "Salvează toate modificările în așteptare"
-      }
-    },
-    "invoicesNotFound": {
-      "cta": "Încarcă aici o factură.",
-      "description": "Se pare că nu ai nicio factură asociată contului tău. Te rugăm să încarci câteva facturi și să revii mai târziu.",
-      "title": "Lipsește ceva aici..."
-    },
-    "loadingInvoices": {
-      "description": "Se încarcă facturi...",
-      "title": "Se încarcă facturi"
-    },
-    "mobileNav": {
-      "ariaLabel": "Navigare mobilă",
-      "home": "Acasă",
-      "invoices": "Facturi",
-      "profile": "Profil",
-      "scan": "Scanare"
-    },
-    "notifications": {
-      "markAllRead": "Marchează toate ca citite",
-      "noNotifications": "Nu există notificări încă",
-      "timeAgo": {
-        "days": "{count, plural, one {acum # zi} other {acum # zile}}",
-        "hours": "{count, plural, one {acum # oră} other {acum # ore}}",
-        "minutes": "{count, plural, one {acum # minut} other {acum # minute}}",
-        "now": "Chiar acum"
-      },
-      "title": "Notificări",
-      "types": {
-        "analysisComplete": "Analiza AI finalizată",
-        "invoiceCreated": "Factură creată",
-        "monthlyReport": "Raportul lunar este gata"
-      }
-    },
-    "onboarding": {
-      "back": "Înapoi",
-      "dontShowAgain": "Nu mai afișa din nou",
-      "getStarted": "Începe",
-      "next": "Următorul",
-      "skip": "Sari peste",
-      "stepOf": "Pasul {current} din {total}",
-      "steps": {
-        "analyze": {
-          "description": "Sistemul nostru bazat pe AI extrage automat numele comercianților, datele, sumele și articolele din chitanțele tale cu acuratețe ridicată.",
-          "title": "AI Extrage Detaliile"
+  "forms": {
+    "invoices": {
+      "createInvoice": {
+        "detailsForm": {
+          "fields": {
+            "category": {
+              "label": "Categorie",
+              "options": {
+                "carAuto": "Auto și vehicule",
+                "fastFood": "Restaurante",
+                "grocery": "Alimente",
+                "homeCleaning": "Casă și curățenie",
+                "notDefined": "Necategorizat",
+                "other": "Altele"
+              },
+              "placeholder": "Selectați o categorie"
+            },
+            "description": {
+              "hint": "Note opționale despre această achiziție",
+              "label": "Descriere",
+              "placeholder": "Adăugați orice notițe despre această factură (opțional)"
+            },
+            "name": {
+              "hint": "Dați facturii un nume descriptiv",
+              "label": "Nume factură",
+              "placeholder": "ex., Cumpărături săptămânale"
+            },
+            "paymentType": {
+              "label": "Metodă de plată",
+              "options": {
+                "card": "Card",
+                "cash": "Numerar",
+                "mobilePayment": "Plată mobilă",
+                "other": "Altele",
+                "transfer": "Transfer bancar",
+                "unknown": "Necunoscut",
+                "voucher": "Voucher"
+              },
+              "placeholder": "Selectați metoda de plată"
+            },
+            "transactionDate": {
+              "label": "Data tranzacției"
+            }
+          },
+          "scanPreview": {
+            "title": "Previzualizare Scanare"
+          },
+          "subtitle": "Completați detaliile pentru factura nouă",
+          "title": "Detalii factură"
         },
-        "track": {
-          "description": "Vizualizează analize detaliate și perspective asupra tiparelor tale de cheltuieli. Înțelege unde se duc banii tăi cu diagrame și rapoarte interactive.",
-          "title": "Urmărește Cheltuielile Tale"
+        "emptyState": {
+          "description": "Încărcați mai întâi câteva scanări de bonuri pentru a crea o factură.",
+          "title": "Nicio scanare disponibilă",
+          "uploadButton": "Încarcă scanări",
+          "viewScansButton": "Vezi scanările"
         },
-        "upload": {
-          "description": "Fă o fotografie sau încarcă un PDF al chitanței tale. Sistemul nostru acceptă multiple formate și poate procesa loturi de chitanțe deodată.",
-          "title": "Încarcă Chitanțele Tale"
-        }
-      }
-    },
-    "preferences": {
-      "currency": "Monedă",
-      "defaultView": "Vizualizare Implicită",
-      "pageSize": "Elemente pe Pagină",
-      "save": "Salvează Preferințele",
-      "saved": "Preferințele au fost salvate cu succes",
-      "showStats": "Afișează statistici pe pagina principală",
-      "sortBy": "Sortează După",
-      "sortOptions": {
-        "amountAsc": "Sumă (Mic la Mare)",
-        "amountDesc": "Sumă (Mare la Mic)",
-        "dateAsc": "Dată (Cele mai Vechi)",
-        "dateDesc": "Dată (Cele mai Recente)",
-        "nameAsc": "Nume (A la Z)"
-      },
-      "title": "Preferințe Facturi",
-      "views": {
-        "grid": "Vizualizare Grilă",
-        "table": "Vizualizare Tabel"
-      }
-    },
-    "shortcuts": {
-      "close": "Închide",
-      "closeDialog": "Închide dialogul",
-      "description": "Acces rapid la acțiuni comune folosind tastatura",
-      "newInvoice": "Factură nouă",
-      "openSearch": "Deschide căutarea",
-      "showHelp": "Arată acest ajutor",
-      "title": "Scurtături de la Tastatură",
-      "uploadScan": "Încarcă scanare"
-    },
-    "statesLoading": {
-      "description": "Se încarcă factura cu identificatorul {invoiceIdentifier}.",
-      "title": "Se încarcă factura"
-    },
-    "statesNotFound": {
-      "description": "Factura cu identificatorul {invoiceIdentifier} nu a fost găsită.",
-      "title": "Factură negăsită"
-    },
-    "unknownMerchant": "Comerciant Necunoscut",
-    "workflowProgress": {
-      "create": "Creare",
-      "review": "Revizuire",
-      "upload": "Încărcare"
-    }
-  },
-  "IMS--Create": {
-    "detailsForm": {
-      "fields": {
-        "category": {
-          "label": "Categorie",
-          "options": {
+        "header": {
+          "backToInvoices": "Înapoi la facturi",
+          "subtitle": "Urmați pașii de mai jos pentru a crea o factură nouă din scanările dvs.",
+          "title": "Creare factură"
+        },
+        "metadata": {
+          "description": "Creați o factură nouă din scanările încărcate.",
+          "title": "Sistem de gestionare a facturilor - Creare factură"
+        },
+        "navigation": {
+          "back": "Înapoi",
+          "next": "Înainte"
+        },
+        "reviewStep": {
+          "actions": {
+            "create": "Creează factură",
+            "creating": "Se creează factura...",
+            "hint": "Factura va fi creată și scanările selectate vor fi încărcate."
+          },
+          "categories": {
             "carAuto": "Auto și vehicule",
             "fastFood": "Restaurante",
             "grocery": "Alimente",
@@ -2035,21 +2185,7 @@
             "notDefined": "Necategorizat",
             "other": "Altele"
           },
-          "placeholder": "Selectați o categorie"
-        },
-        "description": {
-          "hint": "Note opționale despre această achiziție",
-          "label": "Descriere",
-          "placeholder": "Adăugați orice notițe despre această factură (opțional)"
-        },
-        "name": {
-          "hint": "Dați facturii un nume descriptiv",
-          "label": "Nume factură",
-          "placeholder": "ex., Cumpărături săptămânale"
-        },
-        "paymentType": {
-          "label": "Metodă de plată",
-          "options": {
+          "paymentTypes": {
             "card": "Card",
             "cash": "Numerar",
             "mobilePayment": "Plată mobilă",
@@ -2058,1260 +2194,52 @@
             "unknown": "Necunoscut",
             "voucher": "Voucher"
           },
-          "placeholder": "Selectați metoda de plată"
-        },
-        "transactionDate": {
-          "label": "Data tranzacției"
-        }
-      },
-      "scanPreview": {
-        "title": "Previzualizare Scanare"
-      },
-      "subtitle": "Completați detaliile pentru factura nouă",
-      "title": "Detalii factură"
-    },
-    "emptyState": {
-      "description": "Încărcați mai întâi câteva scanări de bonuri pentru a crea o factură.",
-      "title": "Nicio scanare disponibilă",
-      "uploadButton": "Încarcă scanări",
-      "viewScansButton": "Vezi scanările"
-    },
-    "header": {
-      "backToInvoices": "Înapoi la facturi",
-      "subtitle": "Urmați pașii de mai jos pentru a crea o factură nouă din scanările dvs.",
-      "title": "Creare factură"
-    },
-    "metadata": {
-      "description": "Creați o factură nouă din scanările încărcate.",
-      "title": "Sistem de gestionare a facturilor - Creare factură"
-    },
-    "navigation": {
-      "back": "Înapoi",
-      "next": "Înainte"
-    },
-    "reviewStep": {
-      "actions": {
-        "create": "Creează factură",
-        "creating": "Se creează factura...",
-        "hint": "Factura va fi creată și scanările selectate vor fi încărcate."
-      },
-      "categories": {
-        "carAuto": "Auto și vehicule",
-        "fastFood": "Restaurante",
-        "grocery": "Alimente",
-        "homeCleaning": "Casă și curățenie",
-        "notDefined": "Necategorizat",
-        "other": "Altele"
-      },
-      "paymentTypes": {
-        "card": "Card",
-        "cash": "Numerar",
-        "mobilePayment": "Plată mobilă",
-        "other": "Altele",
-        "transfer": "Transfer bancar",
-        "unknown": "Necunoscut",
-        "voucher": "Voucher"
-      },
-      "sections": {
-        "details": {
-          "category": "Categorie",
-          "description": "Descriere",
-          "name": "Nume",
-          "paymentType": "Metodă de plată",
-          "title": "Detalii factură",
-          "transactionDate": "Data tranzacției"
-        },
-        "scans": {
-          "title": "Scanări"
-        }
-      },
-      "subtitle": "Verificați detaliile facturii înainte de creare",
-      "title": "Verificare și creare"
-    },
-    "scanSelector": {
-      "clearAll": "Golește",
-      "next": "Înainte",
-      "noScans": "Nicio scanare disponibilă",
-      "previous": "Înapoi",
-      "scansCount": "scanări",
-      "selectAll": "Selectează tot",
-      "selectedCount": "{count} selectate",
-      "subtitle": "Alegeți scanările care aparțin acestei facturi",
-      "title": "Selectare scanări"
-    },
-    "steps": {
-      "details": "Detalii factură",
-      "detailsDesc": "Completează detalii",
-      "review": "Verificare și creare",
-      "reviewDesc": "Confirmă și creează",
-      "selectScans": "Selectare scanări",
-      "selectScansDesc": "Alege scanările"
-    }
-  },
-  "IMS--Dialogs": {
-    "addScanDialog": {
-      "buttons": {
-        "cancel": "Anulează",
-        "upload": "Încarcă scan",
-        "uploading": "Se încarcă..."
-      },
-      "console": {
-        "uploadError": "Eroare la încărcarea scanării:"
-      },
-      "description": "Încarcă o imagine nouă a bonului sau un document nou pentru a-l atașa la această factură.",
-      "dropzone": {
-        "dragAndDrop": "Trage și plasează un fișier aici",
-        "dropHere": "Plasează fișierul aici...",
-        "formats": "JPEG, PNG, PDF (max 10MB)",
-        "orClickBrowse": "sau apasă pentru a răsfoi"
-      },
-      "errors": {
-        "unknown": "A apărut o eroare necunoscută",
-        "uploadStorageFailed": "Încărcarea scanării în spațiul de stocare a eșuat"
-      },
-      "scanType": {
-        "jpeg": "Imagine JPEG",
-        "label": "Tip scanare",
-        "other": "Altele",
-        "pdf": "Document PDF",
-        "placeholder": "Selectează tipul de scanare",
-        "png": "Imagine PNG"
-      },
-      "title": "Adaugă o scanare nouă",
-      "toasts": {
-        "fileTooLargeDescription": "Dimensiunea maximă a fișierului este 10MB",
-        "fileTooLargeTitle": "Fișier prea mare",
-        "scanAddedDescription": "Scanarea a fost atașată la factură",
-        "scanAddedTitle": "Scan adăugat cu succes",
-        "scanFailedTitle": "Adăugarea scanării a eșuat"
-      }
-    },
-    "allergenDialog": {
-      "aria": {
-        "removeAllergen": "Elimină alergenul {name}"
-      },
-      "buttons": {
-        "add": "Adaugă",
-        "cancel": "Anulează",
-        "save": "Salvează Modificările",
-        "saving": "Se salvează..."
-      },
-      "defaultDescription": "Conține {name}",
-      "description": "Gestionează alergenii pentru {productName}",
-      "empty": {
-        "noAllergens": "Niciun alergen detectat"
-      },
-      "errors": {
-        "duplicate": "Alergenul {name} este deja adăugat",
-        "emptyName": "Numele alergenului nu poate fi gol",
-        "missingData": "Datele produsului lipsesc",
-        "saveFailed": "Eroare la salvarea alergenilor"
-      },
-      "labels": {
-        "currentAllergens": "Alergeni Actuali",
-        "customAllergen": "Adaugă Alergen Personalizat",
-        "quickAdd": "Adaugă Rapid Alergeni Comuni"
-      },
-      "placeholders": {
-        "customAllergen": "Introdu numele alergenului..."
-      },
-      "success": {
-        "added": "Alergen adăugat: {name}",
-        "removed": "Alergen eliminat: {name}",
-        "saved": "Alergenii au fost actualizați cu succes"
-      },
-      "title": "Editează Alergeni"
-    },
-    "analyzeDialog": {
-      "analysisSteps": {
-        "analyzingWithAi": "Se analizează cu IA...",
-        "categorizingItems": "Se categorisesc articolele...",
-        "finalizingResults": "Se finalizează rezultatele...",
-        "preparingDocument": "Se pregătește documentul...",
-        "processing": "Se procesează...",
-        "runningOcrExtraction": "Se rulează extracția OCR..."
-      },
-      "analyzing": {
-        "progressComplete": "{progress}% complet",
-        "title": "Se analizează factura"
-      },
-      "badges": {
-        "recommended": "Recomandat"
-      },
-      "buttons": {
-        "analyzing": "Se analizează...",
-        "cancel": "Anulează",
-        "startAnalysis": "Pornește analiza"
-      },
-      "enhancements": {
-        "priceComparison": {
-          "description": "Compară prețurile cu date istorice",
-          "label": "Comparare prețuri"
-        },
-        "quickExtract": {
-          "description": "Prioritizează viteza în locul acurateței",
-          "label": "Mod de extragere rapidă"
-        },
-        "savingsTips": {
-          "description": "Primește recomandări de economisire cu IA",
-          "label": "Sugestii de economisire"
-        }
-      },
-      "header": {
-        "description": "Configurează o analiză cu IA pentru factura",
-        "title": "Analizează factura"
-      },
-      "options": {
-        "completeAnalysis": {
-          "description": "Analiză completă cu IA ce include toate datele facturii, articolele și informațiile comerciantului.",
-          "estimatedTime": "2-3 min",
-          "features": {
-            "itemCategorization": "Categorisirea articolelor",
-            "merchantIdentification": "Identificarea comerciantului",
-            "ocrExtraction": "Extracție OCR",
-            "priceAnalysis": "Analiza prețurilor",
-            "receiptValidation": "Validarea bonului"
+          "sections": {
+            "details": {
+              "category": "Categorie",
+              "description": "Descriere",
+              "name": "Nume",
+              "paymentType": "Metodă de plată",
+              "title": "Detalii factură",
+              "transactionDate": "Data tranzacției"
+            },
+            "scans": {
+              "title": "Scanări"
+            }
           },
-          "title": "Analiză completă"
+          "subtitle": "Verificați detaliile facturii înainte de creare",
+          "title": "Verificare și creare"
         },
-        "invoiceOnly": {
-          "description": "Analizează informațiile de bază ale facturii precum totaluri, date și detalii de plată.",
-          "estimatedTime": "30-60 sec",
-          "features": {
-            "dateParsing": "Interpretarea datelor",
-            "paymentMethodDetection": "Detectarea metodei de plată",
-            "totalExtraction": "Extracția totalului"
-          },
-          "title": "Doar datele facturii"
+        "scanSelector": {
+          "clearAll": "Golește",
+          "next": "Înainte",
+          "noScans": "Nicio scanare disponibilă",
+          "previous": "Înapoi",
+          "scansCount": "scanări",
+          "selectAll": "Selectează tot",
+          "selectedCount": "{count} selectate",
+          "subtitle": "Alegeți scanările care aparțin acestei facturi",
+          "title": "Selectare scanări"
         },
-        "itemsOnly": {
-          "description": "Se concentrează pe extragerea și categorisirea articolelor individuale din factură.",
-          "estimatedTime": "1-2 min",
-          "features": {
-            "categoryAssignment": "Atribuirea categoriilor",
-            "itemExtraction": "Extracția articolelor",
-            "pricePerItem": "Preț per articol",
-            "quantityDetection": "Detectarea cantității"
-          },
-          "title": "Analiza articolelor"
-        },
-        "merchantOnly": {
-          "description": "Identifică și analizează informațiile comerciantului, inclusiv locația și categoria.",
-          "estimatedTime": "30-45 sec",
-          "features": {
-            "businessCategory": "Categoria afacerii",
-            "contactInfo": "Informații de contact",
-            "locationExtraction": "Extracția locației",
-            "merchantIdentification": "Identificarea comerciantului"
-          },
-          "title": "Analiza comerciantului"
+        "steps": {
+          "details": "Detalii factură",
+          "detailsDesc": "Completează detalii",
+          "review": "Verificare și creare",
+          "reviewDesc": "Confirmă și creează",
+          "selectScans": "Selectare scanări",
+          "selectScansDesc": "Alege scanările"
         }
-      },
-      "sections": {
-        "analysisType": "Tip analiză",
-        "enhancementsOptional": "Îmbunătățiri (opțional)",
-        "includedFeatures": "Funcționalități incluse"
-      },
-      "summary": {
-        "enhancementsSelected": "+ {count} îmbunătățire(i)",
-        "estimatedTime": "Durată estimată",
-        "noEnhancementsSelected": "Nicio îmbunătățire selectată"
-      },
-      "toasts": {
-        "analysisComplete": {
-          "description": "Factura ta a fost analizată cu succes.",
-          "title": "Analiză finalizată"
-        },
-        "analysisFailed": {
-          "description": "Nu am putut analiza factura ta. Te rugăm să încerci din nou.",
-          "title": "Analiza a eșuat"
-        }
-      }
-    },
-    "bulkCategoryDialog": {
-      "buttons": {
-        "cancel": "Anulează",
-        "save": "Aplică Tuturor",
-        "saving": "Se salvează..."
-      },
-      "description": "{count, plural, one {Schimbă categoria pentru # produs} other {Schimbă categoria pentru # produse}}",
-      "errors": {
-        "allFailed": "Toate produsele nu au putut fi actualizate",
-        "missingData": "Date lipsă",
-        "noProducts": "Niciun produs selectat",
-        "saveFailed": "Eroare la actualizarea categoriilor"
-      },
-      "labels": {
-        "andMore": "...și încă {count}",
-        "newCategory": "Categorie Nouă",
-        "progress": "Progres",
-        "selectedProducts": "Produse Selectate"
-      },
-      "placeholders": {
-        "selectCategory": "Selectează o categorie"
-      },
-      "progress": {
-        "updating": "Se actualizeaza {current} din {total}..."
-      },
-      "success": {
-        "partialSuccess": "{success} produse actualizate, {failed} esuate",
-        "saved": "{count, plural, one {Categoria actualizată pentru # produs} other {Categoria actualizată pentru # produse}}"
-      },
-      "title": "Schimbă Categoria"
-    },
-    "createInvoiceDialog": {
-      "batchMode": {
-        "description": "Creează 1 factură cu toate cele {count} scanări atașate. Ideal pentru chitanțe cu mai multe pagini.",
-        "title": "Combinați într-o singură factură"
-      },
-      "buttons": {
-        "cancel": "Anulare",
-        "close": "Închide",
-        "createMultiple": "Pornește analiza pentru {count} scanări",
-        "createSingle": "Pornește analiza"
-      },
-      "chooseMode": "Alegeți Modul de Creare",
-      "complete": {
-        "description": "Factura dvs. este gata pentru vizualizare și editare.",
-        "descriptionPlural": "Facturile dvs. sunt gata pentru vizualizare și editare.",
-        "errorsLabel": "Scanări Eșuate:",
-        "failureDescription": "Nu am putut crea nicio factură. Vă rugăm să revedeți erorile de mai jos și să încercați din nou.",
-        "failureTitle": "Creare Eșuată",
-        "nextSteps": "Pași următori:",
-        "nextStepsDescription": "Revizuiți factura, verificați datele extrase și faceți orice modificări necesare. Puteți solicita și analiza AI pentru informații despre cheltuieli.",
-        "nextStepsDescriptionPlural": "Revizuiți facturile, verificați datele extrase și faceți orice modificări necesare. Puteți solicita și analiza AI pentru informații despre cheltuieli.",
-        "partialDescription": "Unele scanări nu au putut fi procesate. Facturile create cu succes sunt gata pentru vizualizare.",
-        "partialTitle": "{created} din {total} Facturi Create",
-        "retryButton": "Încearcă Din Nou",
-        "title": "{count} Factură Creată!",
-        "titlePlural": "{count} Facturi Create!",
-        "viewButton": "Vizualizați Factura",
-        "viewButtonPlural": "Vizualizați Facturile"
-      },
-      "creating": {
-        "processing": "Se procesează {count} scanare...",
-        "processingPlural": "Se procesează {count} scanări...",
-        "step1Description": "Se trimit scanările către serverele noastre",
-        "step1Title": "Se încarcă scanările",
-        "step2Description": "Se configurează structurile de date ale facturilor",
-        "step2Title": "Se creează înregistrările facturilor",
-        "step3Description": "Se pregătesc facturile pentru vizualizare",
-        "step3Title": "Finalizare",
-        "title": "Se creează Factura",
-        "titlePlural": "Se creează Facturile"
-      },
-      "description": "Transformă scanările în date structurate de factură.",
-      "errors": {
-        "createFailed": "Nu s-au putut crea facturile: {message}",
-        "partialFail": "Nu s-au putut crea {count} facturi",
-        "unknown": "Eroare necunoscută"
-      },
-      "selectedScans": "Scanări Selectate",
-      "singleMode": {
-        "description": "Creează {count} facturi separate. Ideal când fiecare scanare este o chitanță diferită.",
-        "title": "O factură per scanare"
-      },
-      "singleScanInfo": {
-        "description": "AI-ul nostru va analiza scanarea dvs. și va extrage automat detaliile comerciantului, articolele, prețurile și totalurile. Puteți revizui și edita rezultatele ulterior.",
-        "title": "Ce se întâmplă în continuare?"
-      },
-      "title": "Pornește analiza AI",
-      "titlePlural": "Pornește analiza AI",
-      "totalSize": "total"
-    },
-    "deleteInvoiceDialog": {
-      "buttons": {
-        "cancel": "Anulează",
-        "deletePermanently": "Șterge permanent",
-        "deleting": "Se șterge..."
-      },
-      "confirmation": {
-        "typeToConfirm": "Tastează <highlight>{name}</highlight> pentru confirmare:",
-        "understoodDescription": "Această factură și toate datele ei vor fi șterse definitiv și nu vor putea fi recuperate.",
-        "understoodLabel": "Înțeleg că această acțiune este permanentă"
-      },
-      "console": {
-        "deleteError": "Eroare ștergere factură:"
-      },
-      "deleting": {
-        "description": "Te rugăm să aștepți cât timp ștergem toate datele asociate.",
-        "title": "Ștergere factură..."
-      },
-      "description": "Această acțiune nu poate fi anulată. Te rugăm să verifici atent înainte de a continua.",
-      "impact": {
-        "intro": "Următoarele date vor fi șterse definitiv:",
-        "invoiceRecord": "Înregistrarea facturii și metadatele",
-        "lineItems": "{count} line articol(s)",
-        "sharedAccess": "Acces partajat pentru {count} utilizator(i)",
-        "title": "Ștergere permanentă",
-        "uploadedScans": "{count} scanare(i) încărcată(e)"
-      },
-      "title": "Șterge factură",
-      "toasts": {
-        "deletedDescription": "Factura a fost ștearsă cu succes.",
-        "deletedTitle": "Factură ștearsă",
-        "deleteFailedDescription": "Nu am putut șterge această factură. Te rugăm să încerci din nou.",
-        "deleteFailedTitle": "Șterge eșuat"
-      }
-    },
-    "exportDialog": {
-      "buttons": {
-        "cancel": "Anulează",
-        "copied": "Copiat!",
-        "copy": "Copiază în Clipboard",
-        "export": "Exportă"
-      },
-      "description": "Exportă {count} facturi în formatul preferat.",
-      "estimate": {
-        "label": "Dimensiune estimată fișier:"
-      },
-      "filename": {
-        "hint": "Fișierul va fi salvat cu extensia bazată pe format",
-        "label": "Nume fișier"
-      },
-      "format": {
-        "descriptions": {
-          "csv": "Format de foaie de calcul, compatibil cu Excel",
-          "json": "Format de date structurate",
-          "pdf": "Format document imprimabil"
-        },
-        "labels": {
-          "csv": "CSV",
-          "json": "JSON",
-          "pdf": "PDF"
-        },
-        "title": "Format de export"
-      },
-      "options": {
-        "csv": {
-          "delimiterLabel": "Suprascriere delimitator CSV (opțional):",
-          "delimiterPlaceholder": ",",
-          "includeHeaders": "Include antetele CSV"
-        },
-        "includeMerchant": "Include comerciantul",
-        "includeMetadata": "Include metadatele",
-        "includeProducts": "Include produsele",
-        "json": {
-          "prettyPrint": "Afișare formatată (2 spații)"
-        },
-        "title": "Opțiuni"
-      },
-      "title": "Exportă facturi"
-    },
-    "feedbackDialog": {
-      "buttons": {
-        "cancel": "Anulează",
-        "submit": "Trimite feedback"
-      },
-      "commentsPlaceholder": "Împărtășește-ne părerea ta despre analize...",
-      "description": "Ajută-ne să îmbunătățim analizele pentru {merchant} împărtășindu-ne opinia ta",
-      "features": {
-        "categoryBreakdown": "Categorie Breakdown",
-        "merchantAnalysis": "Merchant Analiză",
-        "priceComparisons": "Preț Comparisons",
-        "savingsTips": "Sfaturi de economisire",
-        "spendingTrends": "Tendințe de cheltuieli",
-        "visualCharts": "Grafice vizuale"
-      },
-      "sections": {
-        "comments": "Comentarii suplimentare (opțional)",
-        "features": "Care funcționalități au fost cele mai utile? (Selectează toate opțiunile aplicabile)",
-        "rating": "Cum ai evalua analizele?"
-      },
-      "title": "Oferă feedback",
-      "toasts": {
-        "error": {
-          "description": "Te rugăm să încerci din nou mai târziu.",
-          "title": "A apărut o eroare la trimiterea feedback-ului"
-        },
-        "ratingRequired": {
-          "description": "Te rugăm să oferi un calificativ cu stele înainte de trimitere",
-          "title": "Evaluare necesară"
-        },
-        "sending": {
-          "description": "Te rugăm să aștepți cât timp trimitem feedback-ul.",
-          "title": "Se trimite feedback-ul..."
-        },
-        "success": {
-          "description": "Feedback trimis cu succes",
-          "title": "Feedback trimis!"
-        }
-      }
-    },
-    "imageDialog": {
-      "imageAlt": "Fotografie a bonului",
-      "title": "Imagine ({image})"
-    },
-    "importDialog": {
-      "buttons": {
-        "cancel": "Anulează",
-        "import": "Importă",
-        "importWithCount": "Importă ({count})"
-      },
-      "description": "Încarcă fișierele de facturi pentru a le importa în sistem.",
-      "dropzone": {
-        "acceptsCsv": "Acceptă fișiere .csv (max 10MB)",
-        "acceptsPdf": "Acceptă fișiere .pdf (max 10MB)",
-        "acceptsXlsx": "Acceptă fișiere .xlsx și .xls (max. 10MB)",
-        "dragAndDrop": "Trage și plasează fișierele aici",
-        "dropHere": "Plasează fișierele aici...",
-        "orClickBrowse": "sau apasă pentru a răsfoi fișierele"
-      },
-      "remove": "Elimină",
-      "selectedFiles": "Fișiere selectate",
-      "status": {
-        "error": "A apărut o eroare la importul fișierelor. Te rugăm să încerci din nou.",
-        "success": "Fișiere importate cu succes!"
-      },
-      "tabs": {
-        "csv": "CSV",
-        "pdf": "PDF",
-        "xlsx": "Excel"
-      },
-      "title": "Importă facturi"
-    },
-    "itemsDialog": {
-      "aria": {
-        "addItem": "Adaugă un articol nou în factură",
-        "cancel": "Anulează editarea și închide dialogul",
-        "deleteItem": "Șterge articol: {name}",
-        "nextPage": "Mergi la pagina următoare (pagina {page})",
-        "previousPage": "Mergi la pagina anterioară (pagina {page})",
-        "save": "Salvează modificările articolelor facturii",
-        "unnamedItem": "unnamed articol"
-      },
-      "buttons": {
-        "addItem": "Adaugă articol",
-        "cancel": "Anulează",
-        "next": "Următor",
-        "previous": "Anterior",
-        "saveChanges": "Salvează changes"
-      },
-      "description": "Actualizează cantitățile, prețurile sau adaugă articole noi în această factură",
-      "footer": {
-        "itemsFound": "{total} articole găsite (se afișează {shown})",
-        "itemsTotal": "{count, plural, one {# articol în total} few {# articole în total} other {# de articole în total}}",
-        "page": "Pagina {current} din {total}"
-      },
-      "table": {
-        "actions": "Acțiuni",
-        "item": "Articol",
-        "price": "Preț",
-        "quantity": "Cantitate",
-        "total": "Total general",
-        "unit": "Unitate"
-      },
-      "title": "Editează articolele facturii"
-    },
-    "merchantDialog": {
-      "buttons": {
-        "openInMaps": "Deschide în Maps"
-      },
-      "description": "Informații despre {merchantName}",
-      "fields": {
-        "address": "Adresă",
-        "parentCompany": "Companie mamă",
-        "phone": "Telefon"
-      },
-      "noMerchantLinked": "Niciun comerciant asociat acestei facturi",
-      "title": "Detalii comerciant"
-    },
-    "merchantReceiptsDialog": {
-      "buttons": {
-        "next": "Următor",
-        "previous": "Anterior"
-      },
-      "dateOptions": {
-        "allTime": "Toată perioada",
-        "last30Days": "Ultimele 30 de zile",
-        "last90Days": "Ultimele 90 de zile",
-        "thisYear": "Anul acesta"
-      },
-      "description": "Vezi și filtrează toate bonurile tale de la acest comerciant",
-      "filters": {
-        "date": "Dată",
-        "sort": "Sortare"
-      },
-      "footer": {
-        "page": "Pagina {current} din {total}",
-        "receiptsFound": "{count} bonuri găsite (afișate {showing})"
-      },
-      "searchPlaceholder": "Caută receipts...",
-      "sortOptions": {
-        "newest": "Cele mai noi primele",
-        "oldest": "Cele mai vechi primele"
-      },
-      "table": {
-        "actions": "Acțiuni",
-        "date": "Dată",
-        "itemsCount": "Articole #",
-        "receipt": "Bon",
-        "view": "Vede"
-      },
-      "title": "Toate bonurile de la {merchant}"
-    },
-    "metadataDialog": {
-      "add": {
-        "description": "Adaugă informații suplimentare la această factură",
-        "title": "Adaugă metadate"
-      },
-      "buttons": {
-        "cancel": "Anulează",
-        "delete": "Șterge",
-        "save": "Salvează"
-      },
-      "delete": {
-        "description": "Sigur vrei să ștergi aceste metadate?",
-        "title": "Șterge metadatele"
-      },
-      "edit": {
-        "description": "Actualizează valoarea acestui câmp de metadate",
-        "fieldLabel": "Câmp metadate",
-        "title": "Editează metadatele"
-      },
-      "fields": {
-        "keyLabel": "Cheie metadate",
-        "keyPlaceholder": "Introdu cheia",
-        "valueLabel": "Valoare metadate",
-        "valuePlaceholder": "Introdu valoarea"
-      }
-    },
-    "recipeDialog": {
-      "actions": {
-        "enhanceInstructions": "Îmbunătățește instrucțiunile",
-        "generateName": "Generează nume"
-      },
-      "buttons": {
-        "add": "Adaugă",
-        "cancel": "Anulează",
-        "close": "Închide",
-        "delete": "Șterge",
-        "save": "Salvează",
-        "saving": "Se salvează..."
-      },
-      "create": {
-        "description": "Completează detaliile pentru a crea o rețetă.",
-        "error": "Nu s-a putut crea rețeta",
-        "success": "Rețeta a fost creată cu succes",
-        "title": "Adaugă o rețetă nouă"
-      },
-      "delete": {
-        "description": "Această acțiune nu poate fi anulată. Va șterge definitiv rețeta <strong>{name}</strong> și toate datele asociate.",
-        "title": "Ești sigur?"
-      },
-      "difficulty": {
-        "easy": "Ușor",
-        "hard": "Greu",
-        "medium": "Mediu"
-      },
-      "fields": {
-        "complexity": "Nivel de complexitate",
-        "cookTime": "Timp de gătire",
-        "description": "Descriere",
-        "difficulty": "Nivel de dificultate",
-        "ingredients": "Ingrediente",
-        "instructions": "Instrucțiuni",
-        "prepTime": "Timp de pregătire",
-        "recipeName": "Nume rețetă",
-        "totalDuration": "Durata Totală"
-      },
-      "minutes": "minute",
-      "placeholders": {
-        "cookTime": "ex. 30 minute",
-        "description": "Introdu o descriere scurtă a rețetei",
-        "instructions": "Introdu instrucțiunile de gătire",
-        "prepTime": "ex. 15 minute",
-        "recipeName": "Introdu numele rețetei",
-        "selectDifficulty": "Selectează dificultatea"
-      },
-      "read": {
-        "description": "Detalii despre rețetă și instrucțiuni de preparare",
-        "noDescription": "Nu a fost furnizată nicio descriere.",
-        "notSpecified": "Nespecificat"
-      },
-      "tooltips": {
-        "enhanceInstructions": "Folosește AI pentru a-ți îmbunătăți instrucțiunile cu mai multe detalii",
-        "generateName": "Generează un nume de rețetă pe baza ingredientelor și a nivelului de dificultate folosind AI"
-      },
-      "update": {
-        "description": "Actualizează detaliile rețetei.",
-        "title": "Actualizează rețeta"
-      }
-    },
-    "removeScanDialog": {
-      "buttons": {
-        "cancel": "Anulează",
-        "remove": "Elimină scan",
-        "removing": "Se elimină..."
-      },
-      "console": {
-        "deleteError": "Eroare ștergere scan:"
-      },
-      "description": "Sigur vrei să elimini scanarea {current} din {total}?",
-      "descriptionLastScan": "Aceasta este singura scanare atașată la această factură. Nu o poți elimina.",
-      "errors": {
-        "unknown": "A apărut o eroare necunoscută"
-      },
-      "scanAlt": "Scanare {index}",
-      "scanCaption": "Scanare {index}",
-      "title": "Elimină scan",
-      "toasts": {
-        "cannotDeleteLastDescription": "O factură trebuie să aibă cel puțin o scanare atașată",
-        "cannotDeleteLastTitle": "Nu poți șterge ultima scanare",
-        "removedDescription": "Scanarea a fost eliminată din factură",
-        "removedTitle": "Scan eliminat cu succes",
-        "removeFailedTitle": "Eliminarea scanării a eșuat"
-      },
-      "warning": {
-        "description": "Fiecare factură trebuie să aibă cel puțin o scanare atașată. Adaugă o altă scanare înainte să o elimini pe aceasta.",
-        "title": "Nu poți elimina ultima scanare"
-      }
-    },
-    "shareAnalyticsDialog": {
-      "description": "Partajează analizele tale de cheltuieli pentru {merchant} cu alte persoane.",
-      "email": {
-        "description": "Trimite analizele la o adresă de email.",
-        "label": "Adresă email",
-        "placeholder": "name@example.com",
-        "send": "Trimite email"
-      },
-      "image": {
-        "copyToClipboard": "Copiază graficul în clipboard",
-        "description": "Descarcă sau copiază graficul de analiză ca imagine PNG, pe care o poți partaja sau salva.",
-        "download": "Descarcă graficul",
-        "previewPlaceholder": "Previzualizare analize"
-      },
-      "tabs": {
-        "email": "email",
-        "image": "Imagine"
-      },
-      "title": "Partajează Analytics",
-      "toasts": {
-        "emailSent": {
-          "description": "Raportul de analiză a fost trimis la {email}",
-          "title": "Email trimis!"
-        },
-        "imageCopied": {
-          "description": "Imaginea analizelor a fost copiată în clipboard",
-          "title": "Imagine copiată!"
-        },
-        "imageSaved": {
-          "description": "Analizele de cheltuieli pentru {merchant} au fost descărcate ca PNG",
-          "title": "Imagine salvată!"
-        }
-      }
-    },
-    "shareInvoiceDialog": {
-      "dialogDescription": {
-        "currentlyPublic": "\"{invoiceName}\" este publică în acest moment",
-        "private": "Trimite \"{invoiceName}\" în privat",
-        "public": "Partajează \"{invoiceName}\" public",
-        "selection": "Alege cum să partajezi „{invoiceName}”"
-      },
-      "errors": {
-        "qrNotFound": "Elementul codului QR nu a fost găsit"
-      },
-      "selection": {
-        "description": "Alege cum vrei să partajezi această factură. Opțiunea aleasă influențează cine poate avea acces.",
-        "privacyNoticeDescription": "Linkurile publice pot fi accesate de oricine are URL-ul. Partajarea privată limitează accesul la destinatarul specificat.",
-        "privacyNoticeTitle": "Notă de confidențialitate",
-        "privateDescription": "Trimite o invitație pe email unei <strong>persoane specifice</strong>. Doar acea persoană va avea acces.",
-        "privateTitle": "Privat sharing",
-        "publicDescription": "Generează un link sau un cod QR pe care <strong>oricine</strong> îl poate folosi pentru a vedea această factură.",
-        "publicTitle": "Partajare publică"
-      },
-      "title": "Partajează factură",
-      "toasts": {
-        "copyLink": {
-          "error": "Eșuat: {message}",
-          "loadingMakePublic": "Factura devine publică...",
-          "loadingPublic": "Se copiază linkul...",
-          "successMadePublic": "Factura este acum publică! Link copiat în clipboard.",
-          "successPublic": "Link copiat în clipboard!"
-        },
-        "copyQr": {
-          "error": "Eșuat: {message}",
-          "loadingMakePublic": "Factura devine publică...",
-          "loadingPublic": "Se copiază codul QR...",
-          "successMadePublic": "Factura este acum publică! Cod QR copiat în clipboard.",
-          "successPublic": "Cod QR copiat în clipboard!"
-        },
-        "revoke": {
-          "error": "Revocarea accesului a eșuat: {message}",
-          "loading": "Se trimite cererea de revocare către server...",
-          "success": "Factura este acum privată. Linkurile existente nu vor mai funcționa."
-        },
-        "sendEmail": {
-          "comingSoon": "Partajarea prin email va fi disponibilă în curând",
-          "error": "Eșuat: {message}",
-          "loading": "Se trimite invitația către {email}...",
-          "success": "Invitație trimisă către {email}!"
-        }
-      }
-    },
-    "shareInvoiceDialogPrivate": {
-      "backToOptions": "Înapoi la opțiuni",
-      "comingSoonTooltip": "Funcția de partajare prin email va fi disponibilă în curând",
-      "description": "Invitația va fi trimisă direct la adresa de email pe care o specifici. Doar acest destinatar va primi acces pentru a vedea factura.",
-      "emailHint": "O invitație pe email va fi trimisă la această adresă cu un link privat pentru a vedea factura.",
-      "emailLabel": "Adresa de email a destinatarului",
-      "emailPlaceholder": "name@example.com",
-      "sending": "Se trimite invitația...",
-      "sendInvitation": "Trimite invitație privată",
-      "title": "Privat sharing"
-    },
-    "shareInvoiceDialogPublic": {
-      "alreadyPublic": {
-        "description": "Această factură este accesibilă public. <strong>Oricine are linkul o poate vedea</strong>, inclusiv toate detaliile facturii, articolele și sumele. Poți revoca accesul public oricând pentru a o face din nou privată.",
-        "revoke": "Revocă accesul public",
-        "revokeHint": "Factura va deveni privată. Linkurile existente nu vor mai funcționa.",
-        "revoking": "Se revocă accesul...",
-        "title": "Această factură este publică în acest moment"
-      },
-      "backToOptions": "Înapoi la opțiuni",
-      "copyQrImage": "Copiază codul QR ca imagine",
-      "hints": {
-        "link": "Copiază acest link și partajează-l. Oricine îl primește va putea vedea factura.",
-        "qr": "Oricine scanează acest cod QR va fi redirecționat pentru a vedea factura."
-      },
-      "tabs": {
-        "directLink": "Link direct",
-        "qrCode": "Cod QR"
-      },
-      "warning": {
-        "description": "Prin partajarea publică a acestei facturi, <strong>oricine are linkul o va putea vedea</strong>. Asta include toate detaliile facturii, articolele și sumele. Continuă doar dacă vrei ca această factură să fie accesibilă publicului.",
-        "title": "Avertisment privind accesul public"
-      }
-    }
-  },
-  "IMS--Edit": {
-    "changeHistory": {
-      "changes": {
-        "categoryUpdated": "Categorie actualizată",
-        "descriptionChanged": "Descriere modificată",
-        "importanceChanged": "Importanță modificată",
-        "markedImportant": "Marcat ca important",
-        "nameChanged": "Nume modificat",
-        "paymentTypeChanged": "Tip plată modificat",
-        "transactionDateChanged": "Data tranzacției modificată",
-        "unmarkedImportant": "Demarcat ca important"
-      },
-      "created": "Factură creată",
-      "modified": "Ultima modificare",
-      "pending": "În așteptare",
-      "time": {
-        "daysAgo": "acum {days} zile",
-        "hoursAgo": "acum {hours} ore",
-        "justNow": "Acum",
-        "minutesAgo": "acum {minutes} minute",
-        "secondsAgo": "acum {seconds} secunde"
-      },
-      "title": "Istoric Modificări",
-      "unsavedChanges": "Modificări nesalvate"
-    },
-    "editInvoiceContext": {
-      "console": {
-        "saveFailed": "Salvarea facturii a eșuat:"
-      },
-      "toasts": {
-        "noChanges": "Nu există modificări de salvat",
-        "saveFailed": "Salvarea modificărilor a eșuat",
-        "updated": "Factura a fost actualizată cu succes"
-      }
-    },
-    "guidedEditBanner": {
-      "actions": {
-        "dismiss": "Închide",
-        "reviewAll": "Revizuiește toate"
-      },
-      "badges": {
-        "lowConfidence": "{count, plural, one {# încredere scăzută} few {# încredere scăzută} other {# încredere scăzută}}",
-        "missingName": "{count, plural, one {# nume lipsă} few {# nume lipsă} other {# nume lipsă}}",
-        "uncategorized": "{count, plural, one {# necategorizat} few {# necategorizate} other {# necategorizate}}"
-      },
-      "summary": {
-        "lowConfidence": "{count, plural, one {# încredere scăzută} few {# încredere scăzută} other {# încredere scăzută}}",
-        "missingName": "{count, plural, one {# nume lipsă} few {# nume lipsă} other {# nume lipsă}}",
-        "uncategorized": "{count, plural, one {# necategorizat} few {# necategorizate} other {# necategorizate}}"
-      },
-      "title": "{count, plural, one {# produs necesită revizuire} few {# produse necesită revizuire} other {# de produse necesită revizuire}}"
-    },
-    "itemsTable": {
-      "actions": {
-        "editAllergens": "Editează alergeni",
-        "remove": "Elimină produs",
-        "restore": "Restabilește produs"
-      },
-      "bulkCategory": {
-        "noSelection": "Vă rugăm să selectați cel puțin un produs"
-      },
-      "bulkToolbar": {
-        "changeCategory": "Schimbă Categoria",
-        "deleteSelected": "Șterge selecționate",
-        "noSelection": "Niciun produs selectat",
-        "selectedCount": "{count, plural, one {# articol selectat} few {# articole selectate} other {# de articole selectate}}"
-      },
-      "buttons": {
-        "addItem": "Adaugă articol",
-        "editItems": "Editează articolele"
-      },
-      "columns": {
-        "actions": "Acțiuni",
-        "name": "Nume",
-        "price": "Preț",
-        "quantity": "Cantitate",
-        "selectAll": "Selectează toate articolele",
-        "selectRow": "Selectează {name}",
-        "total": "Total",
-        "unit": "Unitate"
-      },
-      "deleteConfirm": {
-        "cancel": "Anulează",
-        "confirm": "Șterge",
-        "description": "{count, plural, one {Sigur doriți să ștergeți acest articol?} few {Sigur doriți să ștergeți aceste # articole?} other {Sigur doriți să ștergeți aceste # de articole?}}",
-        "success": "{count, plural, one {# articol șters} few {# articole șterse} other {# de articole șterse}}",
-        "title": "Șterge articole"
-      },
-      "editing": {
-        "cancel": "Editare anulată",
-        "fieldLabel": "Editează {field} pentru {name}",
-        "saved": "Articol actualizat cu succes"
-      },
-      "footer": {
-        "total": "Total"
-      },
-      "indicators": {
-        "allergens": "{count, plural, one {# alergen} other {# alergeni}}",
-        "edited": "Editat",
-        "editedTooltip": "Acest produs a fost modificat manual",
-        "lowConfidence": "Încredere scăzută",
-        "lowConfidenceTooltip": "Încrederea OCR este de {confidence}% - se recomandă revizuire manuală",
-        "missingName": "Nume lipsă",
-        "missingNameTooltip": "Traducerea numelui generic lipsește sau este identică cu textul OCR brut",
-        "uncategorized": "Necategorizat",
-        "uncategorizedTooltip": "Acest produs necesită o categorie atribuită pentru o urmărire mai bună a cheltuielilor"
-      },
-      "newItem": {
-        "added": "Articol nou adăugat",
-        "defaultName": "Articol nou"
-      },
-      "pagination": {
-        "next": "Următor",
-        "pageOf": "Pagina {currentPage} din {totalPages}",
-        "previous": "Anterior",
-        "totalItems": "{count, plural, one {# articol în total} few {# articole în total} other {# de articole în total}}"
-      },
-      "restore": {
-        "error": "Eroare la restabilirea produsului",
-        "success": "Produsul {name} a fost restabilit"
-      },
-      "search": {
-        "placeholder": "Caută articole..."
-      },
-      "softDelete": {
-        "error": "Eroare la eliminarea produsului",
-        "success": "Produsul {name} a fost eliminat"
-      },
-      "tableHeaders": {
-        "item": "Articol",
-        "price": "Preț",
-        "quantity": "Cant.",
-        "total": "Total"
-      },
-      "title": "Articole",
-      "tooltips": {
-        "editInvoiceItemsAndQuantities": "Editează articolele și cantitățile facturii"
-      }
-    },
-    "metadata": {
-      "description": "Vizualizați și editați detaliile facturii, articolele, rețetele și setările de partajare.",
-      "title": "Editare factură"
-    },
-    "metadataTab": {
-      "badges": {
-        "readonly": "Doar citire"
-      },
-      "buttons": {
-        "addField": "Adaugă câmp",
-        "addFirstMetadataField": "Adaugă primul tău câmp de metadate"
-      },
-      "dropdown": {
-        "delete": "Șterge",
-        "edit": "Editează"
-      },
-      "emptyState": {
-        "noMetadataFields": "Nu au fost adăugate câmpuri de metadate"
-      },
-      "header": {
-        "description": "Metadate asociate acestei facturi",
-        "title": "Informații suplimentare"
-      },
-      "tooltips": {
-        "addCustomMetadata": "Adaugă metadate personalizate la această factură"
-      }
-    },
-    "recipesTab": {
-      "buttons": {
-        "addRecipe": "Adaugă rețetă",
-        "createFirstRecipe": "Creează prima ta rețetă",
-        "generate": "Generează"
-      },
-      "emptyState": {
-        "noRecipesAvailable": "Nu există încă rețete disponibile"
-      },
-      "header": {
-        "description": "Pe baza articolelor din această factură",
-        "title": "Rețete pe care le poți prepara"
-      },
-      "pagination": {
-        "next": "Următor",
-        "pageOf": "Pagina {currentPage} din {totalPages}",
-        "previous": "Anterior"
-      },
-      "toasts": {
-        "aiGenerationComingSoon": {
-          "description": "Această funcționalitate este în curs de dezvoltare.",
-          "title": "Generarea rețetelor cu IA vine în curând"
-        }
-      },
-      "tooltips": {
-        "createRecipeWithIngredients": "Creează o rețetă nouă cu aceste ingrediente",
-        "generateRecipeUsingAi": "Generează o rețetă cu IA!"
-      }
-    },
-    "triviaTips": {
-      "banner": {
-        "hint": "Aplică aceste sfaturi pentru a economisi la următoarea vizită la {merchantName}",
-        "potentialSavingsLabel": "Economii potențiale"
-      },
-      "buttons": {
-        "viewMoreSavingsTips": "Vezi mai multe sfaturi de economisire"
-      },
-      "completeLabel": "Factura este complet completă!",
-      "completeness": "Factura este completă în proporție de {percentage}%",
-      "contextActions": {
-        "addDescription": "Adaugă Descriere",
-        "analyze": "Rulează Analiza",
-        "setCategory": "Setează Categoria"
-      },
-      "contextTips": {
-        "defaultCategory": "Schimbă categoria din 'Necategorizat' pentru o urmărire mai bună",
-        "noCategory": "Setează o categorie pentru a urmări modelele de cheltuieli",
-        "noDescription": "Adaugă o descriere pentru a-ți aminti această achiziție",
-        "noItems": "Rulează analiza AI pentru a extrage articolele din bon",
-        "noRecipes": "AI poate sugera rețete bazate pe articolele tale alimentare"
-      },
-      "difficulty": {
-        "easy": "Ușor",
-        "medium": "Mediu"
-      },
-      "disclaimer": "Economiile sunt estimări bazate pe prețuri și promoții medii",
-      "tips": {
-        "bulkPurchase": {
-          "description": "Cumpără produse neperisabile la vrac pentru a reduce costul per unitate.",
-          "title": "Cumpără la vrac"
-        },
-        "digitalCoupons": {
-          "description": "Verifică aplicația {merchantName} pentru cupoane digitale înainte de cumpărături.",
-          "title": "Folosește cupoane digitale"
-        },
-        "loyaltyProgram": {
-          "description": "Înscrie-te în programul de loialitate {merchantName} pentru a câștiga puncte la fiecare achiziție.",
-          "title": "Înscrie-te în programul de loialitate"
-        }
-      },
-      "title": "Sfaturi de economisire",
-      "tooltips": {
-        "estimatedSavings": "Economii estimate cu acest sfat"
-      }
-    }
-  },
-  "IMS--Landing": {
-    "bento": {
-      "ai": {
-        "description": "Extracție GPT-4",
-        "title": "Bazat pe AI"
-      },
-      "analyticsCard": {
-        "description": "Perspective cheltuieli",
-        "title": "Analiză"
-      },
-      "cloud": {
-        "description": "Acces de oriunde",
-        "title": "Sincronizare Cloud"
-      },
-      "description": "Funcționalități puternice concepute pentru a face gestionarea facturilor fără efort",
-      "mobile": "Funcționează excelent pe dispozitive mobile",
-      "ocr": {
-        "description": "Captură automată date",
-        "title": "OCR Inteligent"
-      },
-      "secure": {
-        "description": "Criptare de nivel bancar",
-        "title": "Securizat"
-      },
-      "share": {
-        "description": "Colaborare ușoară",
-        "title": "Partajare"
-      },
-      "title": "Tot Ce Ai Nevoie"
-    },
-    "cta": {
-      "badges": {
-        "ai": "Bazat pe AI",
-        "cloud": "Sincronizat în Cloud",
-        "secure": "Securizat și Privat"
-      },
-      "description": "Încarcă prima ta scanare și experimentează magia gestionării facturilor bazată pe AI.",
-      "learnMore": "Află Mai Multe",
-      "title": "Gata să Începi?",
-      "uploadButton": "Încarcă Prima Scanare"
-    },
-    "features": {
-      "analytics": {
-        "description": "Obține informații detaliate despre tiparele tale de cheltuieli cu grafice și rapoarte.",
-        "title": "Analiză Cheltuieli"
-      },
-      "batch": {
-        "description": "Procesează mai multe scanări simultan - creează facturi individuale sau combină-le într-una singură.",
-        "title": "Procesare în Loturi"
-      },
-      "description": "Tot ce ai nevoie pentru a gestiona facturile eficient",
-      "imageAlt": "Ilustrație cu funcționalitățile facturilor",
-      "ocr": {
-        "description": "AI-ul nostru extrage automat numele comercianților, datele, sumele și articolele din scanări.",
-        "title": "Extracție OCR Inteligentă"
-      },
-      "signIn": "Autentifică-te",
-      "signInPrompt": "Conectează-te pentru a salva facturile permanent și a le accesa de pe orice dispozitiv.",
-      "title": "Funcționalități Puternice"
-    },
-    "hero": {
-      "description": "Încarcă chitanțele și facturile tale, organizează-le și obține informații despre obiceiurile tale de cheltuieli. Sistemul nostru bazat pe AI extrage datele automat.",
-      "getStarted": "Începe Acum",
-      "imageAlt": "Ilustrație pentru gestionarea facturilor",
-      "title": "Gestionează-ți",
-      "titleHighlight": "Facturile",
-      "titleSuffix": "cu Ușurință",
-      "viewMyInvoices": "Vezi Facturile Mele"
-    },
-    "metadata": {
-      "description": "Gestionează chitanțele, creează facturi și obține informații despre obiceiurile tale de cheltuieli.",
-      "title": "Sistemul de Management al Facturilor"
-    },
-    "workflow": {
-      "description": "Trei pași simpli pentru a digitaliza și organiza documentele tale financiare",
-      "step1": {
-        "button": "Încarcă Acum",
-        "description": "Trage și lasă chitanțele, facturile sau bonurile tale. Acceptăm fișiere JPG, PNG și PDF de până la 10MB fiecare.",
-        "title": "Încarcă Scanări"
-      },
-      "step2": {
-        "button": "Vezi Scanările",
-        "description": "Revizuiește scanările încărcate, selectează-le pe cele dorite și creează facturi din ele individual sau în loturi.",
-        "title": "Vizualizează și Organizează"
-      },
-      "step3": {
-        "button": "Vezi Facturile",
-        "description": "Vizualizează facturile, analizează tiparele de cheltuieli și obține perspective bazate pe AI despre obiceiurile tale financiare.",
-        "title": "Gestionează Facturile"
-      },
-      "title": "Cum Funcționează"
-    }
-  },
-  "IMS--List": {
-    "bulkActions": {
-      "categories": {
-        "carAuto": "Mașină & Auto",
-        "fastFood": "Fast Food",
-        "grocery": "Alimente",
-        "homeCleaning": "Curățenie Casă",
-        "notDefined": "Nedefinit",
-        "other": "Altele"
-      },
-      "categoryChanged": "{count, plural, one {Categoria facturii actualizată cu succes} other {# categorii de facturi actualizate cu succes}}",
-      "categoryChangeError": "Eroare la actualizarea categoriilor facturilor. Vă rugăm încercați din nou.",
-      "categoryPartialSuccess": "{success} factură/facturi actualizate, {failed} eșuate",
-      "changeCategory": "Schimbă Categoria",
-      "clearSelection": "Curăță selecția",
-      "delete": "Șterge",
-      "deleteConfirm": {
-        "cancel": "Anulează",
-        "confirm": "Șterge",
-        "description": "{count, plural, one {Ești sigur că dorești să ștergi această factură? Această acțiune nu poate fi anulată.} other {Ești sigur că dorești să ștergi aceste # facturi? Această acțiune nu poate fi anulată.}}",
-        "title": "Șterge Facturile"
-      },
-      "deleteError": "Eroare la ștergerea facturilor. Vă rugăm încercați din nou.",
-      "deletePartialSuccess": "{success} factură/facturi șterse, {failed} eșuate",
-      "deleteSuccess": "{count, plural, one {Factură ștearsă cu succes} other {# facturi șterse cu succes}}",
-      "export": "Exportă",
-      "selected": "{count, plural, one {# factură selectată} other {# facturi selectate}}"
-    },
-    "generativeView": {
-      "chatDescription": "Discută cu AI pentru a-ți analiza facturile și pentru a primi analize utile. Încearcă comenzi precum /find pentru a căuta facturi.",
-      "help": "Ajutor",
-      "settings": {
-        "allowInvoiceData": "Permite accesul la datele facturii",
-        "allowMerchantData": "Permite accesul la datele comerciantului",
-        "dataAccessTitle": "Acces la date",
-        "description": "Configurează preferințele asistentului tău AI",
-        "historyLabel": "Chat istoric",
-        "notificationPreferences": "Preferințe de notificare",
-        "notifyInsights": "Notifică-mă despre analize noi",
-        "retention": {
-          "30": "Păstrează 30 de zile",
-          "60": "Păstrează 60 de zile",
-          "90": "Păstrează 90 de zile",
-          "none": "Don't salvează istoric"
-        },
-        "retentionPlaceholder": "Selectează perioada de păstrare",
-        "save": "Salvează setări",
-        "title": "Chat setări"
-      },
-      "subtitle": "Discută cu AI pentru a-ți analiza facturile și pentru a primi analize utile",
-      "tabs": {
-        "chat": "Conversație",
-        "settings": "Setări"
-      },
-      "title": "Analiză live",
-      "welcomeMessage": "Salut! Sunt asistentul tău de analiză a facturilor. Cu ce te pot ajuta astăzi? Încearcă comenzi precum /find pentru a căuta facturi."
-    },
-    "gridView": {
-      "itemCount": "{count, plural, one {# articol} few {# articole} other {# de articole}}",
-      "tooltips": {
-        "viewDetails": "Vezi detalii"
-      }
-    },
-    "invoicesHeader": {
-      "actions": {
-        "export": "Exportă",
-        "import": "Importă",
-        "newInvoice": "Factură nouă",
-        "print": "Printează"
-      },
-      "description": "Gestionează-ți bonurile și urmărește-ți obiceiurile de cheltuieli",
-      "title": "Gestionare facturi",
-      "tooltips": {
-        "export": "Exportă toate facturile",
-        "import": "Importă facturi din fișiere",
-        "newInvoice": "Creează o factură nouă",
-        "print": "Printează facturile"
-      }
-    },
-    "invoicesView": {
-      "categories": {
-        "all": "Toate categoriile",
-        "dining": "Mese în oraș",
-        "entertainment": "Divertisment",
-        "groceries": "Alimente",
-        "other": "Altele",
-        "travel": "Călătorii",
-        "utilities": "Utilități"
       },
       "filters": {
         "activeCount": "{count} active",
         "amountMax": "Sumă maximă",
         "amountMin": "Sumă minimă",
+        "amountPresets": {
+          "value0to50": "0-50",
+          "value100to500": "100-500",
+          "value500plus": "500+",
+          "value50to100": "50-100"
+        },
         "amountRange": "Interval de sumă",
         "anyValue": "orice",
         "button": "Filtre",
@@ -3322,15 +2250,24 @@
         "currencyAny": "orice",
         "dateFrom": "De la data",
         "datePresets": {
-          "30d": "30z",
-          "90d": "90z",
           "all": "Tot timpul",
           "custom": "Personalizat",
+          "value30d": "30z",
+          "value90d": "90z",
           "ytd": "An curent"
         },
         "dateRange": "Interval de date",
         "dateTo": "Până la data",
         "defaultValue": "implicit",
+        "dynamicHint": "Aceste opțiuni sunt populate din facturile tale — apar doar valorile prezente în datele tale.",
+        "paymentTypeLabels": {
+          "card": "Card",
+          "cash": "Numerar",
+          "mobile": "Mobil",
+          "other": "Altul",
+          "transfer": "Transfer",
+          "voucher": "Tichet"
+        },
         "paymentTypes": "Tipuri de plată",
         "showResults": "Afișează {count, plural, one {# rezultat} other {# rezultate}}",
         "sortBy": "Sortare după",
@@ -3343,1976 +2280,3119 @@
           "nameZA": "Nume (Z-A)"
         },
         "timeOfDay": "Momentul zilei",
-        "title": "Filtre",
-        "amountPresets": {
-          "0to50": "0-50",
-          "100to500": "100-500",
-          "500plus": "500+",
-          "50to100": "50-100"
-        },
-        "dynamicHint": "Aceste opțiuni sunt populate din facturile tale — apar doar valorile prezente în datele tale.",
-        "paymentTypeLabels": {
-          "card": "Card",
-          "cash": "Numerar",
-          "mobile": "Mobil",
-          "other": "Altul",
-          "transfer": "Transfer",
-          "voucher": "Tichet"
+        "title": "Filtre"
+      }
+    }
+  },
+  "pages": {
+    "about": {
+      "author": {
+        "metadata": {
+          "description": "Aflați mai multe despre autor, Alexandru-Razvan Olariu.",
+          "title": "Alexandru-Razvan Olariu"
         }
       },
-      "placeholderPanel": "Vor fi adăugate în curând mai multe controale de filtrare.",
-      "searchPlaceholder": "Caută facturi...",
-      "times": {
-        "all": "Toate intervalele",
-        "day": "Zi (6-18)",
-        "night": "Noapte (18-6)"
-      },
-      "viewModes": {
-        "grid": "Grid vede",
-        "table": "Table vede"
-      }
-    },
-    "messageList": {
-      "aiAssistant": "Asistent AI",
-      "you": "Tu"
-    },
-    "metadata": {
-      "description": "Enumerați toate facturile din sistemul de gestionare a facturilor.",
-      "title": "Enumerați facturile"
-    },
-    "subtitle": "Acesta este inventarul dvs. de bonuri digitale. <br></br> Aici puteți găsi bonurile pe care le-ați încărcat până acum. <br></br> Făcând clic pe o chitanță, veți fi redirecționat către pagina chitanței specifice.",
-    "tableView": {
-      "aria": {
-        "rowsPerPage": "Rânduri pe pagină",
-        "selectAllInvoices": "Selectează toate facturile",
-        "selectInvoice": "Selectează factură {name}",
-        "sortByAmount": "Sortare după sumă",
-        "sortByDate": "Sortare după dată"
-      },
-      "columns": {
-        "actions": "Acțiuni",
-        "amount": "Sumă",
-        "category": "Categorie",
-        "date": "Dată",
-        "invoice": "Factură"
-      },
-      "empty": {
-        "description": "Începeți prin a încărca chitanțele pentru a crea prima factură",
-        "title": "Nu există facturi încă",
-        "uploadCta": "Încărcați prima chitanță"
-      },
-      "nextPage": "Pagina următoare",
-      "pageOf": "Pagina {current} din {total}",
-      "previousPage": "Pagina anterioară",
-      "rowsPerPage": "Rânduri pe pagină:",
-      "tooltips": {
-        "notAnalyzed": "Această factură nu a fost încă analizată"
-      },
-      "viewInvoice": "Vede Factură"
-    },
-    "tableViewActions": {
-      "actions": {
-        "delete": "Șterge",
-        "edit": "Editează",
-        "share": "Partajează"
-      },
-      "tooltips": {
-        "delete": "Șterge definitiv această factură",
-        "edit": "Editează detaliile facturii",
-        "moreActions": "Mai multe acțiuni",
-        "share": "Partajează factura prin link sau e-mail"
-      }
-    },
-    "title": "Bine ați venit, {name}!",
-    "viewInvoicesIsland": {
-      "tabs": {
-        "invoices": "Facturi",
-        "liveAnalysis": "Analiză live",
-        "statistics": "Statistici"
-      }
-    },
-    "viewInvoicesPage": {
-      "guestName": "dragă oaspete"
-    }
-  },
-  "IMS--Stats": {
-    "allergenSummary": {
-      "ariaLabel": "Rezumat frecvență alergeni",
-      "description": "Expunerea la alergeni în produse",
-      "empty": "Niciun alergen detectat în achizițiile tale",
-      "stats": {
-        "ofTotal": "din total",
-        "products": "produse"
-      },
-      "title": "Rezumat Alergeni"
-    },
-    "calendarHeatmap": {
-      "aria": {
-        "calendarGrid": "Calendar cheltuieli zilnice"
-      },
-      "days": {
-        "fri": "Vin",
-        "mon": "Lun",
-        "sat": "Sâm",
-        "sun": "Dum",
-        "thu": "Joi",
-        "tue": "Mar",
-        "wed": "Mie"
-      },
-      "description": "Intensitatea cheltuielilor zilnice în timp",
-      "legend": {
-        "less": "Mai puțin",
-        "more": "Mai mult"
-      },
-      "navigation": {
-        "next": "Luna următoare",
-        "previous": "Luna anterioară"
-      },
-      "title": "Calendar Cheltuieli",
-      "tooltip": {
-        "amount": "Cheltuit",
-        "invoices": "{count} facturi",
-        "noSpending": "Fără cheltuieli"
-      }
-    },
-    "categoryBreakdown": {
-      "description": "Distribuție pe categorii",
-      "title": "Cheltuieli pe categorii",
-      "tooltip": {
-        "invoiceCount": "{count} facturi"
-      },
-      "totalLabel": "Cheltuieli totale"
-    },
-    "comparison": {
-      "decrease": "scădere",
-      "description": "Comparație cu luna anterioară",
-      "discovered": "descoperiți",
-      "increase": "creștere",
-      "invoiceCount": "Număr de facturi",
-      "newMerchants": "Comercianți noi",
-      "none": "niciunul",
-      "spendingDelta": "Variația cheltuielilor",
-      "title": "Lună de lună"
-    },
-    "currencyDistribution": {
-      "description": "Defalcarea cheltuielilor pe valute cu conversie în RON",
-      "invoiceCount": "Facturi",
-      "originalAmount": "Original",
-      "ronEquivalent": "Echivalent RON",
-      "showOriginal": "Arată Original",
-      "showRON": "Arată RON",
-      "singleCurrency": "Toate facturile în {currency} ({symbol})",
-      "title": "Distribuție Valutară",
-      "toggleLabel": "Comutați vizualizarea valutei",
-      "totalAmount": "Sumă Totală",
-      "totalCurrencies": "Total Valute",
-      "totalSpending": "Cheltuieli Totale"
-    },
-    "empty": {
-      "cta": "Încarcă bon",
-      "subtitle": "Încărcați bonuri pentru a vedea statisticile",
-      "title": "Nicio statistică încă"
-    },
-    "kpi": {
-      "acrossInvoices": "din {count} facturi",
-      "averageItems": "Med. produse",
-      "avgPerInvoice": "medie {amount} per factură",
-      "invoiceCount": "Număr de facturi",
-      "noneYet": "Niciun rezultat încă",
-      "topMerchant": "Comerciant principal",
-      "totalSpending": "Cheltuieli totale",
-      "visits": "{count} vizite",
-      "vsLastMonth": "{delta}% față de luna trecută"
-    },
-    "merchantLeaderboard": {
-      "description": "Unde cheltuiești cel mai mult",
-      "empty": "Nu sunt date disponibile despre comercianți",
-      "labels": {
-        "totalSpent": "Total Cheltuit"
-      },
-      "title": "Comercianți de Top",
-      "tooltip": {
-        "invoiceCount": "{count} facturi"
-      },
-      "unknownMerchant": "Comerciant necunoscut"
-    },
-    "merchantTrends": {
-      "aria": {
-        "sparkline": "Tendință cheltuieli pentru {merchant}"
-      },
-      "description": "Modele lunare de cheltuieli pentru comercianții de top",
-      "empty": "Nu există date despre comercianți încă",
-      "labels": {
-        "merchant": "Comerciant",
-        "totalSpend": "Total Cheltuit",
-        "trend": "Tendință (Ultimele 6 Luni)"
-      },
-      "title": "Tendințe Cheltuieli Comercianți"
-    },
-    "merchantVisit": {
-      "description": "Frecvența cumpărăturilor și informații despre coș",
-      "empty": "Nu există date de vizite încă",
-      "metrics": {
-        "avgSpend": "Cheltuială Medie/Vizită",
-        "basketSize": "Coș Mediu",
-        "preferredDay": "Zi Preferată",
-        "totalVisits": "Total Vizite",
-        "visitsPerMonth": "Vizite/Lună"
-      },
-      "title": "Modele de Vizitare Comercianți"
-    },
-    "priceDistribution": {
-      "description": "Distribuția prețurilor produselor",
-      "labels": {
-        "itemCount": "Număr de produse"
-      },
-      "title": "Distribuția prețurilor",
-      "tooltip": {
-        "itemCount": "{count} produse"
-      }
-    },
-    "productAnalytics": {
-      "subtitle": "Detalii despre articolele achiziționate",
-      "title": "Analiză Produse"
-    },
-    "productCategory": {
-      "description": "Defalcare cheltuieli după tip de produs",
-      "empty": "Niciun produs de analizat încă",
-      "title": "Cheltuieli pe Categorii de Produse",
-      "tooltip": {
-        "productCount": "{count} produse"
-      }
-    },
-    "spendingOverTime": {
-      "description": "Urmăriți tendințele cheltuielilor",
-      "labels": {
-        "amount": "Sumă"
-      },
-      "title": "Cheltuieli în Timp",
-      "tooltip": {
-        "andMore": "și încă {count}...",
-        "invoiceCount": "{count} facturi"
-      }
-    },
-    "subtitle": "Gestionează bonurile și urmărește obiceiurile tale de cheltuieli",
-    "timeOfDay": {
-      "description": "Când faceți cumpărături",
-      "labels": {
-        "invoiceCount": "Număr de facturi"
-      },
-      "title": "Obiceiuri de cumpărare",
-      "tooltip": {
-        "invoiceCount": "{count} facturi"
-      }
-    },
-    "title": "Statistici facturi",
-    "topProducts": {
-      "ariaLabel": "Clasament produse preferate",
-      "description": "Cele mai cumpărate articole",
-      "empty": "Niciun produs cumpărat încă",
-      "headers": {
-        "avgPrice": "Preț Mediu",
-        "product": "Produs",
-        "purchases": "Achiziții",
-        "quantity": "Cant",
-        "rank": "#",
-        "totalSpent": "Total"
-      },
-      "title": "Produse Preferate"
-    }
-  },
-  "IMS--UploadScans": {
-    "breadcrumb": "Înapoi la Facturi",
-    "buttons": {
-      "myInvoices": "Facturile Mele",
-      "uploadFirst": "Încărcați Prima Scanare",
-      "viewScans": "Vizualizați Scanările"
-    },
-    "errors": {
-      "tooLarge": "Fișier prea mare: {name} (max 10MB)",
-      "unsupportedType": "Tip de fișier neacceptat: {type}"
-    },
-    "header": {
-      "description": "Încărcați imagini sau PDF-uri cu chitanțe. Creați facturi din ele mai târziu.",
-      "title": "Încărcare Scanări",
-      "tooltip": "Încărcați chitanțele, facturile sau bonurile dvs. aici. Puteți selecta mai multe fișiere și le puteți organiza în facturi mai târziu din pagina Vizualizare Scanări."
-    },
-    "metadata": {
-      "description": "Încărcați scanări de chitanțe în contul dvs. pentru procesare ulterioară în facturi.",
-      "title": "Sistem de gestionare a facturilor - Încărcare scanări"
-    },
-    "postUpload": {
-      "createInvoice": "Da, începe analiza",
-      "dismiss": "Închide",
-      "subtitle": "{count, plural, one {Această scanare reprezintă o singură achiziție?} few {Aceste # scanări reprezintă o singură achiziție?} other {Aceste # de scanări reprezintă o singură achiziție?}}",
-      "title": "Încărcare finalizată!",
-      "viewScans": "Nu, analizează-le separat"
-    },
-    "preview": {
-      "pagination": {
-        "next": "Următor",
-        "pageInfo": "{current} / {total} ({count} scanări)",
-        "previous": "Anterior"
-      },
-      "pendingTooltip": "Această scanare nu va fi salvată până nu apăsați pe Încarcă",
-      "removeTooltip": "Elimină acest fișier",
-      "retryAttempt": "Reîncercarea {attempt}",
-      "status": {
-        "completed": "Finalizat",
-        "failed": "Eșuat",
-        "pending": "În așteptare",
-        "retrying": "Reîncercare",
-        "uploading": "Se încarcă"
-      },
-      "title": "Încărcări în așteptare ({count})"
-    },
-    "sidebar": {
-      "formats": {
-        "documentExtensions": ".pdf",
-        "documents": "Documente",
-        "imageExtensions": ".jpg, .jpeg, .png",
-        "images": "Imagini",
-        "maxSize": "Dimensiune maximă: 10MB per fișier",
-        "title": "Formate Acceptate"
-      },
-      "nextSteps": {
-        "button": "Continuați la Vizualizare Scanări",
-        "description": "Scanările dvs. sunt gata. Mergeți la Vizualizare Scanări pentru a le organiza în facturi.",
-        "title": "Toate încărcările sunt complete!"
-      },
-      "security": {
-        "description": "Scanările dvs. sunt criptate și stocate în siguranță. Doar dvs. le puteți accesa.",
-        "title": "Stocare Securizată"
-      },
-      "tips": {
-        "tip1": "Folosiți iluminare bună când fotografiați chitanțele",
-        "tip2": "Asigurați-vă că textul este clar și lizibil",
-        "tip3": "Evitați umbrele și reflexiile",
-        "tip4": "Capturați întreaga chitanță în cadru",
-        "tip5": "PDF-urile funcționează cel mai bine pentru chitanțele digitale",
-        "title": "Sfaturi pentru Rezultate Optime"
-      }
-    },
-    "stats": {
-      "added": "Adăugate",
-      "completed": "Finalizate",
-      "failed": "Eșuate",
-      "pending": "În așteptare",
-      "uploading": "Se încarcă"
-    },
-    "subtitle": "Încărcați imagini sau PDF-uri cu chitanțe. Creați facturi din ele mai târziu.",
-    "title": "Încărcare Scanări",
-    "upload": {
-      "browse": "Răsfoiți fișiere",
-      "dropzone": "Trageți și plasați imaginile sau PDF-urile cu chitanțe aici",
-      "or": "sau"
-    },
-    "uploadArea": {
-      "actions": {
-        "clearAll": "Șterge tot",
-        "uploading": "Se încarcă...",
-        "uploadScans": "Încarcă scanările"
-      },
-      "aria": {
-        "uploadFiles": "Încarcă fișiere"
-      },
-      "compact": {
-        "dropActive": "Plasează fișierele pentru a le adăuga",
-        "dropInactive": "Trage fișiere aici sau fă clic pentru a naviga",
-        "subtitle": "JPG, PNG, PDF până la 10MB"
-      },
-      "empty": {
-        "chooseFiles": "Alege fișiere",
-        "dropActive": "Plasează fișierele pentru încărcare",
-        "dropInactive": "Fă clic sau trage fișiere pentru încărcare",
-        "formats": "Formate acceptate: JPG, PNG, PDF (maxim 10MB fiecare)",
-        "note": "Poți selecta mai multe fișiere.",
-        "pasteHint": "Sfat: poți lipi o imagine direct din clipboard (Ctrl+V).",
-        "title": "Trage și plasează fișierele aici"
-      },
-      "tooltips": {
-        "clearAll": "Elimină toate încărcările în așteptare",
-        "uploadScans": "Pornește încărcarea tuturor scanărilor în așteptare"
-      }
-    }
-  },
-  "IMS--View": {
-    "analysisPanel": {
-      "analyzing": {
-        "progress": "{progress}% completat",
-        "title": "Se analizează..."
-      },
-      "buttons": {
-        "reanalyze": "Re-analizează Factura"
-      },
-      "description": "Re-analizează această factură cu AI pentru a extrage sau actualiza datele",
-      "labels": {
-        "analysisComplete": "Analiză Completă — Toate datele au fost extrase",
-        "granularOptions": "Sau alege o analiză specifică",
-        "lastAnalyzed": "Ultima Analiză",
-        "updates": "{count, plural, one {# actualizare} other {# actualizări}}"
-      },
-      "options": {
-        "completeAnalysis": "Analiză Completă",
-        "invoiceOnly": "Doar Factura",
-        "itemsOnly": "Doar Articole",
-        "merchantOnly": "Doar Comerciant"
-      },
-      "steps": {
-        "analyzing": "Se analizează cu AI...",
-        "complete": "Analiză completă!",
-        "extracting": "Se rulează extragerea OCR...",
-        "finalizing": "Se finalizează rezultatele...",
-        "preparing": "Se pregătește documentul...",
-        "processing": "Se procesează articolele..."
-      },
-      "tip": "Sfat Rapid: Analiza completă durează 30-60 secunde, dar oferă cele mai precise rezultate.",
-      "title": "Analiză AI",
-      "toasts": {
-        "error": {
-          "description": "Nu s-a putut analiza factura. Vă rugăm să încercați din nou mai târziu.",
-          "title": "Analiză Eșuată"
+      "hub": {
+        "cta": {
+          "footer": "Construit cu pasiune în România",
+          "primary": "Vezi pe GitHub",
+          "secondary": "Ia legătura",
+          "subtitle": "Începe-ți călătoria prin platformă sau conectează-te cu autorul.",
+          "title": "Gata de explorare?"
         },
-        "success": {
-          "description": "Factura a fost re-analizată cu succes cu date actualizate.",
-          "title": "Analiză Completă"
+        "faq": {
+          "questions": {
+            "q1": {
+              "answer": "arolariu.ro este o platformă full-stack cuprinzătoare care servește atât ca portofoliu personal, cât și ca vitrină tehnologică. Demonstrează practici moderne de dezvoltare web folosind Next.js, .NET și servicii cloud Azure.",
+              "question": "Ce este arolariu.ro?"
+            },
+            "q2": {
+              "answer": "Da! Întreaga platformă este open source și disponibilă pe GitHub. Poți explora codul sursă, să înveți din el sau chiar să contribui la dezvoltarea lui.",
+              "question": "Este această platformă open source?"
+            },
+            "q3": {
+              "answer": "Platforma folosește Next.js 16 cu React 19 pentru frontend, .NET 10 cu ASP.NET Core pentru backend și Azure pentru infrastructura cloud. Include și o bibliotecă de componente cuprinzătoare și testare extensivă.",
+              "question": "Ce tehnologii sunt folosite?"
+            },
+            "q4": {
+              "answer": "Absolut! Platforma este proiectată să prezinte cele mai bune practici în ingineria software. Simte-te liber să o folosești ca referință pentru arhitectură, modele și detalii de implementare.",
+              "question": "Pot folosi aceasta ca referință pentru propriile mele proiecte?"
+            }
+          },
+          "subtitle": "Întrebări comune despre platformă și scopul ei",
+          "title": "Întrebări frecvente"
+        },
+        "hero": {
+          "badge": "Despre noi",
+          "ctaPrimary": "Explorează platforma",
+          "ctaSecondary": "Cunoaște autorul",
+          "subtitle": "O platformă full-stack modernă construită cu pasiune, proiectată pentru inovație și creată cu atenție la detalii.",
+          "title": "Descoperă arolariu.ro"
+        },
+        "mission": {
+          "description": "arolariu.ro este mai mult decât un simplu site web - este un teren de joacă pentru tehnologii moderne, o vitrină de bune practici și o platformă care demonstrează ce este posibil atunci când excelența în inginerie întâlnește viziunea creativă.",
+          "pillars": {
+            "innovation": {
+              "description": "Adoptăm tehnologii de ultimă oră și modele arhitecturale moderne",
+              "title": "Inovație"
+            },
+            "openness": {
+              "description": "Open source, transparent și orientat spre comunitate",
+              "title": "Deschidere"
+            },
+            "quality": {
+              "description": "Menținem standarde înalte cu acoperire de teste de peste 90%",
+              "title": "Calitate"
+            }
+          },
+          "statement": "Să construim software care face diferența.",
+          "title": "Misiunea noastră"
+        },
+        "navigation": {
+          "author": {
+            "cta": "Cunoaște-l pe Alexandru",
+            "features": {
+              "item0": "Inginer Microsoft",
+              "item1": "Arhitect de soluții",
+              "item2": "Entuziast tehnologie"
+            },
+            "subtitle": "Cunoaște-l pe Alexandru-Răzvan Olariu, inginerul software din spatele acestei platforme.",
+            "title": "Autorul"
+          },
+          "platform": {
+            "cta": "Explorează platforma",
+            "features": {
+              "item0": "Frontend Next.js 16",
+              "item1": "Backend .NET 10",
+              "item2": "Infrastructură Azure Cloud"
+            },
+            "subtitle": "Descoperă arhitectura, stack-ul tehnologic și funcționalitățile care alimentează arolariu.ro.",
+            "title": "Platforma"
+          },
+          "subtitle": "Aprofundează ce face arolariu.ro unic",
+          "title": "Explorează mai departe"
+        },
+        "stats": {
+          "items": {
+            "linesOfCode": {
+              "description": "Între frontend și backend",
+              "label": "Linii de cod",
+              "value": "50K+"
+            },
+            "technologies": {
+              "description": "Stack tehnologic modern",
+              "label": "Tehnologii",
+              "value": "25+"
+            },
+            "testCoverage": {
+              "description": "Standard de asigurare a calității",
+              "label": "Acoperire teste",
+              "value": "90%"
+            },
+            "yearsActive": {
+              "description": "În continuă evoluție din 2022",
+              "label": "Ani activi",
+              "value": "3+"
+            }
+          },
+          "subtitle": "Metrici cheie care demonstrează angajamentul nostru față de calitate",
+          "title": "În cifre"
+        },
+        "values": {
+          "items": {
+            "accessibility": {
+              "description": "Construit pentru toți, cu navigare prin tastatură și suport pentru cititoare de ecran.",
+              "title": "Design accesibil"
+            },
+            "community": {
+              "description": "Open source din suflet, contribuind înapoi la comunitatea de dezvoltatori.",
+              "title": "Comunitatea pe primul loc"
+            },
+            "engineering": {
+              "description": "Fiecare funcționalitate este construită cu arhitectură curată, testare adecvată și mentenabilitate în minte.",
+              "title": "Excelență în inginerie"
+            },
+            "learning": {
+              "description": "Această platformă servește ca teren de testare pentru noi tehnologii și abordări.",
+              "title": "Învățare continuă"
+            },
+            "performance": {
+              "description": "Optimizat pentru viteză cu randare pe server și implementări pe edge.",
+              "title": "Orientat spre performanță"
+            },
+            "privacy": {
+              "description": "Protecția datelor utilizatorilor și confidențialitatea sunt fundamentale, nu gânduri secundare.",
+              "title": "Axat pe confidențialitate"
+            }
+          },
+          "subtitle": "Principiile care ghidează fiecare linie de cod",
+          "title": "Valori fundamentale"
         }
       },
-      "tooltips": {
-        "completeAnalysis": "Extragere OCR completă + procesare AI a tuturor datelor facturii",
-        "invoiceOnly": "Re-extrage informații de bază ale facturii (dată, total, plată)",
-        "itemsOnly": "Re-categorizează și analizează doar articolele individuale",
-        "merchantOnly": "Re-identifică comerciantul și datele de locație",
-        "reanalyze": "Declanșează re-analiza completă cu toate caracteristicile AI"
+      "platform": {
+        "metadata": {
+          "description": "Aflați mai multe despre platformă, Arolariu.ro.",
+          "title": "Platforma"
+        }
       }
     },
-    "categoryComparisonChart": {
-      "description": "Factura aceasta vs media ta",
-      "labels": {
-        "average": "Medie",
-        "current": "Curent"
+    "auth": {
+      "button": {
+        "login": "Conectare",
+        "logout": "Deconectare"
       },
-      "title": "Comparație pe categorii"
-    },
-    "export": {
-      "copyError": "Eroare la copierea rezumatului",
-      "copySuccess": "Rezumat copiat în clipboard",
-      "copySummary": {
-        "description": "Copiază rezumatul text în clipboard",
-        "title": "Copiază Rezumat"
-      },
-      "csv": {
-        "description": "Descarcă articolele ca foaie de calcul",
-        "title": "Exportă ca CSV"
-      },
-      "csvError": "Eroare la exportul CSV",
-      "csvSuccess": "Fișier CSV descărcat cu succes",
-      "description": "Exportă datele facturii în diverse formate",
-      "json": {
-        "description": "Descarcă datele complete ale facturii",
-        "title": "Exportă ca JSON"
-      },
-      "jsonError": "Eroare la exportul JSON",
-      "jsonSuccess": "Fișier JSON descărcat cu succes",
-      "pdf": {
-        "description": "Descarcă document profesional de factură",
-        "title": "Exportă ca PDF"
-      },
-      "pdfError": "Eroare la generarea PDF-ului",
-      "pdfGenerating": "Se generează PDF...",
-      "pdfSuccess": "Fișier PDF descărcat cu succes",
-      "print": {
-        "description": "Printează factura folosind browserul",
-        "title": "Printare"
-      },
-      "printError": "Eroare la deschiderea dialogului de printare",
-      "printSuccess": "Dialog de printare deschis",
-      "title": "Exportă Factură"
-    },
-    "healthScore": {
-      "cta": {
-        "analyze": "Rulează Analiza AI",
-        "edit": "Editează Factura"
-      },
-      "dialogTitle": "Raport de sănătate factură",
-      "factors": {
-        "categoriesAssigned": "Categorii atribuite",
-        "merchantLinked": "Comerciant asociat",
-        "ocrConfidence": "Confidență OCR",
-        "paymentInfo": "Informații plată",
-        "productCompleteness": "Completitudine produse",
-        "productsPresent": "Produse extrase",
-        "recipesGenerated": "Rețete generate"
-      },
-      "hideDetails": "Ascunde detalii factori",
-      "points": "puncte",
-      "seeReport": "Vezi raport detaliat",
-      "showDetails": "Arată detalii factori",
-      "status": {
-        "excellent": "Excelent",
-        "good": "Bun",
-        "incomplete": "Incomplet",
-        "needsAttention": "Necesită Atenție"
-      },
-      "subtitle": "Evaluare comprehensivă a calității datelor",
-      "suggestions": {
-        "fix": "Rezolvă",
-        "incompletePayment": "Informații plată incomplete — adaugă data tranzacției, suma și moneda",
-        "incompleteProducts": "<strong>{count}</strong> produse incomplete — revizuiește și completează câmpurile lipsă",
-        "lowOcrConfidence": "Confidență OCR scăzută la <strong>{count}</strong> produse — revizuiește manual pentru acuratețe",
-        "noMerchant": "Niciun comerciant asociat — adaugă detalii comerciant pentru statistici mai bune",
-        "noProducts": "Nu sunt produse găsite — încarcă un bon sau adaugă articole manual",
-        "noRecipes": "Nu sunt rețete generate — rulează analiza AI pentru a descoperi idei de mese",
-        "title": "Îmbunătățiri Sugerate",
-        "uncategorizedProducts": "<strong>{count}</strong> produse fără categorie — atribuie categorii pentru analiza cheltuielilor"
-      },
-      "title": "Scor Sănătate Factură"
-    },
-    "invoiceAnalytics": {
-      "emptyState": {
-        "description": "Adaugă mai multe facturi pentru a vedea tendințe de cheltuieli, defalcări pe comercianți și comparații pe categorii.",
-        "title": "Date insuficiente pentru comparații"
-      },
-      "tabs": {
-        "compare": "Comparație",
-        "current": "Factura curentă"
-      },
-      "title": "Analize și insight-uri"
-    },
-    "invoiceGuestBanner": {
-      "description": "În prezent nu ești proprietarul acestei facturi. Vizualizarea este limitată la ce a configurat proprietarul în setările de partajare.",
-      "title": "Vizualizare invitat"
-    },
-    "invoiceTabs": {
-      "actions": {
-        "generate": "Generează rețete",
-        "regenerate": "Regenerează rețetele",
-        "regenerateTooltip": "Re-analizează factura pentru a genera noi sugestii de rețete"
-      },
-      "empty": {
-        "additionalInfo": "Nu există informații suplimentare",
-        "recipes": "Nu există sugestii de rețete"
-      },
-      "recipe": {
-        "duration": "{minutes} min",
-        "ingredients": "Ingrediente",
-        "instructions": "Instrucțiuni",
-        "prepCook": "Pregătire: {prep}m • Gătire: {cook}m",
-        "viewRecipe": "Vezi rețeta"
-      },
-      "tabs": {
-        "additionalInfo": "Informații suplimentare",
-        "possibleRecipes": "Rețete posibile"
-      }
-    },
-    "invoiceTimeline": {
-      "eventCount": "{count, plural, one {# eveniment} few {# evenimente} other {# de evenimente}}",
-      "subtitle": "Istoric complet al acțiunilor și modificărilor",
-      "title": "Cronologia facturii"
-    },
-    "itemAnalytics": {
-      "columns": {
-        "category": "Categorie",
-        "name": "Nume",
-        "price": "Preț",
-        "quantity": "Cant.",
-        "total": "Total"
-      },
-      "confidence": {
-        "ariaLabel": "Incredere {level}: {percent}%",
-        "high": "Ridicata",
-        "label": "Încredere OCR",
-        "low": "Scazuta",
-        "lowWarning": "Încredere scăzută — verificați acest produs",
-        "medium": "Medie"
-      },
-      "empty": {
-        "subtitle": "Rulați analiza AI pentru a extrage produsele din bon",
-        "title": "Niciun produs"
-      },
-      "searchPlaceholder": "Caută produse...",
-      "summary": {
-        "allergens": "{count} alergeni detectați",
-        "categories": "{count} categorii",
-        "cheapest": "Cel mai ieftin",
-        "mostExpensive": "Cel mai scump",
-        "title": "Rezumat"
-      },
-      "title": "Produse",
-      "totalLabel": "TOTAL"
-    },
-    "itemsBreakdownChart": {
-      "description": "Articole cu cele mai mari cheltuieli",
-      "labels": {
-        "price": "Preț",
-        "quantity": "Cant."
-      },
-      "title": "Top articole după cost"
-    },
-    "merchantBreakdownChart": {
-      "description": "Totaluri cumulative pe toți comercianții",
-      "labels": {
-        "averagePerVisit": "Medie/vizită",
-        "total": "Total",
-        "totalSpent": "Total cheltuit",
-        "visits": "Vizite"
-      },
-      "title": "Cheltuieli pe magazin",
-      "unknownMerchant": "Comerciant Necunoscut"
-    },
-    "metadata": {
-      "description": "Vizualizați detaliile facturii, articolele și informațiile despre comerciant.",
-      "title": "Vizualizare factură"
-    },
-    "priceDistributionChart": {
-      "description": "Articole pe intervale de preț ({currency})",
-      "labels": {
-        "items": "Articole"
-      },
-      "title": "Distribuția prețurilor",
-      "tooltip": {
-        "itemCount": "{count, plural, one {# articol} few {# articole} other {# de articole}}"
-      }
-    },
-    "print": {
-      "generatedOn": "Tipărit pe {date}",
-      "labels": {
-        "date": "Data",
-        "items": "Articole",
-        "merchant": "Comerciant",
-        "total": "Suma Totală"
-      },
-      "page": "Pagina"
-    },
-    "relatedInvoices": {
-      "noRelated": "Nu s-au găsit facturi conexe",
-      "sameCategory": "Aceeași Categorie",
-      "sameMerchant": "Același Comerciant",
-      "similarAmount": "Sumă Similară",
-      "subtitle": "Facturi similare bazate pe comerciant, categorie sau sumă",
-      "title": "Facturi Conexe",
-      "viewInvoice": "Vizualizare"
-    },
-    "shareCollaborate": {
-      "activity": {
-        "created": "Creat {time}",
-        "daysAgo": "{count, plural, one {acum # zi} other {acum # zile}}",
-        "modified": "Ultima modificare {time}",
-        "title": "Activitate",
-        "today": "astăzi"
-      },
-      "copied": "Link copiat în clipboard!",
-      "copyError": "Nu s-a putut copia linkul",
-      "copyLink": "Copiază Link",
-      "madePrivate": "Factura este acum privată",
-      "madePublic": "Factura este acum publică",
-      "manageSharing": "Gestionează Partajarea",
-      "private": "Privat",
-      "public": "Public",
-      "publicAccess": "Acces Public",
-      "publicAccessDescription": "Oricine cu link-ul poate vizualiza această factură",
-      "qrCode": "Cod QR",
-      "qrCopied": "Link copiat! Generarea codului QR va fi adăugată în curând.",
-      "shared": "Partajat",
-      "sharedWith": "Partajat cu",
-      "shareEmail": "Partajează prin Email",
-      "title": "Partajare & Colaborare",
-      "toggleError": "Eroare la actualizarea setărilor de partajare"
-    },
-    "spendingByCategoryChart": {
-      "description": "Distribuția cheltuielilor",
-      "title": "Cheltuieli pe categorie",
-      "tooltip": {
-        "itemCount": "{count, plural, one {# articol} few {# articole} other {# de articole}}"
-      },
-      "totalLabel": "Total cheltuieli"
-    },
-    "spendingTrendChart": {
-      "description": "Trendul istoricului tău de facturi",
-      "labels": {
-        "amount": "Sumă"
-      },
-      "title": "Evoluția cheltuielilor",
-      "tooltip": {
-        "andMore": "și încă {count}...",
-        "currentInvoice": "Factura curentă"
-      }
-    },
-    "timelineItem": {
-      "aria": {
-        "moreInfo": "Mai multe informații despre {title}"
-      },
-      "confidence": "Încredere: {value}%",
-      "events": {
-        "aiAnalysis": {
-          "description": "{count, plural, one {# articol detectat și categorisit} few {# articole detectate și categorisite} other {# de articole detectate și categorisite}}",
-          "title": "Analiză AI finalizată"
+      "island": {
+        "callToAction": "Efectuați procesul de autentificare",
+        "description": "Conectați-vă utilizând serverul nostru securizat de autentificare OAuth 2.0. \nProfilul dvs. va fi menținut sincronizat în timpul acestei sesiuni de browser. \nPuteți folosi conturile de rețele sociale pentru a vă conecta.",
+        "footer": "Puteți schimba furnizorii oricând. Autentificarea este gestionată de furnizorul nostru de identitate de încredere.",
+        "hero": {
+          "badge": "Autentificare Securizată",
+          "subtitle": "Alegeți o variantă și continuați cu furnizorul preferat. Totul rămâne rapid, sigur și localizat.",
+          "title": "Bun venit la punctul de intrare securizat"
         },
-        "categorized": {
-          "description": "Categorizare automată pe baza articolelor",
-          "title": "Categorie atribuită"
+        "signIn": {
+          "bullets": {
+            "first": "Continuați cu furnizorul de identitate pe care îl folosiți deja.",
+            "second": "Reluați de unde ați rămas pe orice dispozitiv.",
+            "third": "Sesiunea rămâne sincronizată în timpul navigării."
+          },
+          "cta": "Conectare",
+          "description": "Accesați contul și păstrați sesiunea sincronizată în timpul acestei sesiuni de browser.",
+          "illustrationAlt": "Ilustrație pentru conectare",
+          "secondaryAction": "Creați unul",
+          "secondaryPrompt": "Nu aveți cont?",
+          "title": "Conectare"
         },
-        "created": {
-          "description": "Scanată și digitalizată din bon",
-          "title": "Factură creată"
+        "signUp": {
+          "bullets": {
+            "first": "Creați un cont în câteva secunde cu furnizori OAuth.",
+            "second": "Fără parole de reținut.",
+            "third": "Începeți să folosiți platforma imediat."
+          },
+          "cta": "Creați un cont",
+          "description": "Alăturați-vă platformei și deblocați experiențe dedicate membrilor în spațiul de domeniu.",
+          "illustrationAlt": "Ilustrație pentru înregistrare",
+          "secondaryAction": "Conectați-vă",
+          "secondaryPrompt": "Aveți deja cont?",
+          "title": "Înregistrare"
         },
-        "edited": {
-          "title": "Factură actualizată"
-        },
-        "exported": {
-          "title": "Factură exportată"
-        },
-        "markedImportant": {
-          "description": "Marcată pentru urmărire prioritară",
-          "title": "Marcată ca importantă"
-        },
-        "recipesGenerated": {
-          "description": "{count, plural, one {# rețetă sugerată} few {# rețete sugerate} other {# de rețete sugerate}}",
-          "title": "Rețete generate"
-        },
-        "shared": {
-          "description": "Partajată cu {count, plural, one {# persoană} few {# persoane} other {# de persoane}}",
-          "title": "Partajată cu alții"
+        "step1": "Pasul 1",
+        "step2": "Pasul 2",
+        "title": "Autentificați-vă cu serverul nostru securizat de autentificare OAuth 2.0.",
+        "trust": {
+          "oauth": "OAuth 2.0",
+          "privacy": "Confidențialitate",
+          "session": "Sesiune sincronizată"
         }
       },
-      "fallbacks": {
-        "ocr": "OCR",
-        "pdf": "PDF"
-      },
-      "relativeTime": {
-        "now": "Chiar acum"
-      },
-      "tooltips": {
-        "aiAnalysis": "AI a procesat această factură în {duration} și a analizat {count, plural, one {# articol} few {# articole} other {# de articole}}.",
-        "categorized": "Facturii i-a fost atribuită o categorie pentru o organizare mai bună.",
-        "created": "Factura a fost scanată și digitalizată folosind {method}.",
-        "edited": "Au fost făcute modificări manuale facturii.",
-        "exported": "Factura a fost exportată în format {format}.",
-        "markedImportant": "Factura a fost marcată ca importantă pentru acces rapid.",
-        "recipesGenerated": "Pe baza ingredientelor cumpărate, {count, plural, one {a fost generată # rețetă} few {au fost generate # rețete} other {au fost generate # de rețete}}.",
-        "shared": "Factura a fost partajată cu {count, plural, one {# utilizator} few {# utilizatori} other {# de utilizatori}}.",
-        "unavailable": "Detaliile evenimentului nu sunt disponibile"
-      }
-    },
-    "timelineSharedWithList": {
-      "actions": {
-        "manageSharing": "Gestionează partajarea",
-        "sendEmail": "Trimite email"
-      },
-      "aria": {
-        "sendEmail": "Trimite email către {user}"
-      },
-      "header": {
-        "publicBadge": "Public",
-        "title": "Partajată cu"
-      },
-      "publicAccess": {
-        "description": "Această factură este accesibilă public. Oricine are linkul o poate vedea, inclusiv invitații fără cont.",
-        "title": "Acces public activat"
-      }
-    }
-  },
-  "IMS--ViewScans": {
-    "breadcrumb": "Înapoi la Facturi",
-    "createFromAll": {
-      "button": "Creează din Toate Scanările",
-      "description": "Creează facturi din toate cele {count} scanări deodată",
-      "title": "Toate scanările sunt gata!"
-    },
-    "emptyState": {
-      "description": "Începeți prin a încărca chitanțele și facturile dvs. Iată cum funcționează:",
-      "learnMoreButton": "Aflați Mai Multe",
-      "step1Description": "Fotografiați chitanțele sau încărcați PDF-uri cu facturi digitale",
-      "step1Title": "Încărcați scanările",
-      "step2Description": "Alegeți care scanări să fie convertite în facturi",
-      "step2Title": "Selectați și organizați",
-      "step3Description": "AI-ul nostru extrage automat toate datele pentru dvs.",
-      "step3Title": "Creați facturi",
-      "title": "Nicio scanare încă",
-      "uploadButton": "Încărcați Prima Scanare"
-    },
-    "groupBanner": {
-      "createInvoice": "Creează Factură",
-      "dismiss": "Renunță",
-      "subtitle": "Creați o factură din aceste scanări?",
-      "title": "Aceste {count} scanări au fost încărcate împreună"
-    },
-    "header": {
-      "invoices": "Facturi",
-      "lastSynced": "Ultima sincronizare: {time}",
-      "myInvoices": "Facturile Mele",
-      "myInvoicesTooltip": "Vizualizați facturile create",
-      "subtitle": "Selectați scanări pentru a crea facturi din ele",
-      "sync": "Sincronizare",
-      "syncing": "Se sincronizează...",
-      "syncTooltip": "Reîmprospătați scanările de pe server",
-      "title": "Scanările Tale",
-      "titleWithCount": "Scanările Tale ({count})",
-      "tooltip": "Selectați scanări pentru a crea facturi din ele. Puteți crea o factură per scanare sau combina mai multe scanări într-o singură factură.",
-      "upload": "Încărcați",
-      "uploadMore": "Încărcați Mai Multe",
-      "uploadTooltip": "Încărcați mai multe scanări în contul dvs."
-    },
-    "metadata": {
-      "description": "Vizualizați și gestionați scanările încărcate. Creați facturi din scanările selectate.",
-      "title": "Sistem de gestionare a facturilor - Vizualizare Scanări"
-    },
-    "pagination": {
-      "next": "Următor",
-      "pageInfo": "{current} / {total} ({count} scanări)",
-      "previous": "Anterior"
-    },
-    "scanCard": {
-      "actions": {
-        "delete": "Ștergeți scanarea",
-        "rename": "Redenumește scanarea",
-        "rotateCCW": "Rotește 90° în sens antiorar",
-        "rotateCW": "Rotește 90° în sens orar",
-        "rotateError": "Nu s-a putut roti imaginea",
-        "rotateSuccess": "Imaginea a fost rotită cu succes",
-        "rotateUnsupported": "Nu se pot roti fișierele PDF",
-        "rotating": "Se rotește..."
-      },
-      "delete": "Ștergeți scanarea",
-      "deleteDialog": {
-        "cancel": "Anulare",
-        "delete": "Ștergere",
-        "deleting": "Se șterge...",
-        "description": "Sigur doriți să ștergeți \"{name}\"? Această acțiune nu poate fi anulată și scanarea va fi eliminată permanent din stocare.",
-        "error": "Nu s-a putut șterge scanarea",
-        "linkedDescription": "Ștergerea acesteia va elimina scanarea din stocare, dar factura va păstra o copie a imaginii. Această acțiune nu poate fi anulată.",
-        "linkedWarning": "Această scanare este asociată cu o factură.",
-        "success": "Scanarea a fost ștearsă cu succes",
-        "title": "Ștergeți scanarea?"
-      },
-      "linked": "Asociată",
-      "loading": "Se încarcă...",
-      "preview": "Previzualizare scanare",
-      "previewTitle": "Previzualizare Scanare",
-      "rename": "Redenumește scanarea",
-      "renamePlaceholder": "Introduceți un nume nou"
-    },
-    "sidebar": {
-      "howTo": {
-        "step1Description": "Faceți clic pe scanări pentru a le selecta",
-        "step1Title": "Selectați Scanări",
-        "step2Description": "O factură per scanare sau combinați mai multe",
-        "step2Title": "Alegeți Modul",
-        "step3Description": "AI extrage datele automat",
-        "step3Title": "Creați Factura",
-        "title": "Cum să Creați Facturi"
-      },
-      "quickUpload": {
-        "button": "Încărcare",
-        "description": "Încărcați chitanțe suplimentare",
-        "title": "Aveți nevoie de mai multe scanări?"
-      },
-      "selectionStatus": {
-        "plural": "scanări selectate",
-        "readyPlural": "Creați mai multe facturi sau combinați-le într-una singură",
-        "readySingular": "Pregătit pentru a crea o factură",
-        "singular": "scanare selectată"
-      }
-    },
-    "stats": {
-      "ready": "Pregătite",
-      "selected": "Selectate",
-      "selectHint": "Faceți clic pe scanări pentru a le selecta pentru crearea facturilor",
-      "tapHint": "Atingeți pentru a selecta",
-      "totalScans": "Total Scanări"
-    },
-    "subtitle": "Selectați scanări pentru a crea facturi din ele.",
-    "title": "Scanările Tale",
-    "toolbar": {
-      "clearSelection": "Ștergeți",
-      "createInvoice": "Creați Factură",
-      "createInvoices": "Creați Facturi",
-      "delete": {
-        "button": "Șterge ({count})",
-        "cancel": "Anulează",
-        "confirm": "Șterge",
-        "confirmDescription": "Aceasta va șterge permanent {count} scanare(i) din stocare. Această acțiune nu poate fi anulată.",
-        "confirmTitle": "Ștergeți scanările selectate?",
-        "error": "A apărut o eroare la ștergerea scanărilor",
-        "failed": "Nu s-au putut șterge scanările",
-        "partial": "{success} șterse, {failed} eșuate",
-        "success": "{count} scanare(i) șterse cu succes"
-      },
-      "selected": "selectat(e)"
-    }
-  },
-  "Legal": {
-    "PrivacyPolicy": {
-      "contactInformation": {
-        "content": "Dacă aveți întrebări despre Politica noastră de confidențialitate, vă rugăm să ne contactați la admin@arolariu.ro",
-        "title": "Informații de contact"
-      },
-      "last_updated": "Ultima actualizare: 1 ianuarie 2024",
       "metadata": {
-        "description": "Pagina politicii de confidențialitate pentru platforma `arolariu.ro`.",
-        "title": "Politica de Confidențialitate"
+        "description": "Pagina de autorizare pentru platforma Arolariu.ro.",
+        "title": "Autorizare"
       },
-      "terms": {
-        "childrenPrivacy": {
-          "content": "Site-ul nostru web nu este destinat copiilor cu vârsta sub 13 ani. Nu colectăm cu bună știință Date cu caracter personal de la copii sub 13 ani. Dacă sunteți părinte sau tutore și știți că copilul dumneavoastră ne-a furnizat date cu caracter personal, vă rugăm să \ncontactaţi-ne. \nDacă aflăm că am colectat date cu caracter personal de la copii fără verificarea consimțământului părinților, vom lua măsuri pentru a elimina acele informații de pe serverele noastre.",
-          "title": "Confidențialitatea copiilor"
+      "signIn": {
+        "bullets": {
+          "first": "Conectare rapidă cu furnizori de încredere.",
+          "second": "Sesiunea rămâne consecventă în întreaga aplicație.",
+          "third": "Optimizat pentru mobil și desktop."
         },
-        "cookiesDefinition": {
-          "content": "Cookie-urile sunt fragmente mici de date stocate pe dispozitivul dumneavoastră (computer sau dispozitiv mobil). \nCookie-urile sunt folosite pentru a vă îmbunătăți experiența pe site-ul nostru web și pentru a vă oferi conținut relevant. \nPentru mai multe informații despre cookie-uri, vă rugăm să vizitați https://www.allaboutcookies.org/ <br></br><br></br><br></br> Folosim cookie-uri pentru a colecta informații despre dispozitivul dvs. \nutilizarea site-ului nostru web. \nFurnizorul nostru de analiză a site-ului web folosește cookie-uri pentru a genera informații statistice și alte informații despre utilizarea site-ului web prin intermediul cookie-urilor. \n<br></br><br></br><br></br> Puteți renunța la cookie-uri utilizând setările din browser. \nVă rugăm să rețineți că, dacă dezactivați cookie-urile, este posibil să nu puteți utiliza toate funcțiile site-ului nostru. \n<br></br><br></br><br></br> Vom păstra datele dumneavoastră cu caracter personal numai atât timp cât este necesar pentru scopul pentru care au fost colectate datele respective și în măsura cerută de legea aplicabilă \n. \nCând nu mai avem nevoie de Date cu caracter personal, le vom elimina din sistemele noastre și/sau vom lua măsuri pentru a le anonimiza.",
-          "title": "Ce sunt cookie-urile?"
+        "footer": "Protejat prin securitate de nivel enterprise.",
+        "form": {
+          "kicker": "Conectați-vă cu furnizorul preferat",
+          "secondaryAction": "Creați un cont",
+          "secondaryPrompt": "Sunteți nou aici?"
         },
-        "dataCollectionTerms": {
-          "content": "a) Când efectuați o achiziție sau încercați să faceți o achiziție, colectăm următoarele tipuri de date cu caracter personal: <ul> <li> Informații de plată, cum ar fi adresa dvs. de facturare, numărul de telefon, cardul de credit, cardul de debit și/sau alte plăți \ninformatii despre metoda; \n</li><li> Informații despre cont, cum ar fi numele dvs., numele de utilizator, adresa de e-mail; \n</li><li> Informații de achiziție, în special dacă sunt personalizate sau unice;</li> <li>Datele demografice;</li> <li>Datele despre locație.</li> </ul> <br></br> \n<br></br> b) Când vizitați și utilizați site-ul nostru web, colectăm automat următoarele tipuri de date cu caracter personal: <ul> <li> Informații de plată, cum ar fi adresa dvs. de facturare, numărul de telefon, cardul de credit, cardul de debit și \n/sau alte informații despre metoda de plată; \n</li> <li>Datele dispozitivului, cum ar fi computerul, telefonul, tableta sau alt dispozitiv pe care îl utilizați pentru a accesa site-ul nostru web;</li> <li>Datele de comunicare, cum ar fi preferințele dvs. pentru a primi comunicări de la noi;</li> <li>Feedback, cum ar fi asistența pentru clienți, recenzii despre produse, sondaje și/sau alte feedback;</li> <li>Datele despre conținut, cum ar fi conținutul pe care ni-l trimiteți: postări, documente, sunet, imagini etc. \n;</li> \n<li>Datele de utilizare, cum ar fi modul în care utilizați site-ul nostru web, produsele și serviciile;</li> <li>Informațiile despre cont, cum ar fi numele dvs., numele de utilizator, adresa de e-mail;</li> <li>Informațiile de cumpărare în special dacă \npersonalizate sau unice;</li> <li>Date demografice;</li> <li>Date despre locație;</li></ul>",
-          "title": "Ce date personale colectăm"
+        "hero": {
+          "subtitle": "Folosiți furnizorul în care aveți încredere și continuați instant.",
+          "title": "Bun venit înapoi"
         },
-        "dataTransferTerms": {
-          "content": "Acolo unde este posibil, stocăm și procesăm date pe servere din regiunea geografică generală în care locuiți (notă: este posibil să nu fie în țara în care locuiți). \n<span> Mai exact, pentru utilizatorii, companiile și clienții din Europa, avem servere în Spațiul Economic European (SEE). \n</span> Datele dvs. personale pot fi, de asemenea, transferate și menținute pe servere care au reședința în afara statului, provinciei, țării sau a altei jurisdicții guvernamentale în care legile privind datele pot diferi de cele din jurisdicția dvs. \nVom lua măsurile adecvate pentru a ne asigura că datele dumneavoastră cu caracter personal sunt tratate în siguranță și în conformitate cu această politică, precum și cu legea aplicabilă privind protecția datelor. \nDatele pot fi păstrate în alte țări care sunt considerate adecvate conform legilor dumneavoastră. \n<br></br><br></br><br></br><br></br> Mai multe informații despre aceste clauze pot fi găsite aici: https://eur-lex.europa.eu/ \nlegal-content/en/TXT/?uri=CELEX:32021D0914",
-          "title": "Transfer și stocare internațională de date"
-        },
-        "deviceUsageTerms": {
-          "content": "Când vizitați un site web <code>AROLARIU.RO</code> și/sau o aplicație mobilă, colectăm și stocăm automat informații despre vizita dumneavoastră folosind cookie-uri de browser (fișiere care sunt trimise de noi către computerul dumneavoastră) sau tehnologii similare. \nPuteți solicita browserului dumneavoastră să refuze toate cookie-urile sau să indice când este trimis un cookie. \nFuncția „Ajutor” de pe majoritatea browserelor vă va oferi informații despre cum să acceptați cookie-uri, cum să dezactivați cookie-urile sau să vă anunțe când primiți un cookie nou. \nDacă nu acceptați cookie-uri, este posibil să nu puteți utiliza unele funcții ale Serviciului nostru și vă recomandăm să le lăsați activate. \n<br></br><br></br><br></br> De asemenea, procesăm informații atunci când utilizați serviciile și produsele noastre. \nAceste informații pot include: <ul> <li> Informații despre interacțiunile dvs. cu serviciile noastre, inclusiv ora și data interacțiunilor dvs. și interacțiunile dvs. cu e-mailurile noastre; \n</li> <li> Informații despre utilizarea serviciilor noastre, inclusiv tipul de browser pe care îl utilizați, timpii de acces, paginile vizualizate, adresa dumneavoastră IP; \n</li> <li> Informații despre achizițiile dvs., inclusiv articolele pe care le cumpărați, data achiziției și metoda de plată pe care o utilizați; \n</li> <li> Informații despre dispozitivul dvs., inclusiv tipul de dispozitiv, sistemul său de operare și informații despre rețeaua mobilă; \n</li> <li> Alte informații pe care ni le furnizați, inclusiv feedback-ul, comentariile și alte informații pe care ni le furnizați; \n</li> <li>Informații despre locația dvs., inclusiv locația dvs. generală bazată pe adresa dvs. IP;</li> <li>Alte informații pe care le colectăm cu consimțământul dvs. sau conform permisului sau cerut de lege;</li> <li \n>Informații despre preferințele dvs., inclusiv despre preferințele dvs. de limbă.</li> </ul>",
-          "title": "Date despre dispozitiv și utilizare"
-        },
-        "exerciseRights": {
-          "content": "Pentru a vă exercita drepturile, vă rugăm să ne contactați folosind datele de contact furnizate în secțiunea „Contactați-ne” de mai jos. \nVom răspunde solicitării dumneavoastră într-un interval de timp rezonabil și în conformitate cu legea aplicabilă. \n<br></br><br></br> Pentru siguranța și securitatea dvs., este posibil să fie nevoie să vă verificăm identitatea înainte de a răspunde solicitării dvs. \nVom depune eforturi rezonabile pentru a vă verifica identitatea solicitând informațiile pe care le avem în dosar despre dumneavoastră.",
-          "title": "Cum să-ți exerciți drepturile"
-        },
-        "howWeCollectDataTerms": {
-          "content": "Colectăm date personale în următoarele moduri: <br></br><br></br> <span>1. \nDe la dvs.</span> <br></br> Colectăm date cu caracter personal de la dvs. atunci când ni le furnizați direct sau indirect, utilizând site-ul nostru web, produsele sau serviciile. \nAceasta include: <br></br> <ul> <li>Când creați un cont sau cumpărați produse de pe site-ul nostru web;</li> <li>Când descărcați software și/aplicația noastră mobilă;</li> \n<li>Când participați la sondajele, concursurile sau promoțiile noastre;</li> <li>Când creați conținut prin produsele și serviciile noastre;</li> <li>Când ne contactați pentru o întrebare sau pentru a raporta o problemă \n;</li> <li>Când vă exprimați interes(e) față de produsele și serviciile noastre;</li> <li>Când ne folosiți site-ul web, produsele sau serviciile;</li> <li>Când interacționați cu noi pe rețelele sociale;</li> <li>Când vă abonați la buletinul nostru informativ;</li> <li>Când ni-l furnizați direct;</li> <li>Când comunicați cu noi.</li> </ul> \n<br></br><br></br><br></br><br></br> <span>2. \nTehnologii sau interacțiuni automate.</span> <br></br> <br></br> Pe măsură ce interacționați cu site-ul nostru web, este posibil să colectăm automat următoarele tipuri de date (toate așa cum este descris mai sus): Date despre dispozitiv despre dvs. \nechipamente, Date de utilizare despre acțiunile și modelele dvs. de navigare și Date de contact în care sarcinile efectuate prin intermediul site-ului nostru web rămân nefinalizate, cum ar fi comenzile incomplete sau coșurile abandonate. \nColectăm aceste date utilizând cookie-uri, jurnalele de server și alte tehnologii similare. \nVă rugăm să consultați secțiunea Cookie (mai jos) pentru mai multe detalii. \n<br></br><br></br><br></br><br></br> <span>3. \nTerți sau surse disponibile public.</span> <br></br><br></br> Este posibil să primim date personale despre dvs. de la diverse terțe părți, inclusiv: <ul> <li> Informații despre cont și date de plată \nde la terți, inclusiv organizații (cum ar fi agențiile de aplicare a legii), asociații și grupuri, care împărtășesc date în scopul prevenirii și detectarii fraudei și al reducerii riscului de credit </li> <li>Date de contact, financiare și de tranzacții de la furnizorii de servicii tehnice \n, plata si livrarea \nservicii</li> <li>Date tehnice de la furnizori de analize, cum ar fi Google Analytics</li> <li>Date de identitate și de contact de la brokerii de date sau agregatori</li> <li>Date de identitate și de contact din surse disponibile public</li> </ul> <br></br><br></br><br></br><br></br><span> Dacă ne furnizați nouă, sau furnizorilor noștri de servicii, orice \nDate referitoare la alte persoane, declarați că aveți \nautoritatea de a face acest lucru și de a recunoaște că va fi utilizat în conformitate cu această Politică. \nDacă credeți că datele dumneavoastră cu caracter personal ne-au fost furnizate în mod necorespunzător sau pentru a vă exercita în alt mod drepturile referitoare la datele dumneavoastră cu caracter personal, vă rugăm să ne contactați utilizând informațiile prezentate în secțiunea „Contactați-ne” de mai jos.</span>",
-          "title": "Cum colectăm datele personale"
-        },
-        "legalTerms": {
-          "content": "Putem folosi sau dezvălui datele dumneavoastră cu caracter personal pentru a ne conforma unei obligații legale, în legătură cu o solicitare din partea unei autorități publice sau guvernamentale sau în legătură cu proceduri judiciare, pentru a preveni pierderea vieții sau rănirea sau pentru a ne proteja drepturi sau proprietate. \nAcolo unde este posibil și practic să facem acest lucru, vă vom informa în avans cu privire la o astfel de dezvăluire.",
-          "title": "Cerințe legale"
-        },
-        "personalDataRights": {
-          "content": "Aveți dreptul de a accesa, corecta, actualiza sau șterge datele dumneavoastră cu caracter personal. Aveți, de asemenea, dreptul de a vă opune prelucrării datelor dumneavoastră cu caracter personal, de a ne cere să restricționăm prelucrarea datelor dumneavoastră cu caracter personal sau de a solicita portabilitatea datelor dumneavoastră cu caracter personal. Vă puteți exercita aceste drepturi contactându-ne folosind datele de contact furnizate în secțiunea „Contactați-ne”; secțiunea de mai jos. <br></br><br></br><br></br> În funcție de locația dvs. geografică și de cetățenie, drepturile dumneavoastră sunt supuse reglementărilor locale privind confidențialitatea datelor. Aceste drepturi pot include: <ul> <li> Dreptul de a fi uitat (dreptul la ștergere) (articolul 17 din GDPR, CCPA/CPRA, CPA, VCDPA, CTDPA, UCPA, LGPD, POPIA) </li> <li>Dreptul la Acces (PIPEDA, GDPR Articolul 15, CCPA/CPRA, CPA, VCDPA, CTDPA, UCPA, LGPD, POPIA)</li> <li>Dreptul la rectificare (PIPEDA, articolul 16 din GDPR, CPRA, CPA, VCDPA, CTDPA, LGPD, POPIA)</li> <li>Nediscriminare și nerăzbunare (CCPA/CPRA, CPA, VCDPA, CTDPA, UCPA)</li> <li>Dreptul la restricționarea prelucrării (articolul 18 GDPR, LGPD)</li> <li>Dreptul la renunțare (CPRA, CPA, VCDPA, CTDPA, UCPA)</li> <li>Dreptul la portabilitate (PIPEDA, GDPR articolul 20, LGPD)</li> <li>Dreptul la obiecție (GDPR articolul 21, LGPD, POPIA)</li> </ul> <br></br><br></br><br></br> Dacă doriți să depuneți o contestație sau o plângere cu privire la modul în care procesăm datele dumneavoastră cu caracter personal, ne puteți contacta folosind datele de contact furnizate în secțiunea „Contactați-ne”; secțiunea de mai jos. De asemenea, aveți dreptul de a depune o plângere la autoritatea de protecție a datelor din jurisdicția dumneavoastră. <br></br> În cazul în care ne-ați contactat și nu sunteți mulțumit de răspunsul nostru, aveți dreptul de a depune o contestație la procurorul general situat aici: <ul> <li> Dacă aveți sediul în SEE, vă rugăm să vizitați site-ul https://edpb.europa.eu/about-edpb/about-edpb/members_en pentru o listă a autorităților locale de protecție a datelor. </li> <li> Dacă vă aflați în Connecticut, vă rugăm să vizitați site-ul https://portal.ct.gov/AG/Common/Complaint-Form-Landing-page pentru a depune o reclamație. </li> <li> Dacă vă aflați în Colorado, vă rugăm să vizitați site-ul https://complaints.coag.gov/s/contact-us pentru a depune o reclamație. </li> <li> Dacă vă aflați în Virginia, vă rugăm să vizitați https://www.oag.state.va.us/consumer-protection/index.php/file-a-complaint site-ul web pentru a depune o plângere. </li></ul>",
-          "title": "Drepturile dumneavoastră pentru datele dumneavoastră personale"
-        },
-        "policyChanges": {
-          "content": "Este posibil să actualizăm această Politică din când în când. \nDacă facem modificări semnificative, vă vom anunța, dar vă rugăm să verificați regulat această Politică pentru a vă asigura că sunteți la curent cu cea mai actualizată versiune.",
-          "title": "Modificări ale acestei politici"
-        },
-        "processingDataTerms": {
-          "content": "Colectăm și folosim datele dumneavoastră cu caracter personal cu consimțământul dumneavoastră pentru a furniza, menține și dezvolta produsele și serviciile noastre și pentru a înțelege cum să le îmbunătățim în continuare. \n<br></br><br></br><br></br> Aceste scopuri includ: <ul> <li>Construirea unui mediu sigur și securizat pentru utilizatorii noștri și comunitatea noastră;</li> <li \n>Efectuarea de cercetări și analize pentru a îmbunătăți produsele și serviciile noastre;</li> <li>Comunicarea cu dvs. despre contul dvs., achiziții sau întrebări;</li> <li>Investigați și preveniți incidentele de securitate și alte activități ilegale;</li> <li>Personalizarea experienței dvs. cu produsele noastre \nși servicii;</li> <li>Livrarea, întreținerea și îmbunătățirea produselor și serviciilor noastre;</li> <li>Oferirea de produse și servicii pe care le solicitați;</li> <li>Oferirea de comunicări de marketing; \n</li> <li>Oferirea de asistență pentru clienți;</li> <li>Protejarea produselor și serviciilor noastre;</li> <li>Alte scopuri cu consimțământul dvs.;</li> <li>Respectarea obligațiilor legale \n.</li> </ul> \n<br></br><br></br><br></br><br></br> În cazul în care prelucrăm datele dumneavoastră cu caracter personal pentru a furniza un produs sau un serviciu, facem acest lucru deoarece este necesar pentru a efectua \nobligatii contractuale. \nToate procesările de mai sus sunt necesare în interesul nostru legitim pentru a furniza produse și servicii și pentru a menține relația noastră cu dvs. și pentru a ne proteja afacerea, de exemplu, împotriva fraudei. \nConsimțământul va fi necesar pentru a iniția servicii cu dvs. \nVa fi necesar un nou consimțământ dacă sunt aduse modificări tipului de date colectate. \nÎn cadrul contractului nostru, dacă nu oferiți consimțământul, este posibil ca unele servicii să nu vă fie disponibile.",
-          "title": "Scopul și temeiul juridic pentru prelucrarea datelor cu caracter personal"
-        },
-        "processingTerms": {
-          "content": "Această politică se aplică atunci când vizitați site-ul nostru web, utilizați produsele sau serviciile noastre sau interacționați cu noi. \n<br></br> În plus, această politică se aplică atunci când: <ul> <li> Folosiți aplicația și serviciile noastre ca utilizator autorizat;</li> <li>Vizitați oricare dintre site-urile noastre web care fac trimitere la această Confidențialitate \nPolitică;</li> <li>Primiți orice comunicare de la noi, inclusiv e-mailuri.</li></ul>",
-          "title": "Activități de procesare"
-        },
-        "safeDataTerms": {
-          "content": "Am implementat măsuri de securitate tehnice și organizatorice adecvate menite să protejeze securitatea oricăror Date personale pe care le procesăm. \nCu toate acestea, vă rugăm să rețineți că nu putem garanta că internetul în sine este 100% sigur. \nDeși vom face tot posibilul pentru a vă proteja datele personale, transmiterea datelor cu caracter personal către și de la site-ul nostru web se face pe propriul risc. \nAr trebui să accesați serviciile numai într-un mediu securizat. \n<br></br><br></br><br></br> Avem măsuri de protecție organizaționale adecvate și măsuri de securitate pentru a vă proteja datele personale împotriva pierderii accidentale, utilizate sau accesate într-un mod neautorizat, modificate \nsau dezvăluite. \n<br></br><br></br><br></br> Comunicarea dintre browserul dvs. și site-ul nostru web folosește o conexiune criptată securizată oriunde sunt implicate Datele dvs. personale. \n<br></br><br></br><br></br> Solicităm oricărei terțe părți care este contractată să prelucreze datele dumneavoastră cu caracter personal în numele nostru să aibă măsuri de securitate pentru a vă proteja datele și pentru a trata \nastfel de date în conformitate cu legea. \n<br></br><br></br><br></br> În cazul nefericit al unei încălcări a datelor cu caracter personal, vă vom anunța pe dumneavoastră și orice autoritate de reglementare aplicabilă atunci când suntem obligați legal să facem acest lucru.",
-          "title": "Cum vă păstrăm datele în siguranță"
-        },
-        "scopeTerms": {
-          "content": "Această politică se aplică site-ului, produselor și serviciilor <code> AROLARIU.RO </code>. \nSe aplică, de asemenea, utilizării site-ului web, produselor și serviciilor noastre de către clienții, partenerii și vizitatorii noștri. \n<br></br><br></br> Această politică nu se aplică aplicațiilor, site-urilor web, produselor, serviciilor sau platformelor terțe care pot fi accesate prin (non-<code>AROLARIU.RO</code> \n) link-uri pe care vi le putem furniza. \nAceste site-uri sunt deținute și operate independent de noi și au propriile lor practici separate de confidențialitate și de colectare a datelor. \nOrice Date cu caracter personal pe care le furnizați acestor site-uri web vor fi guvernate de politica de confidențialitate a terței părți. \nNu putem accepta răspunderea pentru acțiunile sau politicile acestor site-uri independente și nu suntem responsabili pentru conținutul sau practicile de confidențialitate ale acestor site-uri.",
-          "title": "Domeniul de aplicare al politicii"
-        },
-        "serviceProviderTerms": {
-          "content": "Putem folosi un furnizor de servicii terță parte, contractori independenți, agenții sau consultanți pentru a livra și a ne ajuta să ne îmbunătățim produsele și serviciile. \nPutem împărtăși datele dumneavoastră cu caracter personal agențiilor de marketing, furnizorilor de servicii de baze de date, furnizorilor de servicii de backup și recuperare în caz de dezastru, furnizorilor de servicii de e-mail și altora, dar numai pentru a menține și îmbunătăți produsele și serviciile noastre. \n<br></br><br></br> Pentru mai multe informații despre destinatarii datelor dumneavoastră cu caracter personal, vă rugăm să ne contactați utilizând informațiile din secțiunea „Contactați-ne” de mai jos.",
-          "title": "Furnizorii de servicii și alți terți"
-        },
-        "sharingAndDisclosureTerms": {
-          "content": "Vom partaja datele dumneavoastră cu caracter personal cu terți numai în modurile prevăzute în această politică sau stabilite la momentul în care datele cu caracter personal sunt colectate. <br></br><br></br><br></br> De asemenea, folosim Google Analytics pentru a ne ajuta să înțelegem cum folosesc clienții noștri site-ul. Puteți citi mai multe despre modul în care Google vă folosește datele personale aici: https://www.google.com/intl/en/policies/privacy/ <br></br><br></br><br></br> De asemenea, puteți renunța la Google Analytics aici: https://tools.google.com/dlpage/gaoptout <br></br><br></br><br></br> De asemenea, putem \nîmpărtășiți datele dumneavoastră cu caracter personal cu terți, acolo unde este cerut de lege, în cazul în care este necesar pentru a administra relația dintre noi \nsau unde avem un alt interes legitim în a face acest lucru. \nDe asemenea, putem împărtăși datele dumneavoastră cu caracter personal cu terțe părți cărora le putem alege să vindem, să transferăm sau să unim părți ale afacerii noastre sau ale activelor noastre. \nAlternativ, putem încerca să achiziționăm alte afaceri sau să fuzionem cu acestea. \n<br></br><br></br><br></br> Pentru mai multe informații despre cum funcționează publicitatea direcționată, puteți vizita pagina educațională a Network Advertising Initiative (NAI) la: https://www.networkadvertising.org/understanding-online-advertising/how-does-it-work <br></br><br></br><br></br> În plus, puteți renunța la unele dintre aceste servicii prin \nvizitând Publicitatea digitală \nRenunțarea Alianței: https://optout.aboutads.info/",
-          "title": "Partajarea și dezvăluirea datelor cu caracter personal"
-        },
-        "thirdPartyData": {
-          "content": "Este posibil să primim Datele dumneavoastră cu caracter personal de la terți, cum ar fi companii care se abonează la serviciile <code>AROLARIU.RO</code>, parteneri și alte surse. \nAceste Date cu caracter personal nu sunt colectate de noi, ci de o terță parte și sunt supuse politicilor separate de confidențialitate și de colectare a datelor ale terței părți relevante. \nNu deținem niciun control sau intrare asupra modului în care datele dumneavoastră cu caracter personal sunt tratate de către terți. \nCa întotdeauna, aveți dreptul de a revizui și de a rectifica aceste informații. \nDacă aveți întrebări, trebuie să contactați mai întâi terțul relevant pentru mai multe informații despre datele dumneavoastră cu caracter personal. \nÎn cazul în care acea terță parte nu răspunde drepturilor dumneavoastră, puteți contacta Responsabilul cu protecția datelor la <code> AROLARIU.RO </code> (detalii de contact mai jos). \n<br></br><br></br><br></br> Site-urile și serviciile noastre pot conține link-uri către alte site-uri web, aplicații și servicii întreținute de terți. \nPracticile de informare ale acestor alte servicii sau ale rețelelor de social media care găzduiesc paginile noastre de rețele sociale de marcă sunt guvernate de declarațiile de confidențialitate ale terților, pe care ar trebui să le examinați pentru a înțelege mai bine practicile de confidențialitate ale acelor terți.",
-          "title": "Date pe care le colectăm de la terți"
-        },
-        "whatIsTerms": {
-          "content": "La <code> AROLARIU.RO </code> („noi”, „noi”, „nostru” sau „Compania“) prețuim confidențialitatea dumneavoastră și importanța protejării datelor dumneavoastră. Această Politică de confidențialitate („Politica”) descrie practicile noastre de confidențialitate pentru activitățile prezentate mai jos. <br></br> <br></br> În conformitate cu drepturile dumneavoastră, vă informăm cum colectăm, stocăm, accesăm și procesăm în alt mod informațiile referitoare la persoane. În această Politică, datele cu caracter personal („Date cu caracter personal”) se referă la orice informație care, în sine, sau în combinație cu alte informații disponibile, poate identifica o persoană. <br></br> <br></br> Ne angajăm să vă protejăm confidențialitatea în conformitate cu cel mai înalt nivel de reglementare a confidențialității. Ca atare, respectăm obligațiile conform reglementărilor de mai jos: <ul> <li> Legea privind confidențialitatea consumatorilor din California (CCPA) / Legea privind drepturile de confidențialitate din California (CPRA) și Legea privind protecția confidențialității online din California (CalOPPA) </li> <li> Legea privind protecția datelor cu caracter personal și a documentelor electronice din Canada (PIPEDA) și legislațiile provinciale aplicabile </li> <li> Regulamentul general privind protecția datelor (GDPR) al Uniunii Europene </li> <li> Protecția Africii de Sud din Legea privind informațiile personale (POPIA) </li> <li> Virginia Consumer Data Protection Act (VCDPA) </li> <li> Legislația Braziliei privind protecția datelor (LGPD) </li> <li> Connecticut Data Privacy Act (CTDPA) </li> <li> Utah Consumer Privacy Act (UCPA) Colorado Privacy Act (CPA) </li> </ul>",
-          "title": "Ce este AROLARIU.RO?"
-        },
-        "withdrawingConsent": {
-          "content": "Dacă v-ați dat consimțământul pentru prelucrarea datelor dumneavoastră cu caracter personal, aveți dreptul să vă retrageți consimțământul în orice moment. \nPentru a vă retrage consimțământul, vă rugăm să ne contactați folosind datele de contact furnizate în secțiunea „Contactați-ne” de mai jos.",
-          "title": "Retragerea consimțământului"
+        "illustrationAlt": "Ilustrație pentru pagina de conectare",
+        "metadata": {
+          "description": "Conectați-vă pentru a continua sesiunea pe arolariu.ro.",
+          "title": "Conectare"
         }
       },
-      "title": "Politica de confidentialitate"
+      "signUp": {
+        "bullets": {
+          "first": "Înregistrare rapidă cu furnizori OAuth.",
+          "second": "Nu este necesar niciun card.",
+          "third": "Începeți să explorați platforma imediat."
+        },
+        "footer": "Înregistrare rapidă și sigură.",
+        "form": {
+          "kicker": "Creați contul cu furnizorul preferat",
+          "secondaryAction": "Conectare",
+          "secondaryPrompt": "Aveți deja cont?"
+        },
+        "hero": {
+          "subtitle": "Creați-vă contul în câteva secunde și începeți.",
+          "title": "Alăturați-vă astăzi"
+        },
+        "illustrationAlt": "Ilustrație pentru pagina de înregistrare",
+        "metadata": {
+          "description": "Creați un cont și începeți să folosiți arolariu.ro.",
+          "title": "Înregistrare"
+        }
+      }
     },
-    "TermsOfService": {
-      "contactInformation": {
-        "content": "Dacă aveți întrebări cu privire la Termenii noștri de utilizare, vă rugăm să ne contactați la admin@arolariu.ro.",
-        "title": "Contact"
-      },
-      "last_updated": "Ultima actualizare: 2024-01-01",
+    "domains": {
       "metadata": {
-        "description": "Termenii de serviciu pentru arolariu.ro",
-        "title": "Termeni de Serviciu"
+        "description": "Serviciile de spațiu din domeniu sunt servicii care sunt oferite vizitatorilor și membrilor spațiului de domeniu `arolariu.ro`",
+        "title": "Servicii spațiului de domeniu"
       },
-      "terms": {
-        "amendmentsTerms": {
-          "content": "Ne rezervăm dreptul de a modifica, suplimenta sau înlocui termenii acordului, în vigoare la publicarea pe www.arolariu.ro sau la notificarea dumneavoastră în caz contrar. Dacă nu doriți să fiți de acord cu modificările la Acord, puteți rezilia Acordul în orice moment, conform termenilor din prezentul document. În cazul în care o revizuire este materială, vom oferi o notificare cu cel puțin 30 de zile înainte de intrarea în vigoare a noilor termeni. Ceea ce constituie o modificare materială va fi stabilit la discreția noastră exclusivă. Continuând să accesați sau să utilizați serviciul nostru după intrarea în vigoare a oricărei revizuiri, sunteți de acord să vă supuneți termenilor revizuiți. Dacă nu sunteți de acord cu noii termeni, nu mai sunteți autorizat să utilizați serviciul nostru.",
-          "title": "Modificari ale acordului"
-        },
-        "arbitrateTerms": {
-          "content": "Prezentul acord și orice litigiu sau reclamație care decurge din sau este legată de acesta, de interpretarea sa, de încălcarea, încetarea sau valabilitatea acestuia, de relațiile care rezultă din prezentul acord, inclusiv de executarea, încălcarea sau valabilitatea prezentului acord, vor fi guvernate de legile României. Jurisdicția exclusivă și locul de desfășurare a oricărei acțiuni în temeiul prezentului acord vor fi instanțele situate în România, iar dumneavoastră vă supuneți prin prezenta jurisdicției personale a acestor instanțe. Prin prezenta, renunțați la orice drept la un proces cu juriu în orice procedură care decurge din sau este legată de acest Acord. Convenția Națiunilor Unite privind contractele de vânzare internațională de bunuri nu se aplică prezentului acord. Termenul \"litigiu\" înseamnă orice dispută, acțiune sau altă controversă între dvs. și noi cu privire la Servicii sau la acest acord, fie că este vorba de contract, garanție, delict, statut, regulament, ordonanță sau orice alt temei legal sau echitabil. \"Dispută\" va avea cel mai larg înțeles posibil permis de lege.",
-          "title": "Acord de arbitraj"
-        },
-        "changesToTos": {
-          "content": "AROLARIU.RO își rezervă dreptul de a modifica acești Termeni de utilizare în orice moment. Cu toate acestea, vă recomandăm să citiți această pagină în mod regulat pentru a vă asigura că sunteți la curent cu orice modificări. Utilizarea în continuare a site-ului după publicarea modificărilor va însemna că acceptați și sunteți de acord cu modificările. Recunoașteți și sunteți de acord că putem înceta (permanent sau temporar) să vă furnizăm Serviciul (sau orice caracteristici din cadrul Serviciului) dumneavoastră sau utilizatorilor în general, la discreția noastră exclusivă, fără a vă anunța în prealabil. Puteți înceta să utilizați Serviciul în orice moment. Nu este necesar să ne informați în mod specific atunci când încetați să utilizați Serviciul. Recunoașteți și sunteți de acord că, în cazul în care vă dezactivăm accesul la contul dvs., este posibil să nu puteți accesa Serviciul, detaliile contului dvs. sau orice fișiere sau alte materiale care sunt conținute în contul dvs.",
-          "title": "Schimbari ale termenilor si conditiilor"
-        },
-        "consentTerms": {
-          "content": "Ne-am actualizat Termenii și condițiile pentru a vă oferi o transparență completă cu privire la ceea ce este setat atunci când vizitați site-ul nostru și la modul în care este utilizat. Prin utilizarea site-ului nostru, vă exprimați acordul cu privire la Termenii și condițiile noastre de utilizare și sunteți de acord cu Termenii și condițiile.",
-          "title": "Consimtamintele dumneavoastra"
-        },
-        "cookiesTerms": {
-          "content": "Utilizăm \"module cookie\" pentru a identifica zonele din site-ul nostru web pe care le-ați vizitat. Un \"Cookie\" este o mică bucată de date stocată pe computerul sau dispozitivul dvs. mobil de către browserul dvs. web. Utilizăm Cookie-uri pentru a îmbunătăți performanța și funcționalitatea serviciului nostru, dar nu sunt esențiale pentru utilizarea lor. Cu toate acestea, fără aceste module cookie, anumite funcționalități, cum ar fi videoclipurile, pot deveni indisponibile sau ar trebui să introduceți datele de conectare de fiecare dată când vizitați platforma noastră, deoarece nu am putea să ne amintim că v-ați conectat anterior. Majoritatea browserelor web pot fi setate pentru a dezactiva utilizarea cookie-urilor. Cu toate acestea, dacă dezactivați modulele cookie, este posibil să nu puteți accesa corect sau deloc funcționalitățile de pe site-ul nostru. Nu plasăm niciodată informații de identificare personală în modulele cookie.",
-          "title": "Cookies si module cookie"
-        },
-        "copyrightTerms": {
-          "content": "Dacă sunteți proprietarul drepturilor de autor sau agentul unui astfel de proprietar și considerați că orice material de la noi constituie o încălcare a drepturilor de autor, vă rugăm să ne contactați furnizând următoarele informații: (a) o semnătură fizică sau electronică a proprietarului drepturilor de autor sau a unei persoane autorizate să acționeze în numele acestuia; (b) identificarea materialului despre care se pretinde că încalcă drepturile de autor; (c) informațiile dumneavoastră de contact, inclusiv adresa, numărul de telefon și un e-mail; (d) o declarație din partea dumneavoastră că aveți o convingere de bună credință că utilizarea materialului nu este autorizată de către proprietarii drepturilor de autor; și (e) o declarație că informațiile din notificare sunt corecte și, sub sancțiunea de sperjur, sunteți autorizat să acționați în numele proprietarului.",
-          "title": "Protectie a drepturilor de autor"
-        },
-        "definitionTerms": {
-          "content": "Termenii \"noi\" sau \"al nostru\" se referă la AROLARIU.RO, proprietarul site-ului. Un client este persoana sau organizația care cumpără sau este de acord să cumpere produsul. 'Produsul' nostru se referă la site-ul web, produsele sau serviciile oferite spre vânzare pe site-ul nostru web. Un \"utilizator\" este o persoană care utilizează site-ul nostru web sau serviciile noastre. Termenul \"dumneavoastră\" se referă la utilizatorul sau privitorul site-ului nostru web.",
-          "title": "Definiții"
-        },
-        "disclaimerTerms": {
-          "content": "În măsura maximă permisă de legea aplicabilă, excludem toate declarațiile, garanțiile și condițiile referitoare la site-ul nostru web și la utilizarea acestui site web. Nu vom fi răspunzători pentru nicio daune care decurg din utilizarea sau incapacitatea de a utiliza materialele de pe site-ul AROLARIU.RO, chiar dacă AROLARIU.RO sau un reprezentant autorizat al AROLARIU.RO a fost informat, verbal sau în scris, despre posibilitatea a unei astfel de pagube. Deoarece unele jurisdicții nu permit limitări ale garanțiilor implicite sau limitări ale răspunderii pentru daune consecutive sau incidentale, este posibil ca aceste limitări să nu se aplice în cazul dumneavoastră. Nu suntem responsabili pentru niciun conținut, cod sau orice altă imprecizie. Nu oferim garanții sau garanții. În nici un caz nu vom fi răspunzători pentru orice daune speciale, directe, indirecte, consecvente sau incidentale sau orice daune de orice fel, fie ca urmare a unei acțiuni contractuale, neglijențe sau alte delicte, care decurg din sau în legătură cu utilizarea Serviciului sau conținutul Serviciului. Ne rezervăm dreptul de a face adăugiri, ștergeri sau modificări la conținutul Serviciului în orice moment, fără notificare prealabilă. Serviciul nostru și conținutul acestuia sunt furnizate „CA AȘA ESTE” și „AȘAT DISPONIBIL” fără nicio garanție sau reprezentare de niciun fel, indiferent dacă este expresă sau implicită. Suntem un distribuitor și nu un editor al conținutului furnizat de terți; ca atare, nostru nu exercită niciun control editorial asupra acestui conținut și nu face nicio garanție sau reprezentare cu privire la acuratețea, fiabilitatea sau actualitatea oricărei informații, conținut, serviciu sau mărfuri furnizate prin sau accesibile prin intermediul Serviciului nostru. Fără a limita cele de mai sus, declinăm în mod special toate garanțiile și declarațiile în orice conținut transmis pe sau în legătură cu Serviciul nostru sau pe site-uri care pot apărea ca link-uri pe Serviciul nostru, sau în produsele furnizate ca parte a sau în alt mod în legătură cu , Serviciul nostru, incluzând fără limitare orice garanții de vandabilitate, potrivire pentru un anumit scop sau neîncălcare a drepturilor terților. Niciun sfat oral sau informații scrise oferite de noi sau de oricare dintre afiliații săi, angajații, ofițerii, directorii, agenții sau altele asemenea nu vor crea o garanție. Informațiile despre preț și disponibilitate pot fi modificate fără notificare. Fără a limita cele de mai sus, nu garantăm că Serviciul nostru va fi neîntrerupt, necorupt, în timp util sau fără erori.",
-          "title": "Exonerare de răspundere"
-        },
-        "disputeNoticeTerms": {
-          "content": "În cazul unui litigiu, dvs. sau AROLARIU.RO trebuie să transmiteți celeilalte părți o Notificare de litigiu, care este o declarație scrisă care stabilește numele, adresa și informațiile de contact ale părții care o transmite, faptele care dau naștere litigiului și soluția solicitată. Trebuie să trimiteți orice Notificare a litigiului prin e-mail la: admin@arolariu.ro. AROLARIU.RO vă va trimite orice Notificare a litigiului prin poștă la adresa dumneavoastră, dacă o avem, sau, în caz contrar, la adresa dumneavoastră de e-mail. Dumneavoastră și AROLARIU.RO veți încerca să rezolvați orice litigiu prin negocieri informale în termen de șaizeci (60) de zile de la data trimiterii Notificării de litigiu. După șaizeci (60) de zile, dumneavoastră sau AROLARIU.RO puteți începe arbitrajul.",
-          "title": "Notificare a litigiului"
-        },
-        "entireAgreementTerms": {
-          "content": "Termenii de utilizare constituie întregul acord între dvs. și AROLARIU.RO în ceea ce privește utilizarea serviciului și înlocuiesc toate acordurile anterioare și contemporane, scrise sau orale, dintre dvs. și AROLARIU.RO. Este posibil să faceți obiectul unor termeni și condiții suplimentare care se aplică atunci când utilizați sau achiziționați alte servicii ale AROLARIU.RO, pe care AROLARIU.RO vi le va furniza în momentul utilizării sau achiziționării respective.",
-          "title": "Intregul acord"
-        },
-        "generalTerms": {
-          "content": "Prin accesarea și plasarea unei comenzi la AROLARIU.RO, confirmați că sunteți de acord și că sunteți obligat să respectați termenii de serviciu conținuți în Termenii și condițiile prezentate mai jos. Acești termeni se aplică întregului site web și oricărui e-mail sau alt tip de comunicare între dumneavoastră și AROLARIU.RO. În nicio circumstanță echipa AROLARIU.RO nu va fi răspunzătoare pentru daune directe, indirecte, speciale, accidentale sau de consecință, inclusiv, dar fără a se limita la, pierderea de date sau profit, care rezultă din utilizarea sau incapacitatea de a utiliza materialele de pe acest site, chiar dacă echipa AROLARIU.RO sau un reprezentant autorizat a fost informat de posibilitatea unor astfel de daune. În cazul în care utilizarea materialelor de pe acest site are ca rezultat necesitatea întreținerii, reparării sau corectării echipamentelor sau datelor, vă asumați toate costurile aferente. AROLARIU.RO nu va fi responsabil pentru niciun rezultat care ar putea apărea pe parcursul utilizării resurselor noastre. Ne rezervăm dreptul de a modifica prețurile și de a revizui politica de utilizare a resurselor în orice moment.",
-          "title": "Termeni generali"
-        },
-        "liabilityTerms": {
-          "content": "În măsura permisă de legea aplicabilă, în nici un caz AROLARIU.RO nu va fi răspunzător față de dvs. din orice teorie juridică pentru orice daune incidentale, directe, indirecte, punitive, reale, consecutive, speciale, exemplare sau de altă natură, inclusiv, fără limitare, pierderi de venituri sau venituri, profituri pierdute, durere și suferință, suferință emoțională, costul bunurilor sau serviciilor de substituție sau daune similare suferite sau suferite de dvs. sau de orice terță parte care apar în legătură cu serviciul (sau încetarea acestuia din orice motiv). ), chiar dacă AROLARIU.RO a fost anunțat despre posibilitatea unor astfel de daune. AROLARIU.RO nu va fi răspunzător pentru nicio daune, răspundere sau pierdere care decurg din: (i) utilizarea sau încrederea de către dumneavoastră a serviciului sau incapacitatea dumneavoastră de a accesa sau utiliza serviciul; sau (ii) orice tranzacție sau relație între dumneavoastră și orice furnizor terț, chiar dacă AROLARIU.RO a fost informat despre posibilitatea unor astfel de daune. AROLARIU.RO nu va fi răspunzător pentru întârzierea sau nerespectarea executării rezultate din cauze care nu pot fi controlate în mod rezonabil al AROLARIU.RO. Recunoașteți că serviciul poate fi supus limitărilor, întârzierilor și altor probleme inerente utilizării internetului și a comunicațiilor electronice. AROLARIU.RO nu este responsabil pentru eventualele întârzieri, eșecuri de livrare sau alte daune rezultate din astfel de probleme. În măsura maximă permisă de legea aplicabilă, în niciun caz noi sau furnizorii noștri nu vom fi răspunzători pentru orice daune speciale, incidentale, indirecte sau consecutive (inclusiv, dar fără a se limita la, daune pentru pierderea de profit, pentru pierderea de date sau alte informații, pentru întreruperea activității, pentru vătămarea personală, pentru pierderea confidențialității care rezultă din sau în orice fel legate de utilizarea sau incapacitatea de a utiliza serviciul, software-ul terță parte și/sau hardware-ul terță parte utilizat cu serviciul, sau în alt mod în legătură cu orice prevedere a acestui Acord), chiar dacă noi sau orice furnizor am fost informați cu privire la posibilitatea unor astfel de daune și chiar dacă remedierea nu își atinge scopul esențial. Unele state/jurisdicții nu permit excluderea sau limitarea daunelor incidentale sau consecutive, astfel încât limitarea sau excluderea de mai sus este posibil să nu se aplice în cazul dumneavoastră.",
-          "title": "Limitare a raspunderii"
-        },
-        "licenseTerms": {
-          "content": "Prin achiziționarea unui produs de la AROLARIU.RO, vi se acordă o licență neexclusivă și netransferabilă de acces la produs. Produsul este destinat utilizării personale și comerciale. Aveți voie să instalați produsul pe mai multe calculatoare sau dispozitive, dar nu aveți voie să partajați produsul cu alte persoane. Nu aveți voie să modificați, să adaptați, să traduceți, să faceți inginerie inversă, să decompilați, să dezasamblați sau să creați lucrări derivate bazate pe produs fără acordul prealabil scris al AROLARIU.RO. Nu aveți voie să vindeți, să închiriați, să dați în leasing sau să sublicențiați produsul. Nu aveți voie să puneți produsul la dispoziție într-o rețea în care acesta ar putea fi utilizat de mai multe dispozitive în același timp. Nu aveți voie să utilizați produsul pentru a încălca niciun drept de autor sau marcă comercială. Nu aveți voie să utilizați produsul pentru a crea materiale ilegale, dăunătoare, amenințătoare, abuzive, hărțuitoare, delictuale, defăimătoare, vulgare, obscene, calomnioase, care încalcă viața privată a altora, care incită la ură sau care sunt reprobabile din punct de vedere rasial, etnic sau de altă natură.",
-          "title": "Termeni de licenta"
-        },
-        "linksToOtherSitesTerms": {
-          "content": "Serviciul nostru poate conține linkuri către alte site-uri web care nu sunt operate de Noi. Dacă faceți clic pe un link al unei terțe părți, veți fi direcționat către site-ul acelei terțe părți. Vă sfătuim cu tărie să consultați Termenii și condițiile fiecărui site pe care îl vizitați. Nu avem niciun control și nu ne asumăm nicio responsabilitate pentru conținutul, Termenii și condițiile sau practicile site-urilor sau serviciilor terților.",
-          "title": "Adrese catre alte platforme"
-        },
-        "miscellaneousTerms": {
-          "content": "Dacă, din orice motiv, o instanță de jurisdicție competentă consideră că orice prevedere sau porțiune din acești Termeni și condiții nu este aplicabilă, restul acestor Termeni și condiții va continua în vigoare și efect. Orice renunțare la orice prevedere a acestor Termeni și Condiții va intra în vigoare numai dacă este în scris și este semnată de un reprezentant autorizat al nostru. Vom avea dreptul la injoncție sau alte măsuri echitabile (fără obligația de a depune vreo garanție sau garanție) în cazul oricărei încălcări sau încălcări anticipate din partea dvs. Operăm și controlăm Serviciul nostru din birourile noastre din România. Serviciul nu este destinat distribuției sau utilizării de către nicio persoană sau entitate în nicio jurisdicție sau țară în care o astfel de distribuție sau utilizare ar fi contrară legii sau reglementărilor. În consecință, acele persoane care aleg să acceseze Serviciul nostru din alte locații fac acest lucru din proprie inițiativă și sunt singurele responsabile pentru conformitatea cu legile locale, dacă și în măsura în care legile locale sunt aplicabile. Acești Termeni și Condiții (care includ și încorporează Politica noastră de confidențialitate) conțin întreaga înțelegere și înlocuiesc toate înțelegerile anterioare dintre dvs. și noi cu privire la subiectul acesteia și nu pot fi modificate sau modificate de dvs. Titlurile secțiunilor utilizate în acest acord sunt doar pentru comoditate și nu vor primi nicio importanță legală. Neexercitarea de către oricare dintre părți a oricărui drept prevăzut aici nu va fi considerată o renunțare la orice alte drepturi în temeiul prezentului. AROLARIU.RO nu va fi răspunzător pentru nicio neîndeplinire a obligațiilor care îi revin în temeiul prezentului, în cazul în care o astfel de neexecuție rezultă din orice cauză.",
-          "title": "Diverse"
-        },
-        "noWarrantiesTerms": {
-          "content": "Acest site web este furnizat „ca atare”, cu toate greșelile, iar AROLARIU.RO nu face nicio declarație sau garanție, expresă sau implicită, de nici un fel legată de acest site sau de materialele conținute pe acest site. În plus, nimic din conținutul acestui site web nu va fi interpretat ca oferind consultanță sau consiliere. Serviciul vă este oferit „CA AȘA ESTE” și „AȘAT DISPONIBIL” și cu toate defecțiunile și defectele fără garanție de niciun fel. În măsura maximă permisă de legea aplicabilă, noi, în numele nostru și în numele afiliaților noștri și al licențiatorilor și furnizorilor noștri de servicii respectivi, renunțăm în mod expres la toate garanțiile, indiferent dacă sunt exprese, implicite, statutare sau de altă natură, cu privire la serviciu, inclusiv toate garanțiile implicite de vandabilitate, potrivire pentru un anumit scop, titlu și neîncălcare și garanțiile care pot apărea din cursul tranzacției, cursul performanței, utilizarea sau practica comercială. Fără a se limita la cele de mai sus, nu oferim nicio garanție sau angajament și nu facem nicio declarație de niciun fel că serviciul va îndeplini cerințele dumneavoastră, va obține rezultatele dorite, va fi compatibil sau va funcționa cu orice alt software, site-uri web, sisteme sau servicii, va funcționa fără întreruperea, îndeplinirea oricăror standarde de performanță sau fiabilitate sau să fie fără erori sau că orice erori sau defecte pot sau vor fi corectate. Fără a limita cele de mai sus, nici noi, nici niciun furnizor nu face nicio declarație sau garanție de orice fel, expresă sau implicită: (i) cu privire la funcționarea sau disponibilitatea serviciului sau la informațiile, conținutul și materialele sau produsele incluse în acesta; (ii) că serviciul va fi neîntrerupt sau fără erori; (iii) în ceea ce privește acuratețea, fiabilitatea sau actualitatea oricărei informații sau conținut furnizat prin intermediul serviciului; sau (iv) că serviciul, serverele sale, conținutul sau e-mailurile trimise de la sau în numele nostru sunt lipsite de viruși, scripturi, cai troieni, viermi, malware, bombe cu timp sau alte componente dăunătoare. Unele jurisdicții nu permit excluderea sau limitările garanțiilor implicite sau limitările privind drepturile legale aplicabile ale unui consumator, astfel încât unele sau toate excluderile și limitările de mai sus s-ar putea să nu vi se aplice.",
-          "title": "Fara garantii"
-        },
-        "promotionTerms": {
-          "content": "Putem, din când în când, să includem concursuri, promoții, tombole sau alte activități (\"Promoții\") care vă cer să trimiteți materiale sau informații despre dumneavoastră. Vă rugăm să rețineți că toate Promoțiile pot fi guvernate de reguli separate care pot conține anumite cerințe de eligibilitate, cum ar fi restricții privind vârsta și locația geografică. Sunteți responsabil să citiți toate regulile Promoțiilor pentru a determina dacă sunteți sau nu eligibil pentru a participa. Dacă vă înscrieți în orice Promoție, sunteți de acord să respectați și să vă conformați tuturor Regulilor Promoțiilor. Termeni și condiții suplimentare se pot aplica achizițiilor de bunuri sau servicii pe sau prin intermediul Serviciilor, termeni și condiții care fac parte integrantă din prezentul Acord prin această referință. Orice promoții puse la dispoziție prin intermediul serviciului pot fi guvernate de reguli care sunt separate de acești Termeni. Dacă participați la orice promoții, vă rugăm să consultați regulile aplicabile, precum și Politica noastră de confidențialitate. În cazul în care regulile unei promoții intră în conflict cu acești Termeni, se vor aplica regulile promoției.",
-          "title": "Promotii"
-        },
-        "restrictionTerms": {
-          "content": "Vi se interzice în mod specific să publicați, să vindeți, să sublicențiați sau să comercializați în alt mod orice material de pe site-ul web; să folosiți acest site web în orice mod care este sau poate fi dăunător pentru acest site web; să folosiți acest site web în orice mod care afectează accesul utilizatorilor la acest site web; să folosiți acest site web contrar legilor și reglementărilor aplicabile sau care, în orice mod, poate cauza prejudicii site-ului web sau oricărei persoane sau entități de afaceri; să vă implicați în activități de extragere de date, de recoltare de date, de extragere de date sau în orice altă activitate similară în legătură cu acest site web; să folosiți acest site web pentru a vă implica în orice activitate de publicitate sau de marketing.",
-          "title": "Restricții"
-        },
-        "severabilityTerms": {
-          "content": "Dacă orice prevedere a acestor Termeni este considerată inaplicabilă sau invalidă, o astfel de prevedere va fi modificată și interpretată pentru a îndeplini obiectivele unei astfel de prevederi în cea mai mare măsură posibilă în conformitate cu legislația aplicabilă, iar prevederile rămase vor continua în vigoare și în vigoare. Acest Acord, împreună cu Politica de confidențialitate și orice alte notificări legale publicate de noi pe Servicii, vor constitui întregul acord între dvs. și noi cu privire la Servicii. Dacă orice prevedere a prezentului acord este considerată invalidă de către o instanță de jurisdicție competentă, invaliditatea unei astfel de prevederi nu va afecta valabilitatea prevederilor rămase ale prezentului acord, care vor rămâne în vigoare și în vigoare. Nicio renunțare la niciun termen din prezentul Acord nu va fi considerată o renunțare ulterioară sau continuă la un astfel de termen sau la orice alt termen, iar eșecul nostru de a afirma orice drept sau prevedere în temeiul prezentului Acord nu va constitui o renunțare la acest drept sau prevedere. TU ȘI NOI SUNTEȚI DE ACORD CĂ ORICE CAUZA DE ACȚIUNE DECORATA DIN SAU LEGATĂ DE SERVICII TREBUIE SĂ ÎNCEPE ÎN TIMPUL DE UN (1) AN DUPĂ CAUZA ACȚIUNII SE ACUMULĂ. ÎN CARTĂ CAUZA, ACESTE CAUZA DE ACȚIUNE ESTE INTERDITĂ PERMANENT.",
-          "title": "Separabilitate"
-        },
-        "submissionsAndPrivacyTerms": {
-          "content": "Când vizitați site-ul web sau ne trimiteți e-mailuri, comunicați cu noi electronic. Sunteți de acord să primiți comunicări de la noi pe cale electronică. Vom comunica cu dvs. prin e-mail sau prin postarea de notificări pe site. Sunteți de acord că toate acordurile, notificările, dezvăluirile și alte comunicări pe care le furnizăm electronic îndeplinesc orice cerință legală ca astfel de comunicări să fie în scris. AROLARIU.RO poate, dar nu va fi obligat să monitorizeze, să revizuiască sau să editeze Conținutul utilizatorului. În toate cazurile, AROLARIU.RO își rezervă dreptul de a elimina sau dezactiva accesul la orice Conținut al Utilizatorului pentru orice motiv sau fără motiv, inclusiv, dar fără a se limita la, Conținutul Utilizatorului care, la discreția exclusivă a AROLARIU.RO, încalcă Acordurile. AROLARIU.RO poate întreprinde aceste acțiuni fără notificare prealabilă către dumneavoastră sau oricărei terțe părți. Eliminarea sau dezactivarea accesului la Conținutul utilizatorului va fi la discreția noastră exclusivă și nu promitem să eliminăm sau să dezactivăm accesul la orice Conținut specific al utilizatorului. În cazul în care trimiteți sau postați idei, sugestii creative, design, fotografii, informații, reclame, date sau propuneri, inclusiv idei pentru produse, servicii, caracteristici, tehnologii sau promoții noi sau îmbunătățite, sunteți de acord în mod expres că astfel de trimiteri vor fi automat fi tratat ca neconfidențial și neproprietar și va deveni proprietatea exclusivă a noastră fără nicio compensație sau credit pentru dvs. Noi și afiliații noștri nu vom avea nicio obligație cu privire la astfel de trimiteri sau postări și putem folosi ideile conținute în astfel de trimiteri sau postări în orice scop în orice mediu, în permanență, inclusiv, dar fără a se limita la, dezvoltarea, fabricarea și comercializarea produselor și servicii folosind astfel de idei.",
-          "title": "Propuneri si confidentialitate"
-        },
-        "terminationTerms": {
-          "content": "Putem rezilia sau suspenda contul dvs. și vă putem interzice accesul la serviciu imediat, fără notificare prealabilă sau răspundere, la discreția noastră exclusivă, din orice motiv și fără limitare, inclusiv, dar fără a ne limita la încălcarea Termenilor. Dacă doriți să vă închideți contul, puteți pur și simplu să nu mai utilizați serviciul. Toate dispozițiile din Termeni care, prin natura lor, ar trebui să supraviețuiască rezilierii, vor supraviețui rezilierii, inclusiv, dar fără a se limita la acestea, dispozițiile privind proprietatea, exonerările de garanție, despăgubirile și limitările de răspundere.",
-          "title": "Terminare"
-        },
-        "thirdPartyTerms": {
-          "content": "În cadrul utilizării serviciului, este posibil să utilizați servicii, produse, software, încorporări sau aplicații dezvoltate de o terță parte (\"Servicii ale terților\"). Orice utilizare a unui Serviciu terț este pe riscul dumneavoastră, iar noi nu vom fi responsabili sau răspunzători față de nimeni pentru site-urile sau Serviciile terților. Recunoașteți și sunteți de acord că nu vom fi responsabili sau răspunzători pentru orice daune sau pierderi cauzate sau presupuse a fi cauzate de sau în legătură cu utilizarea unui astfel de conținut, bunuri sau servicii disponibile pe sau prin intermediul unor astfel de site-uri web sau servicii. Nu ne asumăm și nu vom avea nicio răspundere sau responsabilitate față de dvs. sau față de orice altă persoană sau entitate pentru orice Servicii ale terților. Serviciile terțelor părți și linkurile aferente sunt furnizate doar pentru a vă fi de folos, iar dumneavoastră le accesați și le utilizați în întregime pe propriul risc și în conformitate cu termenii și condițiile terțelor părți.",
-          "title": "Servicii terte"
-        },
-        "typographyErrorsTerms": {
-          "content": "În cazul în care un produs AROLARIU.RO este listat din greșeală la un preț incorect, AROLARIU.RO își rezervă dreptul de a refuza sau de a anula orice comandă plasată pentru produsul listat la prețul incorect. AROLARIU.RO își rezervă dreptul de a refuza sau de a anula orice astfel de comenzi, indiferent dacă comanda a fost sau nu confirmată și dacă a fost sau nu încasată de pe cardul de credit. În cazul în care cardul dvs. de credit a fost deja taxat pentru achiziție și comanda dvs. este anulată, AROLARIU.RO va emite un credit în contul cardului dvs. de credit în valoare de prețul incorect.",
-          "title": "Erori de tipografie"
-        },
-        "updateOfServicesTerms": {
-          "content": "AROLARIU.RO își actualizează în mod constant serviciile, ceea ce înseamnă că putem adăuga sau elimina caracteristici, produse sau funcționalități și putem, de asemenea, să suspendăm sau să oprim complet serviciul. Putem lua oricare dintre aceste măsuri în orice moment, iar atunci când o facem, este posibil să nu vă oferim nicio notificare în prealabil. Recunoașteți că AROLARIU.RO poate stabili practici generale și limite privind utilizarea serviciului, inclusiv, fără a se limita la perioada maximă de timp în care datele sau alt conținut vor fi reținute de către serviciu și la spațiul maxim de stocare care va fi alocat pe serverele AROLARIU.RO în numele dvs. Sunteți de acord cu faptul că AROLARIU.RO nu are nicio responsabilitate sau răspundere pentru ștergerea sau imposibilitatea de a stoca orice date sau alt conținut păstrat sau încărcat de către serviciu. Recunoașteți că AROLARIU.RO își rezervă dreptul de a închide conturile care sunt inactive pentru o perioadă lungă de timp. Sunteți de acord că nu avem nicio obligație de a (i) furniza orice Actualizări sau (ii) de a continua să furnizăm sau să activăm anumite caracteristici și/sau funcționalități ale serviciului pentru dumneavoastră. Sunteți de acord, de asemenea, că toate Actualizările vor fi (i) considerate ca făcând parte integrantă din serviciu și (ii) supuse termenilor și condițiilor din prezentul Acord.",
-          "title": "Actualizari ale serviciului"
-        },
-        "waiverTerms": {
-          "content": "Cu excepția cazului în care se prevede în prezentul acord, neexercitarea unui drept sau neexecutarea unei obligații în temeiul prezentului acord nu afectează capacitatea unei părți de a exercita un astfel de drept sau de a solicita o astfel de executare în orice moment ulterior și nici renunțarea la o încălcare nu constituie o renunțare la orice încălcare ulterioară. Nici o neexercitare și nici o întârziere în exercitarea de către oricare dintre părți a unui drept sau a unei competențe în temeiul prezentului acord nu poate fi considerată ca o renunțare la dreptul sau competența respectivă. De asemenea, exercitarea unică sau parțială a unui drept sau a unei competențe în temeiul prezentului acord nu împiedică exercitarea ulterioară a acelui drept sau a oricărui alt drept acordat prin prezentul acord. În cazul unui conflict între prezentul acord și orice alte condiții de achiziție sau alte condiții aplicabile, prevalează termenii prezentului acord.",
-          "title": "Renuntare"
+      "services": {
+        "callToAction": "Vizitați acest serviciu de domeniu",
+        "invoices": {
+          "card": {
+            "description": "Acest serviciu de domeniu ajută la transformarea digitală a chitanțelor fizice. \nPermite utilizatorilor să încarce chitanțe și să obțină informații bine elaborate despre obiceiurile lor de cheltuieli.",
+            "imageAlt": "Ilustrație a Sistemului de Management al Facturilor care prezintă digitalizarea chitanțelor",
+            "title": "Sistem de management al bonurilor fiscale"
+          }
         }
       },
-      "title": "Termenii serviciului"
-    }
-  },
-  "Navigation": {
-    "about": "Despre",
-    "domains": "Domenii",
-    "invoices": "Facturi",
-    "mobile": {
-      "closeNavigation": "Închide navigarea",
-      "openNavigation": "Deschide navigarea",
-      "title": "Navigare"
+      "subtitle": "Platforma <code>arolariu.ro</code> oferă o gamă largă de servicii sub umbrela sa. <br></br> Majoritatea serviciilor necesită să aveți un cont creat pe această platformă, astfel încât datele dumneavoastră să poată fi sincronizate în siguranță între toate serviciile domeniului. <br></br> <br></br> Aici puteți vedea o prezentare a tuturor serviciilor de domeniu disponibile pentru explorare.",
+      "title": "Servicii disponibile"
     },
-    "myInvoices": "Facturile mele",
-    "myProfile": "Profilul meu",
-    "theAuthor": "Autorul",
-    "thePlatform": "Platforma",
-    "uploadScans": "Încarcă scanări",
-    "viewScans": "Vezi scanările"
-  },
-  "Profile": {
-    "header": {
-      "completionHint": "Completați profilul pentru a debloca toate funcțiile",
-      "daysActive": "zile active",
-      "editProfile": "Editează Profilul",
-      "editProfileClerkNote": "Informațiile profilului sunt gestionate prin Clerk. Faceți clic mai jos pentru a actualiza detaliile.",
-      "editProfileDescription": "Actualizați informațiile profilului",
-      "editProfileTitle": "Editează Profilul",
-      "manageOnClerk": "Gestionează pe Clerk",
-      "memberSince": "Membru din {date}",
-      "premium": "Premium",
-      "profileCompletion": "Completare Profil",
-      "userId": "ID Utilizator"
-    },
-    "island": {
-      "merchants": "{count} comercianți",
-      "scans": "{count} scanări",
-      "settingsNavigationAriaLabel": "Navigare setări",
-      "totalInvoices": "Total facturi"
-    },
-    "metadata": {
-      "description": "Gestionați setările și preferințele contului",
-      "title": "Profilul Meu"
-    },
-    "settings": {
-      "ai": {
-        "behavior": {
-          "description": "Alegeți cum răspunde AI-ul",
-          "title": "Presetare Comportament"
+    "home": {
+      "appreciation": "MULȚUMESC PENTRU TIMPUL PETRECUT PE SITE.",
+      "cta": "Începeți să explorați",
+      "featuresTab": {
+        "azure": {
+          "description": "Cloud-ul Microsoft Azure este utilizat pentru a găzdui platforma și toate serviciile sale. Acest lucru asigură faptul că platforma este întotdeauna disponibilă și că poate fi extinsă la cerere.",
+          "title": "Microsoft Azure"
         },
-        "description": "Configurați comportamentul și preferințele asistentului AI",
+        "csharp": {
+          "description": "Platforma este construită folosind .NET 8 LTS - cea mai recentă versiune stabilă a .NET. Acest lucru asigură faptul că platforma este rapidă, fiabilă și ușor de utilizat. Platforma este construită folosind C# și F#.",
+          "title": ".NET 8 LTS"
+        },
+        "description": "Platforma `arolariu.ro` este construita folosind cele mai noi tehnologii stabile.",
+        "githubActions": {
+          "description": "Experiența DevOps este alimentată de acțiuni Github. \n(CI/CD, testare etc.)",
+          "title": "GitHub Actions"
+        },
+        "learnMoreBtn": "Interesant? \nFaceți clic aici pentru a afla mai multe ...",
+        "nextJs": {
+          "description": "Platforma este construită folosind NextJS - cel mai popular cadru React pentru producție.  Este proiectat pentru aplicații React de nivel de producție. NextJS este cel mai popular cadru React pentru un motiv: este rapid, fiabil și ușor de utilizat.",
+          "title": "Next.JS 15"
+        },
+        "otel": {
+          "description": "Observabilitate completă cu metrici, urme și jurnale integrate. Totul este instrumentat utilizând OpenTelemetry. Acest lucru permite o experiență de telemetrie unificată pe toată linia. (3PO: metrici, jurnale, urme)",
+          "title": "Open Telemetry"
+        },
+        "svelte": {
+          "description": "Folosim Svelte pentru componente UI reactive, rapide, reactive. \nPlatforma `cv.arolariu.ro` este construită doar folosind Svelte și SvelteKit (v5)",
+          "title": "Svelte"
+        },
+        "title": "Caracteristici cheie"
+      },
+      "subtitle": "Această platformă a fost construită de Alexandru-Răzvan Olariu ca loc de joacă pentru noile tehnologii. Platforma este construită folosind tehnologii de ultimă oră, de nivel enterprise. <br> </br> <br> </br> Sunteți binevenit să explorați toate aplicațiile și serviciile care sunt găzduite pe acest spațiu de domeniu.",
+      "technologyTab": {
+        "badgeTitle": "Arhitectură modernă",
+        "description": "Această platformă utilizează cele mai recente tehnologii web, combinând Next.js pentru frontend cu .NET pentru servicii backend robuste, toate implementate pe Microsoft Azure.",
+        "learnMoreBtn": "Explorați arhitectura",
+        "points": {
+          "point1": "Arhitectură fără server pentru o scalare și performanță optimă",
+          "point2": "TypeScript full-stack pentru siguranța tipurilor în întreaga aplicație",
+          "point3": "Telemetrie și monitorizare cuprinzătoare cu OpenTelemetry"
+        },
+        "title": "Construit pentru viitor."
+      },
+      "title": "Bine ai venit pe arolariu.ro"
+    },
+    "invoices": {
+      "editInvoice": {
+        "changeHistory": {
+          "changes": {
+            "categoryUpdated": "Categorie actualizată",
+            "descriptionChanged": "Descriere modificată",
+            "importanceChanged": "Importanță modificată",
+            "markedImportant": "Marcat ca important",
+            "nameChanged": "Nume modificat",
+            "paymentTypeChanged": "Tip plată modificat",
+            "transactionDateChanged": "Data tranzacției modificată",
+            "unmarkedImportant": "Demarcat ca important"
+          },
+          "created": "Factură creată",
+          "modified": "Ultima modificare",
+          "pending": "În așteptare",
+          "time": {
+            "daysAgo": "acum {days} zile",
+            "hoursAgo": "acum {hours} ore",
+            "justNow": "Acum",
+            "minutesAgo": "acum {minutes} minute",
+            "secondsAgo": "acum {seconds} secunde"
+          },
+          "title": "Istoric Modificări",
+          "unsavedChanges": "Modificări nesalvate"
+        },
+        "editInvoiceContext": {
+          "console": {
+            "saveFailed": "Salvarea facturii a eșuat:"
+          },
+          "toasts": {
+            "noChanges": "Nu există modificări de salvat",
+            "saveFailed": "Salvarea modificărilor a eșuat",
+            "updated": "Factura a fost actualizată cu succes"
+          }
+        },
+        "guidedEditBanner": {
+          "actions": {
+            "dismiss": "Închide",
+            "reviewAll": "Revizuiește toate"
+          },
+          "badges": {
+            "lowConfidence": "{count, plural, one {# încredere scăzută} few {# încredere scăzută} other {# încredere scăzută}}",
+            "missingName": "{count, plural, one {# nume lipsă} few {# nume lipsă} other {# nume lipsă}}",
+            "uncategorized": "{count, plural, one {# necategorizat} few {# necategorizate} other {# necategorizate}}"
+          },
+          "summary": {
+            "lowConfidence": "{count, plural, one {# încredere scăzută} few {# încredere scăzută} other {# încredere scăzută}}",
+            "missingName": "{count, plural, one {# nume lipsă} few {# nume lipsă} other {# nume lipsă}}",
+            "uncategorized": "{count, plural, one {# necategorizat} few {# necategorizate} other {# necategorizate}}"
+          },
+          "title": "{count, plural, one {# produs necesită revizuire} few {# produse necesită revizuire} other {# de produse necesită revizuire}}"
+        },
+        "itemsTable": {
+          "actions": {
+            "editAllergens": "Editează alergeni",
+            "remove": "Elimină produs",
+            "restore": "Restabilește produs"
+          },
+          "bulkCategory": {
+            "noSelection": "Vă rugăm să selectați cel puțin un produs"
+          },
+          "bulkToolbar": {
+            "changeCategory": "Schimbă Categoria",
+            "deleteSelected": "Șterge selecționate",
+            "noSelection": "Niciun produs selectat",
+            "selectedCount": "{count, plural, one {# articol selectat} few {# articole selectate} other {# de articole selectate}}"
+          },
+          "buttons": {
+            "addItem": "Adaugă articol",
+            "editItems": "Editează articolele"
+          },
+          "columns": {
+            "actions": "Acțiuni",
+            "name": "Nume",
+            "price": "Preț",
+            "quantity": "Cantitate",
+            "selectAll": "Selectează toate articolele",
+            "selectRow": "Selectează {name}",
+            "total": "Total",
+            "unit": "Unitate"
+          },
+          "deleteConfirm": {
+            "cancel": "Anulează",
+            "confirm": "Șterge",
+            "description": "{count, plural, one {Sigur doriți să ștergeți acest articol?} few {Sigur doriți să ștergeți aceste # articole?} other {Sigur doriți să ștergeți aceste # de articole?}}",
+            "success": "{count, plural, one {# articol șters} few {# articole șterse} other {# de articole șterse}}",
+            "title": "Șterge articole"
+          },
+          "editing": {
+            "cancel": "Editare anulată",
+            "fieldLabel": "Editează {field} pentru {name}",
+            "saved": "Articol actualizat cu succes"
+          },
+          "footer": {
+            "total": "Total"
+          },
+          "indicators": {
+            "allergens": "{count, plural, one {# alergen} other {# alergeni}}",
+            "edited": "Editat",
+            "editedTooltip": "Acest produs a fost modificat manual",
+            "lowConfidence": "Încredere scăzută",
+            "lowConfidenceTooltip": "Încrederea OCR este de {confidence}% - se recomandă revizuire manuală",
+            "missingName": "Nume lipsă",
+            "missingNameTooltip": "Traducerea numelui generic lipsește sau este identică cu textul OCR brut",
+            "uncategorized": "Necategorizat",
+            "uncategorizedTooltip": "Acest produs necesită o categorie atribuită pentru o urmărire mai bună a cheltuielilor"
+          },
+          "newItem": {
+            "added": "Articol nou adăugat",
+            "defaultName": "Articol nou"
+          },
+          "pagination": {
+            "next": "Următor",
+            "pageOf": "Pagina {currentPage} din {totalPages}",
+            "previous": "Anterior",
+            "totalItems": "{count, plural, one {# articol în total} few {# articole în total} other {# de articole în total}}"
+          },
+          "restore": {
+            "error": "Eroare la restabilirea produsului",
+            "success": "Produsul {name} a fost restabilit"
+          },
+          "search": {
+            "placeholder": "Caută articole..."
+          },
+          "softDelete": {
+            "error": "Eroare la eliminarea produsului",
+            "success": "Produsul {name} a fost eliminat"
+          },
+          "tableHeaders": {
+            "item": "Articol",
+            "price": "Preț",
+            "quantity": "Cant.",
+            "total": "Total"
+          },
+          "title": "Articole",
+          "tooltips": {
+            "editInvoiceItemsAndQuantities": "Editează articolele și cantitățile facturii"
+          }
+        },
+        "metadata": {
+          "description": "Vizualizați și editați detaliile facturii, articolele, rețetele și setările de partajare.",
+          "title": "Editare factură"
+        },
+        "metadataTab": {
+          "badges": {
+            "readonly": "Doar citire"
+          },
+          "buttons": {
+            "addField": "Adaugă câmp",
+            "addFirstMetadataField": "Adaugă primul tău câmp de metadate"
+          },
+          "dropdown": {
+            "delete": "Șterge",
+            "edit": "Editează"
+          },
+          "emptyState": {
+            "noMetadataFields": "Nu au fost adăugate câmpuri de metadate"
+          },
+          "header": {
+            "description": "Metadate asociate acestei facturi",
+            "title": "Informații suplimentare"
+          },
+          "tooltips": {
+            "addCustomMetadata": "Adaugă metadate personalizate la această factură"
+          }
+        },
+        "recipesTab": {
+          "buttons": {
+            "addRecipe": "Adaugă rețetă",
+            "createFirstRecipe": "Creează prima ta rețetă",
+            "generate": "Generează"
+          },
+          "emptyState": {
+            "noRecipesAvailable": "Nu există încă rețete disponibile"
+          },
+          "header": {
+            "description": "Pe baza articolelor din această factură",
+            "title": "Rețete pe care le poți prepara"
+          },
+          "pagination": {
+            "next": "Următor",
+            "pageOf": "Pagina {currentPage} din {totalPages}",
+            "previous": "Anterior"
+          },
+          "toasts": {
+            "aiGenerationComingSoon": {
+              "description": "Această funcționalitate este în curs de dezvoltare.",
+              "title": "Generarea rețetelor cu IA vine în curând"
+            }
+          },
+          "tooltips": {
+            "createRecipeWithIngredients": "Creează o rețetă nouă cu aceste ingrediente",
+            "generateRecipeUsingAi": "Generează o rețetă cu IA!"
+          }
+        },
+        "triviaTips": {
+          "banner": {
+            "hint": "Aplică aceste sfaturi pentru a economisi la următoarea vizită la {merchantName}",
+            "potentialSavingsLabel": "Economii potențiale"
+          },
+          "buttons": {
+            "viewMoreSavingsTips": "Vezi mai multe sfaturi de economisire"
+          },
+          "completeLabel": "Factura este complet completă!",
+          "completeness": "Factura este completă în proporție de {percentage}%",
+          "contextActions": {
+            "addDescription": "Adaugă Descriere",
+            "analyze": "Rulează Analiza",
+            "setCategory": "Setează Categoria"
+          },
+          "contextTips": {
+            "defaultCategory": "Schimbă categoria din 'Necategorizat' pentru o urmărire mai bună",
+            "noCategory": "Setează o categorie pentru a urmări modelele de cheltuieli",
+            "noDescription": "Adaugă o descriere pentru a-ți aminti această achiziție",
+            "noItems": "Rulează analiza AI pentru a extrage articolele din bon",
+            "noRecipes": "AI poate sugera rețete bazate pe articolele tale alimentare"
+          },
+          "difficulty": {
+            "easy": "Ușor",
+            "medium": "Mediu"
+          },
+          "disclaimer": "Economiile sunt estimări bazate pe prețuri și promoții medii",
+          "tips": {
+            "bulkPurchase": {
+              "description": "Cumpără produse neperisabile la vrac pentru a reduce costul per unitate.",
+              "title": "Cumpără la vrac"
+            },
+            "digitalCoupons": {
+              "description": "Verifică aplicația {merchantName} pentru cupoane digitale înainte de cumpărături.",
+              "title": "Folosește cupoane digitale"
+            },
+            "loyaltyProgram": {
+              "description": "Înscrie-te în programul de loialitate {merchantName} pentru a câștiga puncte la fiecare achiziție.",
+              "title": "Înscrie-te în programul de loialitate"
+            }
+          },
+          "title": "Sfaturi de economisire",
+          "tooltips": {
+            "estimatedSavings": "Economii estimate cu acest sfat"
+          }
+        }
+      },
+      "landing": {
+        "bento": {
+          "ai": {
+            "description": "Extracție GPT-4",
+            "title": "Bazat pe AI"
+          },
+          "analyticsCard": {
+            "description": "Perspective cheltuieli",
+            "title": "Analiză"
+          },
+          "cloud": {
+            "description": "Acces de oriunde",
+            "title": "Sincronizare Cloud"
+          },
+          "description": "Funcționalități puternice concepute pentru a face gestionarea facturilor fără efort",
+          "mobile": "Funcționează excelent pe dispozitive mobile",
+          "ocr": {
+            "description": "Captură automată date",
+            "title": "OCR Inteligent"
+          },
+          "secure": {
+            "description": "Criptare de nivel bancar",
+            "title": "Securizat"
+          },
+          "share": {
+            "description": "Colaborare ușoară",
+            "title": "Partajare"
+          },
+          "title": "Tot Ce Ai Nevoie"
+        },
+        "cta": {
+          "badges": {
+            "ai": "Bazat pe AI",
+            "cloud": "Sincronizat în Cloud",
+            "secure": "Securizat și Privat"
+          },
+          "description": "Încarcă prima ta scanare și experimentează magia gestionării facturilor bazată pe AI.",
+          "learnMore": "Află Mai Multe",
+          "title": "Gata să Începi?",
+          "uploadButton": "Încarcă Prima Scanare"
+        },
         "features": {
-          "autoSuggest": "Auto-Sugestie",
-          "autoSuggestHint": "Primiți sugestii automate în timp ce lucrați",
-          "contextAwareness": "Conștientizare Context",
-          "contextAwarenessHint": "AI folosește context din facturile dvs.",
-          "description": "Activați sau dezactivați capabilitățile AI",
-          "memory": "Memorie Conversație",
-          "memoryHint": "AI își amintește conversațiile anterioare",
-          "title": "Funcții AI"
+          "analytics": {
+            "description": "Obține informații detaliate despre tiparele tale de cheltuieli cu grafice și rapoarte.",
+            "title": "Analiză Cheltuieli"
+          },
+          "batch": {
+            "description": "Procesează mai multe scanări simultan - creează facturi individuale sau combină-le într-una singură.",
+            "title": "Procesare în Loturi"
+          },
+          "description": "Tot ce ai nevoie pentru a gestiona facturile eficient",
+          "imageAlt": "Ilustrație cu funcționalitățile facturilor",
+          "ocr": {
+            "description": "AI-ul nostru extrage automat numele comercianților, datele, sumele și articolele din scanări.",
+            "title": "Extracție OCR Inteligentă"
+          },
+          "signIn": "Autentifică-te",
+          "signInPrompt": "Conectează-te pentru a salva facturile permanent și a le accesa de pe orice dispozitiv.",
+          "title": "Funcționalități Puternice"
         },
-        "maxTokens": {
-          "description": "Maximum tokeni per răspuns",
-          "title": "Lungime Răspuns"
+        "hero": {
+          "description": "Încarcă chitanțele și facturile tale, organizează-le și obține informații despre obiceiurile tale de cheltuieli. Sistemul nostru bazat pe AI extrage datele automat.",
+          "getStarted": "Începe Acum",
+          "imageAlt": "Ilustrație pentru gestionarea facturilor",
+          "title": "Gestionează-ți",
+          "titleHighlight": "Facturile",
+          "titleSuffix": "cu Ușurință",
+          "viewMyInvoices": "Vezi Facturile Mele"
         },
-        "model": {
-          "description": "Selectați modelul AI pentru asistent",
-          "title": "Model AI"
+        "metadata": {
+          "description": "Gestionează chitanțele, creează facturi și obține informații despre obiceiurile tale de cheltuieli.",
+          "title": "Sistemul de Management al Facturilor"
         },
-        "temperature": {
-          "creative": "Creativ",
-          "description": "Echilibru între precizie și creativitate",
-          "precise": "Precis",
-          "title": "Stil Răspuns"
-        },
-        "title": "Setări Asistent AI",
-        "voice": {
-          "description": "Configurați interacțiunea vocală",
-          "enabled": "Intrare Vocală",
-          "enabledHint": "Utilizați comenzi vocale cu AI",
-          "title": "Setări Voce"
+        "workflow": {
+          "description": "Trei pași simpli pentru a digitaliza și organiza documentele tale financiare",
+          "step1": {
+            "button": "Încarcă Acum",
+            "description": "Trage și lasă chitanțele, facturile sau bonurile tale. Acceptăm fișiere JPG, PNG și PDF de până la 10MB fiecare.",
+            "title": "Încarcă Scanări"
+          },
+          "step2": {
+            "button": "Vezi Scanările",
+            "description": "Revizuiește scanările încărcate, selectează-le pe cele dorite și creează facturi din ele individual sau în loturi.",
+            "title": "Vizualizează și Organizează"
+          },
+          "step3": {
+            "button": "Vezi Facturile",
+            "description": "Vizualizează facturile, analizează tiparele de cheltuieli și obține perspective bazate pe AI despre obiceiurile tale financiare.",
+            "title": "Gestionează Facturile"
+          },
+          "title": "Cum Funcționează"
         }
       },
-      "analytics": {
-        "advanced": {
-          "benchmarking": "Comparație",
-          "benchmarkingHint": "Comparați cu utilizatori similari",
-          "description": "Funcții premium de analiză",
-          "predictive": "Analiză Predictivă",
-          "predictiveHint": "Predicții de cheltuieli bazate pe AI",
-          "title": "Analize Avansate"
+      "uploadScans": {
+        "breadcrumb": "Înapoi la Facturi",
+        "buttons": {
+          "myInvoices": "Facturile Mele",
+          "uploadFirst": "Încărcați Prima Scanare",
+          "viewScans": "Vizualizați Scanările"
         },
-        "dataUsage": {
-          "info": "Datele dvs. de analiză sunt procesate local și nu sunt partajate niciodată fără consimțământul explicit.",
-          "title": "Utilizare Date"
+        "errors": {
+          "tooLarge": "Fișier prea mare: {name} (max 10MB)",
+          "unsupportedType": "Tip de fișier neacceptat: {type}"
         },
-        "description": "Configurați cum sunt analizate și raportate datele",
-        "enabled": {
-          "description": "Activați sau dezactivați funcțiile de analiză",
-          "hint": "Urmăriți și analizați tiparele de cheltuieli",
-          "label": "Activează Analize",
-          "title": "Analize"
+        "header": {
+          "description": "Încărcați imagini sau PDF-uri cu chitanțe. Creați facturi din ele mai târziu.",
+          "title": "Încărcare Scanări",
+          "tooltip": "Încărcați chitanțele, facturile sau bonurile dvs. aici. Puteți selecta mai multe fișiere și le puteți organiza în facturi mai târziu din pagina Vizualizare Scanări."
         },
-        "export": {
-          "description": "Format implicit pentru exporturi de date",
-          "title": "Format Export"
+        "metadata": {
+          "description": "Încărcați scanări de chitanțe în contul dvs. pentru procesare ulterioară în facturi.",
+          "title": "Sistem de gestionare a facturilor - Încărcare scanări"
         },
-        "granularity": {
-          "description": "Cât de detaliate să fie analizele",
-          "title": "Granularitate Date"
+        "postUpload": {
+          "createInvoice": "Da, începe analiza",
+          "dismiss": "Închide",
+          "subtitle": "{count, plural, one {Această scanare reprezintă o singură achiziție?} few {Aceste # scanări reprezintă o singură achiziție?} other {Aceste # de scanări reprezintă o singură achiziție?}}",
+          "title": "Încărcare finalizată!",
+          "viewScans": "Nu, analizează-le separat"
         },
-        "title": "Setări Analize",
-        "tracking": {
-          "categories": "Urmărește Categorii",
-          "categoriesHint": "Analizați cheltuielile pe categorii",
-          "description": "Alegeți ce să urmăriți",
-          "merchants": "Urmărește Comercianți",
-          "merchantsHint": "Monitorizați date specifice comercianților",
-          "spending": "Urmărește Cheltuieli",
-          "spendingHint": "Monitorizați cheltuielile generale",
-          "title": "Opțiuni Urmărire"
+        "preview": {
+          "pagination": {
+            "next": "Următor",
+            "pageInfo": "{current} / {total} ({count} scanări)",
+            "previous": "Anterior"
+          },
+          "pendingTooltip": "Această scanare nu va fi salvată până nu apăsați pe Încarcă",
+          "removeTooltip": "Elimină acest fișier",
+          "retryAttempt": "Reîncercarea {attempt}",
+          "status": {
+            "completed": "Finalizat",
+            "failed": "Eșuat",
+            "pending": "În așteptare",
+            "retrying": "Reîncercare",
+            "uploading": "Se încarcă"
+          },
+          "title": "Încărcări în așteptare ({count})"
+        },
+        "sidebar": {
+          "formats": {
+            "documentExtensions": ".pdf",
+            "documents": "Documente",
+            "imageExtensions": ".jpg, .jpeg, .png",
+            "images": "Imagini",
+            "maxSize": "Dimensiune maximă: 10MB per fișier",
+            "title": "Formate Acceptate"
+          },
+          "nextSteps": {
+            "button": "Continuați la Vizualizare Scanări",
+            "description": "Scanările dvs. sunt gata. Mergeți la Vizualizare Scanări pentru a le organiza în facturi.",
+            "title": "Toate încărcările sunt complete!"
+          },
+          "security": {
+            "description": "Scanările dvs. sunt criptate și stocate în siguranță. Doar dvs. le puteți accesa.",
+            "title": "Stocare Securizată"
+          },
+          "tips": {
+            "tip1": "Folosiți iluminare bună când fotografiați chitanțele",
+            "tip2": "Asigurați-vă că textul este clar și lizibil",
+            "tip3": "Evitați umbrele și reflexiile",
+            "tip4": "Capturați întreaga chitanță în cadru",
+            "tip5": "PDF-urile funcționează cel mai bine pentru chitanțele digitale",
+            "title": "Sfaturi pentru Rezultate Optime"
+          }
+        },
+        "stats": {
+          "added": "Adăugate",
+          "completed": "Finalizate",
+          "failed": "Eșuate",
+          "pending": "În așteptare",
+          "uploading": "Se încarcă"
+        },
+        "subtitle": "Încărcați imagini sau PDF-uri cu chitanțe. Creați facturi din ele mai târziu.",
+        "title": "Încărcare Scanări",
+        "upload": {
+          "browse": "Răsfoiți fișiere",
+          "dropzone": "Trageți și plasați imaginile sau PDF-urile cu chitanțe aici",
+          "or": "sau"
+        },
+        "uploadArea": {
+          "actions": {
+            "clearAll": "Șterge tot",
+            "uploading": "Se încarcă...",
+            "uploadScans": "Încarcă scanările"
+          },
+          "aria": {
+            "uploadFiles": "Încarcă fișiere"
+          },
+          "compact": {
+            "dropActive": "Plasează fișierele pentru a le adăuga",
+            "dropInactive": "Trage fișiere aici sau fă clic pentru a naviga",
+            "subtitle": "JPG, PNG, PDF până la 10MB"
+          },
+          "empty": {
+            "chooseFiles": "Alege fișiere",
+            "dropActive": "Plasează fișierele pentru încărcare",
+            "dropInactive": "Fă clic sau trage fișiere pentru încărcare",
+            "formats": "Formate acceptate: JPG, PNG, PDF (maxim 10MB fiecare)",
+            "note": "Poți selecta mai multe fișiere.",
+            "pasteHint": "Sfat: poți lipi o imagine direct din clipboard (Ctrl+V).",
+            "title": "Trage și plasează fișierele aici"
+          },
+          "tooltips": {
+            "clearAll": "Elimină toate încărcările în așteptare",
+            "uploadScans": "Pornește încărcarea tuturor scanărilor în așteptare"
+          }
         }
       },
-      "appearance": {
-        "advanced": {
-          "animations": "Animații",
-          "animationsHint": "Activați animațiile interfeței",
-          "compactMode": "Mod Compact",
-          "compactModeHint": "Reduceți spațierea pentru mai mult conținut",
-          "description": "Opțiuni suplimentare de personalizare",
-          "title": "Opțiuni Avansate"
+      "viewInvoice": {
+        "analysisPanel": {
+          "analyzing": {
+            "progress": "{progress}% completat",
+            "title": "Se analizează..."
+          },
+          "buttons": {
+            "reanalyze": "Re-analizează Factura"
+          },
+          "description": "Re-analizează această factură cu AI pentru a extrage sau actualiza datele",
+          "labels": {
+            "analysisComplete": "Analiză Completă — Toate datele au fost extrase",
+            "granularOptions": "Sau alege o analiză specifică",
+            "lastAnalyzed": "Ultima Analiză",
+            "updates": "{count, plural, one {# actualizare} other {# actualizări}}"
+          },
+          "options": {
+            "completeAnalysis": "Analiză Completă",
+            "invoiceOnly": "Doar Factura",
+            "itemsOnly": "Doar Articole",
+            "merchantOnly": "Doar Comerciant"
+          },
+          "steps": {
+            "analyzing": "Se analizează cu AI...",
+            "complete": "Analiză completă!",
+            "extracting": "Se rulează extragerea OCR...",
+            "finalizing": "Se finalizează rezultatele...",
+            "preparing": "Se pregătește documentul...",
+            "processing": "Se procesează articolele..."
+          },
+          "tip": "Sfat Rapid: Analiza completă durează 30-60 secunde, dar oferă cele mai precise rezultate.",
+          "title": "Analiză AI",
+          "toasts": {
+            "error": {
+              "description": "Nu s-a putut analiza factura. Vă rugăm să încercați din nou mai târziu.",
+              "title": "Analiză Eșuată"
+            },
+            "success": {
+              "description": "Factura a fost re-analizată cu succes cu date actualizate.",
+              "title": "Analiză Completă"
+            }
+          },
+          "tooltips": {
+            "completeAnalysis": "Extragere OCR completă + procesare AI a tuturor datelor facturii",
+            "invoiceOnly": "Re-extrage informații de bază ale facturii (dată, total, plată)",
+            "itemsOnly": "Re-categorizează și analizează doar articolele individuale",
+            "merchantOnly": "Re-identifică comerciantul și datele de locație",
+            "reanalyze": "Declanșează re-analiza completă cu toate caracteristicile AI"
+          }
         },
-        "colors": {
-          "description": "Personalizați schema de culori",
-          "preview": "Previzualizare Gradient",
-          "previewText": "Text Gradient Exemplu",
-          "primary": "Culoare Primară",
-          "secondary": "Culoare Secundară",
-          "intermediary": "Culoare Intermediară",
-          "title": "Culori Personalizate"
+        "categoryComparisonChart": {
+          "description": "Factura aceasta vs media ta",
+          "labels": {
+            "average": "Medie",
+            "current": "Curent"
+          },
+          "title": "Comparație pe categorii"
         },
-        "description": "Personalizați aspectul și senzația experienței",
-        "font": {
-          "description": "Selectați un font confortabil",
-          "dyslexic": "Prietenos pentru dislexici",
-          "dyslexicHint": "Font OpenDyslexic pentru lizibilitate îmbunătățită",
-          "normal": "Standard",
-          "title": "Font"
-        },
-        "locale": {
-          "description": "Setați limba preferată",
-          "title": "Limbă"
-        },
-        "presets": {
-          "custom": "Personalizat",
-          "customDescription": "Creați-vă propria schemă de culori",
-          "description": "Alegeți o schemă de culori predefinită sau creați-o pe a voastră",
-          "title": "Presetare Temă"
-        },
-        "theme": {
-          "dark": "Întunecat",
-          "description": "Alegeți schema de culori preferată",
-          "hint": "Comutați între temă deschisă, întunecată sau preferința sistemului",
-          "light": "Deschis",
-          "system": "Sistem",
-          "title": "Temă"
-        },
-        "title": "Setări Aspect"
-      },
-      "data": {
-        "backup": {
-          "autoBackup": "Backup Automat",
-          "autoBackupHint": "Backup automat al datelor",
-          "description": "Configurare backup automat",
-          "frequency": "Frecvență Backup",
-          "title": "Setări Backup"
-        },
-        "danger": {
-          "deleteAccount": "Șterge Cont",
-          "deleteAccountHint": "Ștergeți permanent contul",
-          "deleteButton": "Șterge Date",
-          "deleteData": "Șterge Toate Datele",
-          "deleteDataHint": "Eliminați permanent toate facturile și scanările",
-          "description": "Acțiuni ireversibile",
-          "manageAccount": "Gestionează pe Clerk",
-          "title": "Zonă Periculoasă"
-        },
-        "description": "Controlați stocarea datelor și setările de confidențialitate",
         "export": {
-          "description": "Descărcați o copie a datelor",
-          "downloadAll": "Descarcă Toate Datele",
-          "hint": "Exportul va include toate facturile, scanările și setările",
-          "title": "Export Date"
+          "copyError": "Eroare la copierea rezumatului",
+          "copySuccess": "Rezumat copiat în clipboard",
+          "copySummary": {
+            "description": "Copiază rezumatul text în clipboard",
+            "title": "Copiază Rezumat"
+          },
+          "csv": {
+            "description": "Descarcă articolele ca foaie de calcul",
+            "title": "Exportă ca CSV"
+          },
+          "csvError": "Eroare la exportul CSV",
+          "csvSuccess": "Fișier CSV descărcat cu succes",
+          "description": "Exportă datele facturii în diverse formate",
+          "json": {
+            "description": "Descarcă datele complete ale facturii",
+            "title": "Exportă ca JSON"
+          },
+          "jsonError": "Eroare la exportul JSON",
+          "jsonSuccess": "Fișier JSON descărcat cu succes",
+          "pdf": {
+            "description": "Descarcă document profesional de factură",
+            "title": "Exportă ca PDF"
+          },
+          "pdfError": "Eroare la generarea PDF-ului",
+          "pdfGenerating": "Se generează PDF...",
+          "pdfSuccess": "Fișier PDF descărcat cu succes",
+          "print": {
+            "description": "Printează factura folosind browserul",
+            "title": "Printare"
+          },
+          "printError": "Eroare la deschiderea dialogului de printare",
+          "printSuccess": "Dialog de printare deschis",
+          "title": "Exportă Factură"
         },
-        "privacy": {
-          "description": "Controlați cum sunt folosite datele",
-          "shareAnonymous": "Partajare Date Anonime",
-          "shareAnonymousHint": "Ajutați la îmbunătățirea serviciului cu date anonimizate",
-          "title": "Setări Confidențialitate"
+        "healthScore": {
+          "cta": {
+            "analyze": "Rulează Analiza AI",
+            "edit": "Editează Factura"
+          },
+          "dialogTitle": "Raport de sănătate factură",
+          "factors": {
+            "categoriesAssigned": "Categorii atribuite",
+            "merchantLinked": "Comerciant asociat",
+            "ocrConfidence": "Confidență OCR",
+            "paymentInfo": "Informații plată",
+            "productCompleteness": "Completitudine produse",
+            "productsPresent": "Produse extrase",
+            "recipesGenerated": "Rețete generate"
+          },
+          "hideDetails": "Ascunde detalii factori",
+          "points": "puncte",
+          "seeReport": "Vezi raport detaliat",
+          "showDetails": "Arată detalii factori",
+          "status": {
+            "excellent": "Excelent",
+            "good": "Bun",
+            "incomplete": "Incomplet",
+            "needsAttention": "Necesită Atenție"
+          },
+          "subtitle": "Evaluare comprehensivă a calității datelor",
+          "suggestions": {
+            "fix": "Rezolvă",
+            "incompletePayment": "Informații plată incomplete — adaugă data tranzacției, suma și moneda",
+            "incompleteProducts": "<strong>{count}</strong> produse incomplete — revizuiește și completează câmpurile lipsă",
+            "lowOcrConfidence": "Confidență OCR scăzută la <strong>{count}</strong> produse — revizuiește manual pentru acuratețe",
+            "noMerchant": "Niciun comerciant asociat — adaugă detalii comerciant pentru statistici mai bune",
+            "noProducts": "Nu sunt produse găsite — încarcă un bon sau adaugă articole manual",
+            "noRecipes": "Nu sunt rețete generate — rulează analiza AI pentru a descoperi idei de mese",
+            "title": "Îmbunătățiri Sugerate",
+            "uncategorizedProducts": "<strong>{count}</strong> produse fără categorie — atribuie categorii pentru analiza cheltuielilor"
+          },
+          "title": "Scor Sănătate Factură"
         },
-        "retention": {
-          "description": "Cât timp să păstrați datele",
-          "hint": "Datele mai vechi vor fi arhivate automat",
-          "title": "Retenție Date"
+        "invoiceAnalytics": {
+          "emptyState": {
+            "description": "Adaugă mai multe facturi pentru a vedea tendințe de cheltuieli, defalcări pe comercianți și comparații pe categorii.",
+            "title": "Date insuficiente pentru comparații"
+          },
+          "tabs": {
+            "compare": "Comparație",
+            "current": "Factura curentă"
+          },
+          "title": "Analize și insight-uri"
         },
-        "title": "Gestionare Date"
+        "invoiceGuestBanner": {
+          "description": "În prezent nu ești proprietarul acestei facturi. Vizualizarea este limitată la ce a configurat proprietarul în setările de partajare.",
+          "title": "Vizualizare invitat"
+        },
+        "invoiceTabs": {
+          "actions": {
+            "generate": "Generează rețete",
+            "regenerate": "Regenerează rețetele",
+            "regenerateTooltip": "Re-analizează factura pentru a genera noi sugestii de rețete"
+          },
+          "empty": {
+            "additionalInfo": "Nu există informații suplimentare",
+            "recipes": "Nu există sugestii de rețete"
+          },
+          "recipe": {
+            "duration": "{minutes} min",
+            "ingredients": "Ingrediente",
+            "instructions": "Instrucțiuni",
+            "prepCook": "Pregătire: {prep}m • Gătire: {cook}m",
+            "viewRecipe": "Vezi rețeta"
+          },
+          "tabs": {
+            "additionalInfo": "Informații suplimentare",
+            "possibleRecipes": "Rețete posibile"
+          }
+        },
+        "invoiceTimeline": {
+          "eventCount": "{count, plural, one {# eveniment} few {# evenimente} other {# de evenimente}}",
+          "subtitle": "Istoric complet al acțiunilor și modificărilor",
+          "title": "Cronologia facturii"
+        },
+        "itemAnalytics": {
+          "columns": {
+            "category": "Categorie",
+            "name": "Nume",
+            "price": "Preț",
+            "quantity": "Cant.",
+            "total": "Total"
+          },
+          "confidence": {
+            "ariaLabel": "Incredere {level}: {percent}%",
+            "high": "Ridicata",
+            "label": "Încredere OCR",
+            "low": "Scazuta",
+            "lowWarning": "Încredere scăzută — verificați acest produs",
+            "medium": "Medie"
+          },
+          "empty": {
+            "subtitle": "Rulați analiza AI pentru a extrage produsele din bon",
+            "title": "Niciun produs"
+          },
+          "searchPlaceholder": "Caută produse...",
+          "summary": {
+            "allergens": "{count} alergeni detectați",
+            "categories": "{count} categorii",
+            "cheapest": "Cel mai ieftin",
+            "mostExpensive": "Cel mai scump",
+            "title": "Rezumat"
+          },
+          "title": "Produse",
+          "totalLabel": "TOTAL"
+        },
+        "itemsBreakdownChart": {
+          "description": "Articole cu cele mai mari cheltuieli",
+          "labels": {
+            "price": "Preț",
+            "quantity": "Cant."
+          },
+          "title": "Top articole după cost"
+        },
+        "merchantBreakdownChart": {
+          "description": "Totaluri cumulative pe toți comercianții",
+          "labels": {
+            "averagePerVisit": "Medie/vizită",
+            "total": "Total",
+            "totalSpent": "Total cheltuit",
+            "visits": "Vizite"
+          },
+          "title": "Cheltuieli pe magazin",
+          "unknownMerchant": "Comerciant Necunoscut"
+        },
+        "metadata": {
+          "description": "Vizualizați detaliile facturii, articolele și informațiile despre comerciant.",
+          "title": "Vizualizare factură"
+        },
+        "priceDistributionChart": {
+          "description": "Articole pe intervale de preț ({currency})",
+          "labels": {
+            "items": "Articole"
+          },
+          "title": "Distribuția prețurilor",
+          "tooltip": {
+            "itemCount": "{count, plural, one {# articol} few {# articole} other {# de articole}}"
+          }
+        },
+        "print": {
+          "generatedOn": "Tipărit pe {date}",
+          "labels": {
+            "date": "Data",
+            "items": "Articole",
+            "merchant": "Comerciant",
+            "total": "Suma Totală"
+          },
+          "page": "Pagina"
+        },
+        "relatedInvoices": {
+          "noRelated": "Nu s-au găsit facturi conexe",
+          "sameCategory": "Aceeași Categorie",
+          "sameMerchant": "Același Comerciant",
+          "similarAmount": "Sumă Similară",
+          "subtitle": "Facturi similare bazate pe comerciant, categorie sau sumă",
+          "title": "Facturi Conexe",
+          "viewInvoice": "Vizualizare"
+        },
+        "shareCollaborate": {
+          "activity": {
+            "created": "Creat {time}",
+            "daysAgo": "{count, plural, one {acum # zi} other {acum # zile}}",
+            "modified": "Ultima modificare {time}",
+            "title": "Activitate",
+            "today": "astăzi"
+          },
+          "copied": "Link copiat în clipboard!",
+          "copyError": "Nu s-a putut copia linkul",
+          "copyLink": "Copiază Link",
+          "madePrivate": "Factura este acum privată",
+          "madePublic": "Factura este acum publică",
+          "manageSharing": "Gestionează Partajarea",
+          "private": "Privat",
+          "public": "Public",
+          "publicAccess": "Acces Public",
+          "publicAccessDescription": "Oricine cu link-ul poate vizualiza această factură",
+          "qrCode": "Cod QR",
+          "qrCopied": "Link copiat! Generarea codului QR va fi adăugată în curând.",
+          "shared": "Partajat",
+          "sharedWith": "Partajat cu",
+          "shareEmail": "Partajează prin Email",
+          "title": "Partajare & Colaborare",
+          "toggleError": "Eroare la actualizarea setărilor de partajare"
+        },
+        "spendingByCategoryChart": {
+          "description": "Distribuția cheltuielilor",
+          "title": "Cheltuieli pe categorie",
+          "tooltip": {
+            "itemCount": "{count, plural, one {# articol} few {# articole} other {# de articole}}"
+          },
+          "totalLabel": "Total cheltuieli"
+        },
+        "spendingTrendChart": {
+          "description": "Trendul istoricului tău de facturi",
+          "labels": {
+            "amount": "Sumă"
+          },
+          "title": "Evoluția cheltuielilor",
+          "tooltip": {
+            "andMore": "și încă {count}...",
+            "currentInvoice": "Factura curentă"
+          }
+        },
+        "timelineSharedWithList": {
+          "actions": {
+            "manageSharing": "Gestionează partajarea",
+            "sendEmail": "Trimite email"
+          },
+          "aria": {
+            "sendEmail": "Trimite email către {user}"
+          },
+          "header": {
+            "publicBadge": "Public",
+            "title": "Partajată cu"
+          },
+          "publicAccess": {
+            "description": "Această factură este accesibilă public. Oricine are linkul o poate vedea, inclusiv invitații fără cont.",
+            "title": "Acces public activat"
+          }
+        }
       },
-      "notifications": {
-        "description": "Gestionați cum și când primiți notificări",
-        "email": {
-          "description": "Configurați preferințele de comunicare prin email",
-          "enabled": "Activează Notificările Email",
-          "enabledHint": "Primiți actualizări prin email",
-          "title": "Notificări Email"
+      "viewInvoices": {
+        "bulkActions": {
+          "categories": {
+            "carAuto": "Mașină & Auto",
+            "fastFood": "Fast Food",
+            "grocery": "Alimente",
+            "homeCleaning": "Curățenie Casă",
+            "notDefined": "Nedefinit",
+            "other": "Altele"
+          },
+          "categoryChanged": "{count, plural, one {Categoria facturii actualizată cu succes} other {# categorii de facturi actualizate cu succes}}",
+          "categoryChangeError": "Eroare la actualizarea categoriilor facturilor. Vă rugăm încercați din nou.",
+          "categoryPartialSuccess": "{success} factură/facturi actualizate, {failed} eșuate",
+          "changeCategory": "Schimbă Categoria",
+          "clearSelection": "Curăță selecția",
+          "delete": "Șterge",
+          "deleteConfirm": {
+            "cancel": "Anulează",
+            "confirm": "Șterge",
+            "description": "{count, plural, one {Ești sigur că dorești să ștergi această factură? Această acțiune nu poate fi anulată.} other {Ești sigur că dorești să ștergi aceste # facturi? Această acțiune nu poate fi anulată.}}",
+            "title": "Șterge Facturile"
+          },
+          "deleteError": "Eroare la ștergerea facturilor. Vă rugăm încercați din nou.",
+          "deletePartialSuccess": "{success} factură/facturi șterse, {failed} eșuate",
+          "deleteSuccess": "{count, plural, one {Factură ștearsă cu succes} other {# facturi șterse cu succes}}",
+          "export": "Exportă",
+          "selected": "{count, plural, one {# factură selectată} other {# facturi selectate}}"
         },
-        "financial": {
-          "budgetAlerts": "Alerte Buget",
-          "budgetAlertsHint": "Alertă când vă apropiați de limitele bugetare",
-          "description": "Fiți notificat despre cheltuieli",
-          "spendingAlerts": "Alerte Cheltuieli",
-          "spendingAlertsHint": "Notificare când cheltuielile depășesc pragul",
-          "title": "Alerte Financiare"
+        "generativeView": {
+          "chatDescription": "Discută cu AI pentru a-ți analiza facturile și pentru a primi analize utile. Încearcă comenzi precum /find pentru a căuta facturi.",
+          "help": "Ajutor",
+          "settings": {
+            "allowInvoiceData": "Permite accesul la datele facturii",
+            "allowMerchantData": "Permite accesul la datele comerciantului",
+            "dataAccessTitle": "Acces la date",
+            "description": "Configurează preferințele asistentului tău AI",
+            "historyLabel": "Chat istoric",
+            "notificationPreferences": "Preferințe de notificare",
+            "notifyInsights": "Notifică-mă despre analize noi",
+            "retention": {
+              "item30": "Păstrează 30 de zile",
+              "item60": "Păstrează 60 de zile",
+              "item90": "Păstrează 90 de zile",
+              "none": "Don't salvează istoric"
+            },
+            "retentionPlaceholder": "Selectează perioada de păstrare",
+            "save": "Salvează setări",
+            "title": "Chat setări"
+          },
+          "subtitle": "Discută cu AI pentru a-ți analiza facturile și pentru a primi analize utile",
+          "tabs": {
+            "chat": "Conversație",
+            "settings": "Setări"
+          },
+          "title": "Analiză live",
+          "welcomeMessage": "Salut! Sunt asistentul tău de analiză a facturilor. Cu ce te pot ajuta astăzi? Încearcă comenzi precum /find pentru a căuta facturi."
         },
-        "reports": {
-          "description": "Livrare programată a rapoartelor",
-          "monthlyReport": "Raport Lunar",
-          "monthlyReportHint": "Analiză detaliată a cheltuielilor lunare",
-          "title": "Rapoarte",
-          "weeklyDigest": "Rezumat Săptămânal",
-          "weeklyDigestHint": "Rezumatul activității săptămânale"
+        "gridView": {
+          "itemCount": "{count, plural, one {# articol} few {# articole} other {# de articole}}",
+          "tooltips": {
+            "viewDetails": "Vezi detalii"
+          }
+        },
+        "invoicesHeader": {
+          "actions": {
+            "export": "Exportă",
+            "import": "Importă",
+            "newInvoice": "Factură nouă",
+            "print": "Printează"
+          },
+          "description": "Gestionează-ți bonurile și urmărește-ți obiceiurile de cheltuieli",
+          "title": "Gestionare facturi",
+          "tooltips": {
+            "export": "Exportă toate facturile",
+            "import": "Importă facturi din fișiere",
+            "newInvoice": "Creează o factură nouă",
+            "print": "Printează facturile"
+          }
+        },
+        "invoicesView": {
+          "categories": {
+            "all": "Toate categoriile",
+            "dining": "Mese în oraș",
+            "entertainment": "Divertisment",
+            "groceries": "Alimente",
+            "other": "Altele",
+            "travel": "Călătorii",
+            "utilities": "Utilități"
+          },
+          "placeholderPanel": "Vor fi adăugate în curând mai multe controale de filtrare.",
+          "searchPlaceholder": "Caută facturi...",
+          "times": {
+            "all": "Toate intervalele",
+            "day": "Zi (6-18)",
+            "night": "Noapte (18-6)"
+          },
+          "viewModes": {
+            "grid": "Grid vede",
+            "table": "Table vede"
+          }
+        },
+        "messageList": {
+          "aiAssistant": "Asistent AI",
+          "you": "Tu"
+        },
+        "metadata": {
+          "description": "Enumerați toate facturile din sistemul de gestionare a facturilor.",
+          "title": "Enumerați facturile"
+        },
+        "subtitle": "Acesta este inventarul dvs. de bonuri digitale. <br></br> Aici puteți găsi bonurile pe care le-ați încărcat până acum. <br></br> Făcând clic pe o chitanță, veți fi redirecționat către pagina chitanței specifice.",
+        "tableView": {
+          "aria": {
+            "rowsPerPage": "Rânduri pe pagină",
+            "selectAllInvoices": "Selectează toate facturile",
+            "selectInvoice": "Selectează factură {name}",
+            "sortByAmount": "Sortare după sumă",
+            "sortByDate": "Sortare după dată"
+          },
+          "columns": {
+            "actions": "Acțiuni",
+            "amount": "Sumă",
+            "category": "Categorie",
+            "date": "Dată",
+            "invoice": "Factură"
+          },
+          "empty": {
+            "description": "Începeți prin a încărca chitanțele pentru a crea prima factură",
+            "title": "Nu există facturi încă",
+            "uploadCta": "Încărcați prima chitanță"
+          },
+          "nextPage": "Pagina următoare",
+          "pageOf": "Pagina {current} din {total}",
+          "previousPage": "Pagina anterioară",
+          "rowsPerPage": "Rânduri pe pagină:",
+          "tooltips": {
+            "notAnalyzed": "Această factură nu a fost încă analizată"
+          },
+          "viewInvoice": "Vede Factură"
+        },
+        "tableViewActions": {
+          "actions": {
+            "delete": "Șterge",
+            "edit": "Editează",
+            "share": "Partajează"
+          },
+          "tooltips": {
+            "delete": "Șterge definitiv această factură",
+            "edit": "Editează detaliile facturii",
+            "moreActions": "Mai multe acțiuni",
+            "share": "Partajează factura prin link sau e-mail"
+          }
+        },
+        "title": "Bine ați venit, {name}!",
+        "viewInvoicesIsland": {
+          "tabs": {
+            "invoices": "Facturi",
+            "liveAnalysis": "Analiză live",
+            "statistics": "Statistici"
+          }
+        },
+        "viewInvoicesPage": {
+          "guestName": "dragă oaspete"
+        }
+      },
+      "viewScans": {
+        "breadcrumb": "Înapoi la Facturi",
+        "createFromAll": {
+          "button": "Creează din Toate Scanările",
+          "description": "Creează facturi din toate cele {count} scanări deodată",
+          "title": "Toate scanările sunt gata!"
+        },
+        "emptyState": {
+          "description": "Începeți prin a încărca chitanțele și facturile dvs. Iată cum funcționează:",
+          "learnMoreButton": "Aflați Mai Multe",
+          "step1Description": "Fotografiați chitanțele sau încărcați PDF-uri cu facturi digitale",
+          "step1Title": "Încărcați scanările",
+          "step2Description": "Alegeți care scanări să fie convertite în facturi",
+          "step2Title": "Selectați și organizați",
+          "step3Description": "AI-ul nostru extrage automat toate datele pentru dvs.",
+          "step3Title": "Creați facturi",
+          "title": "Nicio scanare încă",
+          "uploadButton": "Încărcați Prima Scanare"
+        },
+        "groupBanner": {
+          "createInvoice": "Creează Factură",
+          "dismiss": "Renunță",
+          "subtitle": "Creați o factură din aceste scanări?",
+          "title": "Aceste {count} scanări au fost încărcate împreună"
+        },
+        "header": {
+          "invoices": "Facturi",
+          "lastSynced": "Ultima sincronizare: {time}",
+          "myInvoices": "Facturile Mele",
+          "myInvoicesTooltip": "Vizualizați facturile create",
+          "subtitle": "Selectați scanări pentru a crea facturi din ele",
+          "sync": "Sincronizare",
+          "syncing": "Se sincronizează...",
+          "syncTooltip": "Reîmprospătați scanările de pe server",
+          "title": "Scanările Tale",
+          "titleWithCount": "Scanările Tale ({count})",
+          "tooltip": "Selectați scanări pentru a crea facturi din ele. Puteți crea o factură per scanare sau combina mai multe scanări într-o singură factură.",
+          "upload": "Încărcați",
+          "uploadMore": "Încărcați Mai Multe",
+          "uploadTooltip": "Încărcați mai multe scanări în contul dvs."
+        },
+        "metadata": {
+          "description": "Vizualizați și gestionați scanările încărcate. Creați facturi din scanările selectate.",
+          "title": "Sistem de gestionare a facturilor - Vizualizare Scanări"
+        },
+        "pagination": {
+          "next": "Următor",
+          "pageInfo": "{current} / {total} ({count} scanări)",
+          "previous": "Anterior"
+        },
+        "scanCard": {
+          "actions": {
+            "delete": "Ștergeți scanarea",
+            "rename": "Redenumește scanarea",
+            "rotateCCW": "Rotește 90° în sens antiorar",
+            "rotateCW": "Rotește 90° în sens orar",
+            "rotateError": "Nu s-a putut roti imaginea",
+            "rotateSuccess": "Imaginea a fost rotită cu succes",
+            "rotateUnsupported": "Nu se pot roti fișierele PDF",
+            "rotating": "Se rotește..."
+          },
+          "delete": "Ștergeți scanarea",
+          "deleteDialog": {
+            "cancel": "Anulare",
+            "delete": "Ștergere",
+            "deleting": "Se șterge...",
+            "description": "Sigur doriți să ștergeți \"{name}\"? Această acțiune nu poate fi anulată și scanarea va fi eliminată permanent din stocare.",
+            "error": "Nu s-a putut șterge scanarea",
+            "linkedDescription": "Ștergerea acesteia va elimina scanarea din stocare, dar factura va păstra o copie a imaginii. Această acțiune nu poate fi anulată.",
+            "linkedWarning": "Această scanare este asociată cu o factură.",
+            "success": "Scanarea a fost ștearsă cu succes",
+            "title": "Ștergeți scanarea?"
+          },
+          "linked": "Asociată",
+          "loading": "Se încarcă...",
+          "preview": "Previzualizare scanare",
+          "previewTitle": "Previzualizare Scanare",
+          "rename": "Redenumește scanarea",
+          "renamePlaceholder": "Introduceți un nume nou"
+        },
+        "sidebar": {
+          "howTo": {
+            "step1Description": "Faceți clic pe scanări pentru a le selecta",
+            "step1Title": "Selectați Scanări",
+            "step2Description": "O factură per scanare sau combinați mai multe",
+            "step2Title": "Alegeți Modul",
+            "step3Description": "AI extrage datele automat",
+            "step3Title": "Creați Factura",
+            "title": "Cum să Creați Facturi"
+          },
+          "quickUpload": {
+            "button": "Încărcare",
+            "description": "Încărcați chitanțe suplimentare",
+            "title": "Aveți nevoie de mai multe scanări?"
+          },
+          "selectionStatus": {
+            "plural": "scanări selectate",
+            "readyPlural": "Creați mai multe facturi sau combinați-le într-una singură",
+            "readySingular": "Pregătit pentru a crea o factură",
+            "singular": "scanare selectată"
+          }
+        },
+        "stats": {
+          "ready": "Pregătite",
+          "selected": "Selectate",
+          "selectHint": "Faceți clic pe scanări pentru a le selecta pentru crearea facturilor",
+          "tapHint": "Atingeți pentru a selecta",
+          "totalScans": "Total Scanări"
+        },
+        "subtitle": "Selectați scanări pentru a crea facturi din ele.",
+        "title": "Scanările Tale",
+        "toolbar": {
+          "clearSelection": "Ștergeți",
+          "createInvoice": "Creați Factură",
+          "createInvoices": "Creați Facturi",
+          "delete": {
+            "button": "Șterge ({count})",
+            "cancel": "Anulează",
+            "confirm": "Șterge",
+            "confirmDescription": "Aceasta va șterge permanent {count} scanare(i) din stocare. Această acțiune nu poate fi anulată.",
+            "confirmTitle": "Ștergeți scanările selectate?",
+            "error": "A apărut o eroare la ștergerea scanărilor",
+            "failed": "Nu s-au putut șterge scanările",
+            "partial": "{success} șterse, {failed} eșuate",
+            "success": "{count} scanare(i) șterse cu succes"
+          },
+          "selected": "selectat(e)"
+        }
+      }
+    },
+    "legal": {
+      "acknowledgements": {
+        "metadata": {
+          "description": "Pagina de mulțumire pentru pachetele terțe utilizate în acest proiect și colaboratori.",
+          "title": "Mulțumiri"
+        }
+      },
+      "eula": {
+        "accept": "Accept acest acord",
+        "content": "Acest acord de licență pentru utilizatorul final („EULA”) reprezintă un acord între dvs. și AROLARIU.RO și reglementează utilizarea acestui software. Vă rugăm să citiți cu atenție următoarele documente înainte de a utiliza site-ul web:",
+        "cookiesPolicy": {
+          "cookies": {
+            "analytics": {
+              "checkbox": "Activarea cookie-urilor de analiză ne ajută să ne îmbunătățim site-ul.",
+              "description": "Aceste cookie-uri ne permit să numărăm vizitele și sursele de trafic, astfel încât să putem măsura și îmbunătăți performanța site-ului nostru.  Ne ajută să știm care pagini sunt cele mai și mai puțin populare și să vedem cum se deplasează vizitatorii pe site. Toate informațiile colectate de aceste cookie-uri sunt agregate și, prin urmare, pot fi considerate anonime.",
+              "title": "Cookie-uri de analiză"
+            },
+            "cta": "Salvează preferințele cookie-urilor",
+            "essential": {
+              "checkbox": "Aceste cookie-uri sunt necesare pentru ca site-ul să funcționeze corect.",
+              "description": "Cookie-urile esențiale sunt necesare pentru ca site-ul să funcționeze corect. Această categorie include numai cookie-uri care asigură funcționalitățile de bază și caracteristicile de securitate ale site-ului web.",
+              "title": "Cookie-uri esențiale"
+            }
+          },
+          "subtitle": "Acest site folosește cookie-uri pentru a vă îmbunătăți experiența.",
+          "title": "Politica de cookie-uri"
+        },
+        "language": "Limbă",
+        "privacyPolicy": {
+          "cta": "Vizualizați politica",
+          "subtitle": "Politica noastră de confidențialitate explică modul în care colectăm, folosim și protejăm informațiile dvs. personale atunci când utilizați serviciile noastre.",
+          "title": "Politica de confidențialitate"
+        },
+        "subtitle": "Vă rugăm să examinați termenii și condițiile noastre înainte de a utiliza site-ul.",
+        "termsOfService": {
+          "cta": "Vizualizați termenii",
+          "subtitle": "Termenii noștri de serviciu conturează regulile și liniile directoare pentru utilizarea platformei noastre, inclusiv responsabilitățile utilizatorului și obligațiile noastre.",
+          "title": "Termeni de serviciu"
+        },
+        "title": "Acord de licență pentru utilizatorul final"
+      },
+      "privacyPolicy": {
+        "metadata": {
+          "description": "Pagina politicii de confidențialitate pentru platforma `arolariu.ro`.",
+          "title": "Politica de Confidențialitate"
+        }
+      },
+      "termsOfService": {
+        "metadata": {
+          "description": "Termenii de serviciu pentru arolariu.ro",
+          "title": "Termeni de Serviciu"
+        }
+      }
+    },
+    "profile": {
+      "header": {
+        "completionHint": "Completați profilul pentru a debloca toate funcțiile",
+        "daysActive": "zile active",
+        "editProfile": "Editează Profilul",
+        "editProfileClerkNote": "Informațiile profilului sunt gestionate prin Clerk. Faceți clic mai jos pentru a actualiza detaliile.",
+        "editProfileDescription": "Actualizați informațiile profilului",
+        "editProfileTitle": "Editează Profilul",
+        "manageOnClerk": "Gestionează pe Clerk",
+        "memberSince": "Membru din {date}",
+        "premium": "Premium",
+        "profileCompletion": "Completare Profil",
+        "userId": "ID Utilizator"
+      },
+      "island": {
+        "merchants": "{count} comercianți",
+        "scans": "{count} scanări",
+        "settingsNavigationAriaLabel": "Navigare setări",
+        "totalInvoices": "Total facturi"
+      },
+      "metadata": {
+        "description": "Gestionați setările și preferințele contului",
+        "title": "Profilul Meu"
+      },
+      "settings": {
+        "ai": {
+          "behavior": {
+            "description": "Alegeți cum răspunde AI-ul",
+            "title": "Presetare Comportament"
+          },
+          "description": "Configurați comportamentul și preferințele asistentului AI",
+          "features": {
+            "autoSuggest": "Auto-Sugestie",
+            "autoSuggestHint": "Primiți sugestii automate în timp ce lucrați",
+            "contextAwareness": "Conștientizare Context",
+            "contextAwarenessHint": "AI folosește context din facturile dvs.",
+            "description": "Activați sau dezactivați capabilitățile AI",
+            "memory": "Memorie Conversație",
+            "memoryHint": "AI își amintește conversațiile anterioare",
+            "title": "Funcții AI"
+          },
+          "maxTokens": {
+            "description": "Maximum tokeni per răspuns",
+            "title": "Lungime Răspuns"
+          },
+          "model": {
+            "description": "Selectați modelul AI pentru asistent",
+            "title": "Model AI"
+          },
+          "temperature": {
+            "creative": "Creativ",
+            "description": "Echilibru între precizie și creativitate",
+            "precise": "Precis",
+            "title": "Stil Răspuns"
+          },
+          "title": "Setări Asistent AI",
+          "voice": {
+            "description": "Configurați interacțiunea vocală",
+            "enabled": "Intrare Vocală",
+            "enabledHint": "Utilizați comenzi vocale cu AI",
+            "title": "Setări Voce"
+          }
+        },
+        "analytics": {
+          "advanced": {
+            "benchmarking": "Comparație",
+            "benchmarkingHint": "Comparați cu utilizatori similari",
+            "description": "Funcții premium de analiză",
+            "predictive": "Analiză Predictivă",
+            "predictiveHint": "Predicții de cheltuieli bazate pe AI",
+            "title": "Analize Avansate"
+          },
+          "dataUsage": {
+            "info": "Datele dvs. de analiză sunt procesate local și nu sunt partajate niciodată fără consimțământul explicit.",
+            "title": "Utilizare Date"
+          },
+          "description": "Configurați cum sunt analizate și raportate datele",
+          "enabled": {
+            "description": "Activați sau dezactivați funcțiile de analiză",
+            "hint": "Urmăriți și analizați tiparele de cheltuieli",
+            "label": "Activează Analize",
+            "title": "Analize"
+          },
+          "export": {
+            "description": "Format implicit pentru exporturi de date",
+            "title": "Format Export"
+          },
+          "granularity": {
+            "description": "Cât de detaliate să fie analizele",
+            "title": "Granularitate Date"
+          },
+          "title": "Setări Analize",
+          "tracking": {
+            "categories": "Urmărește Categorii",
+            "categoriesHint": "Analizați cheltuielile pe categorii",
+            "description": "Alegeți ce să urmăriți",
+            "merchants": "Urmărește Comercianți",
+            "merchantsHint": "Monitorizați date specifice comercianților",
+            "spending": "Urmărește Cheltuieli",
+            "spendingHint": "Monitorizați cheltuielile generale",
+            "title": "Opțiuni Urmărire"
+          }
+        },
+        "appearance": {
+          "advanced": {
+            "animations": "Animații",
+            "animationsHint": "Activați animațiile interfeței",
+            "compactMode": "Mod Compact",
+            "compactModeHint": "Reduceți spațierea pentru mai mult conținut",
+            "description": "Opțiuni suplimentare de personalizare",
+            "title": "Opțiuni Avansate"
+          },
+          "colors": {
+            "description": "Personalizați schema de culori",
+            "intermediary": "Culoare Intermediară",
+            "preview": "Previzualizare Gradient",
+            "previewText": "Text Gradient Exemplu",
+            "primary": "Culoare Primară",
+            "secondary": "Culoare Secundară",
+            "title": "Culori Personalizate"
+          },
+          "description": "Personalizați aspectul și senzația experienței",
+          "font": {
+            "description": "Selectați un font confortabil",
+            "dyslexic": "Prietenos pentru dislexici",
+            "dyslexicHint": "Font OpenDyslexic pentru lizibilitate îmbunătățită",
+            "normal": "Standard",
+            "title": "Font"
+          },
+          "locale": {
+            "description": "Setați limba preferată",
+            "title": "Limbă"
+          },
+          "presets": {
+            "custom": "Personalizat",
+            "customDescription": "Creați-vă propria schemă de culori",
+            "description": "Alegeți o schemă de culori predefinită sau creați-o pe a voastră",
+            "title": "Presetare Temă"
+          },
+          "theme": {
+            "dark": "Întunecat",
+            "description": "Alegeți schema de culori preferată",
+            "hint": "Comutați între temă deschisă, întunecată sau preferința sistemului",
+            "light": "Deschis",
+            "system": "Sistem",
+            "title": "Temă"
+          },
+          "title": "Setări Aspect"
+        },
+        "data": {
+          "backup": {
+            "autoBackup": "Backup Automat",
+            "autoBackupHint": "Backup automat al datelor",
+            "description": "Configurare backup automat",
+            "frequency": "Frecvență Backup",
+            "title": "Setări Backup"
+          },
+          "danger": {
+            "deleteAccount": "Șterge Cont",
+            "deleteAccountHint": "Ștergeți permanent contul",
+            "deleteButton": "Șterge Date",
+            "deleteData": "Șterge Toate Datele",
+            "deleteDataHint": "Eliminați permanent toate facturile și scanările",
+            "description": "Acțiuni ireversibile",
+            "manageAccount": "Gestionează pe Clerk",
+            "title": "Zonă Periculoasă"
+          },
+          "description": "Controlați stocarea datelor și setările de confidențialitate",
+          "export": {
+            "description": "Descărcați o copie a datelor",
+            "downloadAll": "Descarcă Toate Datele",
+            "hint": "Exportul va include toate facturile, scanările și setările",
+            "title": "Export Date"
+          },
+          "privacy": {
+            "description": "Controlați cum sunt folosite datele",
+            "shareAnonymous": "Partajare Date Anonime",
+            "shareAnonymousHint": "Ajutați la îmbunătățirea serviciului cu date anonimizate",
+            "title": "Setări Confidențialitate"
+          },
+          "retention": {
+            "description": "Cât timp să păstrați datele",
+            "hint": "Datele mai vechi vor fi arhivate automat",
+            "title": "Retenție Date"
+          },
+          "title": "Gestionare Date"
+        },
+        "notifications": {
+          "description": "Gestionați cum și când primiți notificări",
+          "email": {
+            "description": "Configurați preferințele de comunicare prin email",
+            "enabled": "Activează Notificările Email",
+            "enabledHint": "Primiți actualizări prin email",
+            "title": "Notificări Email"
+          },
+          "financial": {
+            "budgetAlerts": "Alerte Buget",
+            "budgetAlertsHint": "Alertă când vă apropiați de limitele bugetare",
+            "description": "Fiți notificat despre cheltuieli",
+            "spendingAlerts": "Alerte Cheltuieli",
+            "spendingAlertsHint": "Notificare când cheltuielile depășesc pragul",
+            "title": "Alerte Financiare"
+          },
+          "reports": {
+            "description": "Livrare programată a rapoartelor",
+            "monthlyReport": "Raport Lunar",
+            "monthlyReportHint": "Analiză detaliată a cheltuielilor lunare",
+            "title": "Rapoarte",
+            "weeklyDigest": "Rezumat Săptămânal",
+            "weeklyDigestHint": "Rezumatul activității săptămânale"
+          },
+          "security": {
+            "alwaysOnNote": "Alertele de securitate nu pot fi complet dezactivate pentru protecția dvs.",
+            "description": "Alerte critice de securitate",
+            "securityAlerts": "Alerte Securitate",
+            "securityAlertsHint": "Notificări importante de securitate",
+            "title": "Notificări Securitate"
+          },
+          "title": "Setări Notificări",
+          "updates": {
+            "description": "Rămâneți informat despre funcții noi",
+            "marketing": "Emailuri Marketing",
+            "marketingHint": "Conținut promoțional și oferte",
+            "newFeatures": "Funcții Noi",
+            "newFeaturesHint": "Fiți notificat despre funcționalități noi",
+            "title": "Actualizări Produs"
+          }
         },
         "security": {
-          "alwaysOnNote": "Alertele de securitate nu pot fi complet dezactivate pentru protecția dvs.",
-          "description": "Alerte critice de securitate",
-          "securityAlerts": "Alerte Securitate",
-          "securityAlertsHint": "Notificări importante de securitate",
-          "title": "Notificări Securitate"
-        },
-        "title": "Setări Notificări",
-        "updates": {
-          "description": "Rămâneți informat despre funcții noi",
-          "marketing": "Emailuri Marketing",
-          "marketingHint": "Conținut promoțional și oferte",
-          "newFeatures": "Funcții Noi",
-          "newFeaturesHint": "Fiți notificat despre funcționalități noi",
-          "title": "Actualizări Produs"
+          "description": "Protejați-vă contul cu măsuri de securitate îmbunătățite",
+          "devices": {
+            "current": "Actual",
+            "description": "Gestionați dispozitivele care pot accesa contul",
+            "empty": "Niciun dispozitiv de încredere configurat",
+            "lastUsed": "Ultima utilizare",
+            "title": "Dispozitive de Încredere"
+          },
+          "password": {
+            "changePassword": "Schimbă Parola",
+            "clerkNote": "Gestionarea parolei se face prin Clerk",
+            "description": "Gestionați credențialele contului",
+            "title": "Parolă și Acces"
+          },
+          "session": {
+            "description": "Gestionați sesiunile de conectare",
+            "hour": "oră",
+            "hours": "ore",
+            "loginNotifications": "Notificări Conectare",
+            "loginNotificationsHint": "Fiți notificat de conectări noi",
+            "minutes": "minute",
+            "timeout": "Expirare Sesiune",
+            "title": "Setări Sesiune"
+          },
+          "title": "Setări Securitate",
+          "twoFactor": {
+            "activeMessage": "Autentificarea în doi pași este activă",
+            "description": "Adăugați un nivel suplimentar de securitate contului",
+            "enabled": "Activează 2FA",
+            "enabledHint": "Necesită un al doilea factor la autentificare",
+            "title": "Autentificare în Doi Pași"
+          }
         }
       },
-      "security": {
-        "description": "Protejați-vă contul cu măsuri de securitate îmbunătățite",
-        "devices": {
-          "current": "Actual",
-          "description": "Gestionați dispozitivele care pot accesa contul",
-          "empty": "Niciun dispozitiv de încredere configurat",
-          "lastUsed": "Ultima utilizare",
-          "title": "Dispozitive de Încredere"
+      "sidebar": {
+        "account": "Cont",
+        "daysActive": "zile active",
+        "manageClerk": "Gestionează Contul pe Clerk",
+        "nav": {
+          "ai": "Asistent AI",
+          "analytics": "Analize",
+          "appearance": "Aspect",
+          "data": "Date",
+          "notifications": "Notificări",
+          "profile": "Profil",
+          "security": "Securitate"
         },
-        "password": {
-          "changePassword": "Schimbă Parola",
-          "clerkNote": "Gestionarea parolei se face prin Clerk",
-          "description": "Gestionați credențialele contului",
-          "title": "Parolă și Acces"
+        "preferences": "Preferințe",
+        "premium": "Premium",
+        "profileCompletion": "Completare Profil"
+      },
+      "stats": {
+        "aiQueries": {
+          "description": "Interacțiuni cu asistentul AI",
+          "title": "Interogări AI"
         },
-        "session": {
-          "description": "Gestionați sesiunile de conectare",
-          "hour": "oră",
-          "hours": "ore",
-          "loginNotifications": "Notificări Conectare",
-          "loginNotificationsHint": "Fiți notificat de conectări noi",
-          "minutes": "minute",
-          "timeout": "Expirare Sesiune",
-          "title": "Setări Sesiune"
+        "description": "Prezentare generală a activității contului",
+        "invoices": {
+          "description": "Facturi procesate și stocate",
+          "title": "Total Facturi"
         },
-        "title": "Setări Securitate",
-        "twoFactor": {
-          "activeMessage": "Autentificarea în doi pași este activă",
-          "description": "Adăugați un nivel suplimentar de securitate contului",
-          "enabled": "Activează 2FA",
-          "enabledHint": "Necesită un al doilea factor la autentificare",
-          "title": "Autentificare în Doi Pași"
-        }
+        "merchants": {
+          "description": "Comercianți unici urmăriți",
+          "title": "Comercianți"
+        },
+        "monthly": {
+          "description": "Cheltuieli medii lunare",
+          "title": "Medie Lunară"
+        },
+        "saved": {
+          "description": "Economii estimate din urmărire",
+          "title": "Total Economisit"
+        },
+        "scans": {
+          "description": "Scanări de bonuri încărcate",
+          "title": "Total Scanări"
+        },
+        "storage": {
+          "description": "Alocarea spațiului de stocare",
+          "title": "Utilizare Stocare",
+          "used": "utilizat"
+        },
+        "title": "Statistici Rapide"
       }
-    },
-    "sidebar": {
-      "account": "Cont",
-      "daysActive": "zile active",
-      "manageClerk": "Gestionează Contul pe Clerk",
-      "nav": {
-        "ai": "Asistent AI",
-        "analytics": "Analize",
-        "appearance": "Aspect",
-        "data": "Date",
-        "notifications": "Notificări",
-        "profile": "Profil",
-        "security": "Securitate"
-      },
-      "preferences": "Preferințe",
-      "premium": "Premium",
-      "profileCompletion": "Completare Profil"
-    },
-    "stats": {
-      "aiQueries": {
-        "description": "Interacțiuni cu asistentul AI",
-        "title": "Interogări AI"
-      },
-      "description": "Prezentare generală a activității contului",
-      "invoices": {
-        "description": "Facturi procesate și stocate",
-        "title": "Total Facturi"
-      },
-      "merchants": {
-        "description": "Comercianți unici urmăriți",
-        "title": "Comercianți"
-      },
-      "monthly": {
-        "description": "Cheltuieli medii lunare",
-        "title": "Medie Lunară"
-      },
-      "saved": {
-        "description": "Economii estimate din urmărire",
-        "title": "Total Economisit"
-      },
-      "scans": {
-        "description": "Scanări de bonuri încărcate",
-        "title": "Total Scanări"
-      },
-      "storage": {
-        "description": "Alocarea spațiului de stocare",
-        "title": "Utilizare Stocare",
-        "used": "utilizat"
-      },
-      "title": "Statistici Rapide"
     }
   },
-  "email": {
-    "layout": {
-      "tagline": "Instrumente practice. Informații clare. Gândit pentru cheltuielile de zi cu zi.",
-      "managePreferences": "Administrează preferințele de email",
-      "unsubscribe": "Dezabonează-te",
-      "buttonFallback": "Dacă butonul nu funcționează, deschide acest link:",
-      "secondaryFallback": "Sau:",
-      "allRightsReserved": "© 2022-{year} {brand}. Toate drepturile rezervate."
-    },
-    "welcome": {
-      "subject": "Bun venit la {brand}",
-      "badge": "Bun venit",
-      "heading": "Bun venit la {brand}",
-      "preview": "Bun venit la {brand}, {name}! Hai să începem.",
-      "greeting": "Salut {name},",
-      "intro": "Mulțumim că ni te-ai alăturat la {brand}. Ne bucurăm că ești aici. Platforma noastră te ajută să transformi bonurile zilnice în informații financiare organizate — cu ajutorul analizei AI.",
-      "howItWorksTitle": "Cum funcționează",
-      "howItWorks": {
-        "0": "Încarcă — fă o fotografie sau încarcă un PDF al oricărui bon",
-        "1": "Analizează — AI-ul nostru extrage produsele, prețurile, comercianții și chiar sugerează rețete din bonurile de băcănie",
-        "2": "Urmărește — vizualizează panouri de cheltuieli pe comerciant, categorie, lună sau an"
+  "sections": {
+    "about": {
+      "author": {
+        "biography": {
+          "fifthPoint": "Alexandru este deschis colaborării în proiecte care implică oricare dintre domeniile Internet of Things, Software Engineering și Network Engineering. El are o experiență dovedită în furnizarea de soluții de înaltă calitate la probleme complexe și este mereu în căutarea de noi provocări.",
+          "firstPoint": "Alexandru are {age} ani și este inginer software și arhitect de soluții. În prezent lucrează la Microsoft ca inginer software în cadrul organizației E+D MSAI FAST, construind soluții care sunt utilizate de milioane de utilizatori din întreaga lume.",
+          "fourthPoint": "Lui Alexandru îi place să citească cărți tehnice și să se joace cu noile tehnologii. A construit această platformă ca un \"banc de testare\" pentru noile tehnologii și ca o modalitate de a învăța lucruri noi. De asemenea, este un mare fan al mișcării \"open-source\" și a contribuit la depozitele OSS ale Microsoft (dotnet/core, dotnet/docs, azure/docs).",
+          "secondPoint": "Alexandru s-a născut pe 8 ianuarie 2000 într-un orășel numit Curtea de Argeș din România. A primit primul său computer când avea doar 5 ani - un Pentium 4 E2200 2.2Ghz Dual-Core cu 512 MB de RAM. De atunci, a rulat diferite versiuni de Windows (a început cu Windows 98!), a bricolat calculatorul personal și și-a dezvoltat abilitățile informatice jucând jocuri video. De asemenea, a învățat o bună parte din limba engleză și a fost capabil să citească, să scrie și să vorbească fluent în limba engleză până la vârsta de 12 ani!",
+          "thirdPoint": "Alexandru este un pasionat de jocuri video. A fost jucător profesionist, clasându-se pe locul 70 în România pentru jocul video numit „DotA 2”. Îi place să joace jocuri de strategie care pun accentul pe mecanică și pe un cadru tehnic, cum ar fi Age of Empires, Age of Mythology, etc. De asemenea, îi place să joace jocuri precum Red Alert, StarCraft și alte jocuri RTS.",
+          "title": "Despre Alexandru"
+        },
+        "certifications": {
+          "certificates": {
+            "ab730": {
+              "code": "AB-730",
+              "coreSkills": "# Strategie AI # Adopție AI # AI Responsabil # Valoare de business AI # Identificarea cazurilor de utilizare AI",
+              "description": "Validează cunoștințele orientate pe business privind AI pentru profesioniștii care conduc sau influențează inițiative AI în cadrul organizației. Este destinată factorilor de decizie, product owner-ilor și consultanților care modelează strategia AI mai degrabă decât o implementează.",
+              "issuer": "Microsoft",
+              "issuerDate": "2026",
+              "link": "https://learn.microsoft.com/en-us/credentials/certifications/ai-business-professional/",
+              "name": "Certificat Microsoft: AI Business Professional"
+            },
+            "ab731": {
+              "code": "AB-731",
+              "coreSkills": "# Transformare AI la nivel de întreprindere # Strategie AI # Managementul schimbării # Guvernanță AI # Leadership executiv",
+              "description": "Validează capacitatea de a conduce inițiative de transformare AI la nivel de întreprindere — definirea strategiei, conducerea schimbării organizaționale și stabilirea guvernanței pentru operaționalizarea AI în întreaga afacere.",
+              "issuer": "Microsoft",
+              "issuerDate": "2026",
+              "link": "https://learn.microsoft.com/en-us/credentials/certifications/ai-transformation-leader/",
+              "name": "Certificat Microsoft: AI Transformation Leader"
+            },
+            "ai900": {
+              "code": "AI-900",
+              "coreSkills": "# Machine Learning # Computer Vision # Natural Language Processing # Conversational AI # Responsible AI",
+              "description": "Demonstrează cunoașterea volumelor de lucru comune de AI și machine learning și a modului de implementare a acestora pe Azure. Această certificare se adresează candidaților cu pregătire atât tehnică, cât și non-tehnică.",
+              "issuer": "Microsoft",
+              "issuerDate": "2023",
+              "link": "https://learn.microsoft.com/en-us/certifications/azure-ai-fundamentals/",
+              "name": "Certificat Microsoft: Azure AI Fundamentals"
+            },
+            "az900": {
+              "code": "AZ-900",
+              "coreSkills": "# Concepte cloud # Servicii Azure de bază # Securitate, confidențialitate, conformitate și încredere # Prețuri, SLA și ciclul de viață Azure",
+              "description": "Validează cunoștințele de bază privind serviciile cloud și modul în care aceste servicii sunt furnizate cu Microsoft Azure. Certificarea este destinată candidaților care abia încep să lucreze cu soluții și servicii bazate pe cloud.",
+              "issuer": "Microsoft",
+              "issuerDate": "2023",
+              "link": "https://learn.microsoft.com/en-us/certifications/azure-fundamentals/",
+              "name": "Certificat Microsoft: Azure Fundamentals"
+            },
+            "gh100": {
+              "code": "GH-100",
+              "coreSkills": "# Autentificare # Gestionarea utilizatorilor și echipelor # Politici de repository # Configurare Enterprise # Securitate și conformitate",
+              "description": "Validează abilitățile necesare pentru a administra organizațiile GitHub Enterprise — gestionarea utilizatorilor, echipelor, repositoriilor, politicilor și integrărilor la scară.",
+              "issuer": "GitHub",
+              "issuerDate": "2026",
+              "link": "https://learn.microsoft.com/en-us/credentials/certifications/github-administration/",
+              "name": "Certificat GitHub: Administration"
+            },
+            "gh200": {
+              "code": "GH-200",
+              "coreSkills": "# Crearea workflow-urilor # Runner-e self-hosted # Securitatea workflow-urilor # Workflow-uri reutilizabile # Pipeline-uri CI/CD",
+              "description": "Validează expertiza în crearea, configurarea și menținerea workflow-urilor GitHub Actions pentru automatizarea build, test și deployment de-a lungul întregului ciclu de viață software.",
+              "issuer": "GitHub",
+              "issuerDate": "2026",
+              "link": "https://learn.microsoft.com/en-us/credentials/certifications/github-actions/",
+              "name": "Certificat GitHub: Actions"
+            },
+            "gh300": {
+              "code": "GH-300",
+              "coreSkills": "# Planuri și funcționalități Copilot # Sugestii de cod # Prompt Engineering # Utilizare AI responsabilă # Copilot Chat",
+              "description": "Validează abilitățile necesare pentru a folosi GitHub Copilot eficient în dezvoltarea software asistată de AI — acoperind funcționalitățile, personalizarea, prompt engineering-ul și utilizarea responsabilă.",
+              "issuer": "GitHub",
+              "issuerDate": "2026",
+              "link": "https://learn.microsoft.com/en-us/credentials/certifications/github-copilot/",
+              "name": "Certificat GitHub: Copilot"
+            },
+            "gh900": {
+              "code": "GH-900",
+              "coreSkills": "# Bazele GitHub # Repository-uri # Colaborare # Produsele GitHub # Issues, Pull Request-uri și workflow-uri",
+              "description": "Validează cunoștințele de bază despre GitHub — acoperind repository-urile, funcționalitățile de colaborare, familia de produse GitHub și workflow-urile esențiale ale dezvoltatorilor.",
+              "issuer": "GitHub",
+              "issuerDate": "2026",
+              "link": "https://learn.microsoft.com/en-us/credentials/certifications/github-foundations/",
+              "name": "Certificat GitHub: Foundations"
+            },
+            "sc900": {
+              "code": "SC-900",
+              "coreSkills": "# Concepte de securitate # Principii de identitate # Microsoft Entra # Soluții de conformitate # Confidențialitate și protecția informațiilor",
+              "description": "Validează cunoștințele de bază privind securitatea, conformitatea și identitatea, împreună cu soluțiile Microsoft cloud aferente — Entra, Defender și Purview.",
+              "issuer": "Microsoft",
+              "issuerDate": "2023",
+              "link": "https://learn.microsoft.com/en-us/credentials/certifications/security-compliance-and-identity-fundamentals/",
+              "name": "Certificat Microsoft: Security, Compliance & Identity Fundamentals"
+            }
+          },
+          "coreSkillsLabel": "Competențe Demonstrate:",
+          "subtitle": "Certificări și acreditări profesionale pe care Alexandru le-a obținut de-a lungul carierei sale.",
+          "title": "Certificări",
+          "viewCertification": "Vezi certificarea"
+        },
+        "competencies": {
+          "competences": {
+            "agileMethodologies": {
+              "description": "Alexandru a învățat despre munca agile și metodologiile agile încă de când era student la licență. El urmează manifestul agile și este un mare fan al tehnicii Kanban de planificare.",
+              "title": "Metodologii Agile"
+            },
+            "algorithmicSkills": {
+              "description": "Alexandru a finalizat multe provocări Hacker Rank, Hacker Earth și Leet Code publicate din 2019 până în 2021. El are o gândire algoritmică puternică și este capabil să construiască algoritmi complecși cu ușurință.",
+              "title": "Competențe Algoritmice"
+            },
+            "customerCentric": {
+              "description": "Alexandru lucrează cu clienții de mulți ani, în perioada în care a lucrat la Microsoft. A acumulat multe cunoștințe și este capabil să se pună în locul clientului. Este capabil să înțeleagă nevoile clientului și să ofere soluții care sunt exact adaptate nevoilor acestuia.",
+              "title": "Centrat pe client"
+            },
+            "domainDrivenDesign": {
+              "description": "Alexandru urmează cu strictețe principiile de proiectare bazate pe domeniu. El este capabil să combine DDD cu TDD pentru a crea soluții complexe care sunt ușor de întreținut și extins. El este, de asemenea, un mare fan al abordărilor „arhitectură în ceapă” și „arhitectură curată”.",
+              "title": "Proiectarea bazată pe domeniu (DDD)"
+            },
+            "engineeringExcellence": {
+              "description": "Alexandru este pasionat de furnizarea celor mai bune soluții pentru problemă și pentru client. El se străduiește mereu să livreze cel mai bun software și să urmeze practicile de excelență în inginerie înțelese. O soluție perfectă este o soluție care este ușor de întreținut, extins și înțeles, nu cea care este cea mai complexă.",
+              "title": "Excelență în domeniul ingineriei"
+            },
+            "testDrivenDevelopment": {
+              "description": "Alexandru este un adept convins al dezvoltării bazate pe teste. Aplică constant această abordare în proiectele sale și încearcă mereu să își îmbunătățească abilitățile de testare. De asemenea, este un mare fan al abordării „red-green-refactor”.",
+              "title": "Dezvoltare bazată pe teste (TDD)"
+            }
+          },
+          "subtitle": "O vitrină a abilităților tehnice și a competențelor profesionale ale lui Alexandru.",
+          "title": "Competențele lui Alexandru"
+        },
+        "contact": {
+          "collaborate": {
+            "discipline1": "Inginerie Software",
+            "discipline2": "Internetul obiectelor (Internet of Things)",
+            "discipline3": "Aplicații native în cloud",
+            "discipline4": "Inginerie de rețea",
+            "footer": " Dacă aveți un proiect interesant sau o oportunitate care se aliniază cu expertiza lui Alexandru, nu ezitați să îl contactați. El este întotdeauna dornic să exploreze noi provocări și colaborări.",
+            "subtitle": "Alexandru este deschis pentru colaborare în proiecte care implică oricare dintre următoarele domenii:",
+            "title": "Să colaborăm!"
+          },
+          "footer": "Mulțumesc.",
+          "socials": {
+            "footer": "Pentru a ajunge la el, utilizați una dintre metodele de contact de mai sus.",
+            "subtitle": "Simțiți-vă liber să vă adresați pentru colaborări, întrebări sau doar să ne cunoastem!",
+            "title": "Luați legătura"
+          },
+          "subtitle": "Dacă doriți să luați legătura cu Alexandru, vă rugăm să utilizați modalitățile de contact de mai jos.",
+          "title": "Conectați-vă cu Alexandru"
+        },
+        "education": {
+          "subtitle": "Trecutul academic al lui Alexandru și călătoria sa de învățare.",
+          "title": "Educaţie",
+          "university": {
+            "aseBucharest": {
+              "aboutTheProgramCta": "Vezi mai multe detalii",
+              "aboutTheProgramDescription": "Licența în Informatică la Universitatea din București este un program riguros care oferă studenților o bază solidă în informatică teoretică și dezvoltare practică de software. Curriculum-ul pune accentul pe abilitățile de rezolvare a problemelor, gândirea algoritmică și principiile ingineriei software.",
+              "aboutTheProgramLearnings": "# Proiectarea și analiza algoritmilor și a structurilor de date # Dezvoltarea de software folosind diverse paradigme de programare # Implementarea sistemelor de baze de date și gestionarea datelor # Înțelegerea rețelelor de calculatoare și a sistemelor distribuite # Aplicarea principiilor ingineriei software la probleme din lumea reală",
+              "aboutTheProgramLearningsTitle": "Rezultatele cheie ale învățării",
+              "aboutTheProgramTitle": "Despre program",
+              "degree": "BSC. \nInformatică",
+              "description": "Diplomă de licență în Informatică și Economie la Universitatea de Studii Economice din București, România. A terminat în top 1% conform statisticilor de evaluare a tezelor.",
+              "institution": "Academia de Studii Economice",
+              "keyCourses": "# Inginerie software # Rețele de calculatoare # Sisteme de operare # Algoritmi și structuri de date # Sisteme de gestionare a bazelor de date # Dezvoltare web # Dezvoltare mobilă",
+              "keyCoursesTitle": "Cursuri cheie",
+              "location": "București, România",
+              "period": "2019 - 2022",
+              "status": "Completat"
+            },
+            "malmoSweden": {
+              "aboutTheProgramCta": "Vezi mai multe detalii",
+              "aboutTheProgramDescription": "MSc în Internet of Things la Universitatea Malmö este un program de ultimă oră care pregătește studenții pentru provocările și oportunitățile revoluției IoT. Planul de învățământ pune accentul pe învățarea practică, colaborarea interdisciplinară și aplicațiile din lumea reală.",
+              "aboutTheProgramLearnings": "# Proiectați și implementați sisteme IoT utilizând diverse platforme hardware și software # Analizați și gestionați datele generate de dispozitivele IoT # Aplicați tehnici de învățare automată și inteligență artificială pentru aplicațiile IoT # Înțelegeți implicațiile sistemelor IoT în materie de securitate și confidențialitate # Colaborați cu parteneri din industrie la proiecte reale",
+              "aboutTheProgramLearningsTitle": "Rezultatele cheie ale învățării",
+              "aboutTheProgramTitle": "Despre program",
+              "degree": "MSC. \nInternetul lucrurilor",
+              "description": "Înscris anterior în programul MSc. Internet of Things la Universitatea Malmö, Suedia. Întrerupt din cauza unor circumstanțe personale și neprevăzute în 2024.",
+              "institution": "Universitatea Malmö",
+              "keyCourses": "# Internet of Things # Cloud Computing # Data Science # Machine Learning # Inteligență artificială # Computer Vision # Robotică",
+              "keyCoursesTitle": "Cursuri cheie",
+              "location": "Malmö, Suedia",
+              "period": "2023 - 2024",
+              "status": "Întrerupt"
+            }
+          }
+        },
+        "experiences": {
+          "achievementsLabel": "Realizări",
+          "intel": {
+            "achievements": "# Am dezvoltat convertoare de spațiu de culoare (CSC) în C și Assembly x8086 (YUV->RGB, Grayscale).# Am creat peste 10 tipuri de filtre de imagine, cum ar fi Fish Eye, Sobel, Edge Detection, Box Blur, etc.# Am refăcut codul .ASM pentru a funcționa mai bine pe dispozitivele IoT și Embedded Systems.",
+            "company": "Intel",
+            "description": "Site-ul din Timișoara abordează mai multe domenii de interes în care se dezvoltă în mod activ software pentru diverse componente hardware, algoritmi de procesare a imaginilor și implementări de nivel scăzut și înalt ale părților componente ale rețelelor neuronale.",
+            "location": "Remote (România - Timisoara)",
+            "period": "2021 (6 luni)",
+            "responsibilites": "#Stăpânirea abilităților în lumea procesării imaginilor. #Înțelegerea domeniului învățării automate (ML). #Practicarea cunoștințelor dobândite prin dezvoltarea unor convertoare diferite de spațiu de culoare.",
+            "techAndSkills": "# C # C++ #Intel x8086 Assembly # Color Space Converters # Python # Embedded Compute # Internet of Things",
+            "title": "Inginer Embedded"
+          },
+          "microsoft1": {
+            "achievements": "# (Excelență Inginerească) M-am impus constant pentru a obține cel mai bun feedback din partea clienților. (Punctaj actual: 4.94 / 5.00) # (Interacțiuni proactive) Am oferit feedback continuu Grupului de Produs pentru produsul Azure Virtual Desktop (AVD), cu privire la implementarea unor caracteristici și servicii specifice. # (Experiența Clientului) Am dezvoltat documentația existentă privind caracteristicile serviciilor Azure Core, precum Azure Virtual Desktop, Azure Virtual Machines, Azure Networks. # Am lucrat exclusiv cu clienți TOP 100 și Fortune 500 și cu profesioniști de top din industrie.",
+            "company": "Microsoft",
+            "description": "Cu peste 12.000 de angajați în întreaga lume, organizația Microsoft Customer Experience & Success (CE&S) este responsabilă pentru strategia, proiectarea și implementarea experienței clienților Microsoft de la un capăt la altul.",
+            "location": "România",
+            "period": "03/2021 – 03/2023",
+            "responsibilites": "# Oferirea de schimb de cunoștințe, coaching tehnic și mentorat colegilor; # Rezolvarea problemelor prin depanare profundă, debugging, analiză de log-uri, testare A/B; # Identificarea și răspunsul la problemele critice de afaceri ale clienților, specifice serviciilor Azure precum Azure Virtual Desktop; # Lucrul exclusiv cu clienți Fortune 500 pentru a înțelege nevoile lor tehnice și pentru a defini un plan de acțiune pentru a le îndeplini, colaborând regulat cu colegi sau alte echipe.",
+            "techAndSkills": "# Network Traffic Analysis # Azure # Customer-centric Approach # Business Relationships # Incident Manager",
+            "title": "Inginer Tehnic Azure"
+          },
+          "microsoft2": {
+            "achievements": "# (Observabilitate-as-a-Service) Am orchestrat și implementat complet cei trei piloni ai observabilității în arhitectura noastră de microservicii folosind standardele Open Telemetry; am construit, de asemenea, declanșatoare automate de monitorizare și alertare bazate pe statistici p95/p99 pentru trafic real și sintetic. # (Cercetare & Dezvoltare) Am contribuit major la dezvoltarea unei biblioteci .NET interne care implementează protocolul de consum de date ODataV4 pentru motoare de baze de date NoSQL precum Azure Data Explorer (ADX), folosind practici Domain-Driven Design (DDD) (de ex. aggregator roots) (brevet în curs de obținere). # (Experiența de Dezvoltare) Am preluat conducerea a două domenii cheie pentru DX: documentația și straturile de consum. Am construit o documentație remarcabilă și am folosit instrumente de generare a site-urilor statice (DocFX) pentru a genera automat documentația API din cod; am oferit straturi de consum API sub formă de UI-uri frontend, tooling CLI și fișiere de specificație OpenAPI. # (Creștere) Am asistat și am participat la interviuri de angajare pentru pozițiile SWE II și Senior SWE.",
+            "company": "Microsoft",
+            "description": "Pe măsură ce guvernele de astăzi se uită la inovația tehnologică, există nevoia de a răspunde cerințelor în evoluție rapidă ale cetățenilor lor, protejând în același timp cele mai sensibile date și respectând promisiunile de încredere și securitate.",
+            "location": "EMEA",
+            "period": "03/2023 – 12/2024",
+            "responsibilites": "# Furnizarea unei platforme de date E+C capabilă să funcționeze pe mai multe cloud-uri și cu mai mulți chiriași în medii suverane și în scenarii air-gapped. # Gestionarea și asigurarea bunăstării operațiunilor platformei de date RISE (Runtime in Sovereign Environments). # Construirea unei noi arhitecturi de întreprindere de tip data mesh utilizând concepte de inginerie a datelor, instrumente precum Azure Data Factory și alte noțiuni de depozit de date.",
+            "techAndSkills": "# .NET # Azure # Microservicii # Cloud-Native Applications # Agile Methodologies # DevOps # Domain-Driven Design # Test-Driven Development # Project Management",
+            "title": "E + D Inginer Software II - Cloud-uri Suverane"
+          },
+          "microsoft3": {
+            "achievements": " ",
+            "company": "Microsoft",
+            "description": "Alexandru lucrează în prezent la Microsoft ca inginer software în cadrul organizației E+D MSAI (M365 AI Experiences).",
+            "location": "Remote (Norvegia)",
+            "period": "11/2024 - prezent",
+            "responsibilites": " ",
+            "techAndSkills": "# React # GraphQL # Dezvoltare la scară largă # Aplicații Cloud-Native # Metodologii Agile # Excelență în inginerie # Leadership",
+            "title": "E + D Inginer Software Fullstack II - M365 AI"
+          },
+          "responsibilitiesLabel": "Responsabilități",
+          "subtitle": "O călătorie prin cariera profesională a lui Alexandru și prin companiile cu care a lucrat.",
+          "techSkillsLabel": "Tehnologii și Competențe",
+          "title": "Experiență profesională",
+          "ubisoft": {
+            "achievements": "# Am depășit constant cota de bug-uri, glitch-uri și artefacte raportate, clasându-mă pe locul #1 ca raportor timp de 5 luni solide din cele 6 lucrate. # Am descoperit și raportat defecte majore de cod, de la race conditions până la defecte de alocare a resurselor de memorie. # Am crescut eficiența raportării zilnice prin valorificarea capacităților de filtrare SQL și JQL.",
+            "company": "Ubisoft",
+            "description": "Am lucrat la Avatar: Frontiers of Pandora™, un joc construit folosind cea mai recentă iterație a motorului Snowdrop (C++) de Massive Entertainment - un studio Ubisoft și testat de Ubisoft România.",
+            "location": "Hibrid (București, România)",
+            "period": "2020 - 2021",
+            "responsibilites": " # Gestionarea regresiei, integrării și testării unităților cu software precum XRAY, TestRail, Bugzilla. # Crearea de suite de teste și planuri de teste de înaltă calitate folosind produsele Atlassian (JIRA / Confluence). # Asigurarea unor comunicații stabile și clare între echipele de producție și cele de testare.",
+            "techAndSkills": "# Testare unitară # Testare de integrare # Testare A/B # Testare de performanță # Testare automată # Testare E2E",
+            "title": "Inginer QA/QC"
+          }
+        },
+        "perspectives": {
+          "perspectiveFromX": {
+            "author": "Anonim",
+            "avatar": " ",
+            "company": "Microsoft",
+            "position": "Inginer software senior",
+            "quote": "Lucrul pe care îl apreciez foarte mult la dvs. este căutarea neîncetată a îmbunătățirii și dorința dvs. de a contesta status quo-ul. Angajamentul tău față de autodezvoltare continuă este evident în modul în care abordezi fiecare sarcină cu o mentalitate orientată spre inovare și excelență. Capacitatea dumneavoastră de a pune în discuție metodele existente și de a propune alternative mai bune a fost esențială pentru progresul proiectelor noastre. Această atitudine proactivă nu numai că îmbunătățește calitatea muncii noastre, dar și inspiră echipa să depună eforturi pentru a atinge standarde mai înalte. Mă bucur că am lucrat cu dvs. și sper că drumurile noastre se vor intersecta din nou în viitor."
+          },
+          "perspectiveFromXX": {
+            "author": "Anonim",
+            "avatar": " ",
+            "company": "Microsoft",
+            "position": "Manager Senior Inginerie Software",
+            "quote": "Alex este un inginer inteligent ale cărui capacități au strălucit în timpul colaborării noastre la proiectele noastre. El demonstrează în mod constant dorința de a ajuta echipa cu orice solicitare, demonstrând dedicarea sa pentru succesul colectiv. Abordarea sa proactivă în ceea ce privește rezolvarea problemelor și dedicarea față de stabilitatea sistemului aduc beneficii majore fluxului de lucru al echipei noastre. În plus, disponibilitatea și dorința lui Alex de a sprijini pe alții în timpul fluxului nostru de lansare evidențiază valoarea sa ca coleg care acordă prioritate muncii în echipă și colaborării."
+          },
+          "perspectiveFromXY": {
+            "author": "Anonim",
+            "avatar": " ",
+            "company": "Microsoft",
+            "position": "Inginer senior de escaladare",
+            "quote": "Alex, dacă ar fi să aleg un lucru pe care îl apreciez cel mai mult la colaborarea cu tine, ar trebui să fie modul tău de gândire - deoarece acesta include mai multe aspecte. Lucrul cu tine este autentic, amuzant, înțelept și relevant în același timp. Este ușor de observat că motivațiile tale zilnice sunt angajamentul, raționamentul și învățarea continuă. Îți admir abordarea, dorința sinceră de a ajuta, de a te baza pe succesul altora și de a-i sprijini pe toți în dezvoltarea lor, ceea ce este o valoare atât de rară. Pe lângă acestea, apreciez răbdarea dumneavoastră, precum și cantitatea mare de cunoștințe pe care o aduceți în interacțiunile noastre. Modul în care gestionați situațiile stresante și abordarea dvs. generală au puterea de a modela un rezultat pozitiv pentru orice problemă sau subiect."
+          },
+          "perspectiveFromXZ": {
+            "author": "Anonim",
+            "avatar": " ",
+            "company": "Microsoft",
+            "position": "Inginer software senior",
+            "quote": "Am fost impresionat în mod constant de rezultatele muncii dvs. Întotdeauna livrați o muncă de înaltă calitate, acordând o atenție deosebită detaliilor și asigurându-vă că totul este făcut la cel mai bun nivel al abilităților dumneavoastră. În plus, aveți o înțelegere profundă a aspectelor tehnice ale muncii noastre, ceea ce a reprezentat un avantaj valoros pentru echipă. Dorința dvs. de a împărtăși cunoștințele și experiența dvs. cu alții a fost de neprețuit și este clar că sunteți mândru să îi îndrumați pe alții și să îi ajutați să se dezvolte."
+          },
+          "perspectiveFromY": {
+            "author": "Anonim",
+            "avatar": " ",
+            "company": "Microsoft",
+            "position": "Software Engineer II",
+            "quote": "Apreciez cu adevărat abordarea dvs. proactivă și spiritul de colaborare, iar sprijinul dvs. și stilul dvs. prietenos de comunicare au fost foarte pozitive pentru experiența mea de integrare și pentru învățarea intrărilor și ieșirilor proiectului nostru. Capacitatea dvs. de a comunica eficient și de a ține pe toată lumea la curent este un lucru pe care îl admir, aveți experiență în relaționarea cu echipele interfuncționale, în special cu echipele noastre partenere, în cunoașterea nevoilor lor și în rezolvarea problemelor lor. Aptitudinile dvs. tehnice sunt impresionante, iar atenția dvs. la detalii este lăudabilă."
+          },
+          "perspectiveFromYX": {
+            "author": "",
+            "avatar": "",
+            "company": "",
+            "position": "",
+            "quote": ""
+          },
+          "perspectiveFromYY": {
+            "author": "",
+            "avatar": "",
+            "company": "",
+            "position": "",
+            "quote": ""
+          },
+          "perspectiveFromYZ": {
+            "author": "",
+            "avatar": "",
+            "company": "",
+            "position": "",
+            "quote": ""
+          },
+          "perspectiveFromZ": {
+            "author": "Anonim",
+            "avatar": " ",
+            "company": "Microsoft",
+            "position": "Inginer software senior",
+            "quote": "Întotdeauna sunteți gata să ajutați, împărțindu-vă timpul cu generozitate, chiar și atunci când aveți propriile dvs. sarcini urgente. Răspunsurile tale rapide și utile la orice întrebare sunt foarte apreciate. Aveți o abordare prioritară și meticuloasă, oferind soluții instantanee care nu numai că ne deblochează pe termen scurt, ci și schițează soluții pe termen lung și termenele lor de implementare. Mentalitatea dvs. orientată spre soluții este un adevărat avantaj pentru echipa noastră. Expertiza ta, dorința de a ajuta și personalitatea ta plăcută fac din tine un coleg excelent. Continuați munca excelentă!"
+          },
+          "subtitle": "Perspective de la colegii care au lucrat cu sau alături de Alexandru.",
+          "title": "Perspective"
+        },
+        "subtitle": "Alexandru-Razvan Olariu este autorul platformei pe care o navigați în prezent.",
+        "title": "Faceți cunoștință cu autorul."
       },
-      "whatYouCanDoTitle": "Ce poți face",
-      "whatYouCanDo": {
-        "0": "Primește alerte despre alergeni pentru produsele alimentare",
-        "1": "Partajează facturi cu membrii familiei sau colegii",
-        "2": "Exportă statistici și rapoarte de cheltuieli",
-        "3": "Accesează-ți datele de pe orice dispozitiv"
-      },
-      "body": "Gata să începi? Încarcă primul tău bon și privește magia în acțiune. Întregul proces durează mai puțin de un minut.",
-      "feedbackPrompt": "Întrebări sau feedback? Ne-ar plăcea să auzim de la tine la <email></email>.",
-      "signOff": {
-        "line1": "Cu drag,",
-        "line2": "Echipa {brand}"
-      },
-      "ctaPrimary": "Încarcă primul tău bon",
-      "ctaSecondary": "Explorează panoul"
-    },
-    "firstInvoiceUploaded": {
-      "subject": "Prima ta factură a sosit!",
-      "badge": "Milestone",
-      "heading": "Prima ta factură a fost încărcată!",
-      "preview": "Felicitări, {name}! Prima ta factură a fost încărcată.",
-      "greeting": "Salut {name},",
-      "intro": "Felicitări pentru încărcarea primei tale facturi! Ai făcut primul pas către urmărirea organizată și perspicace a cheltuielilor. Iată ce avem până acum:",
-      "invoiceSummaryTitle": "Prima Ta Factură",
-      "invoiceSummary": {
-        "invoiceName": "Nume factură",
-        "uploaded": "Încărcat",
-        "status": "Status"
-      },
-      "statusValue": "Gata pentru analiză",
-      "untitledFallback": "Fără titlu",
-      "whatHappensNextTitle": "Ce urmează",
-      "whatHappensNext": {
-        "0": "Analizăm chitanța ta — AI-ul nostru extrage articole, prețuri și informații despre comerciant",
-        "1": "Revizuiești rezultatele — verifică analiza și corectează orice pare greșit",
-        "2": "Tabloul tău de bord se actualizează — grafice de cheltuieli, defalcări pe categorii și tendințe încep să se construiască"
-      },
-      "featuresToExploreTitle": "Funcții de explorat",
-      "featuresToExplore": {
-        "0": "Partajează facturi cu familia sau colegii pentru urmărirea cheltuielilor comune",
-        "1": "Vezi sugestii de rețete generate de AI din articolele tale de cumpărături",
-        "2": "Verifică avertismente despre alergeni pentru produsele alimentare detectate",
-        "3": "Urmărește tiparele de cheltuieli pe comercianți, categorii și perioade de timp"
-      },
-      "body": "Cu cât încarci mai multe facturi, cu atât informațiile despre cheltuieli devin mai bogate. Încearcă să încarci câteva chitanțe în această săptămână pentru a vedea tabloul tău de bord prinde viață.",
-      "feedbackPrompt": "Ai nevoie de ajutor sau ai feedback? Contactează-ne la <email></email>.",
-      "signOff": {
-        "line1": "Cu drag",
-        "line2": "Echipa {brand}"
-      },
-      "ctaPrimary": "Vezi factura ta",
-      "ctaSecondary": "Încarcă altă chitanță"
-    },
-    "invoiceAnalyzed": {
-      "subject": "Factura ta a fost analizată",
-      "badge": "Facturi • Analiză Completă",
-      "heading": "Analiza facturii tale este gata",
-      "preview": "Factura ta este gata, {name}. Analiză completă!",
-      "greeting": "Bună {name},",
-      "intro": "Vești bune! AI-ul nostru a terminat de analizat factura ta. Am extras toate informațiile cheie, am categorisit articolele și am generat perspective asupra cheltuielilor pentru a te ajuta să îți urmărești finanțele.",
-      "summaryTitle": "Rezumat factură",
-      "summary": {
-        "invoiceName": "Nume factură",
-        "merchantId": "ID Comerciant",
-        "itemsDetected": "Articole detectate",
-        "totalAmount": "Suma totală",
-        "notIdentified": "Neidentificat încă"
-      },
-      "whatWasAnalyzedTitle": "Ce a fost analizat",
-      "whatWasAnalyzed": {
-        "0": "Identificarea și categorizarea comerciantului",
-        "1": "Extragerea linie cu linie a articolelor cu prețuri",
-        "2": "Categorizare automată a produselor (produse alimentare, băuturi, articole casnice etc.)",
-        "3": "Detectarea monedei și validarea sumei",
-        "4": "Extragerea datei și orei când este disponibilă"
-      },
-      "body": "Apasă butonul de mai sus pentru a vizualiza analiza completă. Dacă ceva nu arată bine—poate un produs a fost categorizat greșit sau un preț nu a fost detectat corect—poți edita factura direct în tabloul tău de bord și perspectivele se vor actualiza automat.",
-      "feedbackPrompt": "Ai întrebări despre analiză sau ai nevoie de ajutor? Contactează-ne la <email></email>.",
-      "signOff": {
-        "line1": "Cu stimă,",
-        "line2": "Echipa {brand}"
-      },
-      "ctaPrimary": "Vizualizează analiza completă"
-    },
-    "invoiceDeleted": {
-      "subject": "Factura ta a fost ștearsă",
-      "badge": "Facturi • Șters",
-      "heading": "Factură eliminată din contul tău",
-      "preview": "Factura {invoiceLabel} a fost eliminată din contul tău.",
-      "greeting": "Salut {name},",
-      "intro": "Acest email confirmă că o factură a fost eliminată din contul tău {brand}. Ștergerea a fost procesată cu succes.",
-      "detailsTitle": "Detalii ștergere",
-      "details": {
-        "invoice": "Factură",
-        "invoiceId": "ID factură",
-        "status": "Status"
-      },
-      "statusValue": "Șters (ștergere soft)",
-      "placeholder": "—",
-      "whatYouShouldKnowTitle": "Ce trebuie să știi",
-      "whatYouShouldKnow": {
-        "0": "Aceasta este o ștergere soft—datele facturii pot fi păstrate timp de 30 de zile pentru recuperare.",
-        "1": "Orice acces partajat la această factură a fost revocat automat.",
-        "2": "Statisticile și informațiile vor fi recalculate pentru a exclude această factură.",
-        "3": "Dacă trebuie să recuperezi această factură, contactează suportul în 30 de zile."
-      },
-      "body": "Dacă nu ai inițiat această ștergere sau dacă trebuie să recuperezi factura, te rugăm să ne contactezi imediat la <email></email>. Suntem aici să te ajutăm.",
-      "signOff": {
-        "line1": "Cu drag,",
-        "line2": "Echipa {brand}"
-      },
-      "ctaPrimary": "Vezi facturile tale"
-    },
-    "invoiceMadePublic": {
-      "subject": "Factura ta este acum publică",
-      "badge": "Facturi • Link Public",
-      "heading": "Factura ta este acum publică",
-      "preview": "Factura ta \"{invoiceName}\" este acum publică și partajabilă.",
-      "greeting": "Salut {name},",
-      "intro": "Ai făcut cu succes factura publică. Oricine are linkul sau codul QR de mai jos poate vedea această factură—fără autentificare. Acest lucru este perfect pentru partajarea chitanțelor cu colegi, contabili sau pentru rapoarte de cheltuieli.",
-      "detailsTitle": "Detalii factură",
-      "details": {
-        "invoiceName": "Nume factură",
-        "invoiceId": "ID factură",
-        "merchant": "Comerciant",
-        "total": "Total",
-        "created": "Creat",
-        "access": "Acces"
-      },
-      "accessValue": "Public (oricine cu linkul)",
-      "qrTitle": "Cod QR Acces Rapid",
-      "qrSubText": "Scanează cu camera telefonului pentru acces instant.",
-      "qrAlt": "Cod QR pentru acces factură",
-      "howToShareTitle": "Cum să partajezi",
-      "howToShare": {
-        "0": "Copiază linkul direct de mai jos și trimite prin email sau mesaj",
-        "1": "Printează sau fă screenshot codului QR pentru partajare în persoană",
-        "2": "Include în rapoarte de cheltuieli sau cereri de rambursare"
-      },
-      "privacyNoticeTitle": "Notificare Confidențialitate",
-      "privacyNoticeBody": "Facturile publice pot fi accesate de oricine are URL-ul sau codul QR. Pentru a face această factură privată din nou, actualizează setările de partajare din pagina facturii în orice moment.",
-      "directLinkLabel": "Link direct:",
-      "feedbackPrompt": "Întrebări despre partajare sau setări de confidențialitate? Contactează-ne la <email></email>.",
-      "signOff": {
-        "line1": "Cu drag,",
-        "line2": "Echipa {brand}"
-      },
-      "ctaPrimary": "Deschide factura publică"
-    },
-    "invoiceShared": {
-      "subject": "{fromName} a distribuit o factură cu tine",
-      "badge": "Facturi • Distribuite",
-      "heading": "O factură a fost distribuită cu tine",
-      "preview": "{fromName} a distribuit o factură cu tine.",
-      "greeting": "Bună {toName},",
-      "intro": "Vești bune! <from></from> a distribuit o factură cu tine pe {brand}. Aceasta îți oferă acces pentru a vizualiza toate detaliile facturii, inclusiv produsele detaliate, informațiile despre comerciant și analizele.",
-      "detailsTitle": "Detalii distribuire",
-      "details": {
-        "sharedBy": "Distribuit de",
-        "invoiceId": "ID Factură"
-      },
-      "whatYouCanDoTitle": "Ce poți face",
-      "whatYouCanDo": {
-        "0": "Vizualizează detaliile complete ale facturii și descompunerea pe articole",
-        "1": "Vezi analizele și categoriile de cheltuieli",
-        "2": "Descarcă sau printează factura pentru evidențele tale"
-      },
-      "body": "Apasă butonul de mai sus pentru a accesa factura distribuită. Acest link va rămâne activ atât timp cât permisiunile de distribuire sunt în vigoare.",
-      "feedbackPrompt": "Ai întrebări despre această distribuire sau ai nevoie de ajutor? Contactează-ne la <email></email>.",
-      "signOff": {
-        "line1": "Cu stimă,",
-        "line2": "Echipa {brand}"
-      },
-      "ctaPrimary": "Vizualizează factura distribuită"
-    },
-    "invoiceUnshared": {
-      "subject": "Accesul la o factură distribuită a fost revocat",
-      "badge": "Facturi • Acces Revocat",
-      "heading": "Accesul tău la o factură a fost revocat",
-      "preview": "{fromName} a revocat accesul tău la o factură distribuită.",
-      "greeting": "Bună {toName},",
-      "intro": "Îți scriem pentru a te informa că <from></from> a revocat accesul tău la o factură care îți fusese distribuită anterior. Aceasta înseamnă că nu vei mai putea vizualiza această factură.",
-      "detailsTitle": "Detalii revocare",
-      "details": {
-        "revokedBy": "Revocat de",
-        "invoiceId": "ID Factură",
-        "revokedAt": "Revocat la",
-        "yourAccess": "Accesul tău",
-        "accessRevoked": "Revocat",
-        "notProvided": "—"
-      },
-      "whatThisMeansTitle": "Ce înseamnă asta",
-      "whatThisMeans": {
-        "0": "Orice link salvat la această factură nu va mai funcționa pentru tine.",
-        "1": "Această factură nu va mai apărea în lista ta de facturi distribuite.",
-        "2": "Dacă ai nevoie din nou de acces, contactează direct proprietarul facturii."
-      },
-      "body": "Dacă crezi că această schimbare a fost făcută din greșeală, te rugăm să contactezi pe <from></from> sau echipa noastră de suport. Revocările de acces sunt uneori accidentale și suntem bucuroși să ajutăm la facilitarea comunicării dacă este necesar.",
-      "feedbackPrompt": "Ai nevoie de asistență? Trimite-ne un email la <email></email>.",
-      "signOff": {
-        "line1": "Cu stimă,",
-        "line2": "Echipa {brand}"
-      },
-      "ctaPrimary": "Vizualizează facturile tale",
-      "ctaSecondary": "Contactează suportul"
-    },
-    "spendingAlert": {
-      "subject": "Alertă prag de cheltuieli",
-      "badge": "Alertă Cheltuieli • {percent}%",
-      "heading": "{percent, select, 80 {Atenție: te apropii de limita bugetului} 90 {Aproape gata: ai folosit 90% din buget} 100 {Buget atins: ai atins limita de cheltuieli} other {Alertă de cheltuieli}}",
-      "preview": "{name}, ai folosit {percent}% din bugetul tău de {category} pentru {period}.",
-      "greeting": "Salut {name},",
-      "intro": "{state, select, over {Ai atins limita de cheltuieli pentru {category} în {period}. Iată un rezumat al situației tale.} other {Ai folosit {percent}% din bugetul tău de {category} pentru {period}. Iată un rezumat rapid pentru a planifica restul perioadei.}}",
-      "overBudgetWarning": "Cheltuielile tale au atins sau depășit bugetul stabilit. Verifică achizițiile recente pentru a rămâne pe drumul cel bun.",
-      "metricsLabels": {
-        "budgetLimit": "Limită buget",
-        "currentSpending": "Cheltuieli curente",
-        "remaining": "Rămas",
-        "threshold": "Prag"
-      },
-      "overBudgetValue": "Peste buget",
-      "detailsTitle": "Detalii Buget",
-      "detailsLabels": {
-        "category": "Categorie",
-        "period": "Perioadă",
-        "budget": "Buget",
-        "spent": "Cheltuit"
-      },
-      "chartTitle": "Cheltuieli pe categorii",
-      "chartAlt": "Defalcare cheltuieli pe categorii pentru {period}",
-      "tipsTitle": "{state, select, over {Ce poți face} other {Sfaturi pentru a rămâne pe drumul cel bun}}",
-      "tipsOverBudget": {
-        "0": "Verifică achizițiile recente pentru a identifica cheltuielile neesențiale",
-        "1": "Consideră ajustarea bugetului dacă nu mai reflectă realitatea",
-        "2": "Stabilește un prag mai strict (de ex. 80%) pentru avertismente mai timpurii"
-      },
-      "tipsOnTrack": {
-        "0": "Verifică achizițiile recente pentru a vedea unde merg cea mai mare parte",
-        "1": "Prioritizează cheltuielile esențiale pentru restul perioadei",
-        "2": "Consideră să găătești mai mult acasă dacă mesele la restaurant cresc costurile"
-      },
-      "notificationsParagraph": "Poți ajusta pragurile bugetului și preferințele de notificare în <settings></settings>.",
-      "notificationsLink": "setările de notificări",
-      "feedbackPrompt": "Întrebări? Contactează-ne la <email></email>.",
-      "ctaPrimary": "Vezi tabloul de bord",
-      "signOff": {
-        "line1": "Cu respect",
-        "line2": "Echipa {brand}"
+      "platform": {
+        "architecture": {
+          "badge": "Arhitectură tehnică",
+          "description": "O arhitectură modernă nativă cloud care urmează principiile de design bazat pe domeniu, metodologia The Standard și cele mai bune practici din industrie.",
+          "layers": {
+            "ai": {
+              "description": "Procesare inteligentă a documentelor și înțelegere a limbajului natural",
+              "name": "Servicii AI",
+              "technologies": "Azure OpenAI,Document Intelligence,Computer Vision"
+            },
+            "api": {
+              "description": "API-uri RESTful cu documentație OpenAPI și limitare a ratei",
+              "name": "Gateway API",
+              "technologies": ".NET 10,Minimal APIs,OpenAPI,GraphQL"
+            },
+            "auth": {
+              "description": "Autentificare de nivel enterprise cu furnizori multipli",
+              "name": "Identitate și securitate",
+              "technologies": "Azure AD B2C,OAuth 2.0,OIDC,MFA"
+            },
+            "cdn": {
+              "description": "Livrare globală de conținut cu cache la margine și optimizare",
+              "name": "Edge și CDN",
+              "technologies": "Azure CDN,Vercel Edge,Active statice"
+            },
+            "client": {
+              "description": "Frontend-uri moderne bazate pe React cu capacități SSR și SSG",
+              "name": "Nivelul client",
+              "technologies": "Next.js 16,React 19,TypeScript,Module SCSS"
+            },
+            "data": {
+              "description": "Strategie de baze de date multi-model pentru performanță optimă",
+              "name": "Nivelul de date",
+              "technologies": "CosmosDB,Azure SQL,Redis Cache,Blob Storage"
+            },
+            "infra": {
+              "description": "Infrastructură Azure complet gestionată cu implementare IaC",
+              "name": "Infrastructură cloud",
+              "technologies": "Azure,Bicep IaC,Container Apps,Key Vault"
+            },
+            "services": {
+              "description": "Design bazat pe domeniu cu contexte delimitate și arhitectură curată",
+              "name": "Microservicii",
+              "technologies": "DDD,CQRS,Event Sourcing,The Standard"
+            }
+          },
+          "principles": {
+            "appRouter": {
+              "description": "Rutare bazată pe fișiere cu layout-uri, stări de încărcare și limite de erori",
+              "title": "Arhitectură App Router"
+            },
+            "cloudNative": {
+              "description": "Microservicii containerizate cu auto-scalare și capacități de auto-vindecare",
+              "title": "Design nativ cloud"
+            },
+            "rsc": {
+              "description": "Utilizarea RSC pentru performanță optimă cu randare server-side și streaming",
+              "title": "React Server Components"
+            }
+          },
+          "title": "Construit pentru",
+          "titleHighlight": "scalabilitate și fiabilitate"
+        },
+        "callToAction": {
+          "cta": {
+            "createAccount": "Creează cont",
+            "exploreApplications": "Explorează aplicațiile"
+          },
+          "description": "Explorează platforma, încearcă funcționalitățile și alătură-te comunității. Fie că ești aici să gestionezi facturi, să descoperi rețete sau doar să explorezi, există ceva pentru toată lumea.",
+          "footer": "Construit cu pasiune de",
+          "footerRole": ", un inginer software la Microsoft.",
+          "links": {
+            "getInTouch": "Ia legătura",
+            "meetAuthor": "Cunoaște autorul",
+            "viewSource": "Vezi codul sursă"
+          },
+          "title": "Gata să",
+          "titleHighlight": "începi",
+          "trust": {
+            "freeToUse": {
+              "description": "Fără taxe ascunse sau abonamente",
+              "title": "Gratuit de folosit"
+            },
+            "openSource": {
+              "description": "100% open source cu licență MIT",
+              "title": "Sursă Deschisă"
+            },
+            "privacyFirst": {
+              "description": "Datele tale rămân ale tale, mereu",
+              "title": "Confidențialitate în prim-plan"
+            }
+          }
+        },
+        "features": {
+          "badge": "Funcționalități ale platformei",
+          "description": "O suită completă de instrumente concepute pentru gestionarea modernă a finanțelor personale, organizarea rețetelor și multe altele. Construite cu tehnologii de ultimă generație și un accent pe experiența utilizatorului.",
+          "items": {
+            "ai": {
+              "description": "Automatizare inteligentă la îndemână",
+              "longDescription": "Alimentat de Azure OpenAI, asistentul nostru AI ajută la înțelegerea documentelor, extragerea datelor, categorizarea inteligentă și interogări în limbaj natural despre datele dvs.",
+              "tags": "GPT-4,Azure AI,NLP",
+              "title": "Asistent AI"
+            },
+            "analytics": {
+              "description": "Perspective profunde în cheltuielile dvs.",
+              "longDescription": "Tablou de bord analitic complet cu tendințe de cheltuieli, defalcări pe categorii, comparații lunare și perspective predictive alimentate de algoritmi de învățare automată.",
+              "tags": "Grafice,Tendințe,Rapoarte",
+              "title": "Analize cheltuieli"
+            },
+            "auth": {
+              "description": "Opțiuni de conectare flexibile și sigure",
+              "longDescription": "Conectați-vă cu Microsoft, Google, GitHub sau email. Azure AD B2C oferă gestionarea identității de nivel enterprise cu suport MFA și experiență SSO fără întreruperi.",
+              "tags": "OAuth,MFA,SSO",
+              "title": "Autentificare securizată"
+            },
+            "budgets": {
+              "description": "Urmărire inteligentă a bugetului și alerte",
+              "longDescription": "Setați bugete pe categorii și primiți alerte inteligente când vă apropiați de limite. Vizualizați cheltuielile cu grafice interactive și identificați zonele pentru optimizare.",
+              "tags": "Bugete,Alerte,Planificare",
+              "title": "Gestionare buget"
+            },
+            "i18n": {
+              "description": "Experiență complet internaționalizată",
+              "longDescription": "Platforma suportă mai multe limbi cu suport RTL complet. Disponibilă în prezent în engleză și română, cu mai multe limbi planificate pentru versiunile viitoare.",
+              "tags": "i18n,Engleză,Română",
+              "title": "Multi-limbă"
+            },
+            "invoices": {
+              "description": "Analiză și gestionare a facturilor cu ajutorul AI",
+              "longDescription": "Încărcați fotografii cu bonuri și lăsați AI să extragă detaliile comerciantului, articolele, prețurile și multe altele. Categorizarea automată, urmărirea cheltuielilor și analizele detaliate vă ajută să vă înțelegeți tiparele de cheltuieli.",
+              "tags": "AI,OCR,Analize",
+              "title": "Procesare facturi"
+            },
+            "merchants": {
+              "description": "Detectare automată a comercianților și perspective",
+              "longDescription": "AI-ul nostru identifică comercianții din datele bonurilor, construind o bază de date completă a tiparelor dvs. de cumpărături. Obțineți informații despre unde faceți cumpărături, tendințele cheltuielilor și comparații între comercianți.",
+              "tags": "ML,Perspective,Urmărire",
+              "title": "Inteligență comercianți"
+            },
+            "recipes": {
+              "description": "Organizați și descoperiți creații culinare",
+              "longDescription": "Stocați rețetele preferate, descoperiți unele noi și planificați mesele eficient. Sugestii bazate pe AI în funcție de ingrediente, preferințe dietetice și istoricul de gătit.",
+              "tags": "Gătit,Planificare mese,AI",
+              "title": "Gestionare rețete"
+            },
+            "security": {
+              "description": "Securitate de nivel bancar pentru datele dvs.",
+              "longDescription": "Datele dvs. sunt protejate cu criptare de nivel enterprise, autentificare securizată prin Azure AD B2C și conformitate cu GDPR. Nu vindem și nu împărtășim niciodată informațiile dvs. personale.",
+              "tags": "Criptare,GDPR,SSO",
+              "title": "Securitate enterprise"
+            }
+          },
+          "modal": {
+            "close": "Închide",
+            "exploreFeature": "Explorează funcționalitatea"
+          },
+          "title": "Tot ce ai nevoie,",
+          "titleHighlight": "frumos realizat"
+        },
+        "hero": {
+          "cta": {
+            "exploreFeatures": "Explorează funcționalități",
+            "viewSource": "Vezi codul sursă"
+          },
+          "description": "O platformă full-stack completă care combină Next.js, .NET și servicii cloud Azure. Construită cu arhitectură de nivel enterprise, design bazat pe domeniu și un accent pe experiența dezvoltatorului.",
+          "scrollIndicator": "Derulează pentru a explora",
+          "stats": {
+            "countries": "Țări",
+            "linesOfCode": "Linii de cod",
+            "projects": "Proiecte",
+            "techStack": "Stack tehnologic"
+          },
+          "statusBadge": "Platformă Open Source",
+          "subtitle": "Modern • Scalabil • Open Source",
+          "title": "Bine ai venit pe",
+          "trust": {
+            "freeForever": "Gratuit pentru totdeauna",
+            "openSource": "Sursă Deschisă",
+            "privacyFirst": "Confidențialitate în prim-plan"
+          }
+        },
+        "statistics": {
+          "badge": "Statistici ale platformei",
+          "description": "O privire asupra dimensiunii și impactului platformei arolariu.ro, de la linii de cod la acoperire globală.",
+          "items": {
+            "apis": {
+              "description": "Microservicii",
+              "label": "API-uri",
+              "suffix": "+",
+              "value": "8"
+            },
+            "commits": {
+              "description": "Contribuții de cod",
+              "label": "Commit-uri",
+              "suffix": "+",
+              "value": "2500"
+            },
+            "contributors": {
+              "description": "Sursă deschisă",
+              "label": "Contribuitori",
+              "suffix": "+",
+              "value": "5"
+            },
+            "countries": {
+              "description": "Acoperire globală",
+              "label": "Țări",
+              "suffix": "+",
+              "value": "25"
+            },
+            "linesOfCode": {
+              "description": "În toate proiectele",
+              "label": "Linii de cod",
+              "suffix": "K+",
+              "value": "150"
+            },
+            "projects": {
+              "description": "Repozitorii active",
+              "label": "Proiecte",
+              "suffix": "+",
+              "value": "15"
+            },
+            "stars": {
+              "description": "Stele GitHub",
+              "label": "Stele",
+              "suffix": "+",
+              "value": "50"
+            },
+            "users": {
+              "description": "Activi lunar",
+              "label": "Utilizatori",
+              "suffix": "+",
+              "value": "1000"
+            }
+          },
+          "title": "Numere care",
+          "titleHighlight": "vorbesc de la sine"
+        },
+        "techStack": {
+          "badge": "Stack tehnologic",
+          "categories": {
+            "backend": {
+              "description": "Tehnologii server-side scalabile și API-uri",
+              "name": "Backend"
+            },
+            "cloud": {
+              "description": "Automatizarea infrastructurii și implementării",
+              "name": "Cloud și DevOps"
+            },
+            "frontend": {
+              "description": "Tehnologii web moderne pentru experiențe de utilizator ultra-rapide",
+              "name": "Frontend"
+            },
+            "tooling": {
+              "description": "Unelte și framework-uri pentru excelență în dezvoltare",
+              "name": "Unelte pentru dezvoltatori"
+            }
+          },
+          "description": "Un stack tehnologic atent ales pentru performanță, experiența dezvoltatorului și mentenabilitate pe termen lung.",
+          "stats": {
+            "coverage": {
+              "description": "Teste unitare și E2E",
+              "label": "Acoperire teste",
+              "value": "90%+"
+            },
+            "security": {
+              "description": "Cele mai bune practici",
+              "label": "Grad de securitate",
+              "value": "A+"
+            },
+            "technologies": {
+              "description": "În stack-ul nostru",
+              "label": "Tehnologii",
+              "value": "24+"
+            },
+            "typescript": {
+              "description": "Siguranță completă a tipurilor",
+              "label": "TypeScript",
+              "value": "100%"
+            }
+          },
+          "technologies": {
+            "aspnet": {
+              "description": "API-uri web de înaltă performanță",
+              "name": "ASP.NET Core"
+            },
+            "azure": {
+              "description": "Furnizor cloud principal",
+              "name": "Azure"
+            },
+            "azureDevops": {
+              "description": "Gestionare proiecte și pipeline-uri",
+              "name": "Azure DevOps"
+            },
+            "azuresql": {
+              "description": "Bază de date relațională gestionată",
+              "name": "Azure SQL"
+            },
+            "bicep": {
+              "description": "Infrastructură ca și cod",
+              "name": "Bicep"
+            },
+            "cosmosdb": {
+              "description": "Bază de date NoSQL distribuită global",
+              "name": "CosmosDB"
+            },
+            "docker": {
+              "description": "Platformă de containerizare",
+              "name": "Docker"
+            },
+            "dotnet": {
+              "description": "Framework backend principal",
+              "name": ".NET"
+            },
+            "eslint": {
+              "description": "Linting JavaScript cu 20+ plugin-uri",
+              "name": "ESLint"
+            },
+            "git": {
+              "description": "Sistem de control al versiunilor",
+              "name": "Git"
+            },
+            "githubActions": {
+              "description": "Automatizare CI/CD",
+              "name": "GitHub Actions"
+            },
+            "motion": {
+              "description": "Animații gata de producție",
+              "name": "Motion"
+            },
+            "nextjs": {
+              "description": "Framework React full-stack cu SSR/SSG",
+              "name": "Next.js"
+            },
+            "nodejs": {
+              "description": "BFF și funcții serverless",
+              "name": "Node.js"
+            },
+            "playwright": {
+              "description": "Framework de testare E2E",
+              "name": "Playwright"
+            },
+            "pnpm": {
+              "description": "Gestionare pachete",
+              "name": "pnpm/npm"
+            },
+            "prettier": {
+              "description": "Formatare cod",
+              "name": "Prettier"
+            },
+            "react": {
+              "description": "Bibliotecă UI pentru construirea de interfețe interactive",
+              "name": "React"
+            },
+            "redis": {
+              "description": "Cache în memorie pentru performanță",
+              "name": "Redis"
+            },
+            "scss": {
+              "description": "Foi de stil cu domeniu de aplicare la nivel de component folosind CSS Modules",
+              "name": "Module SCSS"
+            },
+            "typescript": {
+              "description": "JavaScript cu tipuri pentru cod robust",
+              "name": "TypeScript"
+            },
+            "vercel": {
+              "description": "Platformă de implementare frontend",
+              "name": "Vercel"
+            },
+            "vitest": {
+              "description": "Framework de testare unitară",
+              "name": "Vitest"
+            },
+            "zustand": {
+              "description": "Gestionare ușoară a stării",
+              "name": "Zustand"
+            }
+          },
+          "title": "Alimentat de",
+          "titleHighlight": "tehnologii moderne"
+        },
+        "timeline": {
+          "badge": "Călătoria de dezvoltare",
+          "collapseHint": "Click pentru a restrânge",
+          "description": "Călătoria arolariu.ro de la o simplă idee la o platformă completă, cu etape cheie pe parcurs.",
+          "events": {
+            "ai": {
+              "date": "Iunie 2024",
+              "description": "Integrare profundă cu Azure OpenAI pentru procesarea inteligentă a documentelor și interogări în limbaj natural.",
+              "details": "Integrare Azure OpenAI GPT-4,Interogări facturi în limbaj natural,Algoritmi de categorizare inteligentă,Funcționalități de analiză predictivă",
+              "tags": "GPT-4,Azure AI,NLP",
+              "title": "Integrare AI"
+            },
+            "backend": {
+              "date": "Septembrie 2022",
+              "description": "Refacerea completă a backend-ului cu .NET și implementarea arhitecturii native cloud.",
+              "details": "Dezvoltare API .NET 6,Configurare infrastructură cloud Azure,Design bază de date cu CosmosDB,Implementare pipeline CI/CD",
+              "tags": ".NET,Azure,API",
+              "title": "Infrastructură backend"
+            },
+            "expansion": {
+              "date": "Ianuarie 2023",
+              "description": "Adăugări majore de funcționalități incluzând procesarea facturilor și capabilități de analiză alimentate de AI.",
+              "details": "Încărcare facturi și integrare OCR,Integrare Azure Document Intelligence,Algoritmi de detectare a comercianților,Funcționalități de urmărire a bugetului",
+              "tags": "AI,OCR,Facturi",
+              "title": "Extinderea platformei"
+            },
+            "inception": {
+              "date": "Martie 2022",
+              "description": "Platforma arolariu.ro a fost concepută ca un proiect personal de învățare pentru a explora dezvoltarea web modernă.",
+              "details": "Faza inițială de concept și planificare,Cercetare în tehnologii web moderne,Primul repozitoriu creat pe GitHub,Prototip HTML/CSS de bază dezvoltat",
+              "tags": "Planificare,Cercetare",
+              "title": "Începutul proiectului"
+            },
+            "launch": {
+              "date": "Iunie 2023",
+              "description": "Lansare publică oficială cu un set complet de funcționalități și infrastructură gata de producție.",
+              "details": "Implementare în producție pe Azure,Configurare domeniu personalizat,Implementare securitate SSL/TLS,Optimizare performanță",
+              "tags": "Lansare,Producție",
+              "title": "Lansare publică"
+            },
+            "nextjs": {
+              "date": "Decembrie 2023",
+              "description": "Rescrierea completă a frontend-ului la Next.js App Router cu React Server Components.",
+              "details": "Migrare la Next.js 14+,Adoptarea React Server Components,SEO îmbunătățit cu generare statică,Metrici de performanță îmbunătățite",
+              "tags": "Next.js,RSC,Migrare",
+              "title": "Migrare la Next.js"
+            },
+            "present": {
+              "date": "Prezent",
+              "description": "Dezvoltare continuă cu funcționalități noi, optimizări și contribuții din comunitate.",
+              "details": "Actualizări regulate de funcționalități,Îmbunătățiri de performanță,Integrare feedback din comunitate,Planificare roadmap viitor",
+              "tags": "Activ,În creștere",
+              "title": "Evoluție continuă"
+            },
+            "prototype": {
+              "date": "Iunie 2022",
+              "description": "Primul prototip funcțional al platformei a fost dezvoltat folosind React și servicii backend de bază.",
+              "details": "Implementare frontend React,Flux de autentificare de bază,Design UI/UX inițial,Configurare mediu de dezvoltare locală",
+              "tags": "React,Frontend",
+              "title": "Primul prototip"
+            }
+          },
+          "expandHint": "Click pentru a extinde",
+          "futureIndicator": "Călătoria continuă...",
+          "keyAchievements": "Realizări cheie:",
+          "title": "De la idee la",
+          "titleHighlight": "realitate"
+        }
       }
     },
-    "newsletterSubscribed": {
-      "subject": "Te-ai abonat cu succes!",
-      "badge": "Newsletter",
-      "heading": "Bine ai venit — te-ai abonat",
-      "preview": "Bun venit, {name} — te-ai abonat.",
-      "greeting": "Salut {name},",
-      "intro": "Mulțumesc că te-ai abonat la newsletter-ul <brand>{brandName}</brand>. Mă bucur sincer să te am aici. Voi păstra comunicările ușoare, semnificative și merită timpul tău.",
-      "whatToExpectTitle": "La ce să te aștepți",
-      "whatToExpect": {
-        "0": "Actualizări de produs și funcționalități noi pe măsură ce sunt lansate",
-        "1": "Articole și materiale noi despre tehnologie, productivitate și finanțe personale",
-        "2": "Evidențieri ocazionale și resurse curatate (1–2 emailuri pe trimestru)"
-      },
-      "body": "Inbox-ul tău este sacru—respect asta. Fiecare email este creat pentru a oferi valoare genuină, fie că este un sfat care îți economisește ore sau o perspectivă care îți schimbă viziunea asupra finanțelor personale.",
-      "feedbackPrompt": "Întrebări, feedback sau doar vrei să saluti? Răspunde la acest email sau contactează-mă direct la <email></email>.",
-      "ctaPrimary": "Vizitează arolariu.ro",
-      "signOff": {
-        "line1": "Cu respect",
-        "line2": "Echipa {brand}"
-      }
-    },
-    "newsletterUnsubscribed": {
-      "subject": "Te-ai dezabonat",
-      "badge": "Newsletter",
-      "heading": "Te-ai dezabonat",
-      "preview": "Salut {name} — te-ai dezabonat.",
-      "greeting": "Salut {name},",
-      "intro": "Acest email confirmă că ai fost eliminat din lista de newsletter <brand>{brandName}</brand>. Îmi pare rău să te văd plecând.",
-      "whatHappensNextTitle": "Ce urmează",
-      "whatHappensNext": {
-        "0": "Nu vei mai primi actualizări de newsletter de la noi în viitor.",
-        "1": "Este posibil să primești în continuare emailuri esențiale de cont și serviciu dacă folosești produsul.",
-        "2": "Ți-ai schimbat părerea? Te poți reabona oricând folosind butonul de mai sus."
-      },
-      "body": "Apreciez timpul pe care l-ai petrecut cu noi. Dacă ai feedback despre motivul pentru care ai plecat sau despre cum mă pot îmbunătăți, aș fi cu adevărat bucuros să-l aud—doar răspunde la acest email.",
-      "feedbackPrompt": "Dacă nu ai solicitat această dezabonare sau ai nevoie de ajutor cu ceva, te rugăm să contactezi <email></email>.",
-      "ctaPrimary": "Verifică preferințele",
-      "ctaSecondary": "Reabonează-te",
-      "signOff": {
-        "line1": "Cu respect",
-        "line2": "Echipa {brand}"
-      }
-    },
-    "accountInactivity": {
-      "subject": "Ne lipsești la {brand}",
-      "badge": "Cont",
-      "heading": "Notificare de inactivitate a contului",
-      "preview": "Bună {name} — contul tău a fost inactiv de {inactiveDays} zile.",
-      "greeting": "Bună {name},",
-      "intro": "Acesta este un atenționare că contul tău a fost inactiv de <count>{inactiveDays}</count> zile.",
-      "whatThisMeans": {
-        "title": "Ce înseamnă asta",
-        "bullet1": "Autentificarea va menține contul tău activ.",
-        "bullet2": "Dacă nu există activitate în următoarele {daysUntilClosure} zile, contul poate fi programat pentru închidere.",
-        "bullet3": "Dacă dorești să îți păstrezi datele, te rugăm să acționezi înainte de termen."
-      },
+    "invoices": {
       "timeline": {
-        "title": "Cronologie",
-        "inactiveFor": "Inactiv de",
-        "timeRemaining": "Timp rămas",
-        "daysValue": "{days} zile"
-      },
-      "supportPrompt": "Dacă crezi că ai primit acest mesaj din greșeală sau ai nevoie de asistență, te rugăm să contactezi <link>{supportEmail}</link>.",
-      "signOff": {
-        "line1": "Cu respect,",
-        "line2": "Echipa {brand}"
-      },
-      "footnote": "Notă: Această notificare este informativă și are scopul de a te ajuta să eviți pierderea accesului. Politicile reale de retenție a conturilor pot varia în funcție de regiune și produs.",
-      "cta": {
-        "primary": "Autentifică-te",
-        "secondary": "Contactează asistența"
+        "item": {
+          "aria": {
+            "moreInfo": "Mai multe informații despre {title}"
+          },
+          "confidence": "Încredere: {value}%",
+          "events": {
+            "aiAnalysis": {
+              "description": "{count, plural, one {# articol detectat și categorisit} few {# articole detectate și categorisite} other {# de articole detectate și categorisite}}",
+              "title": "Analiză AI finalizată"
+            },
+            "categorized": {
+              "description": "Categorizare automată pe baza articolelor",
+              "title": "Categorie atribuită"
+            },
+            "created": {
+              "description": "Scanată și digitalizată din bon",
+              "title": "Factură creată"
+            },
+            "edited": {
+              "title": "Factură actualizată"
+            },
+            "exported": {
+              "title": "Factură exportată"
+            },
+            "markedImportant": {
+              "description": "Marcată pentru urmărire prioritară",
+              "title": "Marcată ca importantă"
+            },
+            "recipesGenerated": {
+              "description": "{count, plural, one {# rețetă sugerată} few {# rețete sugerate} other {# de rețete sugerate}}",
+              "title": "Rețete generate"
+            },
+            "shared": {
+              "description": "Partajată cu {count, plural, one {# persoană} few {# persoane} other {# de persoane}}",
+              "title": "Partajată cu alții"
+            }
+          },
+          "fallbacks": {
+            "ocr": "OCR",
+            "pdf": "PDF"
+          },
+          "relativeTime": {
+            "now": "Chiar acum"
+          },
+          "tooltips": {
+            "aiAnalysis": "AI a procesat această factură în {duration} și a analizat {count, plural, one {# articol} few {# articole} other {# de articole}}.",
+            "categorized": "Facturii i-a fost atribuită o categorie pentru o organizare mai bună.",
+            "created": "Factura a fost scanată și digitalizată folosind {method}.",
+            "edited": "Au fost făcute modificări manuale facturii.",
+            "exported": "Factura a fost exportată în format {format}.",
+            "markedImportant": "Factura a fost marcată ca importantă pentru acces rapid.",
+            "recipesGenerated": "Pe baza ingredientelor cumpărate, {count, plural, one {a fost generată # rețetă} few {au fost generate # rețete} other {au fost generate # de rețete}}.",
+            "shared": "Factura a fost partajată cu {count, plural, one {# utilizator} few {# utilizatori} other {# de utilizatori}}.",
+            "unavailable": "Detaliile evenimentului nu sunt disponibile"
+          }
+        }
       }
     },
-    "invoiceInactivity": {
-      "subject": "Au trecut {daysWithoutUpload} de zile de la ultima ta factură",
-      "badge": {
-        "3": "Inactivitate • 3 zile",
-        "7": "Inactivitate • 7 zile",
-        "14": "Inactivitate • 14 zile",
-        "30": "Inactivitate • 30 zile"
+    "legal": {
+      "acknowledgements": {
+        "contributors": {
+          "items": {
+            "c1": {
+              "description": "Instrumentație pentru observabilitate",
+              "name": "OpenTelemetry Authors",
+              "packages": "12"
+            },
+            "c2": {
+              "description": "SDK-uri Azure și unelte",
+              "name": "Microsoft Corporation",
+              "packages": "5"
+            },
+            "c3": {
+              "description": "Soluții de autentificare",
+              "name": "Clerk",
+              "packages": "2"
+            },
+            "c4": {
+              "description": "Utilități pentru testare",
+              "name": "Kent C. Dodds",
+              "packages": "3"
+            }
+          },
+          "packages": "{count, plural, one {# pachet} few {# pachete} other {# de pachete}}",
+          "subtitle": "Organizații și indivizi pe ale căror pachete ne bazăm cel mai mult",
+          "title": "Contributori Principali"
+        },
+        "hero": {
+          "badge": "Sursă Deschisă",
+          "lastUpdate": "Ultima actualizare: {date}",
+          "subtitle": "Această platformă este construită pe umerii unor proiecte open-source incredibile. Suntem recunoscători întreținătorilor și contributorilor care își fac munca disponibilă gratuit.",
+          "title": "Mulțumiri"
+        },
+        "lastUpdate": "Ultima actualizare pe: {date}",
+        "licenses": {
+          "apache": "Apache 2.0",
+          "apacheDescription": "Licență open-source prietenoasă pentru întreprinderi",
+          "gpl": "Licență GPL",
+          "gplDescription": "Licență copyleft care asigură că codul rămâne liber",
+          "mit": "Licență MIT",
+          "mitDescription": "Licență permisivă care permite utilizare largă",
+          "other": "Alte Licențe",
+          "otherDescription": "Licențe custom sau diverse alte licențe open-source",
+          "packages": "{count, plural, one {# pachet} few {# pachete} other {# de pachete}}",
+          "title": "Distribuția Licențelor"
+        },
+        "packages": {
+          "subtitle": "Acest site web nu ar fi putut fi posibil fără următoarele pachete terțe. \nAș dori să le mulțumesc autorilor acestor pachete pentru munca grea și dăruirea lor pentru comunitatea open-source.",
+          "title": "Pachete terțe"
+        },
+        "packagesScreen": {
+          "badge": {
+            "development": "Dezvoltare",
+            "production": "Producție"
+          },
+          "card": {
+            "dependencies": "Dependențe:",
+            "license": "Licență:",
+            "viewDependencies": "Vezi dependențele",
+            "website": "Site web"
+          },
+          "dialog": {
+            "dependencies": "Dependențele {name}",
+            "dependenciesCount": "Acest pachet are {count} dependențe."
+          },
+          "emptyState": {
+            "subtitle": "Încercați să ajustați filtrele de mai sus.",
+            "title": "Nu s-au găsit pachete."
+          },
+          "filters": {
+            "allPackages": "Toate pachetele",
+            "ascending": "Crescător",
+            "dependenciesCount": "Număr dependențe",
+            "descending": "Descrescător",
+            "developmentOnly": "Doar dezvoltare",
+            "filterByType": "Filtrează după tip",
+            "name": "Nume",
+            "packageType": "Tip pachet",
+            "productionOnly": "Doar producție",
+            "sortBy": "Sortează după",
+            "sortDirection": "Direcție sortare"
+          },
+          "openSource": {
+            "description": "Acest proiect stă pe umerii unor giganți. Suntem recunoscători comunității open-source și tuturor dezvoltatorilor care au contribuit la aceste pachete.",
+            "title": "Open Source contează"
+          },
+          "search": {
+            "placeholder": "Caută..."
+          },
+          "table": {
+            "dependencies": "Dependențe",
+            "description": "Descriere",
+            "license": "Licență",
+            "package": "Pachet",
+            "type": "Tip",
+            "version": "Versiune",
+            "website": "Site web"
+          },
+          "views": {
+            "gridView": "Vizualizare grilă",
+            "tableView": "Vizualizare tabel"
+          }
+        },
+        "stats": {
+          "development": {
+            "description": "Instrumente de build",
+            "label": "Dezvoltare",
+            "value": "{count}"
+          },
+          "mitLicense": {
+            "description": "Cea mai comună licență",
+            "label": "Licență MIT",
+            "value": "{count}"
+          },
+          "production": {
+            "description": "Dependențe runtime",
+            "label": "Producție",
+            "value": "{count}"
+          },
+          "subtitle": "O privire asupra ecosistemului open-source care alimentează această platformă",
+          "title": "Prezentare Generală a Dependențelor",
+          "total": {
+            "description": "Dependențe utilizate",
+            "label": "Total Pachete",
+            "value": "{count}"
+          }
+        },
+        "title": "Mulțumiri"
       },
-      "heading": {
-        "3": "Verificare rapidă",
-        "7": "O reamintire blândă",
-        "14": "Hai să te aducem înapoi pe drumul cel bun",
-        "30": "A trecut ceva timp"
+      "privacyPolicy": {
+        "contactInformation": {
+          "content": "Dacă aveți întrebări despre Politica noastră de confidențialitate, vă rugăm să ne contactați la admin@arolariu.ro",
+          "title": "Informații de contact"
+        },
+        "lastUpdated": "Ultima actualizare: 1 ianuarie 2024",
+        "terms": {
+          "childrenPrivacy": {
+            "content": "Site-ul nostru web nu este destinat copiilor cu vârsta sub 13 ani. Nu colectăm cu bună știință Date cu caracter personal de la copii sub 13 ani. Dacă sunteți părinte sau tutore și știți că copilul dumneavoastră ne-a furnizat date cu caracter personal, vă rugăm să \ncontactaţi-ne. \nDacă aflăm că am colectat date cu caracter personal de la copii fără verificarea consimțământului părinților, vom lua măsuri pentru a elimina acele informații de pe serverele noastre.",
+            "title": "Confidențialitatea copiilor"
+          },
+          "cookiesDefinition": {
+            "content": "Cookie-urile sunt fragmente mici de date stocate pe dispozitivul dumneavoastră (computer sau dispozitiv mobil). \nCookie-urile sunt folosite pentru a vă îmbunătăți experiența pe site-ul nostru web și pentru a vă oferi conținut relevant. \nPentru mai multe informații despre cookie-uri, vă rugăm să vizitați https://www.allaboutcookies.org/ <br></br><br></br><br></br> Folosim cookie-uri pentru a colecta informații despre dispozitivul dvs. \nutilizarea site-ului nostru web. \nFurnizorul nostru de analiză a site-ului web folosește cookie-uri pentru a genera informații statistice și alte informații despre utilizarea site-ului web prin intermediul cookie-urilor. \n<br></br><br></br><br></br> Puteți renunța la cookie-uri utilizând setările din browser. \nVă rugăm să rețineți că, dacă dezactivați cookie-urile, este posibil să nu puteți utiliza toate funcțiile site-ului nostru. \n<br></br><br></br><br></br> Vom păstra datele dumneavoastră cu caracter personal numai atât timp cât este necesar pentru scopul pentru care au fost colectate datele respective și în măsura cerută de legea aplicabilă \n. \nCând nu mai avem nevoie de Date cu caracter personal, le vom elimina din sistemele noastre și/sau vom lua măsuri pentru a le anonimiza.",
+            "title": "Ce sunt cookie-urile?"
+          },
+          "dataCollectionTerms": {
+            "content": "a) Când efectuați o achiziție sau încercați să faceți o achiziție, colectăm următoarele tipuri de date cu caracter personal: <ul> <li> Informații de plată, cum ar fi adresa dvs. de facturare, numărul de telefon, cardul de credit, cardul de debit și/sau alte plăți \ninformatii despre metoda; \n</li><li> Informații despre cont, cum ar fi numele dvs., numele de utilizator, adresa de e-mail; \n</li><li> Informații de achiziție, în special dacă sunt personalizate sau unice;</li> <li>Datele demografice;</li> <li>Datele despre locație.</li> </ul> <br></br> \n<br></br> b) Când vizitați și utilizați site-ul nostru web, colectăm automat următoarele tipuri de date cu caracter personal: <ul> <li> Informații de plată, cum ar fi adresa dvs. de facturare, numărul de telefon, cardul de credit, cardul de debit și \n/sau alte informații despre metoda de plată; \n</li> <li>Datele dispozitivului, cum ar fi computerul, telefonul, tableta sau alt dispozitiv pe care îl utilizați pentru a accesa site-ul nostru web;</li> <li>Datele de comunicare, cum ar fi preferințele dvs. pentru a primi comunicări de la noi;</li> <li>Feedback, cum ar fi asistența pentru clienți, recenzii despre produse, sondaje și/sau alte feedback;</li> <li>Datele despre conținut, cum ar fi conținutul pe care ni-l trimiteți: postări, documente, sunet, imagini etc. \n;</li> \n<li>Datele de utilizare, cum ar fi modul în care utilizați site-ul nostru web, produsele și serviciile;</li> <li>Informațiile despre cont, cum ar fi numele dvs., numele de utilizator, adresa de e-mail;</li> <li>Informațiile de cumpărare în special dacă \npersonalizate sau unice;</li> <li>Date demografice;</li> <li>Date despre locație;</li></ul>",
+            "title": "Ce date personale colectăm"
+          },
+          "dataTransferTerms": {
+            "content": "Acolo unde este posibil, stocăm și procesăm date pe servere din regiunea geografică generală în care locuiți (notă: este posibil să nu fie în țara în care locuiți). \n<span> Mai exact, pentru utilizatorii, companiile și clienții din Europa, avem servere în Spațiul Economic European (SEE). \n</span> Datele dvs. personale pot fi, de asemenea, transferate și menținute pe servere care au reședința în afara statului, provinciei, țării sau a altei jurisdicții guvernamentale în care legile privind datele pot diferi de cele din jurisdicția dvs. \nVom lua măsurile adecvate pentru a ne asigura că datele dumneavoastră cu caracter personal sunt tratate în siguranță și în conformitate cu această politică, precum și cu legea aplicabilă privind protecția datelor. \nDatele pot fi păstrate în alte țări care sunt considerate adecvate conform legilor dumneavoastră. \n<br></br><br></br><br></br><br></br> Mai multe informații despre aceste clauze pot fi găsite aici: https://eur-lex.europa.eu/ \nlegal-content/en/TXT/?uri=CELEX:32021D0914",
+            "title": "Transfer și stocare internațională de date"
+          },
+          "deviceUsageTerms": {
+            "content": "Când vizitați un site web <code>AROLARIU.RO</code> și/sau o aplicație mobilă, colectăm și stocăm automat informații despre vizita dumneavoastră folosind cookie-uri de browser (fișiere care sunt trimise de noi către computerul dumneavoastră) sau tehnologii similare. \nPuteți solicita browserului dumneavoastră să refuze toate cookie-urile sau să indice când este trimis un cookie. \nFuncția „Ajutor” de pe majoritatea browserelor vă va oferi informații despre cum să acceptați cookie-uri, cum să dezactivați cookie-urile sau să vă anunțe când primiți un cookie nou. \nDacă nu acceptați cookie-uri, este posibil să nu puteți utiliza unele funcții ale Serviciului nostru și vă recomandăm să le lăsați activate. \n<br></br><br></br><br></br> De asemenea, procesăm informații atunci când utilizați serviciile și produsele noastre. \nAceste informații pot include: <ul> <li> Informații despre interacțiunile dvs. cu serviciile noastre, inclusiv ora și data interacțiunilor dvs. și interacțiunile dvs. cu e-mailurile noastre; \n</li> <li> Informații despre utilizarea serviciilor noastre, inclusiv tipul de browser pe care îl utilizați, timpii de acces, paginile vizualizate, adresa dumneavoastră IP; \n</li> <li> Informații despre achizițiile dvs., inclusiv articolele pe care le cumpărați, data achiziției și metoda de plată pe care o utilizați; \n</li> <li> Informații despre dispozitivul dvs., inclusiv tipul de dispozitiv, sistemul său de operare și informații despre rețeaua mobilă; \n</li> <li> Alte informații pe care ni le furnizați, inclusiv feedback-ul, comentariile și alte informații pe care ni le furnizați; \n</li> <li>Informații despre locația dvs., inclusiv locația dvs. generală bazată pe adresa dvs. IP;</li> <li>Alte informații pe care le colectăm cu consimțământul dvs. sau conform permisului sau cerut de lege;</li> <li \n>Informații despre preferințele dvs., inclusiv despre preferințele dvs. de limbă.</li> </ul>",
+            "title": "Date despre dispozitiv și utilizare"
+          },
+          "exerciseRights": {
+            "content": "Pentru a vă exercita drepturile, vă rugăm să ne contactați folosind datele de contact furnizate în secțiunea „Contactați-ne” de mai jos. \nVom răspunde solicitării dumneavoastră într-un interval de timp rezonabil și în conformitate cu legea aplicabilă. \n<br></br><br></br> Pentru siguranța și securitatea dvs., este posibil să fie nevoie să vă verificăm identitatea înainte de a răspunde solicitării dvs. \nVom depune eforturi rezonabile pentru a vă verifica identitatea solicitând informațiile pe care le avem în dosar despre dumneavoastră.",
+            "title": "Cum să-ți exerciți drepturile"
+          },
+          "howWeCollectDataTerms": {
+            "content": "Colectăm date personale în următoarele moduri: <br></br><br></br> <span>1. \nDe la dvs.</span> <br></br> Colectăm date cu caracter personal de la dvs. atunci când ni le furnizați direct sau indirect, utilizând site-ul nostru web, produsele sau serviciile. \nAceasta include: <br></br> <ul> <li>Când creați un cont sau cumpărați produse de pe site-ul nostru web;</li> <li>Când descărcați software și/aplicația noastră mobilă;</li> \n<li>Când participați la sondajele, concursurile sau promoțiile noastre;</li> <li>Când creați conținut prin produsele și serviciile noastre;</li> <li>Când ne contactați pentru o întrebare sau pentru a raporta o problemă \n;</li> <li>Când vă exprimați interes(e) față de produsele și serviciile noastre;</li> <li>Când ne folosiți site-ul web, produsele sau serviciile;</li> <li>Când interacționați cu noi pe rețelele sociale;</li> <li>Când vă abonați la buletinul nostru informativ;</li> <li>Când ni-l furnizați direct;</li> <li>Când comunicați cu noi.</li> </ul> \n<br></br><br></br><br></br><br></br> <span>2. \nTehnologii sau interacțiuni automate.</span> <br></br> <br></br> Pe măsură ce interacționați cu site-ul nostru web, este posibil să colectăm automat următoarele tipuri de date (toate așa cum este descris mai sus): Date despre dispozitiv despre dvs. \nechipamente, Date de utilizare despre acțiunile și modelele dvs. de navigare și Date de contact în care sarcinile efectuate prin intermediul site-ului nostru web rămân nefinalizate, cum ar fi comenzile incomplete sau coșurile abandonate. \nColectăm aceste date utilizând cookie-uri, jurnalele de server și alte tehnologii similare. \nVă rugăm să consultați secțiunea Cookie (mai jos) pentru mai multe detalii. \n<br></br><br></br><br></br><br></br> <span>3. \nTerți sau surse disponibile public.</span> <br></br><br></br> Este posibil să primim date personale despre dvs. de la diverse terțe părți, inclusiv: <ul> <li> Informații despre cont și date de plată \nde la terți, inclusiv organizații (cum ar fi agențiile de aplicare a legii), asociații și grupuri, care împărtășesc date în scopul prevenirii și detectarii fraudei și al reducerii riscului de credit </li> <li>Date de contact, financiare și de tranzacții de la furnizorii de servicii tehnice \n, plata si livrarea \nservicii</li> <li>Date tehnice de la furnizori de analize, cum ar fi Google Analytics</li> <li>Date de identitate și de contact de la brokerii de date sau agregatori</li> <li>Date de identitate și de contact din surse disponibile public</li> </ul> <br></br><br></br><br></br><br></br><span> Dacă ne furnizați nouă, sau furnizorilor noștri de servicii, orice \nDate referitoare la alte persoane, declarați că aveți \nautoritatea de a face acest lucru și de a recunoaște că va fi utilizat în conformitate cu această Politică. \nDacă credeți că datele dumneavoastră cu caracter personal ne-au fost furnizate în mod necorespunzător sau pentru a vă exercita în alt mod drepturile referitoare la datele dumneavoastră cu caracter personal, vă rugăm să ne contactați utilizând informațiile prezentate în secțiunea „Contactați-ne” de mai jos.</span>",
+            "title": "Cum colectăm datele personale"
+          },
+          "legalTerms": {
+            "content": "Putem folosi sau dezvălui datele dumneavoastră cu caracter personal pentru a ne conforma unei obligații legale, în legătură cu o solicitare din partea unei autorități publice sau guvernamentale sau în legătură cu proceduri judiciare, pentru a preveni pierderea vieții sau rănirea sau pentru a ne proteja drepturi sau proprietate. \nAcolo unde este posibil și practic să facem acest lucru, vă vom informa în avans cu privire la o astfel de dezvăluire.",
+            "title": "Cerințe legale"
+          },
+          "personalDataRights": {
+            "content": "Aveți dreptul de a accesa, corecta, actualiza sau șterge datele dumneavoastră cu caracter personal. Aveți, de asemenea, dreptul de a vă opune prelucrării datelor dumneavoastră cu caracter personal, de a ne cere să restricționăm prelucrarea datelor dumneavoastră cu caracter personal sau de a solicita portabilitatea datelor dumneavoastră cu caracter personal. Vă puteți exercita aceste drepturi contactându-ne folosind datele de contact furnizate în secțiunea „Contactați-ne”; secțiunea de mai jos. <br></br><br></br><br></br> În funcție de locația dvs. geografică și de cetățenie, drepturile dumneavoastră sunt supuse reglementărilor locale privind confidențialitatea datelor. Aceste drepturi pot include: <ul> <li> Dreptul de a fi uitat (dreptul la ștergere) (articolul 17 din GDPR, CCPA/CPRA, CPA, VCDPA, CTDPA, UCPA, LGPD, POPIA) </li> <li>Dreptul la Acces (PIPEDA, GDPR Articolul 15, CCPA/CPRA, CPA, VCDPA, CTDPA, UCPA, LGPD, POPIA)</li> <li>Dreptul la rectificare (PIPEDA, articolul 16 din GDPR, CPRA, CPA, VCDPA, CTDPA, LGPD, POPIA)</li> <li>Nediscriminare și nerăzbunare (CCPA/CPRA, CPA, VCDPA, CTDPA, UCPA)</li> <li>Dreptul la restricționarea prelucrării (articolul 18 GDPR, LGPD)</li> <li>Dreptul la renunțare (CPRA, CPA, VCDPA, CTDPA, UCPA)</li> <li>Dreptul la portabilitate (PIPEDA, GDPR articolul 20, LGPD)</li> <li>Dreptul la obiecție (GDPR articolul 21, LGPD, POPIA)</li> </ul> <br></br><br></br><br></br> Dacă doriți să depuneți o contestație sau o plângere cu privire la modul în care procesăm datele dumneavoastră cu caracter personal, ne puteți contacta folosind datele de contact furnizate în secțiunea „Contactați-ne”; secțiunea de mai jos. De asemenea, aveți dreptul de a depune o plângere la autoritatea de protecție a datelor din jurisdicția dumneavoastră. <br></br> În cazul în care ne-ați contactat și nu sunteți mulțumit de răspunsul nostru, aveți dreptul de a depune o contestație la procurorul general situat aici: <ul> <li> Dacă aveți sediul în SEE, vă rugăm să vizitați site-ul https://edpb.europa.eu/about-edpb/about-edpb/members_en pentru o listă a autorităților locale de protecție a datelor. </li> <li> Dacă vă aflați în Connecticut, vă rugăm să vizitați site-ul https://portal.ct.gov/AG/Common/Complaint-Form-Landing-page pentru a depune o reclamație. </li> <li> Dacă vă aflați în Colorado, vă rugăm să vizitați site-ul https://complaints.coag.gov/s/contact-us pentru a depune o reclamație. </li> <li> Dacă vă aflați în Virginia, vă rugăm să vizitați https://www.oag.state.va.us/consumer-protection/index.php/file-a-complaint site-ul web pentru a depune o plângere. </li></ul>",
+            "title": "Drepturile dumneavoastră pentru datele dumneavoastră personale"
+          },
+          "policyChanges": {
+            "content": "Este posibil să actualizăm această Politică din când în când. \nDacă facem modificări semnificative, vă vom anunța, dar vă rugăm să verificați regulat această Politică pentru a vă asigura că sunteți la curent cu cea mai actualizată versiune.",
+            "title": "Modificări ale acestei politici"
+          },
+          "processingDataTerms": {
+            "content": "Colectăm și folosim datele dumneavoastră cu caracter personal cu consimțământul dumneavoastră pentru a furniza, menține și dezvolta produsele și serviciile noastre și pentru a înțelege cum să le îmbunătățim în continuare. \n<br></br><br></br><br></br> Aceste scopuri includ: <ul> <li>Construirea unui mediu sigur și securizat pentru utilizatorii noștri și comunitatea noastră;</li> <li \n>Efectuarea de cercetări și analize pentru a îmbunătăți produsele și serviciile noastre;</li> <li>Comunicarea cu dvs. despre contul dvs., achiziții sau întrebări;</li> <li>Investigați și preveniți incidentele de securitate și alte activități ilegale;</li> <li>Personalizarea experienței dvs. cu produsele noastre \nși servicii;</li> <li>Livrarea, întreținerea și îmbunătățirea produselor și serviciilor noastre;</li> <li>Oferirea de produse și servicii pe care le solicitați;</li> <li>Oferirea de comunicări de marketing; \n</li> <li>Oferirea de asistență pentru clienți;</li> <li>Protejarea produselor și serviciilor noastre;</li> <li>Alte scopuri cu consimțământul dvs.;</li> <li>Respectarea obligațiilor legale \n.</li> </ul> \n<br></br><br></br><br></br><br></br> În cazul în care prelucrăm datele dumneavoastră cu caracter personal pentru a furniza un produs sau un serviciu, facem acest lucru deoarece este necesar pentru a efectua \nobligatii contractuale. \nToate procesările de mai sus sunt necesare în interesul nostru legitim pentru a furniza produse și servicii și pentru a menține relația noastră cu dvs. și pentru a ne proteja afacerea, de exemplu, împotriva fraudei. \nConsimțământul va fi necesar pentru a iniția servicii cu dvs. \nVa fi necesar un nou consimțământ dacă sunt aduse modificări tipului de date colectate. \nÎn cadrul contractului nostru, dacă nu oferiți consimțământul, este posibil ca unele servicii să nu vă fie disponibile.",
+            "title": "Scopul și temeiul juridic pentru prelucrarea datelor cu caracter personal"
+          },
+          "processingTerms": {
+            "content": "Această politică se aplică atunci când vizitați site-ul nostru web, utilizați produsele sau serviciile noastre sau interacționați cu noi. \n<br></br> În plus, această politică se aplică atunci când: <ul> <li> Folosiți aplicația și serviciile noastre ca utilizator autorizat;</li> <li>Vizitați oricare dintre site-urile noastre web care fac trimitere la această Confidențialitate \nPolitică;</li> <li>Primiți orice comunicare de la noi, inclusiv e-mailuri.</li></ul>",
+            "title": "Activități de procesare"
+          },
+          "safeDataTerms": {
+            "content": "Am implementat măsuri de securitate tehnice și organizatorice adecvate menite să protejeze securitatea oricăror Date personale pe care le procesăm. \nCu toate acestea, vă rugăm să rețineți că nu putem garanta că internetul în sine este 100% sigur. \nDeși vom face tot posibilul pentru a vă proteja datele personale, transmiterea datelor cu caracter personal către și de la site-ul nostru web se face pe propriul risc. \nAr trebui să accesați serviciile numai într-un mediu securizat. \n<br></br><br></br><br></br> Avem măsuri de protecție organizaționale adecvate și măsuri de securitate pentru a vă proteja datele personale împotriva pierderii accidentale, utilizate sau accesate într-un mod neautorizat, modificate \nsau dezvăluite. \n<br></br><br></br><br></br> Comunicarea dintre browserul dvs. și site-ul nostru web folosește o conexiune criptată securizată oriunde sunt implicate Datele dvs. personale. \n<br></br><br></br><br></br> Solicităm oricărei terțe părți care este contractată să prelucreze datele dumneavoastră cu caracter personal în numele nostru să aibă măsuri de securitate pentru a vă proteja datele și pentru a trata \nastfel de date în conformitate cu legea. \n<br></br><br></br><br></br> În cazul nefericit al unei încălcări a datelor cu caracter personal, vă vom anunța pe dumneavoastră și orice autoritate de reglementare aplicabilă atunci când suntem obligați legal să facem acest lucru.",
+            "title": "Cum vă păstrăm datele în siguranță"
+          },
+          "scopeTerms": {
+            "content": "Această politică se aplică site-ului, produselor și serviciilor <code> AROLARIU.RO </code>. \nSe aplică, de asemenea, utilizării site-ului web, produselor și serviciilor noastre de către clienții, partenerii și vizitatorii noștri. \n<br></br><br></br> Această politică nu se aplică aplicațiilor, site-urilor web, produselor, serviciilor sau platformelor terțe care pot fi accesate prin (non-<code>AROLARIU.RO</code> \n) link-uri pe care vi le putem furniza. \nAceste site-uri sunt deținute și operate independent de noi și au propriile lor practici separate de confidențialitate și de colectare a datelor. \nOrice Date cu caracter personal pe care le furnizați acestor site-uri web vor fi guvernate de politica de confidențialitate a terței părți. \nNu putem accepta răspunderea pentru acțiunile sau politicile acestor site-uri independente și nu suntem responsabili pentru conținutul sau practicile de confidențialitate ale acestor site-uri.",
+            "title": "Domeniul de aplicare al politicii"
+          },
+          "serviceProviderTerms": {
+            "content": "Putem folosi un furnizor de servicii terță parte, contractori independenți, agenții sau consultanți pentru a livra și a ne ajuta să ne îmbunătățim produsele și serviciile. \nPutem împărtăși datele dumneavoastră cu caracter personal agențiilor de marketing, furnizorilor de servicii de baze de date, furnizorilor de servicii de backup și recuperare în caz de dezastru, furnizorilor de servicii de e-mail și altora, dar numai pentru a menține și îmbunătăți produsele și serviciile noastre. \n<br></br><br></br> Pentru mai multe informații despre destinatarii datelor dumneavoastră cu caracter personal, vă rugăm să ne contactați utilizând informațiile din secțiunea „Contactați-ne” de mai jos.",
+            "title": "Furnizorii de servicii și alți terți"
+          },
+          "sharingAndDisclosureTerms": {
+            "content": "Vom partaja datele dumneavoastră cu caracter personal cu terți numai în modurile prevăzute în această politică sau stabilite la momentul în care datele cu caracter personal sunt colectate. <br></br><br></br><br></br> De asemenea, folosim Google Analytics pentru a ne ajuta să înțelegem cum folosesc clienții noștri site-ul. Puteți citi mai multe despre modul în care Google vă folosește datele personale aici: https://www.google.com/intl/en/policies/privacy/ <br></br><br></br><br></br> De asemenea, puteți renunța la Google Analytics aici: https://tools.google.com/dlpage/gaoptout <br></br><br></br><br></br> De asemenea, putem \nîmpărtășiți datele dumneavoastră cu caracter personal cu terți, acolo unde este cerut de lege, în cazul în care este necesar pentru a administra relația dintre noi \nsau unde avem un alt interes legitim în a face acest lucru. \nDe asemenea, putem împărtăși datele dumneavoastră cu caracter personal cu terțe părți cărora le putem alege să vindem, să transferăm sau să unim părți ale afacerii noastre sau ale activelor noastre. \nAlternativ, putem încerca să achiziționăm alte afaceri sau să fuzionem cu acestea. \n<br></br><br></br><br></br> Pentru mai multe informații despre cum funcționează publicitatea direcționată, puteți vizita pagina educațională a Network Advertising Initiative (NAI) la: https://www.networkadvertising.org/understanding-online-advertising/how-does-it-work <br></br><br></br><br></br> În plus, puteți renunța la unele dintre aceste servicii prin \nvizitând Publicitatea digitală \nRenunțarea Alianței: https://optout.aboutads.info/",
+            "title": "Partajarea și dezvăluirea datelor cu caracter personal"
+          },
+          "thirdPartyData": {
+            "content": "Este posibil să primim Datele dumneavoastră cu caracter personal de la terți, cum ar fi companii care se abonează la serviciile <code>AROLARIU.RO</code>, parteneri și alte surse. \nAceste Date cu caracter personal nu sunt colectate de noi, ci de o terță parte și sunt supuse politicilor separate de confidențialitate și de colectare a datelor ale terței părți relevante. \nNu deținem niciun control sau intrare asupra modului în care datele dumneavoastră cu caracter personal sunt tratate de către terți. \nCa întotdeauna, aveți dreptul de a revizui și de a rectifica aceste informații. \nDacă aveți întrebări, trebuie să contactați mai întâi terțul relevant pentru mai multe informații despre datele dumneavoastră cu caracter personal. \nÎn cazul în care acea terță parte nu răspunde drepturilor dumneavoastră, puteți contacta Responsabilul cu protecția datelor la <code> AROLARIU.RO </code> (detalii de contact mai jos). \n<br></br><br></br><br></br> Site-urile și serviciile noastre pot conține link-uri către alte site-uri web, aplicații și servicii întreținute de terți. \nPracticile de informare ale acestor alte servicii sau ale rețelelor de social media care găzduiesc paginile noastre de rețele sociale de marcă sunt guvernate de declarațiile de confidențialitate ale terților, pe care ar trebui să le examinați pentru a înțelege mai bine practicile de confidențialitate ale acelor terți.",
+            "title": "Date pe care le colectăm de la terți"
+          },
+          "whatIsTerms": {
+            "content": "La <code> AROLARIU.RO </code> („noi”, „noi”, „nostru” sau „Compania“) prețuim confidențialitatea dumneavoastră și importanța protejării datelor dumneavoastră. Această Politică de confidențialitate („Politica”) descrie practicile noastre de confidențialitate pentru activitățile prezentate mai jos. <br></br> <br></br> În conformitate cu drepturile dumneavoastră, vă informăm cum colectăm, stocăm, accesăm și procesăm în alt mod informațiile referitoare la persoane. În această Politică, datele cu caracter personal („Date cu caracter personal”) se referă la orice informație care, în sine, sau în combinație cu alte informații disponibile, poate identifica o persoană. <br></br> <br></br> Ne angajăm să vă protejăm confidențialitatea în conformitate cu cel mai înalt nivel de reglementare a confidențialității. Ca atare, respectăm obligațiile conform reglementărilor de mai jos: <ul> <li> Legea privind confidențialitatea consumatorilor din California (CCPA) / Legea privind drepturile de confidențialitate din California (CPRA) și Legea privind protecția confidențialității online din California (CalOPPA) </li> <li> Legea privind protecția datelor cu caracter personal și a documentelor electronice din Canada (PIPEDA) și legislațiile provinciale aplicabile </li> <li> Regulamentul general privind protecția datelor (GDPR) al Uniunii Europene </li> <li> Protecția Africii de Sud din Legea privind informațiile personale (POPIA) </li> <li> Virginia Consumer Data Protection Act (VCDPA) </li> <li> Legislația Braziliei privind protecția datelor (LGPD) </li> <li> Connecticut Data Privacy Act (CTDPA) </li> <li> Utah Consumer Privacy Act (UCPA) Colorado Privacy Act (CPA) </li> </ul>",
+            "title": "Ce este AROLARIU.RO?"
+          },
+          "withdrawingConsent": {
+            "content": "Dacă v-ați dat consimțământul pentru prelucrarea datelor dumneavoastră cu caracter personal, aveți dreptul să vă retrageți consimțământul în orice moment. \nPentru a vă retrage consimțământul, vă rugăm să ne contactați folosind datele de contact furnizate în secțiunea „Contactați-ne” de mai jos.",
+            "title": "Retragerea consimțământului"
+          }
+        },
+        "title": "Politica de confidentialitate"
       },
-      "preview": "Bună {name} — {days} zile de la ultima încărcare.",
-      "greeting": "Bună {name},",
-      "intro": {
-        "3": "Am observat că nu ai încărcat nicio factură recent.",
-        "7": "Se pare că a trecut o săptămână de la ultima ta încărcare de factură.",
-        "14": "Două săptămâni fără încărcări — vrei o îmboldire rapidă pentru a relua obiceiul?",
-        "30": "A trecut aproximativ o lună de la ultima încărcare — te putem ajuta să reia de unde ai rămas."
-      },
-      "whyWorthIt": {
-        "title": "De ce merită",
-        "bullet1": "Păstrează cronologia cheltuielilor tale exactă.",
-        "bullet2": "Obține totaluri mai clare pe comerciant și categorie.",
-        "bullet3": "Găsește chitanțe mai repede când ai nevoie."
-      },
-      "status": {
-        "title": "Stare",
-        "daysWithoutUpload": "Zile fără încărcare",
-        "lastUpload": "Ultima încărcare"
-      },
-      "tip": {
-        "title": "Sfat (30 secunde)",
-        "message": "Încarcă o factură recentă astăzi — consistența mică bate recuperarea mare."
-      },
-      "important": {
-        "title": "Important",
-        "message": "Dacă ești blocat sau ceva nu funcționează, răspunde la acest email sau contactează suportul — te vom ajuta."
-      },
-      "helpPrompt": "Ai nevoie de ajutor sau ai întrebări? Email <link>{supportEmail}</link>.",
-      "signOff": {
-        "line1": "Cu stimă",
-        "line2": "Echipa {brand}"
-      },
-      "cta": {
-        "primary": "Încarcă o factură",
-        "secondary": "Vezi facturile"
+      "termsOfService": {
+        "contactInformation": {
+          "content": "Dacă aveți întrebări cu privire la Termenii noștri de utilizare, vă rugăm să ne contactați la admin@arolariu.ro.",
+          "title": "Contact"
+        },
+        "lastUpdated": "Ultima actualizare: 2024-01-01",
+        "terms": {
+          "amendmentsTerms": {
+            "content": "Ne rezervăm dreptul de a modifica, suplimenta sau înlocui termenii acordului, în vigoare la publicarea pe www.arolariu.ro sau la notificarea dumneavoastră în caz contrar. Dacă nu doriți să fiți de acord cu modificările la Acord, puteți rezilia Acordul în orice moment, conform termenilor din prezentul document. În cazul în care o revizuire este materială, vom oferi o notificare cu cel puțin 30 de zile înainte de intrarea în vigoare a noilor termeni. Ceea ce constituie o modificare materială va fi stabilit la discreția noastră exclusivă. Continuând să accesați sau să utilizați serviciul nostru după intrarea în vigoare a oricărei revizuiri, sunteți de acord să vă supuneți termenilor revizuiți. Dacă nu sunteți de acord cu noii termeni, nu mai sunteți autorizat să utilizați serviciul nostru.",
+            "title": "Modificari ale acordului"
+          },
+          "arbitrateTerms": {
+            "content": "Prezentul acord și orice litigiu sau reclamație care decurge din sau este legată de acesta, de interpretarea sa, de încălcarea, încetarea sau valabilitatea acestuia, de relațiile care rezultă din prezentul acord, inclusiv de executarea, încălcarea sau valabilitatea prezentului acord, vor fi guvernate de legile României. Jurisdicția exclusivă și locul de desfășurare a oricărei acțiuni în temeiul prezentului acord vor fi instanțele situate în România, iar dumneavoastră vă supuneți prin prezenta jurisdicției personale a acestor instanțe. Prin prezenta, renunțați la orice drept la un proces cu juriu în orice procedură care decurge din sau este legată de acest Acord. Convenția Națiunilor Unite privind contractele de vânzare internațională de bunuri nu se aplică prezentului acord. Termenul \"litigiu\" înseamnă orice dispută, acțiune sau altă controversă între dvs. și noi cu privire la Servicii sau la acest acord, fie că este vorba de contract, garanție, delict, statut, regulament, ordonanță sau orice alt temei legal sau echitabil. \"Dispută\" va avea cel mai larg înțeles posibil permis de lege.",
+            "title": "Acord de arbitraj"
+          },
+          "changesToTos": {
+            "content": "AROLARIU.RO își rezervă dreptul de a modifica acești Termeni de utilizare în orice moment. Cu toate acestea, vă recomandăm să citiți această pagină în mod regulat pentru a vă asigura că sunteți la curent cu orice modificări. Utilizarea în continuare a site-ului după publicarea modificărilor va însemna că acceptați și sunteți de acord cu modificările. Recunoașteți și sunteți de acord că putem înceta (permanent sau temporar) să vă furnizăm Serviciul (sau orice caracteristici din cadrul Serviciului) dumneavoastră sau utilizatorilor în general, la discreția noastră exclusivă, fără a vă anunța în prealabil. Puteți înceta să utilizați Serviciul în orice moment. Nu este necesar să ne informați în mod specific atunci când încetați să utilizați Serviciul. Recunoașteți și sunteți de acord că, în cazul în care vă dezactivăm accesul la contul dvs., este posibil să nu puteți accesa Serviciul, detaliile contului dvs. sau orice fișiere sau alte materiale care sunt conținute în contul dvs.",
+            "title": "Schimbari ale termenilor si conditiilor"
+          },
+          "consentTerms": {
+            "content": "Ne-am actualizat Termenii și condițiile pentru a vă oferi o transparență completă cu privire la ceea ce este setat atunci când vizitați site-ul nostru și la modul în care este utilizat. Prin utilizarea site-ului nostru, vă exprimați acordul cu privire la Termenii și condițiile noastre de utilizare și sunteți de acord cu Termenii și condițiile.",
+            "title": "Consimtamintele dumneavoastra"
+          },
+          "cookiesTerms": {
+            "content": "Utilizăm \"module cookie\" pentru a identifica zonele din site-ul nostru web pe care le-ați vizitat. Un \"Cookie\" este o mică bucată de date stocată pe computerul sau dispozitivul dvs. mobil de către browserul dvs. web. Utilizăm Cookie-uri pentru a îmbunătăți performanța și funcționalitatea serviciului nostru, dar nu sunt esențiale pentru utilizarea lor. Cu toate acestea, fără aceste module cookie, anumite funcționalități, cum ar fi videoclipurile, pot deveni indisponibile sau ar trebui să introduceți datele de conectare de fiecare dată când vizitați platforma noastră, deoarece nu am putea să ne amintim că v-ați conectat anterior. Majoritatea browserelor web pot fi setate pentru a dezactiva utilizarea cookie-urilor. Cu toate acestea, dacă dezactivați modulele cookie, este posibil să nu puteți accesa corect sau deloc funcționalitățile de pe site-ul nostru. Nu plasăm niciodată informații de identificare personală în modulele cookie.",
+            "title": "Cookies si module cookie"
+          },
+          "copyrightTerms": {
+            "content": "Dacă sunteți proprietarul drepturilor de autor sau agentul unui astfel de proprietar și considerați că orice material de la noi constituie o încălcare a drepturilor de autor, vă rugăm să ne contactați furnizând următoarele informații: (a) o semnătură fizică sau electronică a proprietarului drepturilor de autor sau a unei persoane autorizate să acționeze în numele acestuia; (b) identificarea materialului despre care se pretinde că încalcă drepturile de autor; (c) informațiile dumneavoastră de contact, inclusiv adresa, numărul de telefon și un e-mail; (d) o declarație din partea dumneavoastră că aveți o convingere de bună credință că utilizarea materialului nu este autorizată de către proprietarii drepturilor de autor; și (e) o declarație că informațiile din notificare sunt corecte și, sub sancțiunea de sperjur, sunteți autorizat să acționați în numele proprietarului.",
+            "title": "Protectie a drepturilor de autor"
+          },
+          "definitionTerms": {
+            "content": "Termenii \"noi\" sau \"al nostru\" se referă la AROLARIU.RO, proprietarul site-ului. Un client este persoana sau organizația care cumpără sau este de acord să cumpere produsul. 'Produsul' nostru se referă la site-ul web, produsele sau serviciile oferite spre vânzare pe site-ul nostru web. Un \"utilizator\" este o persoană care utilizează site-ul nostru web sau serviciile noastre. Termenul \"dumneavoastră\" se referă la utilizatorul sau privitorul site-ului nostru web.",
+            "title": "Definiții"
+          },
+          "disclaimerTerms": {
+            "content": "În măsura maximă permisă de legea aplicabilă, excludem toate declarațiile, garanțiile și condițiile referitoare la site-ul nostru web și la utilizarea acestui site web. Nu vom fi răspunzători pentru nicio daune care decurg din utilizarea sau incapacitatea de a utiliza materialele de pe site-ul AROLARIU.RO, chiar dacă AROLARIU.RO sau un reprezentant autorizat al AROLARIU.RO a fost informat, verbal sau în scris, despre posibilitatea a unei astfel de pagube. Deoarece unele jurisdicții nu permit limitări ale garanțiilor implicite sau limitări ale răspunderii pentru daune consecutive sau incidentale, este posibil ca aceste limitări să nu se aplice în cazul dumneavoastră. Nu suntem responsabili pentru niciun conținut, cod sau orice altă imprecizie. Nu oferim garanții sau garanții. În nici un caz nu vom fi răspunzători pentru orice daune speciale, directe, indirecte, consecvente sau incidentale sau orice daune de orice fel, fie ca urmare a unei acțiuni contractuale, neglijențe sau alte delicte, care decurg din sau în legătură cu utilizarea Serviciului sau conținutul Serviciului. Ne rezervăm dreptul de a face adăugiri, ștergeri sau modificări la conținutul Serviciului în orice moment, fără notificare prealabilă. Serviciul nostru și conținutul acestuia sunt furnizate „CA AȘA ESTE” și „AȘAT DISPONIBIL” fără nicio garanție sau reprezentare de niciun fel, indiferent dacă este expresă sau implicită. Suntem un distribuitor și nu un editor al conținutului furnizat de terți; ca atare, nostru nu exercită niciun control editorial asupra acestui conținut și nu face nicio garanție sau reprezentare cu privire la acuratețea, fiabilitatea sau actualitatea oricărei informații, conținut, serviciu sau mărfuri furnizate prin sau accesibile prin intermediul Serviciului nostru. Fără a limita cele de mai sus, declinăm în mod special toate garanțiile și declarațiile în orice conținut transmis pe sau în legătură cu Serviciul nostru sau pe site-uri care pot apărea ca link-uri pe Serviciul nostru, sau în produsele furnizate ca parte a sau în alt mod în legătură cu , Serviciul nostru, incluzând fără limitare orice garanții de vandabilitate, potrivire pentru un anumit scop sau neîncălcare a drepturilor terților. Niciun sfat oral sau informații scrise oferite de noi sau de oricare dintre afiliații săi, angajații, ofițerii, directorii, agenții sau altele asemenea nu vor crea o garanție. Informațiile despre preț și disponibilitate pot fi modificate fără notificare. Fără a limita cele de mai sus, nu garantăm că Serviciul nostru va fi neîntrerupt, necorupt, în timp util sau fără erori.",
+            "title": "Exonerare de răspundere"
+          },
+          "disputeNoticeTerms": {
+            "content": "În cazul unui litigiu, dvs. sau AROLARIU.RO trebuie să transmiteți celeilalte părți o Notificare de litigiu, care este o declarație scrisă care stabilește numele, adresa și informațiile de contact ale părții care o transmite, faptele care dau naștere litigiului și soluția solicitată. Trebuie să trimiteți orice Notificare a litigiului prin e-mail la: admin@arolariu.ro. AROLARIU.RO vă va trimite orice Notificare a litigiului prin poștă la adresa dumneavoastră, dacă o avem, sau, în caz contrar, la adresa dumneavoastră de e-mail. Dumneavoastră și AROLARIU.RO veți încerca să rezolvați orice litigiu prin negocieri informale în termen de șaizeci (60) de zile de la data trimiterii Notificării de litigiu. După șaizeci (60) de zile, dumneavoastră sau AROLARIU.RO puteți începe arbitrajul.",
+            "title": "Notificare a litigiului"
+          },
+          "entireAgreementTerms": {
+            "content": "Termenii de utilizare constituie întregul acord între dvs. și AROLARIU.RO în ceea ce privește utilizarea serviciului și înlocuiesc toate acordurile anterioare și contemporane, scrise sau orale, dintre dvs. și AROLARIU.RO. Este posibil să faceți obiectul unor termeni și condiții suplimentare care se aplică atunci când utilizați sau achiziționați alte servicii ale AROLARIU.RO, pe care AROLARIU.RO vi le va furniza în momentul utilizării sau achiziționării respective.",
+            "title": "Intregul acord"
+          },
+          "generalTerms": {
+            "content": "Prin accesarea și plasarea unei comenzi la AROLARIU.RO, confirmați că sunteți de acord și că sunteți obligat să respectați termenii de serviciu conținuți în Termenii și condițiile prezentate mai jos. Acești termeni se aplică întregului site web și oricărui e-mail sau alt tip de comunicare între dumneavoastră și AROLARIU.RO. În nicio circumstanță echipa AROLARIU.RO nu va fi răspunzătoare pentru daune directe, indirecte, speciale, accidentale sau de consecință, inclusiv, dar fără a se limita la, pierderea de date sau profit, care rezultă din utilizarea sau incapacitatea de a utiliza materialele de pe acest site, chiar dacă echipa AROLARIU.RO sau un reprezentant autorizat a fost informat de posibilitatea unor astfel de daune. În cazul în care utilizarea materialelor de pe acest site are ca rezultat necesitatea întreținerii, reparării sau corectării echipamentelor sau datelor, vă asumați toate costurile aferente. AROLARIU.RO nu va fi responsabil pentru niciun rezultat care ar putea apărea pe parcursul utilizării resurselor noastre. Ne rezervăm dreptul de a modifica prețurile și de a revizui politica de utilizare a resurselor în orice moment.",
+            "title": "Termeni generali"
+          },
+          "liabilityTerms": {
+            "content": "În măsura permisă de legea aplicabilă, în nici un caz AROLARIU.RO nu va fi răspunzător față de dvs. din orice teorie juridică pentru orice daune incidentale, directe, indirecte, punitive, reale, consecutive, speciale, exemplare sau de altă natură, inclusiv, fără limitare, pierderi de venituri sau venituri, profituri pierdute, durere și suferință, suferință emoțională, costul bunurilor sau serviciilor de substituție sau daune similare suferite sau suferite de dvs. sau de orice terță parte care apar în legătură cu serviciul (sau încetarea acestuia din orice motiv). ), chiar dacă AROLARIU.RO a fost anunțat despre posibilitatea unor astfel de daune. AROLARIU.RO nu va fi răspunzător pentru nicio daune, răspundere sau pierdere care decurg din: (i) utilizarea sau încrederea de către dumneavoastră a serviciului sau incapacitatea dumneavoastră de a accesa sau utiliza serviciul; sau (ii) orice tranzacție sau relație între dumneavoastră și orice furnizor terț, chiar dacă AROLARIU.RO a fost informat despre posibilitatea unor astfel de daune. AROLARIU.RO nu va fi răspunzător pentru întârzierea sau nerespectarea executării rezultate din cauze care nu pot fi controlate în mod rezonabil al AROLARIU.RO. Recunoașteți că serviciul poate fi supus limitărilor, întârzierilor și altor probleme inerente utilizării internetului și a comunicațiilor electronice. AROLARIU.RO nu este responsabil pentru eventualele întârzieri, eșecuri de livrare sau alte daune rezultate din astfel de probleme. În măsura maximă permisă de legea aplicabilă, în niciun caz noi sau furnizorii noștri nu vom fi răspunzători pentru orice daune speciale, incidentale, indirecte sau consecutive (inclusiv, dar fără a se limita la, daune pentru pierderea de profit, pentru pierderea de date sau alte informații, pentru întreruperea activității, pentru vătămarea personală, pentru pierderea confidențialității care rezultă din sau în orice fel legate de utilizarea sau incapacitatea de a utiliza serviciul, software-ul terță parte și/sau hardware-ul terță parte utilizat cu serviciul, sau în alt mod în legătură cu orice prevedere a acestui Acord), chiar dacă noi sau orice furnizor am fost informați cu privire la posibilitatea unor astfel de daune și chiar dacă remedierea nu își atinge scopul esențial. Unele state/jurisdicții nu permit excluderea sau limitarea daunelor incidentale sau consecutive, astfel încât limitarea sau excluderea de mai sus este posibil să nu se aplice în cazul dumneavoastră.",
+            "title": "Limitare a raspunderii"
+          },
+          "licenseTerms": {
+            "content": "Prin achiziționarea unui produs de la AROLARIU.RO, vi se acordă o licență neexclusivă și netransferabilă de acces la produs. Produsul este destinat utilizării personale și comerciale. Aveți voie să instalați produsul pe mai multe calculatoare sau dispozitive, dar nu aveți voie să partajați produsul cu alte persoane. Nu aveți voie să modificați, să adaptați, să traduceți, să faceți inginerie inversă, să decompilați, să dezasamblați sau să creați lucrări derivate bazate pe produs fără acordul prealabil scris al AROLARIU.RO. Nu aveți voie să vindeți, să închiriați, să dați în leasing sau să sublicențiați produsul. Nu aveți voie să puneți produsul la dispoziție într-o rețea în care acesta ar putea fi utilizat de mai multe dispozitive în același timp. Nu aveți voie să utilizați produsul pentru a încălca niciun drept de autor sau marcă comercială. Nu aveți voie să utilizați produsul pentru a crea materiale ilegale, dăunătoare, amenințătoare, abuzive, hărțuitoare, delictuale, defăimătoare, vulgare, obscene, calomnioase, care încalcă viața privată a altora, care incită la ură sau care sunt reprobabile din punct de vedere rasial, etnic sau de altă natură.",
+            "title": "Termeni de licenta"
+          },
+          "linksToOtherSitesTerms": {
+            "content": "Serviciul nostru poate conține linkuri către alte site-uri web care nu sunt operate de Noi. Dacă faceți clic pe un link al unei terțe părți, veți fi direcționat către site-ul acelei terțe părți. Vă sfătuim cu tărie să consultați Termenii și condițiile fiecărui site pe care îl vizitați. Nu avem niciun control și nu ne asumăm nicio responsabilitate pentru conținutul, Termenii și condițiile sau practicile site-urilor sau serviciilor terților.",
+            "title": "Adrese catre alte platforme"
+          },
+          "miscellaneousTerms": {
+            "content": "Dacă, din orice motiv, o instanță de jurisdicție competentă consideră că orice prevedere sau porțiune din acești Termeni și condiții nu este aplicabilă, restul acestor Termeni și condiții va continua în vigoare și efect. Orice renunțare la orice prevedere a acestor Termeni și Condiții va intra în vigoare numai dacă este în scris și este semnată de un reprezentant autorizat al nostru. Vom avea dreptul la injoncție sau alte măsuri echitabile (fără obligația de a depune vreo garanție sau garanție) în cazul oricărei încălcări sau încălcări anticipate din partea dvs. Operăm și controlăm Serviciul nostru din birourile noastre din România. Serviciul nu este destinat distribuției sau utilizării de către nicio persoană sau entitate în nicio jurisdicție sau țară în care o astfel de distribuție sau utilizare ar fi contrară legii sau reglementărilor. În consecință, acele persoane care aleg să acceseze Serviciul nostru din alte locații fac acest lucru din proprie inițiativă și sunt singurele responsabile pentru conformitatea cu legile locale, dacă și în măsura în care legile locale sunt aplicabile. Acești Termeni și Condiții (care includ și încorporează Politica noastră de confidențialitate) conțin întreaga înțelegere și înlocuiesc toate înțelegerile anterioare dintre dvs. și noi cu privire la subiectul acesteia și nu pot fi modificate sau modificate de dvs. Titlurile secțiunilor utilizate în acest acord sunt doar pentru comoditate și nu vor primi nicio importanță legală. Neexercitarea de către oricare dintre părți a oricărui drept prevăzut aici nu va fi considerată o renunțare la orice alte drepturi în temeiul prezentului. AROLARIU.RO nu va fi răspunzător pentru nicio neîndeplinire a obligațiilor care îi revin în temeiul prezentului, în cazul în care o astfel de neexecuție rezultă din orice cauză.",
+            "title": "Diverse"
+          },
+          "noWarrantiesTerms": {
+            "content": "Acest site web este furnizat „ca atare”, cu toate greșelile, iar AROLARIU.RO nu face nicio declarație sau garanție, expresă sau implicită, de nici un fel legată de acest site sau de materialele conținute pe acest site. În plus, nimic din conținutul acestui site web nu va fi interpretat ca oferind consultanță sau consiliere. Serviciul vă este oferit „CA AȘA ESTE” și „AȘAT DISPONIBIL” și cu toate defecțiunile și defectele fără garanție de niciun fel. În măsura maximă permisă de legea aplicabilă, noi, în numele nostru și în numele afiliaților noștri și al licențiatorilor și furnizorilor noștri de servicii respectivi, renunțăm în mod expres la toate garanțiile, indiferent dacă sunt exprese, implicite, statutare sau de altă natură, cu privire la serviciu, inclusiv toate garanțiile implicite de vandabilitate, potrivire pentru un anumit scop, titlu și neîncălcare și garanțiile care pot apărea din cursul tranzacției, cursul performanței, utilizarea sau practica comercială. Fără a se limita la cele de mai sus, nu oferim nicio garanție sau angajament și nu facem nicio declarație de niciun fel că serviciul va îndeplini cerințele dumneavoastră, va obține rezultatele dorite, va fi compatibil sau va funcționa cu orice alt software, site-uri web, sisteme sau servicii, va funcționa fără întreruperea, îndeplinirea oricăror standarde de performanță sau fiabilitate sau să fie fără erori sau că orice erori sau defecte pot sau vor fi corectate. Fără a limita cele de mai sus, nici noi, nici niciun furnizor nu face nicio declarație sau garanție de orice fel, expresă sau implicită: (i) cu privire la funcționarea sau disponibilitatea serviciului sau la informațiile, conținutul și materialele sau produsele incluse în acesta; (ii) că serviciul va fi neîntrerupt sau fără erori; (iii) în ceea ce privește acuratețea, fiabilitatea sau actualitatea oricărei informații sau conținut furnizat prin intermediul serviciului; sau (iv) că serviciul, serverele sale, conținutul sau e-mailurile trimise de la sau în numele nostru sunt lipsite de viruși, scripturi, cai troieni, viermi, malware, bombe cu timp sau alte componente dăunătoare. Unele jurisdicții nu permit excluderea sau limitările garanțiilor implicite sau limitările privind drepturile legale aplicabile ale unui consumator, astfel încât unele sau toate excluderile și limitările de mai sus s-ar putea să nu vi se aplice.",
+            "title": "Fara garantii"
+          },
+          "promotionTerms": {
+            "content": "Putem, din când în când, să includem concursuri, promoții, tombole sau alte activități (\"Promoții\") care vă cer să trimiteți materiale sau informații despre dumneavoastră. Vă rugăm să rețineți că toate Promoțiile pot fi guvernate de reguli separate care pot conține anumite cerințe de eligibilitate, cum ar fi restricții privind vârsta și locația geografică. Sunteți responsabil să citiți toate regulile Promoțiilor pentru a determina dacă sunteți sau nu eligibil pentru a participa. Dacă vă înscrieți în orice Promoție, sunteți de acord să respectați și să vă conformați tuturor Regulilor Promoțiilor. Termeni și condiții suplimentare se pot aplica achizițiilor de bunuri sau servicii pe sau prin intermediul Serviciilor, termeni și condiții care fac parte integrantă din prezentul Acord prin această referință. Orice promoții puse la dispoziție prin intermediul serviciului pot fi guvernate de reguli care sunt separate de acești Termeni. Dacă participați la orice promoții, vă rugăm să consultați regulile aplicabile, precum și Politica noastră de confidențialitate. În cazul în care regulile unei promoții intră în conflict cu acești Termeni, se vor aplica regulile promoției.",
+            "title": "Promotii"
+          },
+          "restrictionTerms": {
+            "content": "Vi se interzice în mod specific să publicați, să vindeți, să sublicențiați sau să comercializați în alt mod orice material de pe site-ul web; să folosiți acest site web în orice mod care este sau poate fi dăunător pentru acest site web; să folosiți acest site web în orice mod care afectează accesul utilizatorilor la acest site web; să folosiți acest site web contrar legilor și reglementărilor aplicabile sau care, în orice mod, poate cauza prejudicii site-ului web sau oricărei persoane sau entități de afaceri; să vă implicați în activități de extragere de date, de recoltare de date, de extragere de date sau în orice altă activitate similară în legătură cu acest site web; să folosiți acest site web pentru a vă implica în orice activitate de publicitate sau de marketing.",
+            "title": "Restricții"
+          },
+          "severabilityTerms": {
+            "content": "Dacă orice prevedere a acestor Termeni este considerată inaplicabilă sau invalidă, o astfel de prevedere va fi modificată și interpretată pentru a îndeplini obiectivele unei astfel de prevederi în cea mai mare măsură posibilă în conformitate cu legislația aplicabilă, iar prevederile rămase vor continua în vigoare și în vigoare. Acest Acord, împreună cu Politica de confidențialitate și orice alte notificări legale publicate de noi pe Servicii, vor constitui întregul acord între dvs. și noi cu privire la Servicii. Dacă orice prevedere a prezentului acord este considerată invalidă de către o instanță de jurisdicție competentă, invaliditatea unei astfel de prevederi nu va afecta valabilitatea prevederilor rămase ale prezentului acord, care vor rămâne în vigoare și în vigoare. Nicio renunțare la niciun termen din prezentul Acord nu va fi considerată o renunțare ulterioară sau continuă la un astfel de termen sau la orice alt termen, iar eșecul nostru de a afirma orice drept sau prevedere în temeiul prezentului Acord nu va constitui o renunțare la acest drept sau prevedere. TU ȘI NOI SUNTEȚI DE ACORD CĂ ORICE CAUZA DE ACȚIUNE DECORATA DIN SAU LEGATĂ DE SERVICII TREBUIE SĂ ÎNCEPE ÎN TIMPUL DE UN (1) AN DUPĂ CAUZA ACȚIUNII SE ACUMULĂ. ÎN CARTĂ CAUZA, ACESTE CAUZA DE ACȚIUNE ESTE INTERDITĂ PERMANENT.",
+            "title": "Separabilitate"
+          },
+          "submissionsAndPrivacyTerms": {
+            "content": "Când vizitați site-ul web sau ne trimiteți e-mailuri, comunicați cu noi electronic. Sunteți de acord să primiți comunicări de la noi pe cale electronică. Vom comunica cu dvs. prin e-mail sau prin postarea de notificări pe site. Sunteți de acord că toate acordurile, notificările, dezvăluirile și alte comunicări pe care le furnizăm electronic îndeplinesc orice cerință legală ca astfel de comunicări să fie în scris. AROLARIU.RO poate, dar nu va fi obligat să monitorizeze, să revizuiască sau să editeze Conținutul utilizatorului. În toate cazurile, AROLARIU.RO își rezervă dreptul de a elimina sau dezactiva accesul la orice Conținut al Utilizatorului pentru orice motiv sau fără motiv, inclusiv, dar fără a se limita la, Conținutul Utilizatorului care, la discreția exclusivă a AROLARIU.RO, încalcă Acordurile. AROLARIU.RO poate întreprinde aceste acțiuni fără notificare prealabilă către dumneavoastră sau oricărei terțe părți. Eliminarea sau dezactivarea accesului la Conținutul utilizatorului va fi la discreția noastră exclusivă și nu promitem să eliminăm sau să dezactivăm accesul la orice Conținut specific al utilizatorului. În cazul în care trimiteți sau postați idei, sugestii creative, design, fotografii, informații, reclame, date sau propuneri, inclusiv idei pentru produse, servicii, caracteristici, tehnologii sau promoții noi sau îmbunătățite, sunteți de acord în mod expres că astfel de trimiteri vor fi automat fi tratat ca neconfidențial și neproprietar și va deveni proprietatea exclusivă a noastră fără nicio compensație sau credit pentru dvs. Noi și afiliații noștri nu vom avea nicio obligație cu privire la astfel de trimiteri sau postări și putem folosi ideile conținute în astfel de trimiteri sau postări în orice scop în orice mediu, în permanență, inclusiv, dar fără a se limita la, dezvoltarea, fabricarea și comercializarea produselor și servicii folosind astfel de idei.",
+            "title": "Propuneri si confidentialitate"
+          },
+          "terminationTerms": {
+            "content": "Putem rezilia sau suspenda contul dvs. și vă putem interzice accesul la serviciu imediat, fără notificare prealabilă sau răspundere, la discreția noastră exclusivă, din orice motiv și fără limitare, inclusiv, dar fără a ne limita la încălcarea Termenilor. Dacă doriți să vă închideți contul, puteți pur și simplu să nu mai utilizați serviciul. Toate dispozițiile din Termeni care, prin natura lor, ar trebui să supraviețuiască rezilierii, vor supraviețui rezilierii, inclusiv, dar fără a se limita la acestea, dispozițiile privind proprietatea, exonerările de garanție, despăgubirile și limitările de răspundere.",
+            "title": "Terminare"
+          },
+          "thirdPartyTerms": {
+            "content": "În cadrul utilizării serviciului, este posibil să utilizați servicii, produse, software, încorporări sau aplicații dezvoltate de o terță parte (\"Servicii ale terților\"). Orice utilizare a unui Serviciu terț este pe riscul dumneavoastră, iar noi nu vom fi responsabili sau răspunzători față de nimeni pentru site-urile sau Serviciile terților. Recunoașteți și sunteți de acord că nu vom fi responsabili sau răspunzători pentru orice daune sau pierderi cauzate sau presupuse a fi cauzate de sau în legătură cu utilizarea unui astfel de conținut, bunuri sau servicii disponibile pe sau prin intermediul unor astfel de site-uri web sau servicii. Nu ne asumăm și nu vom avea nicio răspundere sau responsabilitate față de dvs. sau față de orice altă persoană sau entitate pentru orice Servicii ale terților. Serviciile terțelor părți și linkurile aferente sunt furnizate doar pentru a vă fi de folos, iar dumneavoastră le accesați și le utilizați în întregime pe propriul risc și în conformitate cu termenii și condițiile terțelor părți.",
+            "title": "Servicii terte"
+          },
+          "typographyErrorsTerms": {
+            "content": "În cazul în care un produs AROLARIU.RO este listat din greșeală la un preț incorect, AROLARIU.RO își rezervă dreptul de a refuza sau de a anula orice comandă plasată pentru produsul listat la prețul incorect. AROLARIU.RO își rezervă dreptul de a refuza sau de a anula orice astfel de comenzi, indiferent dacă comanda a fost sau nu confirmată și dacă a fost sau nu încasată de pe cardul de credit. În cazul în care cardul dvs. de credit a fost deja taxat pentru achiziție și comanda dvs. este anulată, AROLARIU.RO va emite un credit în contul cardului dvs. de credit în valoare de prețul incorect.",
+            "title": "Erori de tipografie"
+          },
+          "updateOfServicesTerms": {
+            "content": "AROLARIU.RO își actualizează în mod constant serviciile, ceea ce înseamnă că putem adăuga sau elimina caracteristici, produse sau funcționalități și putem, de asemenea, să suspendăm sau să oprim complet serviciul. Putem lua oricare dintre aceste măsuri în orice moment, iar atunci când o facem, este posibil să nu vă oferim nicio notificare în prealabil. Recunoașteți că AROLARIU.RO poate stabili practici generale și limite privind utilizarea serviciului, inclusiv, fără a se limita la perioada maximă de timp în care datele sau alt conținut vor fi reținute de către serviciu și la spațiul maxim de stocare care va fi alocat pe serverele AROLARIU.RO în numele dvs. Sunteți de acord cu faptul că AROLARIU.RO nu are nicio responsabilitate sau răspundere pentru ștergerea sau imposibilitatea de a stoca orice date sau alt conținut păstrat sau încărcat de către serviciu. Recunoașteți că AROLARIU.RO își rezervă dreptul de a închide conturile care sunt inactive pentru o perioadă lungă de timp. Sunteți de acord că nu avem nicio obligație de a (i) furniza orice Actualizări sau (ii) de a continua să furnizăm sau să activăm anumite caracteristici și/sau funcționalități ale serviciului pentru dumneavoastră. Sunteți de acord, de asemenea, că toate Actualizările vor fi (i) considerate ca făcând parte integrantă din serviciu și (ii) supuse termenilor și condițiilor din prezentul Acord.",
+            "title": "Actualizari ale serviciului"
+          },
+          "waiverTerms": {
+            "content": "Cu excepția cazului în care se prevede în prezentul acord, neexercitarea unui drept sau neexecutarea unei obligații în temeiul prezentului acord nu afectează capacitatea unei părți de a exercita un astfel de drept sau de a solicita o astfel de executare în orice moment ulterior și nici renunțarea la o încălcare nu constituie o renunțare la orice încălcare ulterioară. Nici o neexercitare și nici o întârziere în exercitarea de către oricare dintre părți a unui drept sau a unei competențe în temeiul prezentului acord nu poate fi considerată ca o renunțare la dreptul sau competența respectivă. De asemenea, exercitarea unică sau parțială a unui drept sau a unei competențe în temeiul prezentului acord nu împiedică exercitarea ulterioară a acelui drept sau a oricărui alt drept acordat prin prezentul acord. În cazul unui conflict între prezentul acord și orice alte condiții de achiziție sau alte condiții aplicabile, prevalează termenii prezentului acord.",
+            "title": "Renuntare"
+          }
+        },
+        "title": "Termenii serviciului"
       }
+    }
+  },
+  "shared": {
+    "accessibility": {
+      "logoAlt": "logo arolariu.ro",
+      "toggleTheme": "Comută tema"
     },
-    "incompleteInvoice": {
-      "subject": "Ai facturi incomplete",
-      "badge": "Memento",
-      "heading": "Factura ta necesită o actualizare rapidă",
-      "preview": "{name}, factura ta \"{invoiceName}\" necesită atenție.",
-      "greeting": "Bună, {name}!",
-      "intro": "Am analizat factura ta {invoiceName}, dar nu am putut extrage totul. Câteva detalii lipsesc, iar completarea lor îți va oferi o perspectivă mai bună asupra cheltuielilor și rapoarte mai precise.",
-      "invoiceDetailsTitle": "Detalii factură",
-      "invoiceLabel": "Factură",
-      "analyzedOnLabel": "Analizată la",
-      "missingFieldsLabel": "Câmpuri lipsă",
-      "whatsMissingTitle": "Ce lipsește",
-      "missingFields": {
-        "merchant": {
-          "label": "Comerciant",
-          "suggestion": "Adaugă manual numele magazinului în vizualizarea de editare"
+    "invoices": {
+      "commandPalette": {
+        "actions": {
+          "createInvoice": "Crează Factură",
+          "uploadScans": "Încarcă Scanări",
+          "viewAll": "Vezi Toate Facturile",
+          "viewStatistics": "Vezi Statistici"
         },
-        "items": {
-          "label": "Articole pe rânduri",
-          "suggestion": "Încearcă să reîncarci o fotografie mai clară sau adaugă articolele manual"
+        "groups": {
+          "quickActions": "Acțiuni Rapide",
+          "recentInvoices": "Facturi Recente",
+          "searchResults": "Rezultate Căutare"
         },
-        "payment": {
-          "label": "Informații de plată",
-          "suggestion": "Introdu suma totală și metoda de plată în vizualizarea de editare"
+        "noResults": "Nu s-au găsit rezultate",
+        "placeholder": "Caută facturi, comercianți, articole..."
+      },
+      "invoiceHeader": {
+        "buttons": {
+          "analyzeWithAi": "Analizează cu IA",
+          "delete": "Șterge",
+          "discard": "Renunță",
+          "edit": "Editează",
+          "export": "Exportă",
+          "print": "Printează",
+          "save": "Salvează",
+          "saving": "Se salvează..."
         },
-        "category": {
-          "label": "Categorie factură",
-          "suggestion": "Selectează o categorie (produse alimentare, fast food, gospodărie, etc.)"
-        },
-        "unknown": {
-          "label": "{field}",
-          "suggestion": "Te rugăm să revizuiești și să actualizezi aceste informații"
+        "id": "Identificator: {id}",
+        "tooltips": {
+          "analyzeSpendingPatterns": "Analizează tiparele de cheltuieli pentru această factură",
+          "delete": "Șterge definitiv această factură",
+          "deleteInvoicePermanently": "Șterge permanent această factură",
+          "discardAllPendingChanges": "Renunță la toate modificările în așteptare",
+          "edit": "Editează această factură",
+          "export": "Exportă datele facturii în diverse formate",
+          "importantInvoice": "Factură importantă",
+          "print": "Printează această factură",
+          "printInvoiceWithAllDetails": "Tipărește această factură cu toate detaliile",
+          "saveAllPendingChanges": "Salvează toate modificările în așteptare"
         }
       },
-      "tipsTitle": "Sfaturi pentru o analiză mai bună",
-      "tips": {
-        "0": "Folosește o suprafață bine iluminată și plată când fotografiezi bonuri",
-        "1": "Asigură-te că întregul bon este vizibil și în focus",
-        "2": "Bonurile PDF de la comenzile online tind să fie analizate cel mai bine",
-        "3": "Poți întotdeauna să adaugi sau să corectezi detaliile manual după analiză"
+      "invoicesNotFound": {
+        "cta": "Încarcă aici o factură.",
+        "description": "Se pare că nu ai nicio factură asociată contului tău. Te rugăm să încarci câteva facturi și să revii mai târziu.",
+        "title": "Lipsește ceva aici..."
       },
-      "bodyText": "Completarea acestor detalii durează mai puțin de un minut și asigură acuratețea rapoartelor tale de cheltuieli.",
-      "feedback": "Întâmpini probleme sau ai nevoie de ajutor? Scrie-ne la <link>{supportEmail}</link>.",
-      "signOff": {
-        "line1": "Cu stimă,",
-        "line2": "Echipa {brand}"
+      "loadingInvoices": {
+        "description": "Se încarcă facturi...",
+        "title": "Se încarcă facturi"
       },
-      "primaryCta": "Completează factura",
-      "secondaryCta": "Reanalizeză"
-    },
-    "unanalyzedInvoices": {
-      "subject": "Ai facturi neanalizate",
-      "badge": "Memento",
-      "heading": "{count, plural, =1 {1 factură în așteptarea analizei} other {# facturi în așteptarea analizei}}",
-      "preview": "{name}, ai {count, plural, =1 {1 factură} other {# facturi}} care așteaptă analiza AI.",
-      "greeting": "Bună, {name}!",
-      "intro": "{count, plural, =1 {Ai 1 factură care nu a fost încă analizată. Rularea analizei noastre AI deblochează întreaga valoare a bonurilor încărcate.} other {Ai # facturi care nu au fost încă analizate. Rularea analizei noastre AI deblochează întreaga valoare a bonurilor încărcate.}}",
-      "invoicesAwaitingTitle": "Facturi în așteptarea analizei",
-      "uploadedDate": "Încărcată la {date}",
-      "andMore": "…și încă {remaining}. Vezi toate în <dashboard></dashboard>.",
-      "analysisProvidedTitle": "Ce oferă analiza",
-      "analysisProvides": {
-        "0": "Extracția rând cu rând a articolelor cu prețuri și categorii",
-        "1": "Identificarea și categorizarea comercianților",
-        "2": "Detectarea alergenilor pe produsele alimentare",
-        "3": "Sugestii de rețete bazate pe articolele din coșul de cumpărături",
-        "4": "Categorizare automată a cheltuielilor pentru informații de pe tablou"
-      },
-      "bodyText": "Analiza durează de obicei mai puțin de un minut per factură. Odată completă, vei primi o notificare cu rezultatele.",
-      "feedback": "Ai nevoie de ajutor? Contactează-ne la <link>{supportEmail}</link>.",
-      "signOff": {
-        "line1": "Cu stimă,",
-        "line2": "Echipa {brand}"
-      },
-      "primaryCta": "Vezi facturile"
-    },
-    "weeklyUploadReminder": {
-      "subject": "Mementoultău săptămânal pentru încărcări",
-      "badge": "Memento Săptămânal",
-      "heading": "Verificarea săptămânală a bonurilor",
-      "preview": "Bună, {name} — iată verificarea săptămânală a bonurilor tale.",
-      "greeting": "Bună, {name}!",
-      "intro": "Iată o privire rapidă asupra activității tale de urmărire a bonurilor. Încărcarea constantă îți oferă cele mai precise informații despre cheltuieli.",
-      "metricsLabels": {
-        "thisWeek": "Săptămâna aceasta",
-        "lastWeek": "Săptămâna trecută",
-        "totalInvoices": "Total facturi",
-        "totalTracked": "Total urmărit"
-      },
-      "quickTipsTitle": "Sfaturi rapide",
-      "quickTips": {
-        "0": "Încarcă bonurile imediat după cumpărături — durează mai puțin de 30 de secunde",
-        "1": "Încarcă în lot la sfârșitul zilei dacă preferi",
-        "2": "Chiar și achizițiile mici ajută la construirea unei imagini complete a cheltuielilor"
-      },
-      "bodyText": "Fiecare bon pe care îl urmărești face ca informațiile despre cheltuieli să fie mai precise și tablourile mai utile.",
-      "feedback": "Întrebări sau feedback? Scrie-ne la <link>{supportEmail}</link>.",
-      "signOff": {
-        "line1": "Cu stimă,",
-        "line2": "Echipa {brand}"
-      },
-      "primaryCta": "Încarcă bonurile din această săptămână",
-      "secondaryCta": "Vezi tabloul de bord"
-    },
-    "invoiceStats": {
-      "subject": "Statisticile tale {frequency, select, daily {zilnice} weekly {săptămânale} monthly {lunare} yearly {anuale} other {periodice}} de facturi",
-      "frequencyLabel": "{frequency, select, daily {Zilnică} weekly {Săptămânală} monthly {Lunară} yearly {Anuală} other {Periodică}}",
-      "title": "Statistici factură {frequencyLabel}",
-      "badge": "Facturi",
-      "heading": "Statistici {frequencyLabel} de factură",
-      "preview": "Statistici {frequencyLabel} pentru {name} — {totalSpend} total.",
-      "greeting": "Salut {name},",
-      "intro": "Acesta este rezumatul activității tale pe facturi și cheltuieli pentru <start></start> → <end></end>.",
-      "metrics": {
+      "mobileNav": {
+        "ariaLabel": "Navigare mobilă",
+        "home": "Acasă",
         "invoices": "Facturi",
-        "scans": "Scanări",
-        "totalSpend": "Cheltuieli totale",
-        "averagePerInvoice": "Medie / factură"
+        "profile": "Profil",
+        "scan": "Scanare"
       },
-      "reportDetailsTitle": "Detalii raport",
-      "reportDetails": {
-        "period": "Perioadă",
-        "currency": "Monedă"
+      "notifications": {
+        "markAllRead": "Marchează toate ca citite",
+        "noNotifications": "Nu există notificări încă",
+        "timeAgo": {
+          "days": "{count, plural, one {acum # zi} other {acum # zile}}",
+          "hours": "{count, plural, one {acum # oră} other {acum # ore}}",
+          "minutes": "{count, plural, one {acum # minut} other {acum # minute}}",
+          "now": "Chiar acum"
+        },
+        "title": "Notificări",
+        "types": {
+          "analysisComplete": "Analiza AI finalizată",
+          "invoiceCreated": "Factură creată",
+          "monthlyReport": "Raportul lunar este gata"
+        }
       },
-      "topMerchantsTitle": "Top comercianți",
-      "topCategoriesTitle": "Top categorii",
-      "noDataFallback": "Încă nu există date — încarcă câteva facturi pentru a debloca statistici.",
-      "breakdownCardTitle": "Detaliere cheltuieli (pe categorie)",
-      "donutChartTitle": "Distribuția cheltuielilor pe categorii",
-      "donutChartAlt": "Grafic inelar arătând distribuția cheltuielilor pe categorii.",
-      "breakdownTableTitle": "Detaliere",
-      "breakdownNote": "Notă: Acest grafic folosește datele de clasare pe categorii disponibile pentru perioadă.",
-      "body": "Pentru o detaliere completă a cheltuielilor tale, vizitează lista de facturi pentru a analiza trendurile, comercianții, categoriile și totalurile în timp. Aceste statistici te pot ajuta să identifici modele de cheltuire și să iei decizii financiare mai informate.",
-      "feedbackPrompt": "Întrebări sau ceva nu pare corect? Scrie-ne la <email></email>.",
-      "signOff": {
-        "line1": "La revedere,",
-        "line2": "Echipa {brand}"
+      "onboarding": {
+        "back": "Înapoi",
+        "dontShowAgain": "Nu mai afișa din nou",
+        "getStarted": "Începe",
+        "next": "Următorul",
+        "skip": "Sari peste",
+        "stepOf": "Pasul {current} din {total}",
+        "steps": {
+          "analyze": {
+            "description": "Sistemul nostru bazat pe AI extrage automat numele comercianților, datele, sumele și articolele din chitanțele tale cu acuratețe ridicată.",
+            "title": "AI Extrage Detaliile"
+          },
+          "track": {
+            "description": "Vizualizează analize detaliate și perspective asupra tiparelor tale de cheltuieli. Înțelege unde se duc banii tăi cu diagrame și rapoarte interactive.",
+            "title": "Urmărește Cheltuielile Tale"
+          },
+          "upload": {
+            "description": "Fă o fotografie sau încarcă un PDF al chitanței tale. Sistemul nostru acceptă multiple formate și poate procesa loturi de chitanțe deodată.",
+            "title": "Încarcă Chitanțele Tale"
+          }
+        }
       },
-      "ctaPrimary": "Vezi facturile",
-      "ctaSecondary": "Încarcă o factură nouă"
+      "preferences": {
+        "currency": "Monedă",
+        "defaultView": "Vizualizare Implicită",
+        "pageSize": "Elemente pe Pagină",
+        "save": "Salvează Preferințele",
+        "saved": "Preferințele au fost salvate cu succes",
+        "showStats": "Afișează statistici pe pagina principală",
+        "sortBy": "Sortează După",
+        "sortOptions": {
+          "amountAsc": "Sumă (Mic la Mare)",
+          "amountDesc": "Sumă (Mare la Mic)",
+          "dateAsc": "Dată (Cele mai Vechi)",
+          "dateDesc": "Dată (Cele mai Recente)",
+          "nameAsc": "Nume (A la Z)"
+        },
+        "title": "Preferințe Facturi",
+        "views": {
+          "grid": "Vizualizare Grilă",
+          "table": "Vizualizare Tabel"
+        }
+      },
+      "shortcuts": {
+        "close": "Închide",
+        "closeDialog": "Închide dialogul",
+        "description": "Acces rapid la acțiuni comune folosind tastatura",
+        "newInvoice": "Factură nouă",
+        "openSearch": "Deschide căutarea",
+        "showHelp": "Arată acest ajutor",
+        "title": "Scurtături de la Tastatură",
+        "uploadScan": "Încarcă scanare"
+      },
+      "statesLoading": {
+        "description": "Se încarcă factura cu identificatorul {invoiceIdentifier}.",
+        "title": "Se încarcă factura"
+      },
+      "statesNotFound": {
+        "description": "Factura cu identificatorul {invoiceIdentifier} nu a fost găsită.",
+        "title": "Factură negăsită"
+      },
+      "unknownMerchant": "Comerciant Necunoscut",
+      "workflowProgress": {
+        "create": "Creare",
+        "review": "Revizuire",
+        "upload": "Încărcare"
+      }
+    },
+    "legacy": {
+      "about": {
+        "cards": {
+          "author": {
+            "cta": "Aflați mai multe despre autor ...",
+            "subtitle": "arolariu este pseudonimul/nickname-ul autorului: Alexandru-Răzvan Olariu. Alexandru este un inginer software cu vechime, arhitect de soluții și învățător pe tot parcursul vieții. Pentru a afla mai multe despre Alexandru, faceți clic pe butonul de mai jos.",
+            "title": "Cine este arolariu?"
+          },
+          "platform": {
+            "cta": "Aflați mai multe despre platformă ...",
+            "subtitle": "Platforma arolariu.ro este o colecție de aplicații care sunt găzduite sub domeniul arolariu.ro. Platforma a fost construită cu scopul de a oferi o experiență unificată pentru toate aplicațiile și proiectele OSS la care lucrează autorul (Alexandru-Răzvan Olariu). Pentru a afla mai multe despre tehnologiile care sunt folosite în acest proces și modul în care acestea interacționează între ele, dați click pe butonul de mai jos.",
+            "title": "Ce este arolariu.ro?"
+          }
+        },
+        "footer": "Vă mulțumesc!",
+        "metadata": {
+          "description": "Aflați mai multe despre autor și platformă.",
+          "title": "Despre noi"
+        },
+        "subtitle": " Povestea arolariu.ro a început în 2022, când autorul - Alexandru-Răzvan Olariu, a vrut să înțeleagă cum funcționează site-urile. Întreaga platformă și integrările subiacente au fost dezvoltate exclusiv de autor, din ceea ce a învățat de-a lungul anilor. Alexandru lucrează în prezent ca inginer software la Microsoft. Pentru a afla mai multe despre el, consultați secțiunea din dreapta a acestei pagini. Platforma este construită folosind cele mai noi tehnologii de ultimă oră. Pentru a afla mai multe despre el, consultați secțiunea din stânga a acestei pagini.",
+        "title": "Despre noi"
+      },
+      "common": {
+        "states": {
+          "forbidden": {
+            "callToAction": "Alatura-te domeniului arolariu.ro.",
+            "description": "Din păcate, această funcționalitate necesită să aveți un cont pe domeniul nostru. \nPrin crearea unui cont pe platforma noastră sau conectarea cu un cont existent, veți putea accesa întregul nostru arsenal de servicii, inclusiv acesta.",
+            "title": "Pierzi distracția!"
+          }
+        }
+      }
+    }
+  },
+  "toasts": {
+    "invoices": {
+      "useInvoiceDelete": {
+        "bulkDeleteError": "Ștergerea a eșuat pentru {count} facturi.",
+        "bulkDeletePartial": "Șterse {successCount}; eșuate {failureCount}.",
+        "bulkDeleteSuccess": "{count} facturi șterse.",
+        "deleteError": "Nu s-a putut șterge factura: {error}",
+        "deleteSuccess": "Factură ștearsă."
+      },
+      "useInvoiceShare": {
+        "emailError": "Nu s-a putut trimite e-mailul către {email}: {error}",
+        "emailSending": "Se trimite e-mailul către {email}…",
+        "emailSuccess": "E-mail trimis către {email}.",
+        "revokeError": "Nu s-a putut revoca accesul.",
+        "toggleError": "Nu s-a putut comuta vizibilitatea facturii."
+      },
+      "useRecipeAdd": {
+        "error": "Nu s-a putut adăuga rețeta."
+      },
+      "useRecipeDelete": {
+        "error": "Nu s-a putut șterge rețeta."
+      },
+      "useRecipeUpdate": {
+        "error": "Nu s-a putut actualiza rețeta."
+      },
+      "useScanAdd": {
+        "addError": "Adăugarea scanării a eșuat",
+        "addSuccess": "Scanare adăugată",
+        "uploadFailed": "Încărcarea a eșuat (status {status})"
+      }
     }
   }
 }

--- a/sites/arolariu.ro/src/app/(privacy-and-terms)/_components/EnhancedLegalArticles.stories.tsx
+++ b/sites/arolariu.ro/src/app/(privacy-and-terms)/_components/EnhancedLegalArticles.stories.tsx
@@ -6,7 +6,7 @@ import EnhancedLegalArticles from "./EnhancedLegalArticles";
  * page type. It uses the RichText component internally to render
  * internationalised titles and content for each article section.
  *
- * Supports two page types: `Legal.PrivacyPolicy` and `Legal.TermsOfService`.
+ * Supports two page types: `sections.legal.privacyPolicy` and `sections.legal.termsOfService`.
  */
 const meta = {
   title: "Pages/Legal/EnhancedLegalArticles",
@@ -22,21 +22,21 @@ type Story = StoryObj<typeof meta>;
 /** Privacy Policy articles — 19 sections covering data handling. */
 export const PrivacyPolicy: Story = {
   args: {
-    pageType: "Legal.PrivacyPolicy",
+    pageType: "sections.legal.privacyPolicy",
   },
 };
 
 /** Terms of Service articles — 23 sections covering usage terms. */
 export const TermsOfService: Story = {
   args: {
-    pageType: "Legal.TermsOfService",
+    pageType: "sections.legal.termsOfService",
   },
 };
 
 /** Privacy Policy — dark mode. */
 export const PrivacyPolicyDark: Story = {
   args: {
-    pageType: "Legal.PrivacyPolicy",
+    pageType: "sections.legal.privacyPolicy",
   },
   parameters: {
     themes: {themeOverride: "dark"},
@@ -46,7 +46,7 @@ export const PrivacyPolicyDark: Story = {
 /** Terms of Service — dark mode. */
 export const TermsOfServiceDark: Story = {
   args: {
-    pageType: "Legal.TermsOfService",
+    pageType: "sections.legal.termsOfService",
   },
   parameters: {
     themes: {themeOverride: "dark"},

--- a/sites/arolariu.ro/src/app/(privacy-and-terms)/_components/EnhancedLegalArticles.tsx
+++ b/sites/arolariu.ro/src/app/(privacy-and-terms)/_components/EnhancedLegalArticles.tsx
@@ -3,7 +3,7 @@
 import {RichText} from "@/presentation/Text";
 import styles from "./EnhancedLegalArticles.module.scss";
 
-type TranslatedPage = Readonly<"Legal.PrivacyPolicy" | "Legal.TermsOfService">;
+type TranslatedPage = Readonly<"sections.legal.privacyPolicy" | "sections.legal.termsOfService">;
 type TranslatedPageArticle = Readonly<{titleKey: string; contentKey: string}>;
 type TranslatedPageArticles = Readonly<TranslatedPageArticle[]>;
 
@@ -56,8 +56,8 @@ const articlesForTermsOfService: TranslatedPageArticles = [
 ] as const;
 
 const articles = {
-  "Legal.PrivacyPolicy": articlesForPrivacyPolicy,
-  "Legal.TermsOfService": articlesForTermsOfService,
+  "sections.legal.privacyPolicy": articlesForPrivacyPolicy,
+  "sections.legal.termsOfService": articlesForTermsOfService,
 } as Readonly<Record<TranslatedPage, TranslatedPageArticles>>;
 
 /**

--- a/sites/arolariu.ro/src/app/(privacy-and-terms)/acknowledgements/_components/Contributors.tsx
+++ b/sites/arolariu.ro/src/app/(privacy-and-terms)/acknowledgements/_components/Contributors.tsx
@@ -39,9 +39,9 @@ export default function Contributors(): React.JSX.Element {
           animate={isInView ? {opacity: 1, y: 0} : {}}
           transition={{duration: 0.6}}>
           <h2 className={styles["title"]}>
-            <span className={styles["titleGradient"]}>{t((m) => m.Acknowledgements.contributors.title)}</span>
+            <span className={styles["titleGradient"]}>{t((m) => m.sections.legal.acknowledgements.contributors.title)}</span>
           </h2>
-          <p className={styles["subtitle"]}>{t((m) => m.Acknowledgements.contributors.subtitle)}</p>
+          <p className={styles["subtitle"]}>{t((m) => m.sections.legal.acknowledgements.contributors.subtitle)}</p>
         </motion.div>
 
         {/* Contributors grid */}
@@ -71,7 +71,7 @@ export default function Contributors(): React.JSX.Element {
                   {/* Package count */}
                   <div className={styles["packageCount"]}>
                     <TbPackage className={styles["packageIcon"]} />
-                    <span>{t((m) => m.Acknowledgements.contributors.packages, {count: Number(t(selectorFromPath(`Acknowledgements.contributors.items.${key}.packages`)))})}</span>
+                    <span>{t((m) => m.sections.legal.acknowledgements.contributors.packages, {count: Number(t(selectorFromPath(`Acknowledgements.contributors.items.${key}.packages`)))})}</span>
                   </div>
 
                   {/* Description */}

--- a/sites/arolariu.ro/src/app/(privacy-and-terms)/acknowledgements/_components/Hero.tsx
+++ b/sites/arolariu.ro/src/app/(privacy-and-terms)/acknowledgements/_components/Hero.tsx
@@ -66,7 +66,7 @@ export default function Hero({lastUpdatedDate}: Readonly<Props>): React.JSX.Elem
             variant='secondary'
             className={styles["badge"]}>
             <TbHeart className={styles["badgeIcon"]} />
-            {t((m) => m.Acknowledgements.hero.badge)}
+            {t((m) => m.sections.legal.acknowledgements.hero.badge)}
           </Badge>
         </motion.div>
 
@@ -76,7 +76,7 @@ export default function Hero({lastUpdatedDate}: Readonly<Props>): React.JSX.Elem
           initial={{opacity: 0, y: 20}}
           animate={isInView ? {opacity: 1, y: 0} : {}}
           transition={{delay: 0.3, duration: 0.6}}>
-          <span className={styles["titleGradient"]}>{t((m) => m.Acknowledgements.hero.title)}</span>
+          <span className={styles["titleGradient"]}>{t((m) => m.sections.legal.acknowledgements.hero.title)}</span>
         </motion.h1>
 
         {/* Subtitle */}
@@ -85,7 +85,7 @@ export default function Hero({lastUpdatedDate}: Readonly<Props>): React.JSX.Elem
           initial={{opacity: 0, y: 20}}
           animate={isInView ? {opacity: 1, y: 0} : {}}
           transition={{delay: 0.4, duration: 0.6}}>
-          {t((m) => m.Acknowledgements.hero.subtitle)}
+          {t((m) => m.sections.legal.acknowledgements.hero.subtitle)}
         </motion.p>
 
         {/* Last updated */}
@@ -95,7 +95,7 @@ export default function Hero({lastUpdatedDate}: Readonly<Props>): React.JSX.Elem
           animate={isInView ? {opacity: 1} : {}}
           transition={{delay: 0.6, duration: 0.5}}>
           <TbPackage className={styles["lastUpdatedIcon"]} />
-          <span>{t((m) => m.Acknowledgements.hero.lastUpdate, {date: lastUpdatedDate})}</span>
+          <span>{t((m) => m.sections.legal.acknowledgements.hero.lastUpdate, {date: lastUpdatedDate})}</span>
         </motion.div>
       </motion.div>
     </section>

--- a/sites/arolariu.ro/src/app/(privacy-and-terms)/acknowledgements/_components/LicenseBreakdown.tsx
+++ b/sites/arolariu.ro/src/app/(privacy-and-terms)/acknowledgements/_components/LicenseBreakdown.tsx
@@ -46,7 +46,7 @@ export default function LicenseBreakdown({packages}: Readonly<Props>): React.JSX
           animate={isInView ? {opacity: 1, y: 0} : {}}
           transition={{duration: 0.6}}>
           <h2 className={styles["title"]}>
-            <span className={styles["titleGradient"]}>{t((m) => m.Acknowledgements.licenses.title)}</span>
+            <span className={styles["titleGradient"]}>{t((m) => m.sections.legal.acknowledgements.licenses.title)}</span>
           </h2>
         </motion.div>
 
@@ -64,8 +64,8 @@ export default function LicenseBreakdown({packages}: Readonly<Props>): React.JSX
                     <TbLicense className={styles["icon"]} />
                   </div>
                   <div className={styles["licenseInfo"]}>
-                    <h3 className={styles["licenseName"]}>{t((m) => m.Acknowledgements.licenses.mit)}</h3>
-                    <p className={styles["packageCount"]}>{t((m) => m.Acknowledgements.licenses.packages, {count: mitCount})}</p>
+                    <h3 className={styles["licenseName"]}>{t((m) => m.sections.legal.acknowledgements.licenses.mit)}</h3>
+                    <p className={styles["packageCount"]}>{t((m) => m.sections.legal.acknowledgements.licenses.packages, {count: mitCount})}</p>
                   </div>
                 </div>
 
@@ -80,7 +80,7 @@ export default function LicenseBreakdown({packages}: Readonly<Props>): React.JSX
                 </div>
 
                 <div className={styles["cardFooter"]}>
-                  <span className={styles["description"]}>{t((m) => m.Acknowledgements.licenses.mitDescription)}</span>
+                  <span className={styles["description"]}>{t((m) => m.sections.legal.acknowledgements.licenses.mitDescription)}</span>
                   <span className={styles["percentage"]}>{mitPercentage}%</span>
                 </div>
               </CardContent>
@@ -99,8 +99,8 @@ export default function LicenseBreakdown({packages}: Readonly<Props>): React.JSX
                     <TbScale className={styles["icon"]} />
                   </div>
                   <div className={styles["licenseInfo"]}>
-                    <h3 className={styles["licenseName"]}>{t((m) => m.Acknowledgements.licenses.apache)}</h3>
-                    <p className={styles["packageCount"]}>{t((m) => m.Acknowledgements.licenses.packages, {count: apacheCount})}</p>
+                    <h3 className={styles["licenseName"]}>{t((m) => m.sections.legal.acknowledgements.licenses.apache)}</h3>
+                    <p className={styles["packageCount"]}>{t((m) => m.sections.legal.acknowledgements.licenses.packages, {count: apacheCount})}</p>
                   </div>
                 </div>
 
@@ -115,7 +115,7 @@ export default function LicenseBreakdown({packages}: Readonly<Props>): React.JSX
                 </div>
 
                 <div className={styles["cardFooter"]}>
-                  <span className={styles["description"]}>{t((m) => m.Acknowledgements.licenses.apacheDescription)}</span>
+                  <span className={styles["description"]}>{t((m) => m.sections.legal.acknowledgements.licenses.apacheDescription)}</span>
                   <span className={styles["percentage"]}>{apachePercentage}%</span>
                 </div>
               </CardContent>
@@ -134,8 +134,8 @@ export default function LicenseBreakdown({packages}: Readonly<Props>): React.JSX
                     <TbCopyright className={styles["icon"]} />
                   </div>
                   <div className={styles["licenseInfo"]}>
-                    <h3 className={styles["licenseName"]}>{t((m) => m.Acknowledgements.licenses.gpl)}</h3>
-                    <p className={styles["packageCount"]}>{t((m) => m.Acknowledgements.licenses.packages, {count: gplCount})}</p>
+                    <h3 className={styles["licenseName"]}>{t((m) => m.sections.legal.acknowledgements.licenses.gpl)}</h3>
+                    <p className={styles["packageCount"]}>{t((m) => m.sections.legal.acknowledgements.licenses.packages, {count: gplCount})}</p>
                   </div>
                 </div>
 
@@ -150,7 +150,7 @@ export default function LicenseBreakdown({packages}: Readonly<Props>): React.JSX
                 </div>
 
                 <div className={styles["cardFooter"]}>
-                  <span className={styles["description"]}>{t((m) => m.Acknowledgements.licenses.gplDescription)}</span>
+                  <span className={styles["description"]}>{t((m) => m.sections.legal.acknowledgements.licenses.gplDescription)}</span>
                   <span className={styles["percentage"]}>{gplPercentage}%</span>
                 </div>
               </CardContent>
@@ -169,8 +169,8 @@ export default function LicenseBreakdown({packages}: Readonly<Props>): React.JSX
                     <TbInfoCircle className={styles["icon"]} />
                   </div>
                   <div className={styles["licenseInfo"]}>
-                    <h3 className={styles["licenseName"]}>{t((m) => m.Acknowledgements.licenses.other)}</h3>
-                    <p className={styles["packageCount"]}>{t((m) => m.Acknowledgements.licenses.packages, {count: otherCount})}</p>
+                    <h3 className={styles["licenseName"]}>{t((m) => m.sections.legal.acknowledgements.licenses.other)}</h3>
+                    <p className={styles["packageCount"]}>{t((m) => m.sections.legal.acknowledgements.licenses.packages, {count: otherCount})}</p>
                   </div>
                 </div>
 
@@ -185,7 +185,7 @@ export default function LicenseBreakdown({packages}: Readonly<Props>): React.JSX
                 </div>
 
                 <div className={styles["cardFooter"]}>
-                  <span className={styles["description"]}>{t((m) => m.Acknowledgements.licenses.otherDescription)}</span>
+                  <span className={styles["description"]}>{t((m) => m.sections.legal.acknowledgements.licenses.otherDescription)}</span>
                   <span className={styles["percentage"]}>{otherPercentage}%</span>
                 </div>
               </CardContent>

--- a/sites/arolariu.ro/src/app/(privacy-and-terms)/acknowledgements/_components/PackagesScreen.tsx
+++ b/sites/arolariu.ro/src/app/(privacy-and-terms)/acknowledgements/_components/PackagesScreen.tsx
@@ -60,24 +60,24 @@ function DependenciesDialog({pkg}: Readonly<{pkg: NodePackageInformation}>): Rea
           <Button
             variant='outline'
             size='sm'>
-            {t((m) => m.Acknowledgements.packagesScreen.card.viewDependencies)}
+            {t((m) => m.sections.legal.acknowledgements.packagesScreen.card.viewDependencies)}
           </Button>
         }
       />
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
-          <DialogTitle>{t((m) => m.Acknowledgements.packagesScreen.dialog.dependencies, {name: pkg.name})}</DialogTitle>
+          <DialogTitle>{t((m) => m.sections.legal.acknowledgements.packagesScreen.dialog.dependencies, {name: pkg.name})}</DialogTitle>
           <DialogDescription>
             {pkg.description} <br /> <br />
-            {t((m) => m.Acknowledgements.packagesScreen.dialog.dependenciesCount, {count: String(pkg.dependents?.length ?? 0)})}
+            {t((m) => m.sections.legal.acknowledgements.packagesScreen.dialog.dependenciesCount, {count: String(pkg.dependents?.length ?? 0)})}
           </DialogDescription>
         </DialogHeader>
         <div className={styles["dialogScrollArea"]}>
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead>{t((m) => m.Acknowledgements.packagesScreen.table.package)}</TableHead>
-                <TableHead>{t((m) => m.Acknowledgements.packagesScreen.table.version)}</TableHead>
+                <TableHead>{t((m) => m.sections.legal.acknowledgements.packagesScreen.table.package)}</TableHead>
+                <TableHead>{t((m) => m.sections.legal.acknowledgements.packagesScreen.table.version)}</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -153,7 +153,7 @@ export default function PackagesScreen({packages}: Readonly<Props>): React.JSX.E
         <div className={styles["searchContainer"]}>
           <Input
             type='text'
-            placeholder={t((m) => m.Acknowledgements.packagesScreen.search.placeholder)}
+            placeholder={t((m) => m.sections.legal.acknowledgements.packagesScreen.search.placeholder)}
             value={searchQuery}
             onChange={handleSearch}
             className={styles["searchInput"]}
@@ -165,12 +165,12 @@ export default function PackagesScreen({packages}: Readonly<Props>): React.JSX.E
               value={packageType}
               onValueChange={handlePackageType}>
               <SelectTrigger>
-                <SelectValue placeholder={t((m) => m.Acknowledgements.packagesScreen.filters.filterByType)} />
+                <SelectValue placeholder={t((m) => m.sections.legal.acknowledgements.packagesScreen.filters.filterByType)} />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value='all'>{t((m) => m.Acknowledgements.packagesScreen.filters.allPackages)}</SelectItem>
-                <SelectItem value='production'>{t((m) => m.Acknowledgements.packagesScreen.filters.productionOnly)}</SelectItem>
-                <SelectItem value='development'>{t((m) => m.Acknowledgements.packagesScreen.filters.developmentOnly)}</SelectItem>
+                <SelectItem value='all'>{t((m) => m.sections.legal.acknowledgements.packagesScreen.filters.allPackages)}</SelectItem>
+                <SelectItem value='production'>{t((m) => m.sections.legal.acknowledgements.packagesScreen.filters.productionOnly)}</SelectItem>
+                <SelectItem value='development'>{t((m) => m.sections.legal.acknowledgements.packagesScreen.filters.developmentOnly)}</SelectItem>
               </SelectContent>
             </Select>
           </div>
@@ -180,12 +180,12 @@ export default function PackagesScreen({packages}: Readonly<Props>): React.JSX.E
               value={sortField}
               onValueChange={handleSortField}>
               <SelectTrigger>
-                <SelectValue placeholder={t((m) => m.Acknowledgements.packagesScreen.filters.sortBy)} />
+                <SelectValue placeholder={t((m) => m.sections.legal.acknowledgements.packagesScreen.filters.sortBy)} />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value='name'>{t((m) => m.Acknowledgements.packagesScreen.filters.name)}</SelectItem>
-                <SelectItem value='dependencies'>{t((m) => m.Acknowledgements.packagesScreen.filters.dependenciesCount)}</SelectItem>
-                <SelectItem value='type'>{t((m) => m.Acknowledgements.packagesScreen.filters.packageType)}</SelectItem>
+                <SelectItem value='name'>{t((m) => m.sections.legal.acknowledgements.packagesScreen.filters.name)}</SelectItem>
+                <SelectItem value='dependencies'>{t((m) => m.sections.legal.acknowledgements.packagesScreen.filters.dependenciesCount)}</SelectItem>
+                <SelectItem value='type'>{t((m) => m.sections.legal.acknowledgements.packagesScreen.filters.packageType)}</SelectItem>
               </SelectContent>
             </Select>
           </div>
@@ -195,11 +195,11 @@ export default function PackagesScreen({packages}: Readonly<Props>): React.JSX.E
               value={sortDirection}
               onValueChange={handleSortDirection}>
               <SelectTrigger>
-                <SelectValue placeholder={t((m) => m.Acknowledgements.packagesScreen.filters.sortDirection)} />
+                <SelectValue placeholder={t((m) => m.sections.legal.acknowledgements.packagesScreen.filters.sortDirection)} />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value='asc'>{t((m) => m.Acknowledgements.packagesScreen.filters.ascending)}</SelectItem>
-                <SelectItem value='desc'>{t((m) => m.Acknowledgements.packagesScreen.filters.descending)}</SelectItem>
+                <SelectItem value='asc'>{t((m) => m.sections.legal.acknowledgements.packagesScreen.filters.ascending)}</SelectItem>
+                <SelectItem value='desc'>{t((m) => m.sections.legal.acknowledgements.packagesScreen.filters.descending)}</SelectItem>
               </SelectContent>
             </Select>
           </div>
@@ -210,8 +210,8 @@ export default function PackagesScreen({packages}: Readonly<Props>): React.JSX.E
         defaultValue='grid'
         className={styles["tabsContainer"]}>
         <TabsList className={styles["tabsList"]}>
-          <TabsTrigger value='grid'>{t((m) => m.Acknowledgements.packagesScreen.views.gridView)}</TabsTrigger>
-          <TabsTrigger value='table'>{t((m) => m.Acknowledgements.packagesScreen.views.tableView)}</TabsTrigger>
+          <TabsTrigger value='grid'>{t((m) => m.sections.legal.acknowledgements.packagesScreen.views.gridView)}</TabsTrigger>
+          <TabsTrigger value='table'>{t((m) => m.sections.legal.acknowledgements.packagesScreen.views.tableView)}</TabsTrigger>
         </TabsList>
 
         <div className={styles["tabsContentWrapper"]}>
@@ -228,7 +228,7 @@ export default function PackagesScreen({packages}: Readonly<Props>): React.JSX.E
                     transition={{duration: 0.3, delay: index * 0.1}}>
                     <Card className={styles["packageCard"]}>
                       <div className={extractPackageType(pkg) === "production" ? styles["productionBanner"] : styles["developmentBanner"]}>
-                        {extractPackageType(pkg) === "production" ? t((m) => m.Acknowledgements.packagesScreen.badge.production) : t((m) => m.Acknowledgements.packagesScreen.badge.development)}
+                        {extractPackageType(pkg) === "production" ? t((m) => m.sections.legal.acknowledgements.packagesScreen.badge.production) : t((m) => m.sections.legal.acknowledgements.packagesScreen.badge.development)}
                       </div>
                       <CardHeader>
                         <div className={styles["cardHeaderRow"]}>
@@ -241,11 +241,11 @@ export default function PackagesScreen({packages}: Readonly<Props>): React.JSX.E
                         <div className={styles["cardDetails"]}>
                           <div className={styles["detailsContent"]}>
                             <div className={styles["detailRow"]}>
-                              <span className={styles["detailLabel"]}>{t((m) => m.Acknowledgements.packagesScreen.card.license)}</span> {pkg.license}
+                              <span className={styles["detailLabel"]}>{t((m) => m.sections.legal.acknowledgements.packagesScreen.card.license)}</span> {pkg.license}
                             </div>
                             <div className={styles["detailRow"]}>
                               <span className={styles["detailLabel"]}>
-                                {t((m) => m.Acknowledgements.packagesScreen.card.dependencies)} {pkg.dependents?.length ?? "N/A"}
+                                {t((m) => m.sections.legal.acknowledgements.packagesScreen.card.dependencies)} {pkg.dependents?.length ?? "N/A"}
                               </span>
                             </div>
                           </div>
@@ -256,7 +256,7 @@ export default function PackagesScreen({packages}: Readonly<Props>): React.JSX.E
                               rel='noopener noreferrer'
                               className={styles["websiteLink"]}>
                               <TbExternalLink className={styles["linkIcon"]} />
-                              <span>{t((m) => m.Acknowledgements.packagesScreen.card.website)}</span>
+                              <span>{t((m) => m.sections.legal.acknowledgements.packagesScreen.card.website)}</span>
                             </a>
                             <DependenciesDialog pkg={pkg} />
                           </div>
@@ -269,8 +269,8 @@ export default function PackagesScreen({packages}: Readonly<Props>): React.JSX.E
             ) : (
               <div className={styles["emptyState"]}>
                 <TbPackage className={styles["emptyIcon"]} />
-                <p className={styles["emptyText"]}>{t((m) => m.Acknowledgements.packagesScreen.emptyState.title)}</p>
-                <p className={styles["emptyText"]}>{t((m) => m.Acknowledgements.packagesScreen.emptyState.subtitle)}</p>
+                <p className={styles["emptyText"]}>{t((m) => m.sections.legal.acknowledgements.packagesScreen.emptyState.title)}</p>
+                <p className={styles["emptyText"]}>{t((m) => m.sections.legal.acknowledgements.packagesScreen.emptyState.subtitle)}</p>
               </div>
             )}
           </TabsContent>
@@ -285,13 +285,13 @@ export default function PackagesScreen({packages}: Readonly<Props>): React.JSX.E
                 <Table>
                   <TableHeader>
                     <TableRow>
-                      <TableHead>{t((m) => m.Acknowledgements.packagesScreen.table.package)}</TableHead>
-                      <TableHead className={styles["hiddenMd"]}>{t((m) => m.Acknowledgements.packagesScreen.table.version)}</TableHead>
-                      <TableHead className={styles["hiddenMd"]}>{t((m) => m.Acknowledgements.packagesScreen.table.type)}</TableHead>
-                      <TableHead className={styles["hiddenLg"]}>{t((m) => m.Acknowledgements.packagesScreen.table.description)}</TableHead>
-                      <TableHead className={styles["hiddenXl"]}>{t((m) => m.Acknowledgements.packagesScreen.table.license)}</TableHead>
-                      <TableHead className={styles["hiddenSm"]}>{t((m) => m.Acknowledgements.packagesScreen.table.dependencies)}</TableHead>
-                      <TableHead>{t((m) => m.Acknowledgements.packagesScreen.table.website)}</TableHead>
+                      <TableHead>{t((m) => m.sections.legal.acknowledgements.packagesScreen.table.package)}</TableHead>
+                      <TableHead className={styles["hiddenMd"]}>{t((m) => m.sections.legal.acknowledgements.packagesScreen.table.version)}</TableHead>
+                      <TableHead className={styles["hiddenMd"]}>{t((m) => m.sections.legal.acknowledgements.packagesScreen.table.type)}</TableHead>
+                      <TableHead className={styles["hiddenLg"]}>{t((m) => m.sections.legal.acknowledgements.packagesScreen.table.description)}</TableHead>
+                      <TableHead className={styles["hiddenXl"]}>{t((m) => m.sections.legal.acknowledgements.packagesScreen.table.license)}</TableHead>
+                      <TableHead className={styles["hiddenSm"]}>{t((m) => m.sections.legal.acknowledgements.packagesScreen.table.dependencies)}</TableHead>
+                      <TableHead>{t((m) => m.sections.legal.acknowledgements.packagesScreen.table.website)}</TableHead>
                     </TableRow>
                   </TableHeader>
                   <TableBody>
@@ -300,7 +300,7 @@ export default function PackagesScreen({packages}: Readonly<Props>): React.JSX.E
                         <TableCell className={styles["packageName"]}>{pkg.name}</TableCell>
                         <TableCell className={styles["hiddenMd"]}>{pkg.version}</TableCell>
                         <TableCell className={styles["hiddenMd"]}>
-                          {extractPackageType(pkg) === "production" ? t((m) => m.Acknowledgements.packagesScreen.badge.production) : t((m) => m.Acknowledgements.packagesScreen.badge.development)}
+                          {extractPackageType(pkg) === "production" ? t((m) => m.sections.legal.acknowledgements.packagesScreen.badge.production) : t((m) => m.sections.legal.acknowledgements.packagesScreen.badge.development)}
                         </TableCell>
                         <TableCell className={styles["hiddenLg"]}>
                           <p className={styles["descriptionText"]}>{pkg.description}</p>
@@ -315,9 +315,9 @@ export default function PackagesScreen({packages}: Readonly<Props>): React.JSX.E
                             target='_blank'
                             rel='noopener noreferrer'
                             className={styles["tableLink"]}
-                            title={t((m) => m.Acknowledgements.packagesScreen.table.website)}>
+                            title={t((m) => m.sections.legal.acknowledgements.packagesScreen.table.website)}>
                             <TbExternalLink className={styles["tableLinkIcon"]} />
-                            <span className={styles["srOnly"]}>{t((m) => m.Acknowledgements.packagesScreen.table.website)}</span>
+                            <span className={styles["srOnly"]}>{t((m) => m.sections.legal.acknowledgements.packagesScreen.table.website)}</span>
                           </a>
                         </TableCell>
                       </TableRow>
@@ -328,8 +328,8 @@ export default function PackagesScreen({packages}: Readonly<Props>): React.JSX.E
             ) : (
               <div className={styles["emptyState"]}>
                 <TbPackage className={styles["emptyIcon"]} />
-                <p className={styles["emptyText"]}>{t((m) => m.Acknowledgements.packagesScreen.emptyState.title)}</p>
-                <p className={styles["emptyText"]}>{t((m) => m.Acknowledgements.packagesScreen.emptyState.subtitle)}</p>
+                <p className={styles["emptyText"]}>{t((m) => m.sections.legal.acknowledgements.packagesScreen.emptyState.title)}</p>
+                <p className={styles["emptyText"]}>{t((m) => m.sections.legal.acknowledgements.packagesScreen.emptyState.subtitle)}</p>
               </div>
             )}
           </TabsContent>
@@ -343,9 +343,9 @@ export default function PackagesScreen({packages}: Readonly<Props>): React.JSX.E
         className={styles["footer"]}>
         <div className={styles["footerHeader"]}>
           <TbPackage className={styles["footerIcon"]} />
-          <h2 className={styles["footerTitle"]}>{t((m) => m.Acknowledgements.packagesScreen.openSource.title)}</h2>
+          <h2 className={styles["footerTitle"]}>{t((m) => m.sections.legal.acknowledgements.packagesScreen.openSource.title)}</h2>
         </div>
-        <p className={styles["footerDescription"]}>{t((m) => m.Acknowledgements.packagesScreen.openSource.description)}</p>
+        <p className={styles["footerDescription"]}>{t((m) => m.sections.legal.acknowledgements.packagesScreen.openSource.description)}</p>
       </motion.div>
     </div>
   );

--- a/sites/arolariu.ro/src/app/(privacy-and-terms)/acknowledgements/_components/Stats.tsx
+++ b/sites/arolariu.ro/src/app/(privacy-and-terms)/acknowledgements/_components/Stats.tsx
@@ -64,9 +64,9 @@ export default function Stats({packages}: Readonly<Props>): React.JSX.Element {
           animate={isInView ? {opacity: 1, y: 0} : {}}
           transition={{duration: 0.6}}>
           <h2 className={styles["title"]}>
-            <span className={styles["titleGradient"]}>{t((m) => m.Acknowledgements.stats.title)}</span>
+            <span className={styles["titleGradient"]}>{t((m) => m.sections.legal.acknowledgements.stats.title)}</span>
           </h2>
-          <p className={styles["subtitle"]}>{t((m) => m.Acknowledgements.stats.subtitle)}</p>
+          <p className={styles["subtitle"]}>{t((m) => m.sections.legal.acknowledgements.stats.subtitle)}</p>
         </motion.div>
 
         {/* Stats grid */}

--- a/sites/arolariu.ro/src/app/(privacy-and-terms)/acknowledgements/island.tsx
+++ b/sites/arolariu.ro/src/app/(privacy-and-terms)/acknowledgements/island.tsx
@@ -68,9 +68,9 @@ export default function RenderAcknowledgementsScreen({packages, lastUpdatedDate}
       <section className={styles["packagesSection"]}>
         <div className={styles["packagesSectionHeader"]}>
           <h2 className={styles["packagesTitle"]}>
-            <span className={styles["packagesTitleGradient"]}>{t((m) => m.Acknowledgements.packages.title)}</span>
+            <span className={styles["packagesTitleGradient"]}>{t((m) => m.sections.legal.acknowledgements.packages.title)}</span>
           </h2>
-          <p className={styles["packagesSubtitle"]}>{t((m) => m.Acknowledgements.packages.subtitle)}</p>
+          <p className={styles["packagesSubtitle"]}>{t((m) => m.sections.legal.acknowledgements.packages.subtitle)}</p>
         </div>
         <PackagesScreen packages={packages} />
       </section>

--- a/sites/arolariu.ro/src/app/(privacy-and-terms)/acknowledgements/layout.tsx
+++ b/sites/arolariu.ro/src/app/(privacy-and-terms)/acknowledgements/layout.tsx
@@ -53,8 +53,8 @@ export async function generateMetadata(): Promise<Metadata> {
   const locale = await getLocale();
   return createMetadata({
     locale,
-    title: t((m) => m.Acknowledgements.metadata.title),
-    description: t((m) => m.Acknowledgements.metadata.description),
+    title: t((m) => m.pages.legal.acknowledgements.metadata.title),
+    description: t((m) => m.pages.legal.acknowledgements.metadata.description),
   });
 }
 

--- a/sites/arolariu.ro/src/app/(privacy-and-terms)/privacy-policy/island.stories.tsx
+++ b/sites/arolariu.ro/src/app/(privacy-and-terms)/privacy-policy/island.stories.tsx
@@ -4,7 +4,7 @@ import RenderPrivacyPolicyScreen from "./island";
 /**
  * Client island for the Privacy Policy page.
  * Delegates rendering to `EnhancedLegalArticles` configured with
- * `pageType="Legal.PrivacyPolicy"`. Renders 19 legal article sections
+ * `pageType="sections.legal.privacyPolicy"`. Renders 19 legal article sections
  * covering data collection, processing, cookies, children's privacy,
  * and user rights.
  */

--- a/sites/arolariu.ro/src/app/(privacy-and-terms)/privacy-policy/island.tsx
+++ b/sites/arolariu.ro/src/app/(privacy-and-terms)/privacy-policy/island.tsx
@@ -31,5 +31,5 @@ import EnhancedLegalArticles from "../_components/EnhancedLegalArticles";
  * ```
  */
 export default function RenderPrivacyPolicyScreen(): React.JSX.Element {
-  return <EnhancedLegalArticles pageType='Legal.PrivacyPolicy' />;
+  return <EnhancedLegalArticles pageType='sections.legal.privacyPolicy' />;
 }

--- a/sites/arolariu.ro/src/app/(privacy-and-terms)/privacy-policy/page.tsx
+++ b/sites/arolariu.ro/src/app/(privacy-and-terms)/privacy-policy/page.tsx
@@ -58,8 +58,8 @@ export async function generateMetadata(): Promise<Metadata> {
   const locale = await getLocale();
   return createMetadata({
     locale,
-    title: t((m) => m.Legal.PrivacyPolicy.metadata.title),
-    description: t((m) => m.Legal.PrivacyPolicy.metadata.description),
+    title: t((m) => m.pages.legal.privacyPolicy.metadata.title),
+    description: t((m) => m.pages.legal.privacyPolicy.metadata.description),
   });
 }
 
@@ -133,11 +133,11 @@ export default async function PrivacyPolicyHomepage(_props: Readonly<PageProps<"
   return (
     <div className={styles["privacyPolicyMain"]}>
       <section className={styles["headerSection"]}>
-        <h1 className={styles["pageTitle"]}>{t((m) => m.Legal.PrivacyPolicy.title)}</h1>
-        <span>{t((m) => m.Legal.PrivacyPolicy.last_updated)}</span>
+        <h1 className={styles["pageTitle"]}>{t((m) => m.sections.legal.privacyPolicy.title)}</h1>
+        <span>{t((m) => m.sections.legal.privacyPolicy.lastUpdated)}</span>
       </section>
       <RenderPrivacyPolicyScreen />
-      <section className={styles["footerSection"]}>{t((m) => m.Legal.PrivacyPolicy.contactInformation.content)}</section>
+      <section className={styles["footerSection"]}>{t((m) => m.sections.legal.privacyPolicy.contactInformation.content)}</section>
     </div>
   );
 }

--- a/sites/arolariu.ro/src/app/(privacy-and-terms)/privacy-policy/page.tsx
+++ b/sites/arolariu.ro/src/app/(privacy-and-terms)/privacy-policy/page.tsx
@@ -20,7 +20,7 @@ import styles from "./page.module.scss";
  * - SEO metadata ensures search engines index this critical legal document
  *
  * **Async Operations**:
- * - Fetches translations from `Legal.PrivacyPolicy.metadata` namespace
+ * - Fetches translations from `sections.legal.privacyPolicy.metadata` namespace
  * - Retrieves current locale for language-specific legal content
  *
  * **Metadata Generation**:

--- a/sites/arolariu.ro/src/app/(privacy-and-terms)/terms-of-service/island.stories.tsx
+++ b/sites/arolariu.ro/src/app/(privacy-and-terms)/terms-of-service/island.stories.tsx
@@ -4,7 +4,7 @@ import RenderTermsOfServiceScreen from "./island";
 /**
  * Client island for the Terms of Service page.
  * Delegates rendering to `EnhancedLegalArticles` configured with
- * `pageType="Legal.TermsOfService"`. Renders 23 legal article sections
+ * `pageType="sections.legal.termsOfService"`. Renders 23 legal article sections
  * covering license, restrictions, cookies, liability, and arbitration.
  */
 const meta = {

--- a/sites/arolariu.ro/src/app/(privacy-and-terms)/terms-of-service/island.tsx
+++ b/sites/arolariu.ro/src/app/(privacy-and-terms)/terms-of-service/island.tsx
@@ -32,5 +32,5 @@ import EnhancedLegalArticles from "../_components/EnhancedLegalArticles";
  * ```
  */
 export default function RenderTermsOfServiceScreen(): React.JSX.Element {
-  return <EnhancedLegalArticles pageType='Legal.TermsOfService' />;
+  return <EnhancedLegalArticles pageType='sections.legal.termsOfService' />;
 }

--- a/sites/arolariu.ro/src/app/(privacy-and-terms)/terms-of-service/page.tsx
+++ b/sites/arolariu.ro/src/app/(privacy-and-terms)/terms-of-service/page.tsx
@@ -21,7 +21,7 @@ import styles from "./page.module.scss";
  * - Proper SEO ensures users can find and reference terms when needed
  *
  * **Async Operations**:
- * - Fetches translations from `Legal.TermsOfService.metadata` namespace
+ * - Fetches translations from `sections.legal.termsOfService.metadata` namespace
  * - Retrieves current locale for language-specific legal content
  *
  * **Metadata Generation**:

--- a/sites/arolariu.ro/src/app/(privacy-and-terms)/terms-of-service/page.tsx
+++ b/sites/arolariu.ro/src/app/(privacy-and-terms)/terms-of-service/page.tsx
@@ -60,8 +60,8 @@ export async function generateMetadata(): Promise<Metadata> {
   const locale = await getLocale();
   return createMetadata({
     locale,
-    title: t((m) => m.Legal.TermsOfService.metadata.title),
-    description: t((m) => m.Legal.TermsOfService.metadata.description),
+    title: t((m) => m.pages.legal.termsOfService.metadata.title),
+    description: t((m) => m.pages.legal.termsOfService.metadata.description),
   });
 }
 
@@ -150,11 +150,11 @@ export default async function TermsOfServiceHomepage(_props: Readonly<PageProps<
   return (
     <div className={styles["termsOfServiceMain"]}>
       <section className={styles["headerSection"]}>
-        <h1 className={styles["pageTitle"]}>{t((m) => m.Legal.TermsOfService.title)}</h1>
-        <span>{t((m) => m.Legal.TermsOfService.last_updated)}</span>
+        <h1 className={styles["pageTitle"]}>{t((m) => m.sections.legal.termsOfService.title)}</h1>
+        <span>{t((m) => m.sections.legal.termsOfService.lastUpdated)}</span>
       </section>
       <RenderTermsOfServiceScreen />
-      <section className={styles["footerSection"]}>{t((m) => m.Legal.TermsOfService.contactInformation.content)}</section>
+      <section className={styles["footerSection"]}>{t((m) => m.sections.legal.termsOfService.contactInformation.content)}</section>
     </div>
   );
 }

--- a/sites/arolariu.ro/src/app/EULA.tsx
+++ b/sites/arolariu.ro/src/app/EULA.tsx
@@ -120,20 +120,20 @@ export default function Eula({locale}: Readonly<Props>): React.JSX.Element {
               <TbShield className={styles["shieldIconSvg"]} />
             </motion.div>
             <CardTitle>
-              <h1 className={styles["title"]}>{t((m) => m.EULA.title)}</h1>
+              <h1 className={styles["title"]}>{t((m) => m.pages.legal.eula.title)}</h1>
             </CardTitle>
-            <CardDescription className={styles["subtitle"]}>{t((m) => m.EULA.subtitle)}</CardDescription>
+            <CardDescription className={styles["subtitle"]}>{t((m) => m.pages.legal.eula.subtitle)}</CardDescription>
 
             <div className={styles["localePicker"]}>
               <Label
                 htmlFor='locale-select'
                 className={styles["localeLabel"]}>
                 <TbGlobe className={styles["globeIcon"]} />
-                {t((m) => m.EULA.language)}
+                {t((m) => m.pages.legal.eula.language)}
               </Label>
               <div className={styles["selectWrapper"]}>
                 <select
-                  title={t((m) => m.EULA.language)}
+                  title={t((m) => m.pages.legal.eula.language)}
                   id='locale-select'
                   defaultValue={locale}
                   onChange={handleLocaleChange}
@@ -157,7 +157,7 @@ export default function Eula({locale}: Readonly<Props>): React.JSX.Element {
               animate={{opacity: 1}}
               transition={{delay: 0.2}}
               className={styles["contentText"]}>
-              <span>{t((m) => m.EULA.content)}</span>
+              <span>{t((m) => m.pages.legal.eula.content)}</span>
             </motion.div>
 
             <div className={styles["policyGrid"]}>
@@ -168,25 +168,25 @@ export default function Eula({locale}: Readonly<Props>): React.JSX.Element {
                   <CardHeader className={styles["policyCardHeader"]}>
                     <CardTitle className={styles["policyCardTitle"]}>
                       <TbLock className={styles["policyIcon"]} />
-                      {t((m) => m.EULA.termsOfService.title)}
+                      {t((m) => m.pages.legal.eula.termsOfService.title)}
                     </CardTitle>
                   </CardHeader>
-                  <CardContent className={styles["policyCardContent"]}>{t((m) => m.EULA.termsOfService.subtitle)}</CardContent>
+                  <CardContent className={styles["policyCardContent"]}>{t((m) => m.pages.legal.eula.termsOfService.subtitle)}</CardContent>
                   <CardFooter>
                     <Dialog>
                       <DialogTrigger
                         render={
                           <Button
                             variant='outline'
-                            title={t((m) => m.EULA.termsOfService.cta)}
+                            title={t((m) => m.pages.legal.eula.termsOfService.cta)}
                             className={styles["policyButton"]}>
-                            {t((m) => m.EULA.termsOfService.cta)}
+                            {t((m) => m.pages.legal.eula.termsOfService.cta)}
                           </Button>
                         }
                       />
                       <DialogContent className={styles["dialogContent"]}>
                         <DialogHeader>
-                          <DialogTitle className={styles["dialogTitle"]}>{t((m) => m.EULA.termsOfService.cta)}</DialogTitle>
+                          <DialogTitle className={styles["dialogTitle"]}>{t((m) => m.pages.legal.eula.termsOfService.cta)}</DialogTitle>
                           <RenderTermsOfServiceScreen />
                         </DialogHeader>
                       </DialogContent>
@@ -202,25 +202,25 @@ export default function Eula({locale}: Readonly<Props>): React.JSX.Element {
                   <CardHeader className={styles["policyCardHeader"]}>
                     <CardTitle className={styles["policyCardTitle"]}>
                       <TbShield className={styles["policyIcon"]} />
-                      {t((m) => m.EULA.privacyPolicy.title)}
+                      {t((m) => m.pages.legal.eula.privacyPolicy.title)}
                     </CardTitle>
                   </CardHeader>
-                  <CardContent className={styles["policyCardContent"]}>{t((m) => m.EULA.privacyPolicy.subtitle)}</CardContent>
+                  <CardContent className={styles["policyCardContent"]}>{t((m) => m.pages.legal.eula.privacyPolicy.subtitle)}</CardContent>
                   <CardFooter>
                     <Dialog>
                       <DialogTrigger
                         render={
                           <Button
                             variant='outline'
-                            title={t((m) => m.EULA.privacyPolicy.cta)}
+                            title={t((m) => m.pages.legal.eula.privacyPolicy.cta)}
                             className={styles["policyButton"]}>
-                            {t((m) => m.EULA.privacyPolicy.cta)}
+                            {t((m) => m.pages.legal.eula.privacyPolicy.cta)}
                           </Button>
                         }
                       />
                       <DialogContent className={styles["dialogContent"]}>
                         <DialogHeader>
-                          <DialogTitle className={styles["dialogTitle"]}>{t((m) => m.EULA.privacyPolicy.cta)}</DialogTitle>
+                          <DialogTitle className={styles["dialogTitle"]}>{t((m) => m.pages.legal.eula.privacyPolicy.cta)}</DialogTitle>
                           <RenderPrivacyPolicyScreen />
                         </DialogHeader>
                       </DialogContent>
@@ -240,11 +240,11 @@ export default function Eula({locale}: Readonly<Props>): React.JSX.Element {
                 <div className={styles["cookiesHeader"]}>
                   <h3 className={styles["cookiesTitle"]}>
                     <TbCookie className={styles["cookieIcon"]} />
-                    {t((m) => m.EULA.cookiesPolicy.title)}
+                    {t((m) => m.pages.legal.eula.cookiesPolicy.title)}
                   </h3>
                 </div>
 
-                <span className={styles["cookiesSubtitle"]}>{t((m) => m.EULA.cookiesPolicy.subtitle)}</span>
+                <span className={styles["cookiesSubtitle"]}>{t((m) => m.pages.legal.eula.cookiesPolicy.subtitle)}</span>
 
                 <Accordion
                   type='single'
@@ -255,13 +255,13 @@ export default function Eula({locale}: Readonly<Props>): React.JSX.Element {
                     <AccordionTrigger className={styles["accordionTrigger"]}>
                       <div className={styles["accordionTriggerContent"]}>
                         <TbLock className={styles["accordionIcon"]} />
-                        <span>{t((m) => m.EULA.cookiesPolicy.cookies.essential.title)}</span>
+                        <span>{t((m) => m.pages.legal.eula.cookiesPolicy.cookies.essential.title)}</span>
                         <Badge className={styles["badgeRequired"]}>Required</Badge>
                       </div>
                     </AccordionTrigger>
                     <AccordionContent>
                       <div className={styles["accordionBody"]}>
-                        <p className={styles["accordionDescription"]}>{t((m) => m.EULA.cookiesPolicy.cookies.essential.description)}</p>
+                        <p className={styles["accordionDescription"]}>{t((m) => m.pages.legal.eula.cookiesPolicy.cookies.essential.description)}</p>
                         <div className={styles["switchRow"]}>
                           <Switch
                             nativeButton
@@ -272,7 +272,7 @@ export default function Eula({locale}: Readonly<Props>): React.JSX.Element {
                           <Label
                             htmlFor='essential'
                             className={styles["switchLabel"]}>
-                            {t((m) => m.EULA.cookiesPolicy.cookies.essential.checkbox)}
+                            {t((m) => m.pages.legal.eula.cookiesPolicy.cookies.essential.checkbox)}
                           </Label>
                         </div>
                       </div>
@@ -283,7 +283,7 @@ export default function Eula({locale}: Readonly<Props>): React.JSX.Element {
                     <AccordionTrigger className={styles["accordionTrigger"]}>
                       <div className={styles["accordionTriggerContent"]}>
                         <TbInfoCircleFilled className={styles["accordionIcon"]} />
-                        <span>{t((m) => m.EULA.cookiesPolicy.cookies.analytics.title)}</span>
+                        <span>{t((m) => m.pages.legal.eula.cookiesPolicy.cookies.analytics.title)}</span>
                         <Badge
                           className={styles["badgeOptional"]}
                           variant='outline'>
@@ -293,7 +293,7 @@ export default function Eula({locale}: Readonly<Props>): React.JSX.Element {
                     </AccordionTrigger>
                     <AccordionContent>
                       <div className={styles["accordionBody"]}>
-                        <p className={styles["accordionDescription"]}>{t((m) => m.EULA.cookiesPolicy.cookies.analytics.description)}</p>
+                        <p className={styles["accordionDescription"]}>{t((m) => m.pages.legal.eula.cookiesPolicy.cookies.analytics.description)}</p>
                         <div className={styles["switchRow"]}>
                           <Switch
                             nativeButton
@@ -304,7 +304,7 @@ export default function Eula({locale}: Readonly<Props>): React.JSX.Element {
                           <Label
                             htmlFor='analytics'
                             className={styles["switchLabel"]}>
-                            {t((m) => m.EULA.cookiesPolicy.cookies.analytics.checkbox)}
+                            {t((m) => m.pages.legal.eula.cookiesPolicy.cookies.analytics.checkbox)}
                           </Label>
                         </div>
                       </div>
@@ -324,10 +324,10 @@ export default function Eula({locale}: Readonly<Props>): React.JSX.Element {
                 onClick={handleAccept}
                 className={styles["acceptButton"]}
                 size='lg'>
-                <TbCheck className={styles["acceptIcon"]} /> {t((m) => m.EULA.accept)}
+                <TbCheck className={styles["acceptIcon"]} /> {t((m) => m.pages.legal.eula.accept)}
               </Button>
             </motion.div>
-            <p className={styles["footerNote"]}>{t((m) => m.EULA.content).split(".")[0]}.</p>
+            <p className={styles["footerNote"]}>{t((m) => m.pages.legal.eula.content).split(".")[0]}.</p>
           </CardFooter>
         </Card>
       </motion.div>

--- a/sites/arolariu.ro/src/app/_components/Features.tsx
+++ b/sites/arolariu.ro/src/app/_components/Features.tsx
@@ -19,33 +19,33 @@ export default function FeaturesSection(): React.JSX.Element {
   const features = [
     {
       icon: <TbBrandNextjs className={styles["cardIcon"]} />,
-      title: t((m) => m.Home.featuresTab.nextJs.title),
-      description: t((m) => m.Home.featuresTab.nextJs.description),
+      title: t((m) => m.pages.home.featuresTab.nextJs.title),
+      description: t((m) => m.pages.home.featuresTab.nextJs.description),
     },
     {
       icon: <TbBrandAzure className={styles["cardIcon"]} />,
-      title: t((m) => m.Home.featuresTab.azure.title),
-      description: t((m) => m.Home.featuresTab.azure.description),
+      title: t((m) => m.pages.home.featuresTab.azure.title),
+      description: t((m) => m.pages.home.featuresTab.azure.description),
     },
     {
       icon: <TbBrandCSharp className={styles["cardIcon"]} />,
-      title: t((m) => m.Home.featuresTab.csharp.title),
-      description: t((m) => m.Home.featuresTab.csharp.description),
+      title: t((m) => m.pages.home.featuresTab.csharp.title),
+      description: t((m) => m.pages.home.featuresTab.csharp.description),
     },
     {
       icon: <TbBrandSvelte className={styles["cardIcon"]} />,
-      title: t((m) => m.Home.featuresTab.svelte.title),
-      description: t((m) => m.Home.featuresTab.svelte.description),
+      title: t((m) => m.pages.home.featuresTab.svelte.title),
+      description: t((m) => m.pages.home.featuresTab.svelte.description),
     },
     {
       icon: <TbBinoculars className={styles["cardIcon"]} />,
-      title: t((m) => m.Home.featuresTab.otel.title),
-      description: t((m) => m.Home.featuresTab.otel.description),
+      title: t((m) => m.pages.home.featuresTab.otel.title),
+      description: t((m) => m.pages.home.featuresTab.otel.description),
     },
     {
       icon: <TbBrandGithub className={styles["cardIcon"]} />,
-      title: t((m) => m.Home.featuresTab.githubActions.title),
-      description: t((m) => m.Home.featuresTab.githubActions.description),
+      title: t((m) => m.pages.home.featuresTab.githubActions.title),
+      description: t((m) => m.pages.home.featuresTab.githubActions.description),
     },
   ] as const;
 
@@ -53,7 +53,7 @@ export default function FeaturesSection(): React.JSX.Element {
     <section className={styles["section"]}>
       <article className={styles["article"]}>
         <TypewriterTextSmooth
-          words={t((m) => m.Home.featuresTab.title)
+          words={t((m) => m.pages.home.featuresTab.title)
             .split(" ")
             .map((word) => ({
               text: word,
@@ -62,7 +62,7 @@ export default function FeaturesSection(): React.JSX.Element {
           className={styles["titleWrapper"]}
           cursorClassName={styles["cursorClass"]}
         />
-        <p className={styles["description"]}>{t((m) => m.Home.featuresTab.description)}</p>
+        <p className={styles["description"]}>{t((m) => m.pages.home.featuresTab.description)}</p>
 
         <div className={styles["grid"]}>
           {features.map((feature) => (
@@ -81,7 +81,7 @@ export default function FeaturesSection(): React.JSX.Element {
         <Link
           href='/about'
           className={styles["learnMoreLink"]}>
-          {t((m) => m.Home.featuresTab.learnMoreBtn)}
+          {t((m) => m.pages.home.featuresTab.learnMoreBtn)}
         </Link>
       </article>
     </section>

--- a/sites/arolariu.ro/src/app/_components/Hero.tsx
+++ b/sites/arolariu.ro/src/app/_components/Hero.tsx
@@ -27,7 +27,7 @@ export default function HeroSection(): React.JSX.Element {
           transition={{duration: 0.8, delay: 0.3}}
           className={styles["content"]}>
           <h1 className={styles["title"]}>
-            <span className={styles["titleGradient"]}>{t((m) => m.Home.title)}</span>
+            <span className={styles["titleGradient"]}>{t((m) => m.pages.home.title)}</span>
           </h1>
           <p className={styles["subtitle"]}>
             <RichText
@@ -41,13 +41,13 @@ export default function HeroSection(): React.JSX.Element {
               href='/domains'
               title=''
               className={styles["ctaButton"]}>
-              {t((m) => m.Home.cta)}
+              {t((m) => m.pages.home.cta)}
             </Link>
           </div>
 
           <div className={styles["appreciation"]}>
             <Separator className={styles["appreciationSeparator"]} />
-            <span className={styles["appreciationText"]}>{t((m) => m.Home.appreciation)}</span>
+            <span className={styles["appreciationText"]}>{t((m) => m.pages.home.appreciation)}</span>
           </div>
         </motion.div>
         {/* Right side */}

--- a/sites/arolariu.ro/src/app/_components/Technologies.tsx
+++ b/sites/arolariu.ro/src/app/_components/Technologies.tsx
@@ -17,15 +17,15 @@ export default function TechnologiesSection(): React.JSX.Element {
   const points = [
     {
       check: <TbCheck className={styles["checkIcon"]} />,
-      text: t((m) => m.Home.technologyTab.points.point1),
+      text: t((m) => m.pages.home.technologyTab.points.point1),
     },
     {
       check: <TbCheck className={styles["checkIcon"]} />,
-      text: t((m) => m.Home.technologyTab.points.point2),
+      text: t((m) => m.pages.home.technologyTab.points.point2),
     },
     {
       check: <TbCheck className={styles["checkIcon"]} />,
-      text: t((m) => m.Home.technologyTab.points.point3),
+      text: t((m) => m.pages.home.technologyTab.points.point3),
     },
   ];
 
@@ -40,9 +40,9 @@ export default function TechnologiesSection(): React.JSX.Element {
             viewport={{once: true}}
             transition={{duration: 0.8}}
             className={styles["content"]}>
-            <Badge className={styles["badge"]}>{t((m) => m.Home.technologyTab.badgeTitle)}</Badge>
-            <h2 className={styles["title"]}>{t((m) => m.Home.technologyTab.title)}</h2>
-            <span className={styles["description"]}>{t((m) => m.Home.technologyTab.description)}</span>
+            <Badge className={styles["badge"]}>{t((m) => m.pages.home.technologyTab.badgeTitle)}</Badge>
+            <h2 className={styles["title"]}>{t((m) => m.pages.home.technologyTab.title)}</h2>
+            <span className={styles["description"]}>{t((m) => m.pages.home.technologyTab.description)}</span>
             <ul className={styles["pointsList"]}>
               {points.map((point) => (
                 <li
@@ -54,7 +54,7 @@ export default function TechnologiesSection(): React.JSX.Element {
               ))}
             </ul>
             <Button className={styles["button"]}>
-              {t((m) => m.Home.technologyTab.learnMoreBtn)} <TbExternalLink className={styles["buttonIcon"]} />
+              {t((m) => m.pages.home.technologyTab.learnMoreBtn)} <TbExternalLink className={styles["buttonIcon"]} />
             </Button>
           </motion.div>
 

--- a/sites/arolariu.ro/src/app/about/_components/CallToAction.tsx
+++ b/sites/arolariu.ro/src/app/about/_components/CallToAction.tsx
@@ -61,9 +61,9 @@ export default function CallToAction(): React.JSX.Element {
           animate={isInView ? {opacity: 1, y: 0} : {}}
           transition={{duration: 0.6}}>
           <h2 className={styles["title"]}>
-            <span className={styles["titleGradient"]}>{t((m) => m.About.Hub.cta.title)}</span>
+            <span className={styles["titleGradient"]}>{t((m) => m.pages.about.hub.cta.title)}</span>
           </h2>
-          <p className={styles["subtitle"]}>{t((m) => m.About.Hub.cta.subtitle)}</p>
+          <p className={styles["subtitle"]}>{t((m) => m.pages.about.hub.cta.subtitle)}</p>
         </motion.div>
 
         {/* CTA buttons */}
@@ -81,7 +81,7 @@ export default function CallToAction(): React.JSX.Element {
               target='_blank'
               rel='noopener noreferrer'>
               <TbBrandGithub className={styles["ctaIcon"]} />
-              {t((m) => m.About.Hub.cta.primary)}
+              {t((m) => m.pages.about.hub.cta.primary)}
             </a>
           </Button>
           <Button
@@ -91,7 +91,7 @@ export default function CallToAction(): React.JSX.Element {
             className={styles["ctaButton"]}>
             <Link href='/about/the-author#contact'>
               <TbMail className={styles["ctaIcon"]} />
-              {t((m) => m.About.Hub.cta.secondary)}
+              {t((m) => m.pages.about.hub.cta.secondary)}
             </Link>
           </Button>
         </motion.div>
@@ -102,7 +102,7 @@ export default function CallToAction(): React.JSX.Element {
           initial={{opacity: 0}}
           animate={isInView ? {opacity: 1} : {}}
           transition={{delay: 0.4, duration: 0.5}}>
-          {t((m) => m.About.Hub.cta.footer)}
+          {t((m) => m.pages.about.hub.cta.footer)}
         </motion.p>
       </div>
     </section>

--- a/sites/arolariu.ro/src/app/about/_components/Faq.tsx
+++ b/sites/arolariu.ro/src/app/about/_components/Faq.tsx
@@ -35,8 +35,8 @@ export default function Faq(): React.JSX.Element {
               <TbQuestionMark className={styles["icon"]} />
             </div>
           </div>
-          <h2 className={styles["title"]}>{t((m) => m.About.Hub.faq.title)}</h2>
-          <p className={styles["subtitle"]}>{t((m) => m.About.Hub.faq.subtitle)}</p>
+          <h2 className={styles["title"]}>{t((m) => m.pages.about.hub.faq.title)}</h2>
+          <p className={styles["subtitle"]}>{t((m) => m.pages.about.hub.faq.subtitle)}</p>
         </motion.div>
 
         {/* Accordion */}

--- a/sites/arolariu.ro/src/app/about/_components/Hero.tsx
+++ b/sites/arolariu.ro/src/app/about/_components/Hero.tsx
@@ -79,7 +79,7 @@ export default function Hero(): React.JSX.Element {
             variant='secondary'
             className={styles["badge"]}>
             <TbSparkles className={styles["badgeIcon"]} />
-            {t((m) => m.About.Hub.hero.badge)}
+            {t((m) => m.pages.about.hub.hero.badge)}
           </Badge>
         </motion.div>
 
@@ -89,7 +89,7 @@ export default function Hero(): React.JSX.Element {
           initial={{y: 20}}
           animate={{y: 0}}
           transition={{delay: 0.3}}>
-          {t((m) => m.About.Hub.hero.title)}
+          {t((m) => m.pages.about.hub.hero.title)}
         </motion.h1>
 
         {/* Subtitle */}
@@ -98,7 +98,7 @@ export default function Hero(): React.JSX.Element {
           initial={{opacity: 0, y: 20}}
           animate={{opacity: 1, y: 0}}
           transition={{delay: 0.4}}>
-          {t((m) => m.About.Hub.hero.subtitle)}
+          {t((m) => m.pages.about.hub.hero.subtitle)}
         </motion.p>
 
         {/* CTA buttons */}
@@ -113,7 +113,7 @@ export default function Hero(): React.JSX.Element {
             className={styles["ctaButton"]}>
             <Link href='/about/the-platform'>
               <TbRocket className={styles["ctaIcon"]} />
-              {t((m) => m.About.Hub.hero.ctaPrimary)}
+              {t((m) => m.pages.about.hub.hero.ctaPrimary)}
             </Link>
           </Button>
           <Button
@@ -121,7 +121,7 @@ export default function Hero(): React.JSX.Element {
             variant='outline'
             size='lg'
             className={styles["ctaButton"]}>
-            <Link href='/about/the-author'>{t((m) => m.About.Hub.hero.ctaSecondary)}</Link>
+            <Link href='/about/the-author'>{t((m) => m.pages.about.hub.hero.ctaSecondary)}</Link>
           </Button>
         </motion.div>
       </motion.div>

--- a/sites/arolariu.ro/src/app/about/_components/Mission.tsx
+++ b/sites/arolariu.ro/src/app/about/_components/Mission.tsx
@@ -41,15 +41,15 @@ export default function Mission(): React.JSX.Element {
           initial={{opacity: 0, y: 20}}
           animate={isInView ? {opacity: 1, y: 0} : {}}
           transition={{duration: 0.6}}>
-          <h2 className={styles["title"]}>{t((m) => m.About.Hub.mission.title)}</h2>
+          <h2 className={styles["title"]}>{t((m) => m.pages.about.hub.mission.title)}</h2>
           <motion.p
             className={styles["statement"]}
             initial={{opacity: 0, scale: 0.95}}
             animate={isInView ? {opacity: 1, scale: 1} : {}}
             transition={{delay: 0.2, duration: 0.5}}>
-            {t((m) => m.About.Hub.mission.statement)}
+            {t((m) => m.pages.about.hub.mission.statement)}
           </motion.p>
-          <p className={styles["description"]}>{t((m) => m.About.Hub.mission.description)}</p>
+          <p className={styles["description"]}>{t((m) => m.pages.about.hub.mission.description)}</p>
         </motion.div>
 
         {/* Pillars grid */}

--- a/sites/arolariu.ro/src/app/about/_components/Navigation.tsx
+++ b/sites/arolariu.ro/src/app/about/_components/Navigation.tsx
@@ -49,8 +49,8 @@ export default function Navigation(): React.JSX.Element {
           initial={{opacity: 0, y: 20}}
           animate={isInView ? {opacity: 1, y: 0} : {}}
           transition={{duration: 0.6}}>
-          <h2 className={styles["title"]}>{t((m) => m.About.Hub.navigation.title)}</h2>
-          <p className={styles["subtitle"]}>{t((m) => m.About.Hub.navigation.subtitle)}</p>
+          <h2 className={styles["title"]}>{t((m) => m.pages.about.hub.navigation.title)}</h2>
+          <p className={styles["subtitle"]}>{t((m) => m.pages.about.hub.navigation.subtitle)}</p>
         </motion.div>
 
         {/* Navigation cards */}

--- a/sites/arolariu.ro/src/app/about/_components/Stats.tsx
+++ b/sites/arolariu.ro/src/app/about/_components/Stats.tsx
@@ -43,8 +43,8 @@ export default function Stats(): React.JSX.Element {
           initial={{opacity: 0, y: 20}}
           animate={isInView ? {opacity: 1, y: 0} : {}}
           transition={{duration: 0.6}}>
-          <h2 className={styles["title"]}>{t((m) => m.About.Hub.stats.title)}</h2>
-          <p className={styles["subtitle"]}>{t((m) => m.About.Hub.stats.subtitle)}</p>
+          <h2 className={styles["title"]}>{t((m) => m.pages.about.hub.stats.title)}</h2>
+          <p className={styles["subtitle"]}>{t((m) => m.pages.about.hub.stats.subtitle)}</p>
         </motion.div>
 
         {/* Stats grid */}

--- a/sites/arolariu.ro/src/app/about/_components/Values.tsx
+++ b/sites/arolariu.ro/src/app/about/_components/Values.tsx
@@ -47,8 +47,8 @@ export default function Values(): React.JSX.Element {
           initial={{opacity: 0, y: 20}}
           animate={isInView ? {opacity: 1, y: 0} : {}}
           transition={{duration: 0.6}}>
-          <h2 className={styles["title"]}>{t((m) => m.About.Hub.values.title)}</h2>
-          <p className={styles["subtitle"]}>{t((m) => m.About.Hub.values.subtitle)}</p>
+          <h2 className={styles["title"]}>{t((m) => m.pages.about.hub.values.title)}</h2>
+          <p className={styles["subtitle"]}>{t((m) => m.pages.about.hub.values.subtitle)}</p>
         </motion.div>
 
         {/* Values grid */}

--- a/sites/arolariu.ro/src/app/about/error.tsx
+++ b/sites/arolariu.ro/src/app/about/error.tsx
@@ -20,17 +20,17 @@ export default function AboutError({error, reset}: AboutErrorProps): React.JSX.E
       role='alert'
       aria-live='assertive'
       data-scope='about'>
-      <h1>{t((m) => m.Errors.globalError.hero.title)}</h1>
-      <p>{t((m) => m.Errors.globalError.hero.subtitle)}</p>
+      <h1>{t((m) => m.app.errors.globalError.hero.title)}</h1>
+      <p>{t((m) => m.app.errors.globalError.hero.subtitle)}</p>
       {error.digest ? (
         <p>
-          <span>{t((m) => m.Errors.globalError.details.errorIdLabel)}</span> <code>{error.digest}</code>
+          <span>{t((m) => m.app.errors.globalError.details.errorIdLabel)}</span> <code>{error.digest}</code>
         </p>
       ) : null}
       <button
         type='button'
         onClick={reset}>
-        {t((m) => m.Errors.globalError.buttons.tryAgain)}
+        {t((m) => m.app.errors.globalError.buttons.tryAgain)}
       </button>
     </section>
   );

--- a/sites/arolariu.ro/src/app/about/page.tsx
+++ b/sites/arolariu.ro/src/app/about/page.tsx
@@ -11,8 +11,8 @@ export async function generateMetadata(): Promise<Metadata> {
   const locale = await getLocale();
   return createMetadata({
     locale,
-    title: t((m) => m.About.metadata.title),
-    description: t((m) => m.About.metadata.description),
+    title: t((m) => m.shared.legacy.about.metadata.title),
+    description: t((m) => m.shared.legacy.about.metadata.description),
   });
 }
 

--- a/sites/arolariu.ro/src/app/about/the-author/_components/Biography.stories.tsx
+++ b/sites/arolariu.ro/src/app/about/the-author/_components/Biography.stories.tsx
@@ -5,7 +5,7 @@ import Biography from "./Biography";
  * Biography section with animated content blocks describing the author.
  * Features five bio points, each with a colored icon, animated gradient
  * background orbs, and staggered entrance animations.
- * Uses the `About.Author.Biography` i18n namespace.
+ * Uses the `sections.about.author.Biography` i18n namespace.
  */
 const meta = {
   title: "Pages/About/TheAuthor/Biography",

--- a/sites/arolariu.ro/src/app/about/the-author/_components/Biography.tsx
+++ b/sites/arolariu.ro/src/app/about/the-author/_components/Biography.tsx
@@ -51,27 +51,27 @@ export default function Biography(): React.JSX.Element {
     {
       key: "first",
       icon: <TbCode className={styles["iconBlue"]} />,
-      content: t((m) => m.About.Author.Biography.FirstPoint, {age: (new Date().getFullYear() - 2000).toString()}),
+      content: t((m) => m.sections.about.author.biography.firstPoint, {age: (new Date().getFullYear() - 2000).toString()}),
     },
     {
       key: "second",
       icon: <TbDeviceGamepad className={styles["iconGreen"]} />,
-      content: t((m) => m.About.Author.Biography.SecondPoint),
+      content: t((m) => m.sections.about.author.biography.secondPoint),
     },
     {
       key: "third",
       icon: <TbBulb className={styles["iconPurple"]} />,
-      content: t((m) => m.About.Author.Biography.ThirdPoint),
+      content: t((m) => m.sections.about.author.biography.thirdPoint),
     },
     {
       key: "fourth",
       icon: <TbBook className={styles["iconAmber"]} />,
-      content: t((m) => m.About.Author.Biography.FourthPoint),
+      content: t((m) => m.sections.about.author.biography.fourthPoint),
     },
     {
       key: "fifth",
       icon: <TbAntenna className={styles["iconPink"]} />,
-      content: t((m) => m.About.Author.Biography.FifthPoint),
+      content: t((m) => m.sections.about.author.biography.fifthPoint),
     },
   ];
 
@@ -105,7 +105,7 @@ export default function Biography(): React.JSX.Element {
         <motion.div
           variants={itemVariants}
           className={styles["header"]}>
-          <h2 className={`blue-underline ${styles["title"]}`}>{t((m) => m.About.Author.Biography.title)}</h2>
+          <h2 className={`blue-underline ${styles["title"]}`}>{t((m) => m.sections.about.author.biography.title)}</h2>
         </motion.div>
 
         <motion.div variants={itemVariants}>

--- a/sites/arolariu.ro/src/app/about/the-author/_components/Certifications.stories.tsx
+++ b/sites/arolariu.ro/src/app/about/the-author/_components/Certifications.stories.tsx
@@ -5,7 +5,7 @@ import Certifications from "./Certifications";
  * Certifications section showcasing professional certifications.
  * Displays interactive cards with certification details, core skills,
  * and external links. Currently shows AZ-900 and AI-900 certifications.
- * Uses the `About.Author.Certifications` i18n namespace.
+ * Uses the `sections.about.author.Certifications` i18n namespace.
  */
 const meta = {
   title: "Pages/About/TheAuthor/Certifications",

--- a/sites/arolariu.ro/src/app/about/the-author/_components/Certifications.tsx
+++ b/sites/arolariu.ro/src/app/about/the-author/_components/Certifications.tsx
@@ -43,100 +43,100 @@ export default function Certifications(): React.JSX.Element {
 
   const certifications = [
     {
-      name: t((m) => m.About.Author.Certifications.certificates.ab730.name),
-      code: t((m) => m.About.Author.Certifications.certificates.ab730.code),
-      issuer: t((m) => m.About.Author.Certifications.certificates.ab730.issuer),
-      issueDate: t((m) => m.About.Author.Certifications.certificates.ab730.issuerDate),
-      description: t((m) => m.About.Author.Certifications.certificates.ab730.description),
-      coreSkills: t((m) => m.About.Author.Certifications.certificates.ab730.coreSkills)
+      name: t((m) => m.sections.about.author.certifications.certificates.ab730.name),
+      code: t((m) => m.sections.about.author.certifications.certificates.ab730.code),
+      issuer: t((m) => m.sections.about.author.certifications.certificates.ab730.issuer),
+      issueDate: t((m) => m.sections.about.author.certifications.certificates.ab730.issuerDate),
+      description: t((m) => m.sections.about.author.certifications.certificates.ab730.description),
+      coreSkills: t((m) => m.sections.about.author.certifications.certificates.ab730.coreSkills)
         .split("#")
         .filter((skill) => skill.trim().length > 3),
       link: "https://learn.microsoft.com/en-us/credentials/certifications/ai-business-professional/",
     },
     {
-      name: t((m) => m.About.Author.Certifications.certificates.ab731.name),
-      code: t((m) => m.About.Author.Certifications.certificates.ab731.code),
-      issuer: t((m) => m.About.Author.Certifications.certificates.ab731.issuer),
-      issueDate: t((m) => m.About.Author.Certifications.certificates.ab731.issuerDate),
-      description: t((m) => m.About.Author.Certifications.certificates.ab731.description),
-      coreSkills: t((m) => m.About.Author.Certifications.certificates.ab731.coreSkills)
+      name: t((m) => m.sections.about.author.certifications.certificates.ab731.name),
+      code: t((m) => m.sections.about.author.certifications.certificates.ab731.code),
+      issuer: t((m) => m.sections.about.author.certifications.certificates.ab731.issuer),
+      issueDate: t((m) => m.sections.about.author.certifications.certificates.ab731.issuerDate),
+      description: t((m) => m.sections.about.author.certifications.certificates.ab731.description),
+      coreSkills: t((m) => m.sections.about.author.certifications.certificates.ab731.coreSkills)
         .split("#")
         .filter((skill) => skill.trim().length > 3),
       link: "https://learn.microsoft.com/en-us/credentials/certifications/ai-transformation-leader/",
     },
     {
-      name: t((m) => m.About.Author.Certifications.certificates.az900.name),
-      code: t((m) => m.About.Author.Certifications.certificates.az900.code),
-      issuer: t((m) => m.About.Author.Certifications.certificates.az900.issuer),
-      issueDate: t((m) => m.About.Author.Certifications.certificates.az900.issuerDate),
-      description: t((m) => m.About.Author.Certifications.certificates.az900.description),
-      coreSkills: t((m) => m.About.Author.Certifications.certificates.az900.coreSkills)
+      name: t((m) => m.sections.about.author.certifications.certificates.az900.name),
+      code: t((m) => m.sections.about.author.certifications.certificates.az900.code),
+      issuer: t((m) => m.sections.about.author.certifications.certificates.az900.issuer),
+      issueDate: t((m) => m.sections.about.author.certifications.certificates.az900.issuerDate),
+      description: t((m) => m.sections.about.author.certifications.certificates.az900.description),
+      coreSkills: t((m) => m.sections.about.author.certifications.certificates.az900.coreSkills)
         .split("#")
         .filter((skill) => skill.trim().length > 3),
       link: "https://learn.microsoft.com/en-us/certifications/azure-fundamentals/",
     },
     {
-      name: t((m) => m.About.Author.Certifications.certificates.ai900.name),
-      code: t((m) => m.About.Author.Certifications.certificates.ai900.code),
-      issuer: t((m) => m.About.Author.Certifications.certificates.ai900.issuer),
-      issueDate: t((m) => m.About.Author.Certifications.certificates.ai900.issuerDate),
-      description: t((m) => m.About.Author.Certifications.certificates.ai900.description),
-      coreSkills: t((m) => m.About.Author.Certifications.certificates.ai900.coreSkills)
+      name: t((m) => m.sections.about.author.certifications.certificates.ai900.name),
+      code: t((m) => m.sections.about.author.certifications.certificates.ai900.code),
+      issuer: t((m) => m.sections.about.author.certifications.certificates.ai900.issuer),
+      issueDate: t((m) => m.sections.about.author.certifications.certificates.ai900.issuerDate),
+      description: t((m) => m.sections.about.author.certifications.certificates.ai900.description),
+      coreSkills: t((m) => m.sections.about.author.certifications.certificates.ai900.coreSkills)
         .split("#")
         .filter((skill) => skill.trim().length > 3),
       link: "https://learn.microsoft.com/en-us/certifications/azure-ai-fundamentals/",
     },
     {
-      name: t((m) => m.About.Author.Certifications.certificates.sc900.name),
-      code: t((m) => m.About.Author.Certifications.certificates.sc900.code),
-      issuer: t((m) => m.About.Author.Certifications.certificates.sc900.issuer),
-      issueDate: t((m) => m.About.Author.Certifications.certificates.sc900.issuerDate),
-      description: t((m) => m.About.Author.Certifications.certificates.sc900.description),
-      coreSkills: t((m) => m.About.Author.Certifications.certificates.sc900.coreSkills)
+      name: t((m) => m.sections.about.author.certifications.certificates.sc900.name),
+      code: t((m) => m.sections.about.author.certifications.certificates.sc900.code),
+      issuer: t((m) => m.sections.about.author.certifications.certificates.sc900.issuer),
+      issueDate: t((m) => m.sections.about.author.certifications.certificates.sc900.issuerDate),
+      description: t((m) => m.sections.about.author.certifications.certificates.sc900.description),
+      coreSkills: t((m) => m.sections.about.author.certifications.certificates.sc900.coreSkills)
         .split("#")
         .filter((skill) => skill.trim().length > 3),
       link: "https://learn.microsoft.com/en-us/credentials/certifications/security-compliance-and-identity-fundamentals/",
     },
     {
-      name: t((m) => m.About.Author.Certifications.certificates.gh900.name),
-      code: t((m) => m.About.Author.Certifications.certificates.gh900.code),
-      issuer: t((m) => m.About.Author.Certifications.certificates.gh900.issuer),
-      issueDate: t((m) => m.About.Author.Certifications.certificates.gh900.issuerDate),
-      description: t((m) => m.About.Author.Certifications.certificates.gh900.description),
-      coreSkills: t((m) => m.About.Author.Certifications.certificates.gh900.coreSkills)
+      name: t((m) => m.sections.about.author.certifications.certificates.gh900.name),
+      code: t((m) => m.sections.about.author.certifications.certificates.gh900.code),
+      issuer: t((m) => m.sections.about.author.certifications.certificates.gh900.issuer),
+      issueDate: t((m) => m.sections.about.author.certifications.certificates.gh900.issuerDate),
+      description: t((m) => m.sections.about.author.certifications.certificates.gh900.description),
+      coreSkills: t((m) => m.sections.about.author.certifications.certificates.gh900.coreSkills)
         .split("#")
         .filter((skill) => skill.trim().length > 3),
       link: "https://learn.microsoft.com/en-us/credentials/certifications/github-foundations/",
     },
     {
-      name: t((m) => m.About.Author.Certifications.certificates.gh100.name),
-      code: t((m) => m.About.Author.Certifications.certificates.gh100.code),
-      issuer: t((m) => m.About.Author.Certifications.certificates.gh100.issuer),
-      issueDate: t((m) => m.About.Author.Certifications.certificates.gh100.issuerDate),
-      description: t((m) => m.About.Author.Certifications.certificates.gh100.description),
-      coreSkills: t((m) => m.About.Author.Certifications.certificates.gh100.coreSkills)
+      name: t((m) => m.sections.about.author.certifications.certificates.gh100.name),
+      code: t((m) => m.sections.about.author.certifications.certificates.gh100.code),
+      issuer: t((m) => m.sections.about.author.certifications.certificates.gh100.issuer),
+      issueDate: t((m) => m.sections.about.author.certifications.certificates.gh100.issuerDate),
+      description: t((m) => m.sections.about.author.certifications.certificates.gh100.description),
+      coreSkills: t((m) => m.sections.about.author.certifications.certificates.gh100.coreSkills)
         .split("#")
         .filter((skill) => skill.trim().length > 3),
       link: "https://learn.microsoft.com/en-us/credentials/certifications/github-administration/",
     },
     {
-      name: t((m) => m.About.Author.Certifications.certificates.gh200.name),
-      code: t((m) => m.About.Author.Certifications.certificates.gh200.code),
-      issuer: t((m) => m.About.Author.Certifications.certificates.gh200.issuer),
-      issueDate: t((m) => m.About.Author.Certifications.certificates.gh200.issuerDate),
-      description: t((m) => m.About.Author.Certifications.certificates.gh200.description),
-      coreSkills: t((m) => m.About.Author.Certifications.certificates.gh200.coreSkills)
+      name: t((m) => m.sections.about.author.certifications.certificates.gh200.name),
+      code: t((m) => m.sections.about.author.certifications.certificates.gh200.code),
+      issuer: t((m) => m.sections.about.author.certifications.certificates.gh200.issuer),
+      issueDate: t((m) => m.sections.about.author.certifications.certificates.gh200.issuerDate),
+      description: t((m) => m.sections.about.author.certifications.certificates.gh200.description),
+      coreSkills: t((m) => m.sections.about.author.certifications.certificates.gh200.coreSkills)
         .split("#")
         .filter((skill) => skill.trim().length > 3),
       link: "https://learn.microsoft.com/en-us/credentials/certifications/github-actions/",
     },
     {
-      name: t((m) => m.About.Author.Certifications.certificates.gh300.name),
-      code: t((m) => m.About.Author.Certifications.certificates.gh300.code),
-      issuer: t((m) => m.About.Author.Certifications.certificates.gh300.issuer),
-      issueDate: t((m) => m.About.Author.Certifications.certificates.gh300.issuerDate),
-      description: t((m) => m.About.Author.Certifications.certificates.gh300.description),
-      coreSkills: t((m) => m.About.Author.Certifications.certificates.gh300.coreSkills)
+      name: t((m) => m.sections.about.author.certifications.certificates.gh300.name),
+      code: t((m) => m.sections.about.author.certifications.certificates.gh300.code),
+      issuer: t((m) => m.sections.about.author.certifications.certificates.gh300.issuer),
+      issueDate: t((m) => m.sections.about.author.certifications.certificates.gh300.issuerDate),
+      description: t((m) => m.sections.about.author.certifications.certificates.gh300.description),
+      coreSkills: t((m) => m.sections.about.author.certifications.certificates.gh300.coreSkills)
         .split("#")
         .filter((skill) => skill.trim().length > 3),
       link: "https://learn.microsoft.com/en-us/credentials/certifications/github-copilot/",
@@ -153,8 +153,8 @@ export default function Certifications(): React.JSX.Element {
           animate={{opacity: 1, y: 0}}
           transition={{duration: 0.6}}
           className={styles["header"]}>
-          <h2 className={`blue-underline ${styles["title"]}`}>{t((m) => m.About.Author.Certifications.title)}</h2>
-          <p className={styles["subtitle"]}>{t((m) => m.About.Author.Certifications.subtitle)}</p>
+          <h2 className={`blue-underline ${styles["title"]}`}>{t((m) => m.sections.about.author.certifications.title)}</h2>
+          <p className={styles["subtitle"]}>{t((m) => m.sections.about.author.certifications.subtitle)}</p>
         </motion.div>
 
         <motion.div
@@ -195,7 +195,7 @@ export default function Certifications(): React.JSX.Element {
                   <p className={styles["description"]}>{cert.description}</p>
 
                   <div className={styles["skillsSection"]}>
-                    <h4 className={styles["skillsTitle"]}>{t((m) => m.About.Author.Certifications.coreSkillsLabel)}</h4>
+                    <h4 className={styles["skillsTitle"]}>{t((m) => m.sections.about.author.certifications.coreSkillsLabel)}</h4>
                     <div className={styles["skillsList"]}>
                       {cert.coreSkills.map((skill, i) => (
                         <motion.div
@@ -219,7 +219,7 @@ export default function Certifications(): React.JSX.Element {
                     rel='noopener noreferrer'
                     className={styles["viewLink"]}
                     whileHover={{x: 5}}>
-                    {t((m) => m.About.Author.Certifications.viewCertification)}
+                    {t((m) => m.sections.about.author.certifications.viewCertification)}
                     <TbExternalLink className={styles["viewLinkIcon"]} />
                   </motion.a>
                 </div>

--- a/sites/arolariu.ro/src/app/about/the-author/_components/Competencies.stories.tsx
+++ b/sites/arolariu.ro/src/app/about/the-author/_components/Competencies.stories.tsx
@@ -4,7 +4,7 @@ import Competencies from "./Competencies";
 /**
  * Competencies section displaying the author's professional skill set.
  * Renders six animated skill cards with icons, titles, and descriptions.
- * Uses the `About.Author.Competencies` i18n namespace.
+ * Uses the `sections.about.author.Competencies` i18n namespace.
  */
 const meta = {
   title: "Pages/About/TheAuthor/Competencies",

--- a/sites/arolariu.ro/src/app/about/the-author/_components/Competencies.tsx
+++ b/sites/arolariu.ro/src/app/about/the-author/_components/Competencies.tsx
@@ -35,34 +35,34 @@ export default function Competencies(): React.JSX.Element {
 
   const skills = [
     {
-      title: t((m) => m.About.Author.Competencies.competences.algorithmicSkills.title),
+      title: t((m) => m.sections.about.author.competencies.competences.algorithmicSkills.title),
       icon: <TbCalculator className={styles["icon"]} />,
-      description: t((m) => m.About.Author.Competencies.competences.algorithmicSkills.description),
+      description: t((m) => m.sections.about.author.competencies.competences.algorithmicSkills.description),
     },
     {
-      title: t((m) => m.About.Author.Competencies.competences.testDrivenDevelopment.title),
+      title: t((m) => m.sections.about.author.competencies.competences.testDrivenDevelopment.title),
       icon: <TbTestPipe className={styles["icon"]} />,
-      description: t((m) => m.About.Author.Competencies.competences.testDrivenDevelopment.description),
+      description: t((m) => m.sections.about.author.competencies.competences.testDrivenDevelopment.description),
     },
     {
-      title: t((m) => m.About.Author.Competencies.competences.domainDrivenDesign.title),
+      title: t((m) => m.sections.about.author.competencies.competences.domainDrivenDesign.title),
       icon: <TbBook2 className={styles["icon"]} />,
-      description: t((m) => m.About.Author.Competencies.competences.domainDrivenDesign.description),
+      description: t((m) => m.sections.about.author.competencies.competences.domainDrivenDesign.description),
     },
     {
-      title: t((m) => m.About.Author.Competencies.competences.agileMethodologies.title),
+      title: t((m) => m.sections.about.author.competencies.competences.agileMethodologies.title),
       icon: <TbUsers className={styles["icon"]} />,
-      description: t((m) => m.About.Author.Competencies.competences.agileMethodologies.description),
+      description: t((m) => m.sections.about.author.competencies.competences.agileMethodologies.description),
     },
     {
-      title: t((m) => m.About.Author.Competencies.competences.customerCentric.title),
+      title: t((m) => m.sections.about.author.competencies.competences.customerCentric.title),
       icon: <TbBrain className={styles["icon"]} />,
-      description: t((m) => m.About.Author.Competencies.competences.customerCentric.description),
+      description: t((m) => m.sections.about.author.competencies.competences.customerCentric.description),
     },
     {
-      title: t((m) => m.About.Author.Competencies.competences.engineeringExcellence.title),
+      title: t((m) => m.sections.about.author.competencies.competences.engineeringExcellence.title),
       icon: <TbCheck className={styles["icon"]} />,
-      description: t((m) => m.About.Author.Competencies.competences.engineeringExcellence.description),
+      description: t((m) => m.sections.about.author.competencies.competences.engineeringExcellence.description),
     },
   ];
 
@@ -73,8 +73,8 @@ export default function Competencies(): React.JSX.Element {
         animate={inView ? {opacity: 1, y: 0} : {opacity: 0, y: 20}}
         transition={{duration: 0.6}}
         className={styles["header"]}>
-        <h2 className={`blue-underline ${styles["title"]}`}>{t((m) => m.About.Author.Competencies.title)}</h2>
-        <p className={styles["subtitle"]}>{t((m) => m.About.Author.Competencies.subtitle)}</p>
+        <h2 className={`blue-underline ${styles["title"]}`}>{t((m) => m.sections.about.author.competencies.title)}</h2>
+        <p className={styles["subtitle"]}>{t((m) => m.sections.about.author.competencies.subtitle)}</p>
       </motion.div>
 
       <motion.div

--- a/sites/arolariu.ro/src/app/about/the-author/_components/Contact.stories.tsx
+++ b/sites/arolariu.ro/src/app/about/the-author/_components/Contact.stories.tsx
@@ -6,7 +6,7 @@ import Contact from "./Contact";
  * collaboration interests. Features two cards: one with social links
  * (email, LinkedIn, GitHub, website) with copy/open actions, and another
  * with collaboration discipline cards.
- * Uses the `About.Author.Contact` i18n namespace.
+ * Uses the `sections.about.author.Contact` i18n namespace.
  */
 const meta = {
   title: "Pages/About/TheAuthor/Contact",

--- a/sites/arolariu.ro/src/app/about/the-author/_components/Contact.tsx
+++ b/sites/arolariu.ro/src/app/about/the-author/_components/Contact.tsx
@@ -88,8 +88,8 @@ export default function Contact(): React.JSX.Element {
         animate={{opacity: 1, y: 0}}
         transition={{duration: 0.6}}
         className={styles["header"]}>
-        <h2 className={`blue-underline ${styles["title"]}`}>{t((m) => m.About.Author.Contact.title)}</h2>
-        <span className={styles["subtitle"]}>{t((m) => m.About.Author.Contact.subtitle)}</span>
+        <h2 className={`blue-underline ${styles["title"]}`}>{t((m) => m.sections.about.author.contact.title)}</h2>
+        <span className={styles["subtitle"]}>{t((m) => m.sections.about.author.contact.subtitle)}</span>
       </motion.div>
 
       <motion.div
@@ -103,8 +103,8 @@ export default function Contact(): React.JSX.Element {
             <div className={styles["cardAccent"]} />
 
             <CardHeader>
-              <CardTitle className={styles["cardTitle"]}>{t((m) => m.About.Author.Contact.socials.title)}</CardTitle>
-              <CardDescription>{t((m) => m.About.Author.Contact.socials.subtitle)}</CardDescription>
+              <CardTitle className={styles["cardTitle"]}>{t((m) => m.sections.about.author.contact.socials.title)}</CardTitle>
+              <CardDescription>{t((m) => m.sections.about.author.contact.socials.subtitle)}</CardDescription>
             </CardHeader>
 
             <CardContent className={styles["linksContainer"]}>
@@ -171,7 +171,7 @@ export default function Contact(): React.JSX.Element {
               </div>
 
               <div className={styles["linksFooter"]}>
-                <span className={styles["linksFooterText"]}>{t((m) => m.About.Author.Contact.socials.footer)}</span>
+                <span className={styles["linksFooterText"]}>{t((m) => m.sections.about.author.contact.socials.footer)}</span>
               </div>
             </CardContent>
           </Card>
@@ -183,17 +183,17 @@ export default function Contact(): React.JSX.Element {
             <div className={styles["cardAccent"]} />
 
             <CardHeader>
-              <CardTitle className={styles["cardTitle"]}>{t((m) => m.About.Author.Contact.collaborate.title)}</CardTitle>
-              <CardDescription>{t((m) => m.About.Author.Contact.collaborate.subtitle)}</CardDescription>
+              <CardTitle className={styles["cardTitle"]}>{t((m) => m.sections.about.author.contact.collaborate.title)}</CardTitle>
+              <CardDescription>{t((m) => m.sections.about.author.contact.collaborate.subtitle)}</CardDescription>
             </CardHeader>
 
             <CardContent>
               <div className={styles["disciplinesGrid"]}>
                 {[
-                  t((m) => m.About.Author.Contact.collaborate.discipline1),
-                  t((m) => m.About.Author.Contact.collaborate.discipline2),
-                  t((m) => m.About.Author.Contact.collaborate.discipline3),
-                  t((m) => m.About.Author.Contact.collaborate.discipline4),
+                  t((m) => m.sections.about.author.contact.collaborate.discipline1),
+                  t((m) => m.sections.about.author.contact.collaborate.discipline2),
+                  t((m) => m.sections.about.author.contact.collaborate.discipline3),
+                  t((m) => m.sections.about.author.contact.collaborate.discipline4),
                 ].map((field, index) => (
                   <motion.div
                     key={field}
@@ -207,7 +207,7 @@ export default function Contact(): React.JSX.Element {
                 ))}
               </div>
 
-              <p className={styles["footerText"]}>{t((m) => m.About.Author.Contact.collaborate.footer)}</p>
+              <p className={styles["footerText"]}>{t((m) => m.sections.about.author.contact.collaborate.footer)}</p>
 
               <motion.div
                 initial={{opacity: 0}}
@@ -224,7 +224,7 @@ export default function Contact(): React.JSX.Element {
                     repeat: Number.POSITIVE_INFINITY,
                     repeatType: "reverse",
                   }}>
-                  <h3 className={styles["ctaText"]}>{t((m) => m.About.Author.Contact.footer)}</h3>
+                  <h3 className={styles["ctaText"]}>{t((m) => m.sections.about.author.contact.footer)}</h3>
                 </motion.div>
               </motion.div>
             </CardContent>

--- a/sites/arolariu.ro/src/app/about/the-author/_components/Education.stories.tsx
+++ b/sites/arolariu.ro/src/app/about/the-author/_components/Education.stories.tsx
@@ -5,7 +5,7 @@ import Education from "./Education";
  * Education section displaying the author's educational background.
  * Features interactive flip cards for each university with front/back
  * views, course lists, and program details.
- * Uses the `About.Author.Education` i18n namespace.
+ * Uses the `sections.about.author.Education` i18n namespace.
  */
 const meta = {
   title: "Pages/About/TheAuthor/Education",

--- a/sites/arolariu.ro/src/app/about/the-author/_components/Education.tsx
+++ b/sites/arolariu.ro/src/app/about/the-author/_components/Education.tsx
@@ -63,40 +63,40 @@ export default function Education(): React.JSX.Element {
 
   const education = [
     {
-      degree: t((m) => m.About.Author.Education.university.malmoSweden.degree),
-      institution: t((m) => m.About.Author.Education.university.malmoSweden.institution),
-      location: t((m) => m.About.Author.Education.university.malmoSweden.location),
-      period: t((m) => m.About.Author.Education.university.malmoSweden.period),
-      description: t((m) => m.About.Author.Education.university.malmoSweden.description),
-      status: t((m) => m.About.Author.Education.university.malmoSweden.status),
-      coursesTitle: t((m) => m.About.Author.Education.university.malmoSweden.keyCourses_title),
-      courses: t((m) => m.About.Author.Education.university.malmoSweden.keyCourses)
+      degree: t((m) => m.sections.about.author.education.university.malmoSweden.degree),
+      institution: t((m) => m.sections.about.author.education.university.malmoSweden.institution),
+      location: t((m) => m.sections.about.author.education.university.malmoSweden.location),
+      period: t((m) => m.sections.about.author.education.university.malmoSweden.period),
+      description: t((m) => m.sections.about.author.education.university.malmoSweden.description),
+      status: t((m) => m.sections.about.author.education.university.malmoSweden.status),
+      coursesTitle: t((m) => m.sections.about.author.education.university.malmoSweden.keyCoursesTitle),
+      courses: t((m) => m.sections.about.author.education.university.malmoSweden.keyCourses)
         .split("#")
         .filter((course) => course.trim().length > 3),
-      aboutTheProgramCta: t((m) => m.About.Author.Education.university.malmoSweden.aboutTheProgram_cta),
-      aboutTheProgramTitle: t((m) => m.About.Author.Education.university.malmoSweden.aboutTheProgram_title),
-      aboutTheProgramDescription: t((m) => m.About.Author.Education.university.malmoSweden.aboutTheProgram_description),
-      aboutTheProgramLearningsTitle: t((m) => m.About.Author.Education.university.malmoSweden.aboutTheProgram_learnings_title),
-      aboutTheProgramLearnings: t((m) => m.About.Author.Education.university.malmoSweden.aboutTheProgram_learnings)
+      aboutTheProgramCta: t((m) => m.sections.about.author.education.university.malmoSweden.aboutTheProgramCta),
+      aboutTheProgramTitle: t((m) => m.sections.about.author.education.university.malmoSweden.aboutTheProgramTitle),
+      aboutTheProgramDescription: t((m) => m.sections.about.author.education.university.malmoSweden.aboutTheProgramDescription),
+      aboutTheProgramLearningsTitle: t((m) => m.sections.about.author.education.university.malmoSweden.aboutTheProgramLearningsTitle),
+      aboutTheProgramLearnings: t((m) => m.sections.about.author.education.university.malmoSweden.aboutTheProgramLearnings)
         .split("#")
         .filter((learning) => learning.trim().length > 3),
     },
     {
-      degree: t((m) => m.About.Author.Education.university.aseBucharest.degree),
-      institution: t((m) => m.About.Author.Education.university.aseBucharest.institution),
-      location: t((m) => m.About.Author.Education.university.aseBucharest.location),
-      period: t((m) => m.About.Author.Education.university.aseBucharest.period),
-      description: t((m) => m.About.Author.Education.university.aseBucharest.description),
-      status: t((m) => m.About.Author.Education.university.aseBucharest.status),
-      coursesTitle: t((m) => m.About.Author.Education.university.aseBucharest.keyCourses_title),
-      courses: t((m) => m.About.Author.Education.university.aseBucharest.keyCourses)
+      degree: t((m) => m.sections.about.author.education.university.aseBucharest.degree),
+      institution: t((m) => m.sections.about.author.education.university.aseBucharest.institution),
+      location: t((m) => m.sections.about.author.education.university.aseBucharest.location),
+      period: t((m) => m.sections.about.author.education.university.aseBucharest.period),
+      description: t((m) => m.sections.about.author.education.university.aseBucharest.description),
+      status: t((m) => m.sections.about.author.education.university.aseBucharest.status),
+      coursesTitle: t((m) => m.sections.about.author.education.university.aseBucharest.keyCoursesTitle),
+      courses: t((m) => m.sections.about.author.education.university.aseBucharest.keyCourses)
         .split("#")
         .filter((course) => course.trim().length > 3),
-      aboutTheProgramCta: t((m) => m.About.Author.Education.university.aseBucharest.aboutTheProgram_cta),
-      aboutTheProgramTitle: t((m) => m.About.Author.Education.university.aseBucharest.aboutTheProgram_title),
-      aboutTheProgramDescription: t((m) => m.About.Author.Education.university.aseBucharest.aboutTheProgram_description),
-      aboutTheProgramLearningsTitle: t((m) => m.About.Author.Education.university.aseBucharest.aboutTheProgram_learnings_title),
-      aboutTheProgramLearnings: t((m) => m.About.Author.Education.university.aseBucharest.aboutTheProgram_learnings)
+      aboutTheProgramCta: t((m) => m.sections.about.author.education.university.aseBucharest.aboutTheProgramCta),
+      aboutTheProgramTitle: t((m) => m.sections.about.author.education.university.aseBucharest.aboutTheProgramTitle),
+      aboutTheProgramDescription: t((m) => m.sections.about.author.education.university.aseBucharest.aboutTheProgramDescription),
+      aboutTheProgramLearningsTitle: t((m) => m.sections.about.author.education.university.aseBucharest.aboutTheProgramLearningsTitle),
+      aboutTheProgramLearnings: t((m) => m.sections.about.author.education.university.aseBucharest.aboutTheProgramLearnings)
         .split("#")
         .filter((learning) => learning.trim().length > 3),
     },
@@ -129,8 +129,8 @@ export default function Education(): React.JSX.Element {
         animate={{opacity: 1, y: 0}}
         transition={{duration: 0.6}}
         className={styles["header"]}>
-        <h2 className={`blue-underline ${styles["title"]}`}>{t((m) => m.About.Author.Education.title)}</h2>
-        <p className={styles["subtitle"]}>{t((m) => m.About.Author.Education.subtitle)}</p>
+        <h2 className={`blue-underline ${styles["title"]}`}>{t((m) => m.sections.about.author.education.title)}</h2>
+        <p className={styles["subtitle"]}>{t((m) => m.sections.about.author.education.subtitle)}</p>
       </motion.div>
 
       <motion.div

--- a/sites/arolariu.ro/src/app/about/the-author/_components/Experience.stories.tsx
+++ b/sites/arolariu.ro/src/app/about/the-author/_components/Experience.stories.tsx
@@ -6,7 +6,7 @@ import Experience from "./Experience";
  * Features an interactive timeline navigation on the left with detailed
  * experience cards on the right showing responsibilities, achievements,
  * and skills for each role.
- * Uses the `About.Author.Experiences` i18n namespace.
+ * Uses the `sections.about.author.Experiences` i18n namespace.
  */
 const meta = {
   title: "Pages/About/TheAuthor/Experience",

--- a/sites/arolariu.ro/src/app/about/the-author/_components/Experience.tsx
+++ b/sites/arolariu.ro/src/app/about/the-author/_components/Experience.tsx
@@ -47,86 +47,86 @@ export default function Experience(): React.JSX.Element {
 
   const experiences = [
     {
-      company: t((m) => m.About.Author.Experiences.microsoft3.company),
-      role: t((m) => m.About.Author.Experiences.microsoft3.title),
-      period: t((m) => m.About.Author.Experiences.microsoft3.period),
-      location: t((m) => m.About.Author.Experiences.microsoft3.location),
-      description: t((m) => m.About.Author.Experiences.microsoft3.description),
-      responsibilities: t((m) => m.About.Author.Experiences.microsoft3.responsibilites)
+      company: t((m) => m.sections.about.author.experiences.microsoft3.company),
+      role: t((m) => m.sections.about.author.experiences.microsoft3.title),
+      period: t((m) => m.sections.about.author.experiences.microsoft3.period),
+      location: t((m) => m.sections.about.author.experiences.microsoft3.location),
+      description: t((m) => m.sections.about.author.experiences.microsoft3.description),
+      responsibilities: t((m) => m.sections.about.author.experiences.microsoft3.responsibilites)
         .split("#")
         .filter((item) => item.trim().length > 3),
-      achievements: t((m) => m.About.Author.Experiences.microsoft3.achievements)
+      achievements: t((m) => m.sections.about.author.experiences.microsoft3.achievements)
         .split("#")
         .filter((item) => item.trim().length > 3),
-      skills: t((m) => m.About.Author.Experiences.microsoft3.techAndSkills)
+      skills: t((m) => m.sections.about.author.experiences.microsoft3.techAndSkills)
         .split("#")
         .filter((item) => item.trim().length > 0),
       logo: <CgMicrosoft className={styles["logoIcon"]} />,
     },
     {
-      company: t((m) => m.About.Author.Experiences.microsoft2.company),
-      role: t((m) => m.About.Author.Experiences.microsoft2.title),
-      period: t((m) => m.About.Author.Experiences.microsoft2.period),
-      location: t((m) => m.About.Author.Experiences.microsoft2.location),
-      description: t((m) => m.About.Author.Experiences.microsoft2.description),
-      responsibilities: t((m) => m.About.Author.Experiences.microsoft2.responsibilites)
+      company: t((m) => m.sections.about.author.experiences.microsoft2.company),
+      role: t((m) => m.sections.about.author.experiences.microsoft2.title),
+      period: t((m) => m.sections.about.author.experiences.microsoft2.period),
+      location: t((m) => m.sections.about.author.experiences.microsoft2.location),
+      description: t((m) => m.sections.about.author.experiences.microsoft2.description),
+      responsibilities: t((m) => m.sections.about.author.experiences.microsoft2.responsibilites)
         .split("#")
         .filter((item) => item.trim().length > 3),
-      achievements: t((m) => m.About.Author.Experiences.microsoft2.achievements)
+      achievements: t((m) => m.sections.about.author.experiences.microsoft2.achievements)
         .split("#")
         .filter((item) => item.trim().length > 3),
-      skills: t((m) => m.About.Author.Experiences.microsoft2.techAndSkills)
+      skills: t((m) => m.sections.about.author.experiences.microsoft2.techAndSkills)
         .split("#")
         .filter((item) => item.trim().length > 0),
       logo: <CgMicrosoft className={styles["logoIcon"]} />,
     },
     {
-      company: t((m) => m.About.Author.Experiences.microsoft1.company),
-      role: t((m) => m.About.Author.Experiences.microsoft1.title),
-      period: t((m) => m.About.Author.Experiences.microsoft1.period),
-      location: t((m) => m.About.Author.Experiences.microsoft1.location),
-      description: t((m) => m.About.Author.Experiences.microsoft1.description),
-      responsibilities: t((m) => m.About.Author.Experiences.microsoft1.responsibilites)
+      company: t((m) => m.sections.about.author.experiences.microsoft1.company),
+      role: t((m) => m.sections.about.author.experiences.microsoft1.title),
+      period: t((m) => m.sections.about.author.experiences.microsoft1.period),
+      location: t((m) => m.sections.about.author.experiences.microsoft1.location),
+      description: t((m) => m.sections.about.author.experiences.microsoft1.description),
+      responsibilities: t((m) => m.sections.about.author.experiences.microsoft1.responsibilites)
         .split("#")
         .filter((item) => item.trim().length > 3),
-      achievements: t((m) => m.About.Author.Experiences.microsoft1.achievements)
+      achievements: t((m) => m.sections.about.author.experiences.microsoft1.achievements)
         .split("#")
         .filter((item) => item.trim().length > 3),
-      skills: t((m) => m.About.Author.Experiences.microsoft1.techAndSkills)
+      skills: t((m) => m.sections.about.author.experiences.microsoft1.techAndSkills)
         .split("#")
         .filter((item) => item.trim().length > 0),
       logo: <CgMicrosoft className={styles["logoIcon"]} />,
     },
     {
-      company: t((m) => m.About.Author.Experiences.intel.company),
-      role: t((m) => m.About.Author.Experiences.intel.title),
-      period: t((m) => m.About.Author.Experiences.intel.period),
-      location: t((m) => m.About.Author.Experiences.intel.location),
-      description: t((m) => m.About.Author.Experiences.intel.description),
-      responsibilities: t((m) => m.About.Author.Experiences.intel.responsibilites)
+      company: t((m) => m.sections.about.author.experiences.intel.company),
+      role: t((m) => m.sections.about.author.experiences.intel.title),
+      period: t((m) => m.sections.about.author.experiences.intel.period),
+      location: t((m) => m.sections.about.author.experiences.intel.location),
+      description: t((m) => m.sections.about.author.experiences.intel.description),
+      responsibilities: t((m) => m.sections.about.author.experiences.intel.responsibilites)
         .split("#")
         .filter((item) => item.trim().length > 3),
-      achievements: t((m) => m.About.Author.Experiences.intel.achievements)
+      achievements: t((m) => m.sections.about.author.experiences.intel.achievements)
         .split("#")
         .filter((item) => item.trim().length > 3),
-      skills: t((m) => m.About.Author.Experiences.intel.techAndSkills)
+      skills: t((m) => m.sections.about.author.experiences.intel.techAndSkills)
         .split("#")
         .filter((item) => item.trim().length > 0),
       logo: <SiIntel className={styles["logoIcon"]} />,
     },
     {
-      company: t((m) => m.About.Author.Experiences.ubisoft.company),
-      role: t((m) => m.About.Author.Experiences.ubisoft.title),
-      period: t((m) => m.About.Author.Experiences.ubisoft.period),
-      location: t((m) => m.About.Author.Experiences.ubisoft.location),
-      description: t((m) => m.About.Author.Experiences.ubisoft.description),
-      responsibilities: t((m) => m.About.Author.Experiences.ubisoft.responsibilites)
+      company: t((m) => m.sections.about.author.experiences.ubisoft.company),
+      role: t((m) => m.sections.about.author.experiences.ubisoft.title),
+      period: t((m) => m.sections.about.author.experiences.ubisoft.period),
+      location: t((m) => m.sections.about.author.experiences.ubisoft.location),
+      description: t((m) => m.sections.about.author.experiences.ubisoft.description),
+      responsibilities: t((m) => m.sections.about.author.experiences.ubisoft.responsibilites)
         .split("#")
         .filter((item) => item.trim().length > 3),
-      achievements: t((m) => m.About.Author.Experiences.ubisoft.achievements)
+      achievements: t((m) => m.sections.about.author.experiences.ubisoft.achievements)
         .split("#")
         .filter((item) => item.trim().length > 3),
-      skills: t((m) => m.About.Author.Experiences.ubisoft.techAndSkills)
+      skills: t((m) => m.sections.about.author.experiences.ubisoft.techAndSkills)
         .split("#")
         .filter((item) => item.trim().length > 0),
       logo: <SiUbisoft className={styles["logoIcon"]} />,
@@ -141,8 +141,8 @@ export default function Experience(): React.JSX.Element {
           animate={{opacity: 1, y: 0}}
           transition={{duration: 0.6}}
           className={styles["header"]}>
-          <h2 className={`blue-underline ${styles["title"]}`}>{t((m) => m.About.Author.Experiences.title)}</h2>
-          <p className={styles["subtitle"]}>{t((m) => m.About.Author.Experiences.subtitle)}</p>
+          <h2 className={`blue-underline ${styles["title"]}`}>{t((m) => m.sections.about.author.experiences.title)}</h2>
+          <p className={styles["subtitle"]}>{t((m) => m.sections.about.author.experiences.subtitle)}</p>
         </motion.div>
 
         <div className={styles["grid"]}>
@@ -226,7 +226,7 @@ export default function Experience(): React.JSX.Element {
 
                   {experience.responsibilities.length > 0 && (
                     <div className={styles["cardSection"]}>
-                      <h4 className={styles["cardSectionTitle"]}>{t((m) => m.About.Author.Experiences.responsibilitiesLabel)}</h4>
+                      <h4 className={styles["cardSectionTitle"]}>{t((m) => m.sections.about.author.experiences.responsibilitiesLabel)}</h4>
                       <ul className={styles["list"]}>
                         {experience.responsibilities.map((responsability, i) => (
                           <li
@@ -248,7 +248,7 @@ export default function Experience(): React.JSX.Element {
 
                   {experience.achievements.length > 0 && (
                     <div className={styles["cardSection"]}>
-                      <h4 className={styles["cardSectionTitle"]}>{t((m) => m.About.Author.Experiences.achievementsLabel)}</h4>
+                      <h4 className={styles["cardSectionTitle"]}>{t((m) => m.sections.about.author.experiences.achievementsLabel)}</h4>
                       <ul className={styles["list"]}>
                         {experience.achievements.map((achievement, i) => (
                           <li
@@ -269,7 +269,7 @@ export default function Experience(): React.JSX.Element {
                   )}
 
                   <div>
-                    <h4 className={styles["cardSectionTitle"]}>{t((m) => m.About.Author.Experiences.techSkillsLabel)}</h4>
+                    <h4 className={styles["cardSectionTitle"]}>{t((m) => m.sections.about.author.experiences.techSkillsLabel)}</h4>
                     <div className={styles["skills"]}>
                       {experience.skills.map((skill, i) => (
                         <motion.div

--- a/sites/arolariu.ro/src/app/about/the-author/_components/Hero.stories.tsx
+++ b/sites/arolariu.ro/src/app/about/the-author/_components/Hero.stories.tsx
@@ -5,7 +5,7 @@ import Hero from "./Hero";
  * Dynamic hero section for the author's page.
  * Displays the author's profile image with a parallax scrolling effect,
  * a typewriter-animated gradient title, and a subtitle.
- * Uses the `About.Author` i18n namespace.
+ * Uses the `sections.about.author` i18n namespace.
  */
 const meta = {
   title: "Pages/About/TheAuthor/Hero",

--- a/sites/arolariu.ro/src/app/about/the-author/_components/Hero.tsx
+++ b/sites/arolariu.ro/src/app/about/the-author/_components/Hero.tsx
@@ -25,7 +25,7 @@ export default function Hero(): React.JSX.Element {
   const y = useTransform(scrollYProgress, [0, 1], ["0%", "50%"]);
   const opacity = useTransform(scrollYProgress, [0, 0.5], [1, 0]);
 
-  const words = t((m) => m.About.Author.title)
+  const words = t((m) => m.sections.about.author.title)
     .split(" ")
     .map((word) => ({
       text: word,
@@ -68,7 +68,7 @@ export default function Hero(): React.JSX.Element {
             animate={{opacity: 1, y: 0}}
             transition={{delay: 1.5, duration: 0.8}}
             className='blue-underline'>
-            <span className={styles["subtitle"]}>{t((m) => m.About.Author.subtitle)}</span>
+            <span className={styles["subtitle"]}>{t((m) => m.sections.about.author.subtitle)}</span>
           </motion.div>
         </div>
       </motion.div>

--- a/sites/arolariu.ro/src/app/about/the-author/_components/Perspectives.stories.tsx
+++ b/sites/arolariu.ro/src/app/about/the-author/_components/Perspectives.stories.tsx
@@ -5,7 +5,7 @@ import Perspectives from "./Perspectives";
  * Perspectives section displaying testimonials from colleagues and peers.
  * Renders a grid of quote cards, each with an avatar, author name,
  * position, and quote text with staggered entrance animations.
- * Uses the `About.Author.Perspectives` i18n namespace.
+ * Uses the `sections.about.author.Perspectives` i18n namespace.
  */
 const meta = {
   title: "Pages/About/TheAuthor/Perspectives",

--- a/sites/arolariu.ro/src/app/about/the-author/_components/Perspectives.tsx
+++ b/sites/arolariu.ro/src/app/about/the-author/_components/Perspectives.tsx
@@ -42,67 +42,67 @@ export default function Perspectives(): React.JSX.Element {
 
   const perspectives = [
     {
-      author: t((m) => m.About.Author.Perspectives.perspectiveFromX.author),
-      avatar: t((m) => m.About.Author.Perspectives.perspectiveFromX.avatar),
-      position: t((m) => m.About.Author.Perspectives.perspectiveFromX.position),
-      company: t((m) => m.About.Author.Perspectives.perspectiveFromX.company),
-      quote: t((m) => m.About.Author.Perspectives.perspectiveFromX.quote),
+      author: t((m) => m.sections.about.author.perspectives.perspectiveFromX.author),
+      avatar: t((m) => m.sections.about.author.perspectives.perspectiveFromX.avatar),
+      position: t((m) => m.sections.about.author.perspectives.perspectiveFromX.position),
+      company: t((m) => m.sections.about.author.perspectives.perspectiveFromX.company),
+      quote: t((m) => m.sections.about.author.perspectives.perspectiveFromX.quote),
     },
     {
-      author: t((m) => m.About.Author.Perspectives.perspectiveFromY.author),
-      avatar: t((m) => m.About.Author.Perspectives.perspectiveFromY.avatar),
-      position: t((m) => m.About.Author.Perspectives.perspectiveFromY.position),
-      company: t((m) => m.About.Author.Perspectives.perspectiveFromY.company),
-      quote: t((m) => m.About.Author.Perspectives.perspectiveFromY.quote),
+      author: t((m) => m.sections.about.author.perspectives.perspectiveFromY.author),
+      avatar: t((m) => m.sections.about.author.perspectives.perspectiveFromY.avatar),
+      position: t((m) => m.sections.about.author.perspectives.perspectiveFromY.position),
+      company: t((m) => m.sections.about.author.perspectives.perspectiveFromY.company),
+      quote: t((m) => m.sections.about.author.perspectives.perspectiveFromY.quote),
     },
     {
-      author: t((m) => m.About.Author.Perspectives.perspectiveFromZ.author),
-      avatar: t((m) => m.About.Author.Perspectives.perspectiveFromZ.avatar),
-      position: t((m) => m.About.Author.Perspectives.perspectiveFromZ.position),
-      company: t((m) => m.About.Author.Perspectives.perspectiveFromZ.company),
-      quote: t((m) => m.About.Author.Perspectives.perspectiveFromZ.quote),
+      author: t((m) => m.sections.about.author.perspectives.perspectiveFromZ.author),
+      avatar: t((m) => m.sections.about.author.perspectives.perspectiveFromZ.avatar),
+      position: t((m) => m.sections.about.author.perspectives.perspectiveFromZ.position),
+      company: t((m) => m.sections.about.author.perspectives.perspectiveFromZ.company),
+      quote: t((m) => m.sections.about.author.perspectives.perspectiveFromZ.quote),
     },
     {
-      author: t((m) => m.About.Author.Perspectives.perspectiveFromXX.author),
-      avatar: t((m) => m.About.Author.Perspectives.perspectiveFromXX.avatar),
-      position: t((m) => m.About.Author.Perspectives.perspectiveFromXX.position),
-      company: t((m) => m.About.Author.Perspectives.perspectiveFromXX.company),
-      quote: t((m) => m.About.Author.Perspectives.perspectiveFromXX.quote),
+      author: t((m) => m.sections.about.author.perspectives.perspectiveFromXX.author),
+      avatar: t((m) => m.sections.about.author.perspectives.perspectiveFromXX.avatar),
+      position: t((m) => m.sections.about.author.perspectives.perspectiveFromXX.position),
+      company: t((m) => m.sections.about.author.perspectives.perspectiveFromXX.company),
+      quote: t((m) => m.sections.about.author.perspectives.perspectiveFromXX.quote),
     },
     {
-      author: t((m) => m.About.Author.Perspectives.perspectiveFromXY.author),
-      avatar: t((m) => m.About.Author.Perspectives.perspectiveFromXY.avatar),
-      position: t((m) => m.About.Author.Perspectives.perspectiveFromXY.position),
-      company: t((m) => m.About.Author.Perspectives.perspectiveFromXY.company),
-      quote: t((m) => m.About.Author.Perspectives.perspectiveFromXY.quote),
+      author: t((m) => m.sections.about.author.perspectives.perspectiveFromXY.author),
+      avatar: t((m) => m.sections.about.author.perspectives.perspectiveFromXY.avatar),
+      position: t((m) => m.sections.about.author.perspectives.perspectiveFromXY.position),
+      company: t((m) => m.sections.about.author.perspectives.perspectiveFromXY.company),
+      quote: t((m) => m.sections.about.author.perspectives.perspectiveFromXY.quote),
     },
     {
-      author: t((m) => m.About.Author.Perspectives.perspectiveFromXZ.author),
-      avatar: t((m) => m.About.Author.Perspectives.perspectiveFromXZ.avatar),
-      position: t((m) => m.About.Author.Perspectives.perspectiveFromXZ.position),
-      company: t((m) => m.About.Author.Perspectives.perspectiveFromXZ.company),
-      quote: t((m) => m.About.Author.Perspectives.perspectiveFromXZ.quote),
+      author: t((m) => m.sections.about.author.perspectives.perspectiveFromXZ.author),
+      avatar: t((m) => m.sections.about.author.perspectives.perspectiveFromXZ.avatar),
+      position: t((m) => m.sections.about.author.perspectives.perspectiveFromXZ.position),
+      company: t((m) => m.sections.about.author.perspectives.perspectiveFromXZ.company),
+      quote: t((m) => m.sections.about.author.perspectives.perspectiveFromXZ.quote),
     },
     {
-      author: t((m) => m.About.Author.Perspectives.perspectiveFromYX.author),
-      avatar: t((m) => m.About.Author.Perspectives.perspectiveFromYX.avatar),
-      position: t((m) => m.About.Author.Perspectives.perspectiveFromYX.position),
-      company: t((m) => m.About.Author.Perspectives.perspectiveFromYX.company),
-      quote: t((m) => m.About.Author.Perspectives.perspectiveFromYX.quote),
+      author: t((m) => m.sections.about.author.perspectives.perspectiveFromYX.author),
+      avatar: t((m) => m.sections.about.author.perspectives.perspectiveFromYX.avatar),
+      position: t((m) => m.sections.about.author.perspectives.perspectiveFromYX.position),
+      company: t((m) => m.sections.about.author.perspectives.perspectiveFromYX.company),
+      quote: t((m) => m.sections.about.author.perspectives.perspectiveFromYX.quote),
     },
     {
-      author: t((m) => m.About.Author.Perspectives.perspectiveFromYY.author),
-      avatar: t((m) => m.About.Author.Perspectives.perspectiveFromYY.avatar),
-      position: t((m) => m.About.Author.Perspectives.perspectiveFromYY.position),
-      company: t((m) => m.About.Author.Perspectives.perspectiveFromYY.company),
-      quote: t((m) => m.About.Author.Perspectives.perspectiveFromYY.quote),
+      author: t((m) => m.sections.about.author.perspectives.perspectiveFromYY.author),
+      avatar: t((m) => m.sections.about.author.perspectives.perspectiveFromYY.avatar),
+      position: t((m) => m.sections.about.author.perspectives.perspectiveFromYY.position),
+      company: t((m) => m.sections.about.author.perspectives.perspectiveFromYY.company),
+      quote: t((m) => m.sections.about.author.perspectives.perspectiveFromYY.quote),
     },
     {
-      author: t((m) => m.About.Author.Perspectives.perspectiveFromYZ.author),
-      avatar: t((m) => m.About.Author.Perspectives.perspectiveFromYZ.avatar),
-      position: t((m) => m.About.Author.Perspectives.perspectiveFromYZ.position),
-      company: t((m) => m.About.Author.Perspectives.perspectiveFromYZ.company),
-      quote: t((m) => m.About.Author.Perspectives.perspectiveFromYZ.quote),
+      author: t((m) => m.sections.about.author.perspectives.perspectiveFromYZ.author),
+      avatar: t((m) => m.sections.about.author.perspectives.perspectiveFromYZ.avatar),
+      position: t((m) => m.sections.about.author.perspectives.perspectiveFromYZ.position),
+      company: t((m) => m.sections.about.author.perspectives.perspectiveFromYZ.company),
+      quote: t((m) => m.sections.about.author.perspectives.perspectiveFromYZ.quote),
     },
   ] satisfies PerspectiveType[];
 
@@ -117,10 +117,10 @@ export default function Perspectives(): React.JSX.Element {
           transition={{duration: 0.6}}
           className={styles["header"]}>
           <h2 className={styles["title"]}>
-            {t((m) => m.About.Author.Perspectives.title)}
+            {t((m) => m.sections.about.author.perspectives.title)}
             <span className={styles["titleUnderline"]} />
           </h2>
-          <p className={styles["subtitle"]}>{t((m) => m.About.Author.Perspectives.subtitle)}</p>
+          <p className={styles["subtitle"]}>{t((m) => m.sections.about.author.perspectives.subtitle)}</p>
         </motion.div>
 
         <motion.div

--- a/sites/arolariu.ro/src/app/about/the-author/page.tsx
+++ b/sites/arolariu.ro/src/app/about/the-author/page.tsx
@@ -48,8 +48,8 @@ export async function generateMetadata(): Promise<Metadata> {
   const locale = await getLocale();
   return createMetadata({
     locale,
-    title: t((m) => m.About.Author.metadata.title),
-    description: t((m) => m.About.Author.metadata.description),
+    title: t((m) => m.pages.about.author.metadata.title),
+    description: t((m) => m.pages.about.author.metadata.description),
   });
 }
 

--- a/sites/arolariu.ro/src/app/about/the-author/page.tsx
+++ b/sites/arolariu.ro/src/app/about/the-author/page.tsx
@@ -30,7 +30,7 @@ import styles from "./page.module.scss";
  * @remarks
  * **Rendering Context**: Server Component metadata generator.
  *
- * **i18n**: Uses `next-intl` translations from the About.Author namespace.
+ * **i18n**: Uses `next-intl` translations from the sections.about.author namespace.
  *
  * **SEO**: Delegates to `createMetadata` for consistent Open Graph defaults.
  *

--- a/sites/arolariu.ro/src/app/about/the-platform/_components/Architecture.stories.tsx
+++ b/sites/arolariu.ro/src/app/about/the-platform/_components/Architecture.stories.tsx
@@ -6,7 +6,7 @@ import Architecture from "./Architecture";
  * Features an interactive layered diagram with eight architecture layers
  * (Client, CDN, API, Services, Auth, Data, AI, Infra), each showing
  * technologies as badges.
- * Uses the `About.Platform.architecture` i18n namespace.
+ * Uses the `sections.about.platform.architecture` i18n namespace.
  */
 const meta = {
   title: "Pages/About/ThePlatform/Architecture",

--- a/sites/arolariu.ro/src/app/about/the-platform/_components/Architecture.tsx
+++ b/sites/arolariu.ro/src/app/about/the-platform/_components/Architecture.tsx
@@ -116,14 +116,14 @@ export default function Architecture(): React.JSX.Element {
                         <layer.icon className={styles["layerIcon"]} />
                       </motion.div>
                       <div>
-                        <h3 className={styles["layerName"]}>{t(selectorFromPath(`About.Platform.architecture.${`layers.${layer.id}.name`}`))}</h3>
-                        <p className={styles["layerDescription"]}>{t(selectorFromPath(`About.Platform.architecture.${`layers.${layer.id}.description`}`))}</p>
+                        <h3 className={styles["layerName"]}>{t(selectorFromPath(`sections.about.platform.architecture.${`layers.${layer.id}.name`}`))}</h3>
+                        <p className={styles["layerDescription"]}>{t(selectorFromPath(`sections.about.platform.architecture.${`layers.${layer.id}.description`}`))}</p>
                       </div>
                     </div>
 
                     {/* Technologies */}
                     <div className={styles["technologies"]}>
-                      {t(selectorFromPath(`About.Platform.architecture.${`layers.${layer.id}.technologies`}`))
+                      {t(selectorFromPath(`sections.about.platform.architecture.${`layers.${layer.id}.technologies`}`))
                         .split(",")
                         .map((tech, techIndex) => (
                           <motion.div

--- a/sites/arolariu.ro/src/app/about/the-platform/_components/Architecture.tsx
+++ b/sites/arolariu.ro/src/app/about/the-platform/_components/Architecture.tsx
@@ -72,13 +72,13 @@ export default function Architecture(): React.JSX.Element {
             <Badge
               variant='outline'
               className={styles["badge"]}>
-              {t((m) => m.About.Platform.architecture.badge)}
+              {t((m) => m.sections.about.platform.architecture.badge)}
             </Badge>
           </motion.div>
           <h2 className={styles["title"]}>
-            {t((m) => m.About.Platform.architecture.title)} <span className={styles["titleHighlight"]}>{t((m) => m.About.Platform.architecture.titleHighlight)}</span>
+            {t((m) => m.sections.about.platform.architecture.title)} <span className={styles["titleHighlight"]}>{t((m) => m.sections.about.platform.architecture.titleHighlight)}</span>
           </h2>
-          <p className={styles["description"]}>{t((m) => m.About.Platform.architecture.description)}</p>
+          <p className={styles["description"]}>{t((m) => m.sections.about.platform.architecture.description)}</p>
         </motion.div>
 
         {/* Architecture Diagram */}

--- a/sites/arolariu.ro/src/app/about/the-platform/_components/CallToAction.stories.tsx
+++ b/sites/arolariu.ro/src/app/about/the-platform/_components/CallToAction.stories.tsx
@@ -5,7 +5,7 @@ import CallToAction from "./CallToAction";
  * Call-to-action section for the Platform page footer.
  * Features animated background beams, gradient orbs, primary/secondary CTAs,
  * secondary links (GitHub, Author, Contact), and trust indicator cards.
- * Uses the `About.Platform.callToAction` i18n namespace.
+ * Uses the `sections.about.platform.callToAction` i18n namespace.
  */
 const meta = {
   title: "Pages/About/ThePlatform/CallToAction",

--- a/sites/arolariu.ro/src/app/about/the-platform/_components/CallToAction.tsx
+++ b/sites/arolariu.ro/src/app/about/the-platform/_components/CallToAction.tsx
@@ -196,8 +196,8 @@ export default function CallToAction(): React.JSX.Element {
                 transition={{duration: 0.5, delay: 0.6 + index * 0.1}}
                 whileHover={{scale: 1.05, transition: {duration: 0.2}}}>
                 <div className={`${styles["trustAccent"]} ${styles[trustAccentClassMap[trustId]]}`} />
-                <h3 className={styles["trustTitle"]}>{t(selectorFromPath(`About.Platform.callToAction.${`trust.${trustId}.title`}`))}</h3>
-                <p className={styles["trustDescription"]}>{t(selectorFromPath(`About.Platform.callToAction.${`trust.${trustId}.description`}`))}</p>
+                <h3 className={styles["trustTitle"]}>{t(selectorFromPath(`sections.about.platform.callToAction.${`trust.${trustId}.title`}`))}</h3>
+                <p className={styles["trustDescription"]}>{t(selectorFromPath(`sections.about.platform.callToAction.${`trust.${trustId}.description`}`))}</p>
               </motion.div>
             ))}
           </motion.div>

--- a/sites/arolariu.ro/src/app/about/the-platform/_components/CallToAction.tsx
+++ b/sites/arolariu.ro/src/app/about/the-platform/_components/CallToAction.tsx
@@ -87,7 +87,7 @@ export default function CallToAction(): React.JSX.Element {
             animate={isInView ? {opacity: 1, y: 0} : {}}
             transition={{duration: 0.6}}>
             <h2 className={styles["title"]}>
-              {t((m) => m.About.Platform.callToAction.title)} <span className={styles["titleHighlight"]}>{t((m) => m.About.Platform.callToAction.titleHighlight)}?</span>
+              {t((m) => m.sections.about.platform.callToAction.title)} <span className={styles["titleHighlight"]}>{t((m) => m.sections.about.platform.callToAction.titleHighlight)}?</span>
             </h2>
           </motion.div>
 
@@ -97,7 +97,7 @@ export default function CallToAction(): React.JSX.Element {
             initial={{opacity: 0, y: 30}}
             animate={isInView ? {opacity: 1, y: 0} : {}}
             transition={{duration: 0.6, delay: 0.1}}>
-            {t((m) => m.About.Platform.callToAction.description)}
+            {t((m) => m.sections.about.platform.callToAction.description)}
           </motion.p>
 
           {/* CTA Buttons */}
@@ -116,7 +116,7 @@ export default function CallToAction(): React.JSX.Element {
                 className={styles["ctaButton"]}>
                 <Link href='/domains'>
                   <TbRocket className={styles["ctaIcon"]} />
-                  <span>{t((m) => m.About.Platform.callToAction.cta.exploreApplications)}</span>
+                  <span>{t((m) => m.sections.about.platform.callToAction.cta.exploreApplications)}</span>
                   <TbArrowRight className={styles["ctaArrow"]} />
                   <motion.span
                     className={styles["ctaOverlay"]}
@@ -139,7 +139,7 @@ export default function CallToAction(): React.JSX.Element {
                 className={styles["ctaButton"]}>
                 <Link href='/auth/sign-up'>
                   <TbUser className={styles["ctaIcon"]} />
-                  <span>{t((m) => m.About.Platform.callToAction.cta.createAccount)}</span>
+                  <span>{t((m) => m.sections.about.platform.callToAction.cta.createAccount)}</span>
                   <motion.span
                     className={styles["ctaOverlay"]}
                     initial={{x: "-100%", opacity: 0}}
@@ -163,21 +163,21 @@ export default function CallToAction(): React.JSX.Element {
               rel='noopener noreferrer'
               className={styles["secondaryLink"]}>
               <TbBrandGithub className={styles["secondaryLinkIcon"]} />
-              <span>{t((m) => m.About.Platform.callToAction.links.viewSource)}</span>
+              <span>{t((m) => m.sections.about.platform.callToAction.links.viewSource)}</span>
             </Link>
             <span className={styles["linkDivider"]}>|</span>
             <Link
               href='/about/the-author'
               className={styles["secondaryLink"]}>
               <TbUser className={styles["secondaryLinkIcon"]} />
-              <span>{t((m) => m.About.Platform.callToAction.links.meetAuthor)}</span>
+              <span>{t((m) => m.sections.about.platform.callToAction.links.meetAuthor)}</span>
             </Link>
             <span className={styles["linkDivider"]}>|</span>
             <Link
               href='mailto:contact@arolariu.ro'
               className={styles["secondaryLink"]}>
               <TbMail className={styles["secondaryLinkIcon"]} />
-              <span>{t((m) => m.About.Platform.callToAction.links.getInTouch)}</span>
+              <span>{t((m) => m.sections.about.platform.callToAction.links.getInTouch)}</span>
             </Link>
           </motion.div>
 
@@ -209,13 +209,13 @@ export default function CallToAction(): React.JSX.Element {
             animate={isInView ? {opacity: 1} : {}}
             transition={{duration: 0.6, delay: 0.8}}>
             <p className={styles["footerText"]}>
-              {t((m) => m.About.Platform.callToAction.footer)}{" "}
+              {t((m) => m.sections.about.platform.callToAction.footer)}{" "}
               <Link
                 href='/about/the-author'
                 className={styles["footerLink"]}>
                 Alexandru-Razvan Olariu
               </Link>
-              {t((m) => m.About.Platform.callToAction.footerRole)}
+              {t((m) => m.sections.about.platform.callToAction.footerRole)}
             </p>
           </motion.div>
         </div>

--- a/sites/arolariu.ro/src/app/about/the-platform/_components/Features.stories.tsx
+++ b/sites/arolariu.ro/src/app/about/the-platform/_components/Features.stories.tsx
@@ -5,7 +5,7 @@ import Features from "./Features";
  * Features section displaying the platform's main capabilities.
  * Renders nine interactive feature cards with hover effects, tag badges,
  * and a detail modal for expanded descriptions.
- * Uses the `About.Platform.features` i18n namespace.
+ * Uses the `sections.about.platform.features` i18n namespace.
  */
 const meta = {
   title: "Pages/About/ThePlatform/Features",

--- a/sites/arolariu.ro/src/app/about/the-platform/_components/Features.tsx
+++ b/sites/arolariu.ro/src/app/about/the-platform/_components/Features.tsx
@@ -103,13 +103,13 @@ export default function Features(): React.JSX.Element {
             <Badge
               variant='outline'
               className={styles["badge"]}>
-              {t((m) => m.About.Platform.features.badge)}
+              {t((m) => m.sections.about.platform.features.badge)}
             </Badge>
           </motion.div>
           <h2 className={styles["title"]}>
-            {t((m) => m.About.Platform.features.title)} <span className={styles["titleHighlight"]}>{t((m) => m.About.Platform.features.titleHighlight)}</span>
+            {t((m) => m.sections.about.platform.features.title)} <span className={styles["titleHighlight"]}>{t((m) => m.sections.about.platform.features.titleHighlight)}</span>
           </h2>
-          <p className={styles["description"]}>{t((m) => m.About.Platform.features.description)}</p>
+          <p className={styles["description"]}>{t((m) => m.sections.about.platform.features.description)}</p>
         </motion.div>
 
         {/* Features Grid */}
@@ -195,7 +195,7 @@ export default function Features(): React.JSX.Element {
             <button
               type='button'
               className={styles["modalBackdrop"]}
-              aria-label={t((m) => m.About.Platform.features.modal.close)}
+              aria-label={t((m) => m.sections.about.platform.features.modal.close)}
               // eslint-disable-next-line react/jsx-no-bind -- simple modal close
               onClick={() => setSelectedFeature(null)}
             />
@@ -236,7 +236,7 @@ export default function Features(): React.JSX.Element {
                 <Link
                   href={selectedFeature.link}
                   className={`${styles["modalLink"]} ${styles[gradientClassMap[selectedFeature.colorKey]]}`}>
-                  {t((m) => m.About.Platform.features.modal.exploreFeature)}
+                  {t((m) => m.sections.about.platform.features.modal.exploreFeature)}
                   <TbArrowRight className={styles["modalLinkIcon"]} />
                 </Link>
                 <Button
@@ -244,7 +244,7 @@ export default function Features(): React.JSX.Element {
                   // eslint-disable-next-line react/jsx-no-bind -- simple modal close
                   onClick={() => setSelectedFeature(null)}
                   className={styles["modalClose"]}>
-                  {t((m) => m.About.Platform.features.modal.close)}
+                  {t((m) => m.sections.about.platform.features.modal.close)}
                 </Button>
               </div>
             </motion.div>

--- a/sites/arolariu.ro/src/app/about/the-platform/_components/Features.tsx
+++ b/sites/arolariu.ro/src/app/about/the-platform/_components/Features.tsx
@@ -155,15 +155,15 @@ export default function Features(): React.JSX.Element {
                       <TbArrowRight className={`${styles["arrowIcon"]} ${styles[colorClassMap[feature.colorKey]]}`} />
                     </motion.div>
                   </div>
-                  <CardTitle className={styles["cardTitle"]}>{t(selectorFromPath(`About.Platform.features.${`items.${feature.id}.title`}`))}</CardTitle>
+                  <CardTitle className={styles["cardTitle"]}>{t(selectorFromPath(`sections.about.platform.features.${`items.${feature.id}.title`}`))}</CardTitle>
                   <CardDescription className={styles["cardDescription"]}>
-                    {t(selectorFromPath(`About.Platform.features.${`items.${feature.id}.description`}`))}
+                    {t(selectorFromPath(`sections.about.platform.features.${`items.${feature.id}.description`}`))}
                   </CardDescription>
                 </CardHeader>
 
                 <CardContent className={styles["cardContent"]}>
                   <div className={styles["tags"]}>
-                    {t(selectorFromPath(`About.Platform.features.${`items.${feature.id}.tags`}`))
+                    {t(selectorFromPath(`sections.about.platform.features.${`items.${feature.id}.tags`}`))
                       .split(",")
                       .map((tag) => (
                         <Badge
@@ -212,16 +212,16 @@ export default function Features(): React.JSX.Element {
                   <h3
                     id={`feature-modal-title-${selectedFeature.id}`}
                     className={styles["modalTitle"]}>
-                    {t(selectorFromPath(`About.Platform.features.${`items.${selectedFeature.id}.title`}`))}
+                    {t(selectorFromPath(`sections.about.platform.features.${`items.${selectedFeature.id}.title`}`))}
                   </h3>
-                  <p className={styles["modalSubtitle"]}>{t(selectorFromPath(`About.Platform.features.${`items.${selectedFeature.id}.description`}`))}</p>
+                  <p className={styles["modalSubtitle"]}>{t(selectorFromPath(`sections.about.platform.features.${`items.${selectedFeature.id}.description`}`))}</p>
                 </div>
               </div>
 
-              <p className={styles["modalDescription"]}>{t(selectorFromPath(`About.Platform.features.${`items.${selectedFeature.id}.longDescription`}`))}</p>
+              <p className={styles["modalDescription"]}>{t(selectorFromPath(`sections.about.platform.features.${`items.${selectedFeature.id}.longDescription`}`))}</p>
 
               <div className={styles["modalTags"]}>
-                {t(selectorFromPath(`About.Platform.features.${`items.${selectedFeature.id}.tags`}`))
+                {t(selectorFromPath(`sections.about.platform.features.${`items.${selectedFeature.id}.tags`}`))
                   .split(",")
                   .map((tag) => (
                     <Badge

--- a/sites/arolariu.ro/src/app/about/the-platform/_components/Hero.stories.tsx
+++ b/sites/arolariu.ro/src/app/about/the-platform/_components/Hero.stories.tsx
@@ -6,7 +6,7 @@ import Hero from "./Hero";
  * Features a full-height hero with animated background beams, gradient text
  * (GradientText component), floating elements, scroll-based parallax effects,
  * feature pills, and CTA buttons.
- * Uses the `About.Platform.hero` i18n namespace.
+ * Uses the `sections.about.platform.hero` i18n namespace.
  */
 const meta = {
   title: "Pages/About/ThePlatform/Hero",

--- a/sites/arolariu.ro/src/app/about/the-platform/_components/Hero.tsx
+++ b/sites/arolariu.ro/src/app/about/the-platform/_components/Hero.tsx
@@ -124,7 +124,7 @@ export default function Hero(): React.JSX.Element {
                 <span className={styles["statusDotPing"]} />
                 <span className={styles["statusDotInner"]} />
               </motion.span>
-              <span>{t((m) => m.About.Platform.hero.statusBadge)}</span>
+              <span>{t((m) => m.sections.about.platform.hero.statusBadge)}</span>
               <TbSparkles className={styles["statusIcon"]} />
             </motion.span>
           </motion.div>
@@ -142,7 +142,7 @@ export default function Hero(): React.JSX.Element {
                   color: ["hsl(var(--foreground))", "hsl(var(--primary))", "hsl(var(--foreground))"],
                 }}
                 transition={{duration: 6, repeat: Number.POSITIVE_INFINITY, ease: "easeInOut"}}>
-                {t((m) => m.About.Platform.hero.title)}
+                {t((m) => m.sections.about.platform.hero.title)}
               </motion.span>
               <GradientText
                 text='arolariu.ro'
@@ -160,7 +160,7 @@ export default function Hero(): React.JSX.Element {
             initial={{opacity: 0, y: 30}}
             animate={{opacity: 1, y: 0}}
             transition={{duration: 0.6, delay: 0.3}}>
-            {t((m) => m.About.Platform.hero.description)}
+            {t((m) => m.sections.about.platform.hero.description)}
           </motion.p>
 
           {/* Feature Pills */}
@@ -170,9 +170,9 @@ export default function Hero(): React.JSX.Element {
             animate={{opacity: 1, y: 0}}
             transition={{duration: 0.6, delay: 0.4}}>
             {[
-              {icon: TbCode, label: t((m) => m.About.Platform.hero.trust.openSource)},
-              {icon: TbRocket, label: t((m) => m.About.Platform.hero.trust.privacyFirst)},
-              {icon: TbSparkles, label: t((m) => m.About.Platform.hero.trust.freeForever)},
+              {icon: TbCode, label: t((m) => m.sections.about.platform.hero.trust.openSource)},
+              {icon: TbRocket, label: t((m) => m.sections.about.platform.hero.trust.privacyFirst)},
+              {icon: TbSparkles, label: t((m) => m.sections.about.platform.hero.trust.freeForever)},
             ].map((pill, index) => (
               <motion.span
                 key={pill.label}
@@ -205,7 +205,7 @@ export default function Hero(): React.JSX.Element {
                 className={styles["ctaButton"]}>
                 <Link href='/domains'>
                   <TbRocket className={styles["ctaIcon"]} />
-                  <span>{t((m) => m.About.Platform.hero.cta.exploreFeatures)}</span>
+                  <span>{t((m) => m.sections.about.platform.hero.cta.exploreFeatures)}</span>
                   <TbArrowRight className={styles["ctaArrow"]} />
                   <motion.span
                     className={styles["ctaOverlay"]}
@@ -230,7 +230,7 @@ export default function Hero(): React.JSX.Element {
                   target='_blank'
                   rel='noopener noreferrer'>
                   <TbBrandGithub className={styles["ctaIcon"]} />
-                  <span>{t((m) => m.About.Platform.hero.cta.viewSource)}</span>
+                  <span>{t((m) => m.sections.about.platform.hero.cta.viewSource)}</span>
                   <motion.span
                     className={styles["ctaOverlay"]}
                     initial={{x: "-100%", opacity: 0}}

--- a/sites/arolariu.ro/src/app/about/the-platform/_components/Stepper.tsx
+++ b/sites/arolariu.ro/src/app/about/the-platform/_components/Stepper.tsx
@@ -90,7 +90,7 @@ export default function Stepper(): React.JSX.Element {
                     variant='outline'
                     className={styles["dateBadge"]}>
                     <TbCalendar className={styles["dateIcon"]} />
-                    {t(selectorFromPath(`About.Platform.timeline.${`events.${event.id}.date`}`))}
+                    {t(selectorFromPath(`sections.about.platform.timeline.${`events.${event.id}.date`}`))}
                   </Badge>
 
                   <button
@@ -98,14 +98,14 @@ export default function Stepper(): React.JSX.Element {
                     data-event-id={event.id}
                     className={styles["stepButton"]}
                     onClick={handleStepClick}>
-                    <h3 className={styles["stepTitle"]}>{t(selectorFromPath(`About.Platform.timeline.${`events.${event.id}.title`}`))}</h3>
+                    <h3 className={styles["stepTitle"]}>{t(selectorFromPath(`sections.about.platform.timeline.${`events.${event.id}.title`}`))}</h3>
                   </button>
 
-                  <p className={styles["stepDescription"]}>{t(selectorFromPath(`About.Platform.timeline.${`events.${event.id}.description`}`))}</p>
+                  <p className={styles["stepDescription"]}>{t(selectorFromPath(`sections.about.platform.timeline.${`events.${event.id}.description`}`))}</p>
 
                   {/* Tags */}
                   <div className={styles["tags"]}>
-                    {t(selectorFromPath(`About.Platform.timeline.${`events.${event.id}.tags`}`))
+                    {t(selectorFromPath(`sections.about.platform.timeline.${`events.${event.id}.tags`}`))
                       .split(",")
                       .map((tag) => (
                         <Badge
@@ -128,7 +128,7 @@ export default function Stepper(): React.JSX.Element {
                         className={styles["expandable"]}>
                         <h4 className={styles["detailsTitle"]}>{t((m) => m.sections.about.platform.timeline.keyAchievements)}</h4>
                         <ul className={styles["detailsList"]}>
-                          {t(selectorFromPath(`About.Platform.timeline.${`events.${event.id}.details`}`))
+                          {t(selectorFromPath(`sections.about.platform.timeline.${`events.${event.id}.details`}`))
                             .split(",")
                             .map((detail) => (
                               <motion.li

--- a/sites/arolariu.ro/src/app/about/the-platform/_components/Stepper.tsx
+++ b/sites/arolariu.ro/src/app/about/the-platform/_components/Stepper.tsx
@@ -55,12 +55,12 @@ export default function Stepper(): React.JSX.Element {
           <Badge
             variant='outline'
             className={styles["badge"]}>
-            {t((m) => m.About.Platform.timeline.badge)}
+            {t((m) => m.sections.about.platform.timeline.badge)}
           </Badge>
           <h2 className={styles["title"]}>
-            {t((m) => m.About.Platform.timeline.title)} <span className={styles["titleHighlight"]}>{t((m) => m.About.Platform.timeline.titleHighlight)}</span>
+            {t((m) => m.sections.about.platform.timeline.title)} <span className={styles["titleHighlight"]}>{t((m) => m.sections.about.platform.timeline.titleHighlight)}</span>
           </h2>
-          <p className={styles["description"]}>{t((m) => m.About.Platform.timeline.description)}</p>
+          <p className={styles["description"]}>{t((m) => m.sections.about.platform.timeline.description)}</p>
         </motion.div>
 
         {/* Stepper list */}
@@ -126,7 +126,7 @@ export default function Stepper(): React.JSX.Element {
                         exit={{height: 0, opacity: 0}}
                         transition={{duration: 0.3}}
                         className={styles["expandable"]}>
-                        <h4 className={styles["detailsTitle"]}>{t((m) => m.About.Platform.timeline.keyAchievements)}</h4>
+                        <h4 className={styles["detailsTitle"]}>{t((m) => m.sections.about.platform.timeline.keyAchievements)}</h4>
                         <ul className={styles["detailsList"]}>
                           {t(selectorFromPath(`About.Platform.timeline.${`events.${event.id}.details`}`))
                             .split(",")
@@ -151,7 +151,7 @@ export default function Stepper(): React.JSX.Element {
                     data-event-id={event.id}
                     className={styles["expandHint"]}
                     onClick={handleStepClick}>
-                    {isExpanded ? t((m) => m.About.Platform.timeline.collapseHint) : t((m) => m.About.Platform.timeline.expandHint)}
+                    {isExpanded ? t((m) => m.sections.about.platform.timeline.collapseHint) : t((m) => m.sections.about.platform.timeline.expandHint)}
                   </button>
                 </div>
               </motion.div>
@@ -173,7 +173,7 @@ export default function Stepper(): React.JSX.Element {
             transition={{duration: 2, repeat: Number.POSITIVE_INFINITY}}>
             <TbRocket className={styles["futureIcon"]} />
           </motion.div>
-          <p className={styles["futureText"]}>{t((m) => m.About.Platform.timeline.futureIndicator)}</p>
+          <p className={styles["futureText"]}>{t((m) => m.sections.about.platform.timeline.futureIndicator)}</p>
         </motion.div>
       </div>
     </section>

--- a/sites/arolariu.ro/src/app/about/the-platform/_components/TechStack.stories.tsx
+++ b/sites/arolariu.ro/src/app/about/the-platform/_components/TechStack.stories.tsx
@@ -5,8 +5,8 @@ import TechStack from "./TechStack";
  * TechStack section displaying technologies used in the platform.
  * Features tabbed navigation (Frontend, Backend, Cloud, Tooling) with
  * animated technology cards and merged platform statistics with animated
- * counters. Uses the `About.Platform.techStack` and
- * `About.Platform.statistics` i18n namespaces.
+ * counters. Uses the `sections.about.platform.techStack` and
+ * `sections.about.platform.statistics` i18n namespaces.
  */
 const meta = {
   title: "Pages/About/ThePlatform/TechStack",

--- a/sites/arolariu.ro/src/app/about/the-platform/_components/TechStack.tsx
+++ b/sites/arolariu.ro/src/app/about/the-platform/_components/TechStack.tsx
@@ -218,7 +218,7 @@ export default function TechStack(): React.JSX.Element {
                   value={category.id}
                   className={activeTab === category.id ? styles["tabTriggerActive"] : styles["tabTrigger"]}>
                   <category.icon className={styles["tabIcon"]} />
-                  <span className={styles["tabLabel"]}>{t(selectorFromPath(`About.Platform.techStack.${`categories.${category.id}.name`}`))}</span>
+                  <span className={styles["tabLabel"]}>{t(selectorFromPath(`sections.about.platform.techStack.${`categories.${category.id}.name`}`))}</span>
                   {activeTab === category.id && (
                     <motion.span
                       className={`${styles["tabIndicator"]} ${styles[gradientClassMap[category.colorKey]]}`}
@@ -244,7 +244,7 @@ export default function TechStack(): React.JSX.Element {
                   transition={{duration: 0.3}}>
                   {/* Category Description */}
                   <div className={styles["categoryDescription"]}>
-                    <p>{t(selectorFromPath(`About.Platform.techStack.${`categories.${category.id}.description`}`))}</p>
+                    <p>{t(selectorFromPath(`sections.about.platform.techStack.${`categories.${category.id}.description`}`))}</p>
                   </div>
 
                   {/* Technologies Grid */}
@@ -281,7 +281,7 @@ export default function TechStack(): React.JSX.Element {
                             {/* Content */}
                             <div className={styles["techInfo"]}>
                               <div className={styles["techName"]}>
-                                <h3>{t(selectorFromPath(`About.Platform.techStack.${`technologies.${tech.id}.name`}`))}</h3>
+                                <h3>{t(selectorFromPath(`sections.about.platform.techStack.${`technologies.${tech.id}.name`}`))}</h3>
                                 {tech.version !== undefined && (
                                   <Badge
                                     variant='secondary'
@@ -291,7 +291,7 @@ export default function TechStack(): React.JSX.Element {
                                 )}
                               </div>
                               <p className={styles["techDescription"]}>
-                                {t(selectorFromPath(`About.Platform.techStack.${`technologies.${tech.id}.description`}`))}
+                                {t(selectorFromPath(`sections.about.platform.techStack.${`technologies.${tech.id}.description`}`))}
                               </p>
                             </div>
                           </CardContent>
@@ -364,15 +364,15 @@ export default function TechStack(): React.JSX.Element {
                   {/* Animated Number */}
                   <div className={styles["statValue"]}>
                     <CountingNumber
-                      number={Number(tStats(selectorFromPath(`About.Platform.statistics.items.${stat.id}.value`)))}
+                      number={Number(tStats(selectorFromPath(`sections.about.platform.statistics.items.${stat.id}.value`)))}
                       inView
                     />
-                    {tStats(selectorFromPath(`About.Platform.statistics.items.${stat.id}.suffix`))}
+                    {tStats(selectorFromPath(`sections.about.platform.statistics.items.${stat.id}.suffix`))}
                   </div>
 
                   {/* Label */}
-                  <h3 className={styles["statLabel"]}>{tStats(selectorFromPath(`About.Platform.statistics.items.${stat.id}.label`))}</h3>
-                  <p className={styles["statDescription"]}>{tStats(selectorFromPath(`About.Platform.statistics.items.${stat.id}.description`))}</p>
+                  <h3 className={styles["statLabel"]}>{tStats(selectorFromPath(`sections.about.platform.statistics.items.${stat.id}.label`))}</h3>
+                  <p className={styles["statDescription"]}>{tStats(selectorFromPath(`sections.about.platform.statistics.items.${stat.id}.description`))}</p>
                 </CardContent>
 
                 {/* Animated border */}

--- a/sites/arolariu.ro/src/app/about/the-platform/_components/TechStack.tsx
+++ b/sites/arolariu.ro/src/app/about/the-platform/_components/TechStack.tsx
@@ -190,13 +190,13 @@ export default function TechStack(): React.JSX.Element {
             <Badge
               variant='outline'
               className={styles["badge"]}>
-              {t((m) => m.About.Platform.techStack.badge)}
+              {t((m) => m.sections.about.platform.techStack.badge)}
             </Badge>
           </motion.div>
           <h2 className={styles["title"]}>
-            {t((m) => m.About.Platform.techStack.title)} <span className={styles["titleHighlight"]}>{t((m) => m.About.Platform.techStack.titleHighlight)}</span>
+            {t((m) => m.sections.about.platform.techStack.title)} <span className={styles["titleHighlight"]}>{t((m) => m.sections.about.platform.techStack.titleHighlight)}</span>
           </h2>
-          <p className={styles["description"]}>{t((m) => m.About.Platform.techStack.description)}</p>
+          <p className={styles["description"]}>{t((m) => m.sections.about.platform.techStack.description)}</p>
         </motion.div>
 
         {/* Tabs */}
@@ -323,12 +323,12 @@ export default function TechStack(): React.JSX.Element {
           <Badge
             variant='outline'
             className={styles["badge"]}>
-            {tStats((m) => m.About.Platform.statistics.badge)}
+            {tStats((m) => m.sections.about.platform.statistics.badge)}
           </Badge>
           <h3 className={styles["statsTitle"]}>
-            {tStats((m) => m.About.Platform.statistics.title)} <span className={styles["titleHighlight"]}>{tStats((m) => m.About.Platform.statistics.titleHighlight)}</span>
+            {tStats((m) => m.sections.about.platform.statistics.title)} <span className={styles["titleHighlight"]}>{tStats((m) => m.sections.about.platform.statistics.titleHighlight)}</span>
           </h3>
-          <p className={styles["statsDescription"]}>{tStats((m) => m.About.Platform.statistics.description)}</p>
+          <p className={styles["statsDescription"]}>{tStats((m) => m.sections.about.platform.statistics.description)}</p>
         </motion.div>
 
         <div className={styles["statsGrid"]}>

--- a/sites/arolariu.ro/src/app/about/the-platform/page.tsx
+++ b/sites/arolariu.ro/src/app/about/the-platform/page.tsx
@@ -28,7 +28,7 @@ import styles from "./page.module.scss";
  * @remarks
  * **Rendering Context**: Server Component metadata generator.
  *
- * **i18n**: Uses `next-intl` translations from About.Platform.
+ * **i18n**: Uses `next-intl` translations from sections.about.platform.
  *
  * **SEO**: Delegates to `createMetadata` for consistent Open Graph defaults.
  *

--- a/sites/arolariu.ro/src/app/about/the-platform/page.tsx
+++ b/sites/arolariu.ro/src/app/about/the-platform/page.tsx
@@ -46,8 +46,8 @@ export async function generateMetadata(): Promise<Metadata> {
   const locale = await getLocale();
   return createMetadata({
     locale,
-    title: t((m) => m.About.Platform.metadata.title),
-    description: t((m) => m.About.Platform.metadata.description),
+    title: t((m) => m.pages.about.platform.metadata.title),
+    description: t((m) => m.pages.about.platform.metadata.description),
   });
 }
 

--- a/sites/arolariu.ro/src/app/auth/error.tsx
+++ b/sites/arolariu.ro/src/app/auth/error.tsx
@@ -20,17 +20,17 @@ export default function AuthError({error, reset}: AuthErrorProps): React.JSX.Ele
       role='alert'
       aria-live='assertive'
       data-scope='auth'>
-      <h1>{t((m) => m.Errors.globalError.hero.title)}</h1>
-      <p>{t((m) => m.Errors.globalError.hero.subtitle)}</p>
+      <h1>{t((m) => m.app.errors.globalError.hero.title)}</h1>
+      <p>{t((m) => m.app.errors.globalError.hero.subtitle)}</p>
       {error.digest ? (
         <p>
-          <span>{t((m) => m.Errors.globalError.details.errorIdLabel)}</span> <code>{error.digest}</code>
+          <span>{t((m) => m.app.errors.globalError.details.errorIdLabel)}</span> <code>{error.digest}</code>
         </p>
       ) : null}
       <button
         type='button'
         onClick={reset}>
-        {t((m) => m.Errors.globalError.buttons.tryAgain)}
+        {t((m) => m.app.errors.globalError.buttons.tryAgain)}
       </button>
     </section>
   );

--- a/sites/arolariu.ro/src/app/auth/island.tsx
+++ b/sites/arolariu.ro/src/app/auth/island.tsx
@@ -61,20 +61,20 @@ type AuthCard = Readonly<{
 export default function RenderAuthScreen(): React.JSX.Element {
   const t = useTranslations();
 
-  const trustBadges: Readonly<[string, string, string]> = [t((m) => m.Auth.Island.trust.oauth), t((m) => m.Auth.Island.trust.session), t((m) => m.Auth.Island.trust.privacy)];
+  const trustBadges: Readonly<[string, string, string]> = [t((m) => m.pages.auth.island.trust.oauth), t((m) => m.pages.auth.island.trust.session), t((m) => m.pages.auth.island.trust.privacy)];
 
   const cards: ReadonlyArray<AuthCard> = [
     {
       key: "signUp",
       href: "/auth/sign-up/",
       imageSrc: "/images/auth/sign-up.svg",
-      illustrationAlt: t((m) => m.Auth.Island.signUp.illustrationAlt),
-      title: t((m) => m.Auth.Island.signUp.title),
-      description: t((m) => m.Auth.Island.signUp.description),
-      bullets: [t((m) => m.Auth.Island.signUp.bullets.first), t((m) => m.Auth.Island.signUp.bullets.second), t((m) => m.Auth.Island.signUp.bullets.third)],
-      cta: t((m) => m.Auth.Island.signUp.cta),
-      secondaryPrompt: t((m) => m.Auth.Island.signUp.secondaryPrompt),
-      secondaryAction: t((m) => m.Auth.Island.signUp.secondaryAction),
+      illustrationAlt: t((m) => m.pages.auth.island.signUp.illustrationAlt),
+      title: t((m) => m.pages.auth.island.signUp.title),
+      description: t((m) => m.pages.auth.island.signUp.description),
+      bullets: [t((m) => m.pages.auth.island.signUp.bullets.first), t((m) => m.pages.auth.island.signUp.bullets.second), t((m) => m.pages.auth.island.signUp.bullets.third)],
+      cta: t((m) => m.pages.auth.island.signUp.cta),
+      secondaryPrompt: t((m) => m.pages.auth.island.signUp.secondaryPrompt),
+      secondaryAction: t((m) => m.pages.auth.island.signUp.secondaryAction),
       secondaryHref: "/auth/sign-in/",
       icon: TbUserPlus,
       gradientKey: "emerald",
@@ -83,13 +83,13 @@ export default function RenderAuthScreen(): React.JSX.Element {
       key: "signIn",
       href: "/auth/sign-in/",
       imageSrc: "/images/auth/sign-in.svg",
-      illustrationAlt: t((m) => m.Auth.Island.signIn.illustrationAlt),
-      title: t((m) => m.Auth.Island.signIn.title),
-      description: t((m) => m.Auth.Island.signIn.description),
-      bullets: [t((m) => m.Auth.Island.signIn.bullets.first), t((m) => m.Auth.Island.signIn.bullets.second), t((m) => m.Auth.Island.signIn.bullets.third)],
-      cta: t((m) => m.Auth.Island.signIn.cta),
-      secondaryPrompt: t((m) => m.Auth.Island.signIn.secondaryPrompt),
-      secondaryAction: t((m) => m.Auth.Island.signIn.secondaryAction),
+      illustrationAlt: t((m) => m.pages.auth.island.signIn.illustrationAlt),
+      title: t((m) => m.pages.auth.island.signIn.title),
+      description: t((m) => m.pages.auth.island.signIn.description),
+      bullets: [t((m) => m.pages.auth.island.signIn.bullets.first), t((m) => m.pages.auth.island.signIn.bullets.second), t((m) => m.pages.auth.island.signIn.bullets.third)],
+      cta: t((m) => m.pages.auth.island.signIn.cta),
+      secondaryPrompt: t((m) => m.pages.auth.island.signIn.secondaryPrompt),
+      secondaryAction: t((m) => m.pages.auth.island.signIn.secondaryAction),
       secondaryHref: "/auth/sign-up/",
       icon: TbLock,
       gradientKey: "violet",
@@ -108,9 +108,9 @@ export default function RenderAuthScreen(): React.JSX.Element {
               OAuth 2.0
             </Badge>
 
-            <h1 className={styles["heroTitle"]}>{t((m) => m.Auth.Island.hero.title)}</h1>
+            <h1 className={styles["heroTitle"]}>{t((m) => m.pages.auth.island.hero.title)}</h1>
 
-            <p className={styles["heroSubtitle"]}>{t((m) => m.Auth.Island.hero.subtitle)}</p>
+            <p className={styles["heroSubtitle"]}>{t((m) => m.pages.auth.island.hero.subtitle)}</p>
           </div>
 
           <div className={styles["trustBadgesCenter"]}>
@@ -142,7 +142,7 @@ export default function RenderAuthScreen(): React.JSX.Element {
                     <div className={styles["cardIconWrapper"]}>
                       <card.icon className={styles["cardIcon"]} />
                     </div>
-                    <div className={styles["cardStep"]}>{index === 0 ? t((m) => m.Auth.Island.step1) : t((m) => m.Auth.Island.step2)}</div>
+                    <div className={styles["cardStep"]}>{index === 0 ? t((m) => m.pages.auth.island.step1) : t((m) => m.pages.auth.island.step2)}</div>
                   </div>
 
                   {/* Illustration */}
@@ -209,7 +209,7 @@ export default function RenderAuthScreen(): React.JSX.Element {
         </div>
 
         {/* Section footer note */}
-        <p className={styles["footerNote"]}>{t((m) => m.Auth.Island.footer)}</p>
+        <p className={styles["footerNote"]}>{t((m) => m.pages.auth.island.footer)}</p>
       </div>
     </section>
   );

--- a/sites/arolariu.ro/src/app/auth/page.tsx
+++ b/sites/arolariu.ro/src/app/auth/page.tsx
@@ -45,8 +45,8 @@ export async function generateMetadata(): Promise<Metadata> {
   const locale = await getLocale();
   return createMetadata({
     locale,
-    title: t((m) => m.Auth.metadata.title),
-    description: t((m) => m.Auth.metadata.description),
+    title: t((m) => m.pages.auth.metadata.title),
+    description: t((m) => m.pages.auth.metadata.description),
   });
 }
 

--- a/sites/arolariu.ro/src/app/auth/sign-in/[[...sign-in]]/island.tsx
+++ b/sites/arolariu.ro/src/app/auth/sign-in/[[...sign-in]]/island.tsx
@@ -75,22 +75,22 @@ export default function RenderAuthSignInPage(): React.JSX.Element {
     <div className={styles["grid"]}>
       <div className={`${styles["column"]} ${styles["columnReverse"]}`}>
         <AuthMarketingPanel
-          title={t((m) => m.Auth.SignIn.hero.title)}
-          subtitle={t((m) => m.Auth.SignIn.hero.subtitle)}
+          title={t((m) => m.pages.auth.signIn.hero.title)}
+          subtitle={t((m) => m.pages.auth.signIn.hero.subtitle)}
           illustrationSrc='/images/auth/sign-in.svg'
-          illustrationAlt={t((m) => m.Auth.SignIn.illustrationAlt)}
-          bullets={[t((m) => m.Auth.SignIn.bullets.first), t((m) => m.Auth.SignIn.bullets.second), t((m) => m.Auth.SignIn.bullets.third)]}
-          trustBadges={[trust((m) => m.Auth.Island.trust.oauth), trust((m) => m.Auth.Island.trust.session), trust((m) => m.Auth.Island.trust.privacy)]}
+          illustrationAlt={t((m) => m.pages.auth.signIn.illustrationAlt)}
+          bullets={[t((m) => m.pages.auth.signIn.bullets.first), t((m) => m.pages.auth.signIn.bullets.second), t((m) => m.pages.auth.signIn.bullets.third)]}
+          trustBadges={[trust((m) => m.pages.auth.island.trust.oauth), trust((m) => m.pages.auth.island.trust.session), trust((m) => m.pages.auth.island.trust.privacy)]}
         />
       </div>
 
       <div className={`${styles["column"]} ${styles["columnForward"]}`}>
         <AuthFormShell
-          kicker={t((m) => m.Auth.SignIn.form.kicker)}
-          secondaryPrompt={t((m) => m.Auth.SignIn.form.secondaryPrompt)}
-          secondaryAction={t((m) => m.Auth.SignIn.form.secondaryAction)}
+          kicker={t((m) => m.pages.auth.signIn.form.kicker)}
+          secondaryPrompt={t((m) => m.pages.auth.signIn.form.secondaryPrompt)}
+          secondaryAction={t((m) => m.pages.auth.signIn.form.secondaryAction)}
           secondaryHref='/auth/sign-up/'
-          footer={t((m) => m.Auth.SignIn.footer)}>
+          footer={t((m) => m.pages.auth.signIn.footer)}>
           <motion.div
             variants={containerVariants}
             initial='hidden'

--- a/sites/arolariu.ro/src/app/auth/sign-in/[[...sign-in]]/page.tsx
+++ b/sites/arolariu.ro/src/app/auth/sign-in/[[...sign-in]]/page.tsx
@@ -19,8 +19,8 @@ export async function generateMetadata(): Promise<Metadata> {
 
   return createMetadata({
     locale,
-    title: t((m) => m.Auth.SignIn.metadata.title),
-    description: t((m) => m.Auth.SignIn.metadata.description),
+    title: t((m) => m.pages.auth.signIn.metadata.title),
+    description: t((m) => m.pages.auth.signIn.metadata.description),
   });
 }
 

--- a/sites/arolariu.ro/src/app/auth/sign-up/[[...sign-up]]/island.tsx
+++ b/sites/arolariu.ro/src/app/auth/sign-up/[[...sign-up]]/island.tsx
@@ -78,22 +78,22 @@ export default function RenderAuthSignUpPage(): React.JSX.Element {
     <div className={styles["grid"]}>
       <div className={styles["column"]}>
         <AuthMarketingPanel
-          title={t((m) => m.Auth.SignUp.hero.title)}
-          subtitle={t((m) => m.Auth.SignUp.hero.subtitle)}
+          title={t((m) => m.pages.auth.signUp.hero.title)}
+          subtitle={t((m) => m.pages.auth.signUp.hero.subtitle)}
           illustrationSrc='/images/auth/sign-up.svg'
-          illustrationAlt={t((m) => m.Auth.SignUp.illustrationAlt)}
-          bullets={[t((m) => m.Auth.SignUp.bullets.first), t((m) => m.Auth.SignUp.bullets.second), t((m) => m.Auth.SignUp.bullets.third)]}
-          trustBadges={[trust((m) => m.Auth.Island.trust.oauth), trust((m) => m.Auth.Island.trust.session), trust((m) => m.Auth.Island.trust.privacy)]}
+          illustrationAlt={t((m) => m.pages.auth.signUp.illustrationAlt)}
+          bullets={[t((m) => m.pages.auth.signUp.bullets.first), t((m) => m.pages.auth.signUp.bullets.second), t((m) => m.pages.auth.signUp.bullets.third)]}
+          trustBadges={[trust((m) => m.pages.auth.island.trust.oauth), trust((m) => m.pages.auth.island.trust.session), trust((m) => m.pages.auth.island.trust.privacy)]}
         />
       </div>
 
       <div className={styles["column"]}>
         <AuthFormShell
-          kicker={t((m) => m.Auth.SignUp.form.kicker)}
-          secondaryPrompt={t((m) => m.Auth.SignUp.form.secondaryPrompt)}
-          secondaryAction={t((m) => m.Auth.SignUp.form.secondaryAction)}
+          kicker={t((m) => m.pages.auth.signUp.form.kicker)}
+          secondaryPrompt={t((m) => m.pages.auth.signUp.form.secondaryPrompt)}
+          secondaryAction={t((m) => m.pages.auth.signUp.form.secondaryAction)}
           secondaryHref='/auth/sign-in/'
-          footer={t((m) => m.Auth.SignUp.footer)}>
+          footer={t((m) => m.pages.auth.signUp.footer)}>
           <motion.div
             variants={containerVariants}
             initial='hidden'

--- a/sites/arolariu.ro/src/app/auth/sign-up/[[...sign-up]]/page.tsx
+++ b/sites/arolariu.ro/src/app/auth/sign-up/[[...sign-up]]/page.tsx
@@ -19,8 +19,8 @@ export async function generateMetadata(): Promise<Metadata> {
 
   return createMetadata({
     locale,
-    title: t((m) => m.Auth.SignUp.metadata.title),
-    description: t((m) => m.Auth.SignUp.metadata.description),
+    title: t((m) => m.pages.auth.signUp.metadata.title),
+    description: t((m) => m.pages.auth.signUp.metadata.description),
   });
 }
 

--- a/sites/arolariu.ro/src/app/domains/error.tsx
+++ b/sites/arolariu.ro/src/app/domains/error.tsx
@@ -20,17 +20,17 @@ export default function DomainsError({error, reset}: DomainsErrorProps): React.J
       role='alert'
       aria-live='assertive'
       data-scope='domains'>
-      <h1>{t((m) => m.Errors.globalError.hero.title)}</h1>
-      <p>{t((m) => m.Errors.globalError.hero.subtitle)}</p>
+      <h1>{t((m) => m.app.errors.globalError.hero.title)}</h1>
+      <p>{t((m) => m.app.errors.globalError.hero.subtitle)}</p>
       {error.digest ? (
         <p>
-          <span>{t((m) => m.Errors.globalError.details.errorIdLabel)}</span> <code>{error.digest}</code>
+          <span>{t((m) => m.app.errors.globalError.details.errorIdLabel)}</span> <code>{error.digest}</code>
         </p>
       ) : null}
       <button
         type='button'
         onClick={reset}>
-        {t((m) => m.Errors.globalError.buttons.tryAgain)}
+        {t((m) => m.app.errors.globalError.buttons.tryAgain)}
       </button>
     </section>
   );

--- a/sites/arolariu.ro/src/app/domains/invoices/_components/InvoiceNotFound.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_components/InvoiceNotFound.tsx
@@ -13,8 +13,8 @@ export default function InvoiceNotFound({invoiceIdentifier}: Readonly<{invoiceId
   return (
     <section className={styles["section"]}>
       <article className={styles["article"]}>
-        <h1 className={styles["title"]}>{t((m) => m["IMS--Common"].statesNotFound.title)}</h1>
-        <p className={styles["description"]}>{t((m) => m["IMS--Common"].statesNotFound.description, {invoiceIdentifier})}</p>
+        <h1 className={styles["title"]}>{t((m) => m.shared.invoices.statesNotFound.title)}</h1>
+        <p className={styles["description"]}>{t((m) => m.shared.invoices.statesNotFound.description, {invoiceIdentifier})}</p>
       </article>
     </section>
   );

--- a/sites/arolariu.ro/src/app/domains/invoices/_components/InvoicePreferences.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_components/InvoicePreferences.tsx
@@ -79,7 +79,7 @@ export default function InvoicePreferences(): React.JSX.Element {
    */
   const handleSave = useCallback(() => {
     // Preferences are already saved via useLocalStorage setter
-    toast.success(t((m) => m["IMS--Common"].preferences.saved));
+    toast.success(t((m) => m.shared.invoices.preferences.saved));
   }, [t]);
 
   /**
@@ -140,7 +140,7 @@ export default function InvoicePreferences(): React.JSX.Element {
             className={styles["icon"]}
             aria-hidden='true'
           />
-          {t((m) => m["IMS--Common"].preferences.title)}
+          {t((m) => m.shared.invoices.preferences.title)}
         </CardTitle>
       </CardHeader>
       <CardContent className={styles["content"]}>
@@ -148,7 +148,7 @@ export default function InvoicePreferences(): React.JSX.Element {
           <Label
             htmlFor='defaultViewMode'
             className={styles["label"]}>
-            {t((m) => m["IMS--Common"].preferences.defaultView)}
+            {t((m) => m.shared.invoices.preferences.defaultView)}
           </Label>
           <Select
             value={preferences.defaultViewMode}
@@ -159,8 +159,8 @@ export default function InvoicePreferences(): React.JSX.Element {
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value='table'>{t((m) => m["IMS--Common"].preferences.views.table)}</SelectItem>
-              <SelectItem value='grid'>{t((m) => m["IMS--Common"].preferences.views.grid)}</SelectItem>
+              <SelectItem value='table'>{t((m) => m.shared.invoices.preferences.views.table)}</SelectItem>
+              <SelectItem value='grid'>{t((m) => m.shared.invoices.preferences.views.grid)}</SelectItem>
             </SelectContent>
           </Select>
         </div>
@@ -169,7 +169,7 @@ export default function InvoicePreferences(): React.JSX.Element {
           <Label
             htmlFor='defaultSortBy'
             className={styles["label"]}>
-            {t((m) => m["IMS--Common"].preferences.sortBy)}
+            {t((m) => m.shared.invoices.preferences.sortBy)}
           </Label>
           <Select
             value={preferences.defaultSortBy}
@@ -180,11 +180,11 @@ export default function InvoicePreferences(): React.JSX.Element {
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value='dateDesc'>{t((m) => m["IMS--Common"].preferences.sortOptions.dateDesc)}</SelectItem>
-              <SelectItem value='dateAsc'>{t((m) => m["IMS--Common"].preferences.sortOptions.dateAsc)}</SelectItem>
-              <SelectItem value='amountDesc'>{t((m) => m["IMS--Common"].preferences.sortOptions.amountDesc)}</SelectItem>
-              <SelectItem value='amountAsc'>{t((m) => m["IMS--Common"].preferences.sortOptions.amountAsc)}</SelectItem>
-              <SelectItem value='nameAsc'>{t((m) => m["IMS--Common"].preferences.sortOptions.nameAsc)}</SelectItem>
+              <SelectItem value='dateDesc'>{t((m) => m.shared.invoices.preferences.sortOptions.dateDesc)}</SelectItem>
+              <SelectItem value='dateAsc'>{t((m) => m.shared.invoices.preferences.sortOptions.dateAsc)}</SelectItem>
+              <SelectItem value='amountDesc'>{t((m) => m.shared.invoices.preferences.sortOptions.amountDesc)}</SelectItem>
+              <SelectItem value='amountAsc'>{t((m) => m.shared.invoices.preferences.sortOptions.amountAsc)}</SelectItem>
+              <SelectItem value='nameAsc'>{t((m) => m.shared.invoices.preferences.sortOptions.nameAsc)}</SelectItem>
             </SelectContent>
           </Select>
         </div>
@@ -193,7 +193,7 @@ export default function InvoicePreferences(): React.JSX.Element {
           <Label
             htmlFor='defaultPageSize'
             className={styles["label"]}>
-            {t((m) => m["IMS--Common"].preferences.pageSize)}
+            {t((m) => m.shared.invoices.preferences.pageSize)}
           </Label>
           <Select
             value={preferences.defaultPageSize.toString()}
@@ -216,7 +216,7 @@ export default function InvoicePreferences(): React.JSX.Element {
           <Label
             htmlFor='currency'
             className={styles["label"]}>
-            {t((m) => m["IMS--Common"].preferences.currency)}
+            {t((m) => m.shared.invoices.preferences.currency)}
           </Label>
           <Select
             value={preferences.currency}
@@ -245,7 +245,7 @@ export default function InvoicePreferences(): React.JSX.Element {
             <Label
               htmlFor='showStatisticsOnHome'
               className={styles["checkboxLabel"]}>
-              {t((m) => m["IMS--Common"].preferences.showStats)}
+              {t((m) => m.shared.invoices.preferences.showStats)}
             </Label>
           </div>
         </div>
@@ -253,7 +253,7 @@ export default function InvoicePreferences(): React.JSX.Element {
         <Button
           onClick={handleSave}
           className={styles["saveButton"]}>
-          {t((m) => m["IMS--Common"].preferences.save)}
+          {t((m) => m.shared.invoices.preferences.save)}
         </Button>
       </CardContent>
     </Card>

--- a/sites/arolariu.ro/src/app/domains/invoices/_components/InvoicesNotFound.stories.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_components/InvoicesNotFound.stories.tsx
@@ -12,7 +12,7 @@ import messages from "../../../../../messages/en.json";
  * and styling using the English i18n strings directly.
  */
 
-const namespace = messages["IMS--Common"].invoicesNotFound;
+const namespace = messages.shared.invoices.invoicesNotFound;
 
 const meta = {
   title: "Invoices/States/InvoicesNotFound",

--- a/sites/arolariu.ro/src/app/domains/invoices/_components/InvoicesNotFound.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_components/InvoicesNotFound.tsx
@@ -10,12 +10,12 @@ export default async function InvoicesNotFound(): Promise<React.JSX.Element> {
   const t = await getTranslations();
   return (
     <div className={styles["container"]}>
-      <h1 className={styles["title"]}>{t((m) => m["IMS--Common"].invoicesNotFound.title)}</h1>
-      <article className={styles["description"]}>{t((m) => m["IMS--Common"].invoicesNotFound.description)}</article>
+      <h1 className={styles["title"]}>{t((m) => m.shared.invoices.invoicesNotFound.title)}</h1>
+      <article className={styles["description"]}>{t((m) => m.shared.invoices.invoicesNotFound.description)}</article>
       <Link
         href='/domains/invoices/create-invoice'
         className={styles["ctaLink"]}>
-        {t((m) => m["IMS--Common"].invoicesNotFound.cta)}
+        {t((m) => m.shared.invoices.invoicesNotFound.cta)}
       </Link>
     </div>
   );

--- a/sites/arolariu.ro/src/app/domains/invoices/_components/LoadingInvoice.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_components/LoadingInvoice.tsx
@@ -13,8 +13,8 @@ export default function LoadingInvoice({invoiceIdentifier}: Readonly<{invoiceIde
   return (
     <section className={styles["section"]}>
       <article className={styles["article"]}>
-        <h1 className={styles["title"]}>{t((m) => m["IMS--Common"].statesLoading.title)}</h1>
-        <p className={styles["description"]}>{t((m) => m["IMS--Common"].statesLoading.description, {invoiceIdentifier})}</p>
+        <h1 className={styles["title"]}>{t((m) => m.shared.invoices.statesLoading.title)}</h1>
+        <p className={styles["description"]}>{t((m) => m.shared.invoices.statesLoading.description, {invoiceIdentifier})}</p>
       </article>
     </section>
   );

--- a/sites/arolariu.ro/src/app/domains/invoices/_components/LoadingInvoices.stories.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_components/LoadingInvoices.stories.tsx
@@ -11,7 +11,7 @@ import messages from "../../../../../messages/en.json";
  * using the same i18n messages and SCSS module styles.
  */
 
-const namespace = messages["IMS--Common"].loadingInvoices;
+const namespace = messages.shared.invoices.loadingInvoices;
 
 const meta = {
   title: "Invoices/States/LoadingInvoices",

--- a/sites/arolariu.ro/src/app/domains/invoices/_components/LoadingInvoices.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_components/LoadingInvoices.tsx
@@ -10,8 +10,8 @@ export default async function LoadingInvoices(): Promise<React.JSX.Element> {
   return (
     <section className={styles["section"]}>
       <article className={styles["article"]}>
-        <h1 className={styles["title"]}>{t((m) => m["IMS--Common"].loadingInvoices.title)}</h1>
-        <p className={styles["description"]}>{t((m) => m["IMS--Common"].loadingInvoices.description)}</p>
+        <h1 className={styles["title"]}>{t((m) => m.shared.invoices.loadingInvoices.title)}</h1>
+        <p className={styles["description"]}>{t((m) => m.shared.invoices.loadingInvoices.description)}</p>
       </article>
     </section>
   );

--- a/sites/arolariu.ro/src/app/domains/invoices/_components/MobileBottomNav.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_components/MobileBottomNav.tsx
@@ -108,7 +108,7 @@ export default function MobileBottomNav(): React.JSX.Element {
   return (
     <nav
       className={styles["nav"]}
-      aria-label={t((m) => m["IMS--Common"].mobileNav.ariaLabel)}>
+      aria-label={t((m) => m.shared.invoices.mobileNav.ariaLabel)}>
       {navItems.map((item) => {
         const Icon = item.icon;
         const active = isActive(item);
@@ -123,7 +123,7 @@ export default function MobileBottomNav(): React.JSX.Element {
               className={styles["navIcon"]}
               aria-hidden='true'
             />
-            <span className={styles["navLabel"]}>{t(selectorFromPath(`IMS--Common.mobileNav.${item.labelKey}`))}</span>
+            <span className={styles["navLabel"]}>{t(selectorFromPath(`shared.invoices.mobileNav.${item.labelKey}`))}</span>
           </Link>
         );
       })}

--- a/sites/arolariu.ro/src/app/domains/invoices/_components/OnboardingOverlay.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_components/OnboardingOverlay.tsx
@@ -56,18 +56,18 @@ export default function OnboardingOverlay(_props: Readonly<Props>): React.JSX.El
   const steps: Step[] = [
     {
       icon: <TbCamera className={styles["stepIcon"]} />,
-      title: t((m) => m["IMS--Common"].onboarding.steps.upload.title),
-      description: t((m) => m["IMS--Common"].onboarding.steps.upload.description),
+      title: t((m) => m.shared.invoices.onboarding.steps.upload.title),
+      description: t((m) => m.shared.invoices.onboarding.steps.upload.description),
     },
     {
       icon: <TbSparkles className={styles["stepIcon"]} />,
-      title: t((m) => m["IMS--Common"].onboarding.steps.analyze.title),
-      description: t((m) => m["IMS--Common"].onboarding.steps.analyze.description),
+      title: t((m) => m.shared.invoices.onboarding.steps.analyze.title),
+      description: t((m) => m.shared.invoices.onboarding.steps.analyze.description),
     },
     {
       icon: <TbChartBar className={styles["stepIcon"]} />,
-      title: t((m) => m["IMS--Common"].onboarding.steps.track.title),
-      description: t((m) => m["IMS--Common"].onboarding.steps.track.description),
+      title: t((m) => m.shared.invoices.onboarding.steps.track.title),
+      description: t((m) => m.shared.invoices.onboarding.steps.track.description),
     },
   ];
 
@@ -142,14 +142,14 @@ export default function OnboardingOverlay(_props: Readonly<Props>): React.JSX.El
             variant='ghost'
             size='sm'
             onClick={handleClose}
-            aria-label={t((m) => m["IMS--Common"].onboarding.skip)}>
-            {t((m) => m["IMS--Common"].onboarding.skip)}
+            aria-label={t((m) => m.shared.invoices.onboarding.skip)}>
+            {t((m) => m.shared.invoices.onboarding.skip)}
           </Button>
           <Button
             variant='ghost'
             size='icon'
             onClick={handleClose}
-            aria-label={t((m) => m["IMS--Common"].onboarding.skip)}>
+            aria-label={t((m) => m.shared.invoices.onboarding.skip)}>
             <TbX />
           </Button>
         </div>
@@ -174,7 +174,7 @@ export default function OnboardingOverlay(_props: Readonly<Props>): React.JSX.El
               <div className={styles["iconWrapper"]}>{steps.at(currentStep)?.icon}</div>
 
               <p className={styles["stepIndicator"]}>
-                {t((m) => m["IMS--Common"].onboarding.stepOf, {
+                {t((m) => m.shared.invoices.onboarding.stepOf, {
                   current: String(currentStep + 1),
                   total: String(steps.length),
                 })}
@@ -195,7 +195,7 @@ export default function OnboardingOverlay(_props: Readonly<Props>): React.JSX.El
                 key={step.title}
                 className={`${styles["dot"]} ${index === currentStep ? styles["dotActive"] : ""}`}
                 onClick={createStepClickHandler(index)}
-                aria-label={`${t((m) => m["IMS--Common"].onboarding.stepOf, {
+                aria-label={`${t((m) => m.shared.invoices.onboarding.stepOf, {
                   current: String(index + 1),
                   total: String(steps.length),
                 })}`}
@@ -213,7 +213,7 @@ export default function OnboardingOverlay(_props: Readonly<Props>): React.JSX.El
                 checked={dontShowAgain}
                 onChange={handleDontShowAgainChange}
               />
-              <span className={styles["checkboxText"]}>{t((m) => m["IMS--Common"].onboarding.dontShowAgain)}</span>
+              <span className={styles["checkboxText"]}>{t((m) => m.shared.invoices.onboarding.dontShowAgain)}</span>
             </label>
           </div>
 
@@ -223,18 +223,18 @@ export default function OnboardingOverlay(_props: Readonly<Props>): React.JSX.El
                 variant='outline'
                 onClick={handleBack}>
                 <TbArrowLeft />
-                {t((m) => m["IMS--Common"].onboarding.back)}
+                {t((m) => m.shared.invoices.onboarding.back)}
               </Button>
             )}
 
             <Button onClick={handleNext}>
               {currentStep < steps.length - 1 ? (
                 <>
-                  {t((m) => m["IMS--Common"].onboarding.next)}
+                  {t((m) => m.shared.invoices.onboarding.next)}
                   <TbArrowRight />
                 </>
               ) : (
-                t((m) => m["IMS--Common"].onboarding.getStarted)
+                t((m) => m.shared.invoices.onboarding.getStarted)
               )}
             </Button>
           </div>

--- a/sites/arolariu.ro/src/app/domains/invoices/_components/ScanCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_components/ScanCard.tsx
@@ -100,12 +100,12 @@ export default function ScanCard({scan, isSelected, onToggleSelect}: Readonly<Sc
       const result = await deleteScan({blobUrl: scan.blobUrl});
       if (result.success) {
         removeScan(scan.id);
-        toast.success(t((m) => m["IMS--ViewScans"].scanCard.deleteDialog.success));
+        toast.success(t((m) => m.pages.invoices.viewScans.scanCard.deleteDialog.success));
       } else {
-        toast.error(result.error.message || t((m) => m["IMS--ViewScans"].scanCard.deleteDialog.error));
+        toast.error(result.error.message || t((m) => m.pages.invoices.viewScans.scanCard.deleteDialog.error));
       }
     } catch (error) {
-      toast.error(t((m) => m["IMS--ViewScans"].scanCard.deleteDialog.error));
+      toast.error(t((m) => m.pages.invoices.viewScans.scanCard.deleteDialog.error));
       console.error("Error deleting scan:", error);
     } finally {
       setIsDeleting(false);
@@ -128,7 +128,7 @@ export default function ScanCard({scan, isSelected, onToggleSelect}: Readonly<Sc
       const trimmedName = newName.trim();
       if (trimmedName && trimmedName !== scan.name) {
         updateScanName(scan.id, trimmedName);
-        toast.success(t((m) => m["IMS--ViewScans"].scanCard.rename));
+        toast.success(t((m) => m.pages.invoices.viewScans.scanCard.rename));
         setJustRenamed(true);
         setTimeout(() => setJustRenamed(false), 300);
       }
@@ -164,7 +164,7 @@ export default function ScanCard({scan, isSelected, onToggleSelect}: Readonly<Sc
   const handleRotate = useCallback(
     async (degrees: number): Promise<void> => {
       if (!scan.blobUrl || scan.mimeType === "application/pdf") {
-        toast.error(t((m) => m["IMS--ViewScans"].scanCard.actions.rotateUnsupported));
+        toast.error(t((m) => m.pages.invoices.viewScans.scanCard.actions.rotateUnsupported));
         return;
       }
 
@@ -242,12 +242,12 @@ export default function ScanCard({scan, isSelected, onToggleSelect}: Readonly<Sc
         if (result.success && result.data.blobUrl) {
           const cacheBustedUrl = `${result.data.blobUrl}?t=${Date.now()}`;
           updateScanBlobUrl(scan.id, cacheBustedUrl);
-          toast.success(t((m) => m["IMS--ViewScans"].scanCard.actions.rotateSuccess));
+          toast.success(t((m) => m.pages.invoices.viewScans.scanCard.actions.rotateSuccess));
         } else {
-          toast.error(result.success ? t((m) => m["IMS--ViewScans"].scanCard.actions.rotateError) : result.error.message || t((m) => m["IMS--ViewScans"].scanCard.actions.rotateError));
+          toast.error(result.success ? t((m) => m.pages.invoices.viewScans.scanCard.actions.rotateError) : result.error.message || t((m) => m.pages.invoices.viewScans.scanCard.actions.rotateError));
         }
       } catch (error) {
-        toast.error(t((m) => m["IMS--ViewScans"].scanCard.actions.rotateError));
+        toast.error(t((m) => m.pages.invoices.viewScans.scanCard.actions.rotateError));
         console.error("Error rotating scan:", error);
       } finally {
         setIsRotating(false);
@@ -291,7 +291,7 @@ export default function ScanCard({scan, isSelected, onToggleSelect}: Readonly<Sc
             <div className={styles["pdfPlaceholder"]}>{/* Empty placeholder */}</div>
           </div>
           <div className={styles["fileInfo"]}>
-            <div className={styles["fileName"]}>{t((m) => m["IMS--ViewScans"].scanCard.loading)}</div>
+            <div className={styles["fileName"]}>{t((m) => m.pages.invoices.viewScans.scanCard.loading)}</div>
           </div>
         </CardContent>
       </Card>
@@ -371,7 +371,7 @@ export default function ScanCard({scan, isSelected, onToggleSelect}: Readonly<Sc
                 <DropdownMenuContent align='end'>
                   <DropdownMenuItem onClick={handleStartRename}>
                     <TbPencil className={styles["trashIcon"]} />
-                    {t((m) => m["IMS--ViewScans"].scanCard.actions.rename)}
+                    {t((m) => m.pages.invoices.viewScans.scanCard.actions.rename)}
                   </DropdownMenuItem>
                   {scan.mimeType !== "application/pdf" && (
                     <>
@@ -379,13 +379,13 @@ export default function ScanCard({scan, isSelected, onToggleSelect}: Readonly<Sc
                         onClick={handleRotate90}
                         disabled={isRotating}>
                         <TbRotateClockwise className={styles["trashIcon"]} />
-                        {t((m) => m["IMS--ViewScans"].scanCard.actions.rotateCW)}
+                        {t((m) => m.pages.invoices.viewScans.scanCard.actions.rotateCW)}
                       </DropdownMenuItem>
                       <DropdownMenuItem
                         onClick={handleRotateMinus90}
                         disabled={isRotating}>
                         <TbRotate className={styles["trashIcon"]} />
-                        {t((m) => m["IMS--ViewScans"].scanCard.actions.rotateCCW)}
+                        {t((m) => m.pages.invoices.viewScans.scanCard.actions.rotateCCW)}
                       </DropdownMenuItem>
                     </>
                   )}
@@ -393,7 +393,7 @@ export default function ScanCard({scan, isSelected, onToggleSelect}: Readonly<Sc
                     className={styles["deleteMenuItem"]}
                     onClick={handleOpenDeleteDialog}>
                     <TbTrash className={styles["trashIcon"]} />
-                    {t((m) => m["IMS--ViewScans"].scanCard.actions.delete)}
+                    {t((m) => m.pages.invoices.viewScans.scanCard.actions.delete)}
                   </DropdownMenuItem>
                 </DropdownMenuContent>
               </DropdownMenu>
@@ -404,7 +404,7 @@ export default function ScanCard({scan, isSelected, onToggleSelect}: Readonly<Sc
               <div className={styles["linkedBadgePosition"]}>
                 <div className={styles["linkedBadge"]}>
                   <TbLink className={styles["linkedIcon"]} />
-                  {t((m) => m["IMS--ViewScans"].scanCard.linked)}
+                  {t((m) => m.pages.invoices.viewScans.scanCard.linked)}
                 </div>
               </div>
             ) : null}
@@ -413,7 +413,7 @@ export default function ScanCard({scan, isSelected, onToggleSelect}: Readonly<Sc
             {isRotating ? (
               <div className={styles["rotatingOverlay"]}>
                 <div className={styles["rotatingSpinner"]} />
-                <span className={styles["rotatingText"]}>{t((m) => m["IMS--ViewScans"].scanCard.actions.rotating)}</span>
+                <span className={styles["rotatingText"]}>{t((m) => m.pages.invoices.viewScans.scanCard.actions.rotating)}</span>
               </div>
             ) : null}
           </div>
@@ -431,7 +431,7 @@ export default function ScanCard({scan, isSelected, onToggleSelect}: Readonly<Sc
                   onChange={handleNameChange}
                   onKeyDown={handleRenameKeyDown}
                   onBlur={handleCancelRename}
-                  placeholder={t((m) => m["IMS--ViewScans"].scanCard.renamePlaceholder)}
+                  placeholder={t((m) => m.pages.invoices.viewScans.scanCard.renamePlaceholder)}
                   className={styles["renameInput"]}
                 />
                 <div className={styles["renameActions"]}>
@@ -486,7 +486,7 @@ export default function ScanCard({scan, isSelected, onToggleSelect}: Readonly<Sc
         onOpenChange={setShowPreview}>
         <DialogContent className={styles["previewDialog"]}>
           <DialogHeader>
-            <DialogTitle>{t((m) => m["IMS--ViewScans"].scanCard.previewTitle)}</DialogTitle>
+            <DialogTitle>{t((m) => m.pages.invoices.viewScans.scanCard.previewTitle)}</DialogTitle>
           </DialogHeader>
           {scan.mimeType === "application/pdf" ? (
             <div className={styles["pdfPreviewContainer"]}>
@@ -517,25 +517,25 @@ export default function ScanCard({scan, isSelected, onToggleSelect}: Readonly<Sc
         onOpenChange={setShowDeleteDialog}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>{t((m) => m["IMS--ViewScans"].scanCard.deleteDialog.title)}</AlertDialogTitle>
+            <AlertDialogTitle>{t((m) => m.pages.invoices.viewScans.scanCard.deleteDialog.title)}</AlertDialogTitle>
             <AlertDialogDescription>
               {isUsedByInvoice ? (
                 <>
-                  <span className={styles["linkedWarning"]}>{t((m) => m["IMS--ViewScans"].scanCard.deleteDialog.linkedWarning)}</span>
-                  {t((m) => m["IMS--ViewScans"].scanCard.deleteDialog.linkedDescription)}
+                  <span className={styles["linkedWarning"]}>{t((m) => m.pages.invoices.viewScans.scanCard.deleteDialog.linkedWarning)}</span>
+                  {t((m) => m.pages.invoices.viewScans.scanCard.deleteDialog.linkedDescription)}
                 </>
               ) : (
-                <>{t((m) => m["IMS--ViewScans"].scanCard.deleteDialog.description, {name: scan.name})}</>
+                <>{t((m) => m.pages.invoices.viewScans.scanCard.deleteDialog.description, {name: scan.name})}</>
               )}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel disabled={isDeleting}>{t((m) => m["IMS--ViewScans"].scanCard.deleteDialog.cancel)}</AlertDialogCancel>
+            <AlertDialogCancel disabled={isDeleting}>{t((m) => m.pages.invoices.viewScans.scanCard.deleteDialog.cancel)}</AlertDialogCancel>
             <AlertDialogAction
               onClick={handleDelete}
               disabled={isDeleting}
               className={styles["deleteButton"]}>
-              {isDeleting ? t((m) => m["IMS--ViewScans"].scanCard.deleteDialog.deleting) : t((m) => m["IMS--ViewScans"].scanCard.deleteDialog.delete)}
+              {isDeleting ? t((m) => m.pages.invoices.viewScans.scanCard.deleteDialog.deleting) : t((m) => m.pages.invoices.viewScans.scanCard.deleteDialog.delete)}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/sites/arolariu.ro/src/app/domains/invoices/_components/ShortcutsHelpDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_components/ShortcutsHelpDialog.tsx
@@ -111,9 +111,9 @@ export default function ShortcutsHelpDialog({open, onClose}: Readonly<ShortcutsH
               className={styles["icon"]}
               aria-hidden='true'
             />
-            <DialogTitle className={styles["title"]}>{t((m) => m["IMS--Common"].shortcuts.title)}</DialogTitle>
+            <DialogTitle className={styles["title"]}>{t((m) => m.shared.invoices.shortcuts.title)}</DialogTitle>
           </div>
-          <DialogDescription className={styles["description"]}>{t((m) => m["IMS--Common"].shortcuts.description)}</DialogDescription>
+          <DialogDescription className={styles["description"]}>{t((m) => m.shared.invoices.shortcuts.description)}</DialogDescription>
         </DialogHeader>
 
         <div className={styles["shortcutsGrid"]}>
@@ -130,7 +130,7 @@ export default function ShortcutsHelpDialog({open, onClose}: Readonly<ShortcutsH
                   </Kbd>
                 ))}
               </KbdGroup>
-              <span className={styles["shortcutDescription"]}>{t(selectorFromPath(`IMS--Common.shortcuts.${shortcut.descriptionKey}`))}</span>
+              <span className={styles["shortcutDescription"]}>{t(selectorFromPath(`shared.invoices.shortcuts.${shortcut.descriptionKey}`))}</span>
             </div>
           ))}
         </div>
@@ -140,7 +140,7 @@ export default function ShortcutsHelpDialog({open, onClose}: Readonly<ShortcutsH
             onClick={onClose}
             variant='default'
             className={styles["closeButton"]}>
-            {t((m) => m["IMS--Common"].shortcuts.close)}
+            {t((m) => m.shared.invoices.shortcuts.close)}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/sites/arolariu.ro/src/app/domains/invoices/_components/WorkflowProgress.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_components/WorkflowProgress.tsx
@@ -108,21 +108,21 @@ export default function WorkflowProgress({currentStep}: Readonly<Props>): React.
         step='upload'
         isActive={currentStep === "upload"}
         isCompleted={currentOrder > STEP_ORDER["upload"]}
-        label={t((m) => m["IMS--Common"].workflowProgress.upload)}
+        label={t((m) => m.shared.invoices.workflowProgress.upload)}
       />
       <Connector isCompleted={currentOrder > STEP_ORDER["upload"]} />
       <Step
         step='review'
         isActive={currentStep === "review"}
         isCompleted={currentOrder > STEP_ORDER["review"]}
-        label={t((m) => m["IMS--Common"].workflowProgress.review)}
+        label={t((m) => m.shared.invoices.workflowProgress.review)}
       />
       <Connector isCompleted={currentOrder > STEP_ORDER["review"]} />
       <Step
         step='create'
         isActive={currentStep === "create"}
         isCompleted={currentOrder > STEP_ORDER["create"]}
-        label={t((m) => m["IMS--Common"].workflowProgress.create)}
+        label={t((m) => m.shared.invoices.workflowProgress.create)}
       />
     </nav>
   );

--- a/sites/arolariu.ro/src/app/domains/invoices/_components/homepage/EnhancedCTASection.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_components/homepage/EnhancedCTASection.tsx
@@ -26,14 +26,14 @@ export default function EnhancedCTASection(): React.JSX.Element {
   const sectionRef = useRef<HTMLElement>(null);
   const isInView = useInView(sectionRef, {once: true, margin: "-50px"});
   const translations: CtaTranslations = {
-    title: t((m) => m["IMS--Landing"].cta.title),
-    description: t((m) => m["IMS--Landing"].cta.description),
-    uploadButton: t((m) => m["IMS--Landing"].cta.uploadButton),
-    learnMore: t((m) => m["IMS--Landing"].cta.learnMore),
+    title: t((m) => m.pages.invoices.landing.cta.title),
+    description: t((m) => m.pages.invoices.landing.cta.description),
+    uploadButton: t((m) => m.pages.invoices.landing.cta.uploadButton),
+    learnMore: t((m) => m.pages.invoices.landing.cta.learnMore),
     badges: {
-      secure: t((m) => m["IMS--Landing"].cta.badges.secure),
-      cloud: t((m) => m["IMS--Landing"].cta.badges.cloud),
-      ai: t((m) => m["IMS--Landing"].cta.badges.ai),
+      secure: t((m) => m.pages.invoices.landing.cta.badges.secure),
+      cloud: t((m) => m.pages.invoices.landing.cta.badges.cloud),
+      ai: t((m) => m.pages.invoices.landing.cta.badges.ai),
     },
   };
 

--- a/sites/arolariu.ro/src/app/domains/invoices/_components/homepage/FeaturesSection.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_components/homepage/FeaturesSection.tsx
@@ -31,7 +31,7 @@ export default function FeaturesSection({isAuthenticated}: Readonly<Props>): Rea
             transition={{duration: 0.6}}>
             <Image
               src='/images/domains/invoices/invoice-bottom.svg'
-              alt={t((m) => m["IMS--Landing"].features.imageAlt)}
+              alt={t((m) => m.pages.invoices.landing.features.imageAlt)}
               width={500}
               height={500}
               className={styles["featuresImage"]}
@@ -44,32 +44,32 @@ export default function FeaturesSection({isAuthenticated}: Readonly<Props>): Rea
             animate={{opacity: 1, x: 0}}
             transition={{duration: 0.6, delay: 0.2}}>
             <div className={styles["featuresHeader"]}>
-              <h2 className={styles["sectionTitle"]}>{t((m) => m["IMS--Landing"].features.title)}</h2>
-              <p className={styles["sectionDescription"]}>{t((m) => m["IMS--Landing"].features.description)}</p>
+              <h2 className={styles["sectionTitle"]}>{t((m) => m.pages.invoices.landing.features.title)}</h2>
+              <p className={styles["sectionDescription"]}>{t((m) => m.pages.invoices.landing.features.description)}</p>
             </div>
 
             <div className={styles["featuresList"]}>
               <FeatureItem
                 icon={TbPhoto}
-                title={t((m) => m["IMS--Landing"].features.ocr.title)}
-                description={t((m) => m["IMS--Landing"].features.ocr.description)}
+                title={t((m) => m.pages.invoices.landing.features.ocr.title)}
+                description={t((m) => m.pages.invoices.landing.features.ocr.description)}
               />
               <FeatureItem
                 icon={TbChartBar}
-                title={t((m) => m["IMS--Landing"].features.analytics.title)}
-                description={t((m) => m["IMS--Landing"].features.analytics.description)}
+                title={t((m) => m.pages.invoices.landing.features.analytics.title)}
+                description={t((m) => m.pages.invoices.landing.features.analytics.description)}
               />
               <FeatureItem
                 icon={TbFileInvoice}
-                title={t((m) => m["IMS--Landing"].features.batch.title)}
-                description={t((m) => m["IMS--Landing"].features.batch.description)}
+                title={t((m) => m.pages.invoices.landing.features.batch.title)}
+                description={t((m) => m.pages.invoices.landing.features.batch.description)}
               />
             </div>
 
             {!isAuthenticated && (
               <div className={styles["signInPrompt"]}>
                 <p className={styles["signInPromptText"]}>
-                  <strong>{t((m) => m["IMS--Landing"].features.signIn)}</strong> {t((m) => m["IMS--Landing"].features.signInPrompt)}
+                  <strong>{t((m) => m.pages.invoices.landing.features.signIn)}</strong> {t((m) => m.pages.invoices.landing.features.signInPrompt)}
                 </p>
               </div>
             )}

--- a/sites/arolariu.ro/src/app/domains/invoices/_components/homepage/HeroSection.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_components/homepage/HeroSection.tsx
@@ -31,9 +31,9 @@ export default function HeroSection({isAuthenticated}: Readonly<Props>): React.J
               animate={{opacity: 1, y: 0}}
               transition={{duration: 0.6}}>
               <h1 className={styles["heroTitle"]}>
-                {t((m) => m["IMS--Landing"].hero.title)} <span className={styles["heroHighlight"]}>{t((m) => m["IMS--Landing"].hero.titleHighlight)}</span> {t((m) => m["IMS--Landing"].hero.titleSuffix)}
+                {t((m) => m.pages.invoices.landing.hero.title)} <span className={styles["heroHighlight"]}>{t((m) => m.pages.invoices.landing.hero.titleHighlight)}</span> {t((m) => m.pages.invoices.landing.hero.titleSuffix)}
               </h1>
-              <p className={styles["heroDescription"]}>{t((m) => m["IMS--Landing"].hero.description)}</p>
+              <p className={styles["heroDescription"]}>{t((m) => m.pages.invoices.landing.hero.description)}</p>
 
               <div className={styles["heroButtons"]}>
                 <Button
@@ -42,7 +42,7 @@ export default function HeroSection({isAuthenticated}: Readonly<Props>): React.J
                   className={styles["heroPrimaryBtn"]}>
                   <Link href='/domains/invoices/upload-scans'>
                     <TbUpload className={styles["heroButtonIcon"]} />
-                    {t((m) => m["IMS--Landing"].hero.getStarted)}
+                    {t((m) => m.pages.invoices.landing.hero.getStarted)}
                   </Link>
                 </Button>
                 {isAuthenticated ? (
@@ -52,7 +52,7 @@ export default function HeroSection({isAuthenticated}: Readonly<Props>): React.J
                     size='lg'>
                     <Link href='/domains/invoices/view-invoices'>
                       <TbFileInvoice className={styles["heroButtonIcon"]} />
-                      {t((m) => m["IMS--Landing"].hero.viewMyInvoices)}
+                      {t((m) => m.pages.invoices.landing.hero.viewMyInvoices)}
                     </Link>
                   </Button>
                 ) : null}
@@ -67,7 +67,7 @@ export default function HeroSection({isAuthenticated}: Readonly<Props>): React.J
             transition={{duration: 0.6, delay: 0.2}}>
             <Image
               src='/images/domains/invoices/invoice-top.svg'
-              alt={t((m) => m["IMS--Landing"].hero.imageAlt)}
+              alt={t((m) => m.pages.invoices.landing.hero.imageAlt)}
               width={500}
               height={500}
               className={styles["heroImage"]}

--- a/sites/arolariu.ro/src/app/domains/invoices/_components/homepage/WorkflowSection.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_components/homepage/WorkflowSection.tsx
@@ -22,36 +22,36 @@ export default function WorkflowSection(): React.JSX.Element {
           initial={{opacity: 0, y: 20}}
           animate={{opacity: 1, y: 0}}
           transition={{duration: 0.5}}>
-          <h2 className={styles["sectionTitle"]}>{t((m) => m["IMS--Landing"].workflow.title)}</h2>
-          <p className={styles["sectionDescription"]}>{t((m) => m["IMS--Landing"].workflow.description)}</p>
+          <h2 className={styles["sectionTitle"]}>{t((m) => m.pages.invoices.landing.workflow.title)}</h2>
+          <p className={styles["sectionDescription"]}>{t((m) => m.pages.invoices.landing.workflow.description)}</p>
         </motion.div>
 
         <div className={styles["workflowGrid"]}>
           <WorkflowCard
             step={1}
-            title={t((m) => m["IMS--Landing"].workflow.step1.title)}
-            description={t((m) => m["IMS--Landing"].workflow.step1.description)}
+            title={t((m) => m.pages.invoices.landing.workflow.step1.title)}
+            description={t((m) => m.pages.invoices.landing.workflow.step1.description)}
             icon={TbUpload}
             href='/domains/invoices/upload-scans'
-            buttonText={t((m) => m["IMS--Landing"].workflow.step1.button)}
+            buttonText={t((m) => m.pages.invoices.landing.workflow.step1.button)}
             delay={0.1}
           />
           <WorkflowCard
             step={2}
-            title={t((m) => m["IMS--Landing"].workflow.step2.title)}
-            description={t((m) => m["IMS--Landing"].workflow.step2.description)}
+            title={t((m) => m.pages.invoices.landing.workflow.step2.title)}
+            description={t((m) => m.pages.invoices.landing.workflow.step2.description)}
             icon={TbEye}
             href='/domains/invoices/view-scans'
-            buttonText={t((m) => m["IMS--Landing"].workflow.step2.button)}
+            buttonText={t((m) => m.pages.invoices.landing.workflow.step2.button)}
             delay={0.2}
           />
           <WorkflowCard
             step={3}
-            title={t((m) => m["IMS--Landing"].workflow.step3.title)}
-            description={t((m) => m["IMS--Landing"].workflow.step3.description)}
+            title={t((m) => m.pages.invoices.landing.workflow.step3.title)}
+            description={t((m) => m.pages.invoices.landing.workflow.step3.description)}
             icon={TbFileInvoice}
             href='/domains/invoices/view-invoices'
-            buttonText={t((m) => m["IMS--Landing"].workflow.step3.button)}
+            buttonText={t((m) => m.pages.invoices.landing.workflow.step3.button)}
             delay={0.3}
           />
         </div>

--- a/sites/arolariu.ro/src/app/domains/invoices/_dialogs/DeleteInvoiceDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_dialogs/DeleteInvoiceDialog.tsx
@@ -99,15 +99,15 @@ export default function DeleteInvoiceDialog(): React.JSX.Element {
       // This ensures the cached invoice list is immediately updated
       removeInvoice(invoice.id);
 
-      toast(t((m) => m["IMS--Dialogs"].deleteInvoiceDialog.toasts.deletedTitle), {
-        description: t((m) => m["IMS--Dialogs"].deleteInvoiceDialog.toasts.deletedDescription),
+      toast(t((m) => m.dialogs.invoices.deleteInvoiceDialog.toasts.deletedTitle), {
+        description: t((m) => m.dialogs.invoices.deleteInvoiceDialog.toasts.deletedDescription),
       });
       handleClose();
       router.push("/domains/invoices/view-invoices");
     } catch (error) {
-      console.error(t((m) => m["IMS--Dialogs"].deleteInvoiceDialog.console.deleteError), error);
-      toast(t((m) => m["IMS--Dialogs"].deleteInvoiceDialog.toasts.deleteFailedTitle), {
-        description: t((m) => m["IMS--Dialogs"].deleteInvoiceDialog.toasts.deleteFailedDescription),
+      console.error(t((m) => m.dialogs.invoices.deleteInvoiceDialog.console.deleteError), error);
+      toast(t((m) => m.dialogs.invoices.deleteInvoiceDialog.toasts.deleteFailedTitle), {
+        description: t((m) => m.dialogs.invoices.deleteInvoiceDialog.toasts.deleteFailedDescription),
       });
     } finally {
       setIsDeleting(false);

--- a/sites/arolariu.ro/src/app/domains/invoices/_dialogs/DeleteInvoiceDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_dialogs/DeleteInvoiceDialog.tsx
@@ -130,9 +130,9 @@ export default function DeleteInvoiceDialog(): React.JSX.Element {
         <DialogHeader>
           <DialogTitle className={styles["dialogTitleRed"]}>
             <TbTrash className={styles["titleIcon"]} />
-            {t((m) => m["IMS--Dialogs"].deleteInvoiceDialog.title)}
+            {t((m) => m.dialogs.invoices.deleteInvoiceDialog.title)}
           </DialogTitle>
-          <DialogDescription>{t((m) => m["IMS--Dialogs"].deleteInvoiceDialog.description)}</DialogDescription>
+          <DialogDescription>{t((m) => m.dialogs.invoices.deleteInvoiceDialog.description)}</DialogDescription>
         </DialogHeader>
 
         <AnimatePresence mode='wait'>
@@ -149,8 +149,8 @@ export default function DeleteInvoiceDialog(): React.JSX.Element {
                 className={styles["spinnerWrapper"]}>
                 <TbLoader2 className={styles["spinnerIcon"]} />
               </motion.div>
-              <p className={styles["deletingTitle"]}>{t((m) => m["IMS--Dialogs"].deleteInvoiceDialog.deleting.title)}</p>
-              <p className={styles["deletingDescription"]}>{t((m) => m["IMS--Dialogs"].deleteInvoiceDialog.deleting.description)}</p>
+              <p className={styles["deletingTitle"]}>{t((m) => m.dialogs.invoices.deleteInvoiceDialog.deleting.title)}</p>
+              <p className={styles["deletingDescription"]}>{t((m) => m.dialogs.invoices.deleteInvoiceDialog.deleting.description)}</p>
             </motion.div>
           ) : (
             <motion.div
@@ -178,30 +178,30 @@ export default function DeleteInvoiceDialog(): React.JSX.Element {
                 variant='destructive'
                 className={styles["alertRed"]}>
                 <TbAlertTriangle className={styles["impactIcon"]} />
-                <AlertTitle>{t((m) => m["IMS--Dialogs"].deleteInvoiceDialog.impact.title)}</AlertTitle>
+                <AlertTitle>{t((m) => m.dialogs.invoices.deleteInvoiceDialog.impact.title)}</AlertTitle>
                 <AlertDescription>
-                  <p className={styles["impactIntro"]}>{t((m) => m["IMS--Dialogs"].deleteInvoiceDialog.impact.intro)}</p>
+                  <p className={styles["impactIntro"]}>{t((m) => m.dialogs.invoices.deleteInvoiceDialog.impact.intro)}</p>
                   <ul className={styles["impactList"]}>
                     <li className={styles["impactItem"]}>
                       <TbFileX className={styles["impactIcon"]} />
-                      {t((m) => m["IMS--Dialogs"].deleteInvoiceDialog.impact.invoiceRecord)}
+                      {t((m) => m.dialogs.invoices.deleteInvoiceDialog.impact.invoiceRecord)}
                     </li>
                     {scanCount > 0 && (
                       <li className={styles["impactItem"]}>
                         <TbPhoto className={styles["impactIcon"]} />
-                        {t((m) => m["IMS--Dialogs"].deleteInvoiceDialog.impact.uploadedScans, {count: String(scanCount)})}
+                        {t((m) => m.dialogs.invoices.deleteInvoiceDialog.impact.uploadedScans, {count: String(scanCount)})}
                       </li>
                     )}
                     {itemCount > 0 && (
                       <li className={styles["impactItem"]}>
                         <TbShoppingCart className={styles["impactIcon"]} />
-                        {t((m) => m["IMS--Dialogs"].deleteInvoiceDialog.impact.lineItems, {count: String(itemCount)})}
+                        {t((m) => m.dialogs.invoices.deleteInvoiceDialog.impact.lineItems, {count: String(itemCount)})}
                       </li>
                     )}
                     {sharedCount > 0 && (
                       <li className={styles["impactItem"]}>
                         <TbX className={styles["impactIcon"]} />
-                        {t((m) => m["IMS--Dialogs"].deleteInvoiceDialog.impact.sharedAccess, {count: String(sharedCount)})}
+                        {t((m) => m.dialogs.invoices.deleteInvoiceDialog.impact.sharedAccess, {count: String(sharedCount)})}
                       </li>
                     )}
                   </ul>
@@ -214,7 +214,7 @@ export default function DeleteInvoiceDialog(): React.JSX.Element {
               <div className={styles["confirmSection"]}>
                 <div className={styles["confirmField"]}>
                   <Label htmlFor='confirm-name'>
-                    {t.rich((m) => m["IMS--Dialogs"].deleteInvoiceDialog.confirmation.typeToConfirm, {
+                    {t.rich((m) => m.dialogs.invoices.deleteInvoiceDialog.confirmation.typeToConfirm, {
                       name: invoiceName,
                       // eslint-disable-next-line react/no-unstable-nested-components -- single-call site; hoisting is more boilerplate than benefit
                       highlight: (chunks) => <span className={styles["confirmHighlight"]}>{chunks}</span>,
@@ -242,9 +242,9 @@ export default function DeleteInvoiceDialog(): React.JSX.Element {
                     <Label
                       htmlFor='understand-deletion'
                       className={styles["labelCursorSm"]}>
-                      {t((m) => m["IMS--Dialogs"].deleteInvoiceDialog.confirmation.understoodLabel)}
+                      {t((m) => m.dialogs.invoices.deleteInvoiceDialog.confirmation.understoodLabel)}
                     </Label>
-                    <p className={styles["checkboxDescription"]}>{t((m) => m["IMS--Dialogs"].deleteInvoiceDialog.confirmation.understoodDescription)}</p>
+                    <p className={styles["checkboxDescription"]}>{t((m) => m.dialogs.invoices.deleteInvoiceDialog.confirmation.understoodDescription)}</p>
                   </div>
                 </div>
               </div>
@@ -258,7 +258,7 @@ export default function DeleteInvoiceDialog(): React.JSX.Element {
             variant='outline'
             onClick={handleClose}
             disabled={isDeleting}>
-            {t((m) => m["IMS--Dialogs"].deleteInvoiceDialog.buttons.cancel)}
+            {t((m) => m.dialogs.invoices.deleteInvoiceDialog.buttons.cancel)}
           </Button>
           <Button
             type='button'
@@ -268,12 +268,12 @@ export default function DeleteInvoiceDialog(): React.JSX.Element {
             {isDeleting ? (
               <>
                 <TbLoader2 className={styles["buttonSpinnerIcon"]} />
-                {t((m) => m["IMS--Dialogs"].deleteInvoiceDialog.buttons.deleting)}
+                {t((m) => m.dialogs.invoices.deleteInvoiceDialog.buttons.deleting)}
               </>
             ) : (
               <>
                 <TbTrash className={styles["buttonIcon"]} />
-                {t((m) => m["IMS--Dialogs"].deleteInvoiceDialog.buttons.deletePermanently)}
+                {t((m) => m.dialogs.invoices.deleteInvoiceDialog.buttons.deletePermanently)}
               </>
             )}
           </Button>

--- a/sites/arolariu.ro/src/app/domains/invoices/_dialogs/ShareInvoiceDialog.Private.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_dialogs/ShareInvoiceDialog.Private.tsx
@@ -52,40 +52,40 @@ export function PrivateMode({onBack, email, onEmailChange, onSendEmail, isSendin
         onClick={onBack}
         className={styles["backButtonMl"]}>
         <TbArrowLeft className={styles["backIcon"]} />
-        {t((m) => m["IMS--Dialogs"].shareInvoiceDialogPrivate.backToOptions)}
+        {t((m) => m.dialogs.invoices.shareInvoiceDialogPrivate.backToOptions)}
       </Button>
 
       <Alert
         variant='default'
         className={styles["alertGreen"]}>
         <TbLock className={styles["lockIcon"]} />
-        <AlertTitle className={styles["alertGreenTitle"]}>{t((m) => m["IMS--Dialogs"].shareInvoiceDialogPrivate.title)}</AlertTitle>
-        <AlertDescription className={styles["alertGreenDesc"]}>{t((m) => m["IMS--Dialogs"].shareInvoiceDialogPrivate.description)}</AlertDescription>
+        <AlertTitle className={styles["alertGreenTitle"]}>{t((m) => m.dialogs.invoices.shareInvoiceDialogPrivate.title)}</AlertTitle>
+        <AlertDescription className={styles["alertGreenDesc"]}>{t((m) => m.dialogs.invoices.shareInvoiceDialogPrivate.description)}</AlertDescription>
       </Alert>
 
       <form
         onSubmit={onSendEmail}
         className={styles["formBody"]}>
         <div className={styles["fieldGroup"]}>
-          <Label htmlFor='email'>{t((m) => m["IMS--Dialogs"].shareInvoiceDialogPrivate.emailLabel)}</Label>
+          <Label htmlFor='email'>{t((m) => m.dialogs.invoices.shareInvoiceDialogPrivate.emailLabel)}</Label>
           <Input
             id='email'
             type='email'
-            placeholder={t((m) => m["IMS--Dialogs"].shareInvoiceDialogPrivate.emailPlaceholder)}
+            placeholder={t((m) => m.dialogs.invoices.shareInvoiceDialogPrivate.emailPlaceholder)}
             value={email}
             // eslint-disable-next-line react/jsx-no-bind -- input always changes.
             onChange={(e) => onEmailChange(e.target.value)}
             disabled={isSending}
             required
           />
-          <p className={styles["emailHint"]}>{t((m) => m["IMS--Dialogs"].shareInvoiceDialogPrivate.emailHint)}</p>
+          <p className={styles["emailHint"]}>{t((m) => m.dialogs.invoices.shareInvoiceDialogPrivate.emailHint)}</p>
         </div>
         <Button
           type='submit'
           disabled={isSending || !email}
           className={styles["buttonFull"]}>
           <TbMail className={styles["mailIcon"]} />
-          {isSending ? t((m) => m["IMS--Dialogs"].shareInvoiceDialogPrivate.sending) : t((m) => m["IMS--Dialogs"].shareInvoiceDialogPrivate.sendInvitation)}
+          {isSending ? t((m) => m.dialogs.invoices.shareInvoiceDialogPrivate.sending) : t((m) => m.dialogs.invoices.shareInvoiceDialogPrivate.sendInvitation)}
         </Button>
       </form>
     </div>

--- a/sites/arolariu.ro/src/app/domains/invoices/_dialogs/ShareInvoiceDialog.Public.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_dialogs/ShareInvoiceDialog.Public.tsx
@@ -67,13 +67,13 @@ export function ShareLinkAndQRTabs({shareUrl, copied, onCopyLink, onCopyQRCode}:
           value='link'
           className={styles["tabsTriggerCursor"]}>
           <TbCopy className={styles["tabIcon"]} />
-          {t((m) => m["IMS--Dialogs"].shareInvoiceDialogPublic.tabs.directLink)}
+          {t((m) => m.dialogs.invoices.shareInvoiceDialogPublic.tabs.directLink)}
         </TabsTrigger>
         <TabsTrigger
           value='qr'
           className={styles["tabsTriggerCursor"]}>
           <TbQrcode className={styles["tabIcon"]} />
-          {t((m) => m["IMS--Dialogs"].shareInvoiceDialogPublic.tabs.qrCode)}
+          {t((m) => m.dialogs.invoices.shareInvoiceDialogPublic.tabs.qrCode)}
         </TabsTrigger>
       </TabsList>
 
@@ -93,7 +93,7 @@ export function ShareLinkAndQRTabs({shareUrl, copied, onCopyLink, onCopyQRCode}:
             {copied ? <TbCheck className={styles["actionIcon"]} /> : <TbCopy className={styles["actionIcon"]} />}
           </Button>
         </div>
-        <p className={styles["linkHint"]}>{t((m) => m["IMS--Dialogs"].shareInvoiceDialogPublic.hints.link)}</p>
+        <p className={styles["linkHint"]}>{t((m) => m.dialogs.invoices.shareInvoiceDialogPublic.hints.link)}</p>
       </TabsContent>
 
       <TabsContent
@@ -110,13 +110,13 @@ export function ShareLinkAndQRTabs({shareUrl, copied, onCopyLink, onCopyQRCode}:
               level='L'
             />
           </div>
-          <p className={styles["qrHint"]}>{t((m) => m["IMS--Dialogs"].shareInvoiceDialogPublic.hints.qr)}</p>
+          <p className={styles["qrHint"]}>{t((m) => m.dialogs.invoices.shareInvoiceDialogPublic.hints.qr)}</p>
           <Button
             variant='outline'
             onClick={onCopyQRCode}
             className={styles["buttonFull"]}>
             <TbCopy className={styles["tabIcon"]} />
-            {t((m) => m["IMS--Dialogs"].shareInvoiceDialogPublic.copyQrImage)}
+            {t((m) => m.dialogs.invoices.shareInvoiceDialogPublic.copyQrImage)}
           </Button>
         </div>
       </TabsContent>
@@ -151,9 +151,9 @@ export function AlreadyPublicMode({
         variant='destructive'
         className={styles["alertOrange"]}>
         <TbGlobe className={styles["globeAlertIcon"]} />
-        <AlertTitle className={styles["alertOrangeTitle"]}>{t((m) => m["IMS--Dialogs"].shareInvoiceDialogPublic.alreadyPublic.title)}</AlertTitle>
+        <AlertTitle className={styles["alertOrangeTitle"]}>{t((m) => m.dialogs.invoices.shareInvoiceDialogPublic.alreadyPublic.title)}</AlertTitle>
         <AlertDescription className={styles["alertOrangeDesc"]}>
-          {t.rich((m) => m["IMS--Dialogs"].shareInvoiceDialogPublic.alreadyPublic.description, {
+          {t.rich((m) => m.dialogs.invoices.shareInvoiceDialogPublic.alreadyPublic.description, {
             // eslint-disable-next-line react/no-unstable-nested-components -- single-call site
             strong: (chunks) => <strong>{chunks}</strong>,
           })}
@@ -174,9 +174,9 @@ export function AlreadyPublicMode({
           disabled={isRevoking}
           className={styles["buttonFull"]}>
           <TbShieldOff className={styles["tabIcon"]} />
-          {isRevoking ? t((m) => m["IMS--Dialogs"].shareInvoiceDialogPublic.alreadyPublic.revoking) : t((m) => m["IMS--Dialogs"].shareInvoiceDialogPublic.alreadyPublic.revoke)}
+          {isRevoking ? t((m) => m.dialogs.invoices.shareInvoiceDialogPublic.alreadyPublic.revoking) : t((m) => m.dialogs.invoices.shareInvoiceDialogPublic.alreadyPublic.revoke)}
         </Button>
-        <p className={styles["revokeHint"]}>{t((m) => m["IMS--Dialogs"].shareInvoiceDialogPublic.alreadyPublic.revokeHint)}</p>
+        <p className={styles["revokeHint"]}>{t((m) => m.dialogs.invoices.shareInvoiceDialogPublic.alreadyPublic.revokeHint)}</p>
       </div>
     </div>
   );
@@ -204,16 +204,16 @@ export function PublicMode({onBack, shareUrl, copied, onCopyLink, onCopyQRCode}:
         onClick={onBack}
         className={styles["backButtonMl"]}>
         <TbArrowLeft className={styles["backIcon"]} />
-        {t((m) => m["IMS--Dialogs"].shareInvoiceDialogPublic.backToOptions)}
+        {t((m) => m.dialogs.invoices.shareInvoiceDialogPublic.backToOptions)}
       </Button>
 
       <Alert
         variant='destructive'
         className={styles["alertOrange"]}>
         <TbAlertTriangle className={styles["globeAlertIcon"]} />
-        <AlertTitle className={styles["alertOrangeTitle"]}>{t((m) => m["IMS--Dialogs"].shareInvoiceDialogPublic.warning.title)}</AlertTitle>
+        <AlertTitle className={styles["alertOrangeTitle"]}>{t((m) => m.dialogs.invoices.shareInvoiceDialogPublic.warning.title)}</AlertTitle>
         <AlertDescription className={styles["alertOrangeDesc"]}>
-          {t.rich((m) => m["IMS--Dialogs"].shareInvoiceDialogPublic.warning.description, {
+          {t.rich((m) => m.dialogs.invoices.shareInvoiceDialogPublic.warning.description, {
             // eslint-disable-next-line react/no-unstable-nested-components -- single-call site
             strong: (chunks) => <strong>{chunks}</strong>,
           })}

--- a/sites/arolariu.ro/src/app/domains/invoices/_dialogs/ShareInvoiceDialog.stories.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_dialogs/ShareInvoiceDialog.stories.tsx
@@ -95,7 +95,7 @@ export const Default: Story = {
             <h4 style={{fontSize: "0.875rem", fontWeight: "600"}}>Privacy Notice</h4>
           </div>
           <p style={{marginTop: "0.25rem", fontSize: "0.75rem", color: "#4b5563"}}>
-            Public links allow anyone with the URL to view this invoice. Private sharing sends a secure invitation via email.
+            Public links allow anyone with the URL to view this invoice. Private sharing sends a secure invitation via emails.
           </p>
         </div>
       </div>

--- a/sites/arolariu.ro/src/app/domains/invoices/_dialogs/ShareInvoiceDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/_dialogs/ShareInvoiceDialog.tsx
@@ -65,7 +65,7 @@ interface SelectionModeProps {
 function SelectionMode({onSelectPublic, onSelectPrivate, t}: Readonly<SelectionModeProps>): React.JSX.Element {
   return (
     <div className={styles["selectionBody"]}>
-      <p className={styles["selectionDescription"]}>{t((m) => m["IMS--Dialogs"].shareInvoiceDialog.selection.description)}</p>
+      <p className={styles["selectionDescription"]}>{t((m) => m.dialogs.invoices.shareInvoiceDialog.selection.description)}</p>
 
       <div className={styles["selectionGrid"]}>
         <Card
@@ -76,9 +76,9 @@ function SelectionMode({onSelectPublic, onSelectPrivate, t}: Readonly<SelectionM
               <TbGlobe className={styles["globeIcon"]} />
             </div>
             <div className={styles["cardContent"]}>
-              <CardTitle className={styles["cardTitleBase"]}>{t((m) => m["IMS--Dialogs"].shareInvoiceDialog.selection.publicTitle)}</CardTitle>
+              <CardTitle className={styles["cardTitleBase"]}>{t((m) => m.dialogs.invoices.shareInvoiceDialog.selection.publicTitle)}</CardTitle>
               <CardDescription className={styles["cardDescSm"]}>
-                {t.rich((m) => m["IMS--Dialogs"].shareInvoiceDialog.selection.publicDescription, {
+                {t.rich((m) => m.dialogs.invoices.shareInvoiceDialog.selection.publicDescription, {
                   // eslint-disable-next-line react/no-unstable-nested-components -- single-call site
                   strong: (chunks) => <strong>{chunks}</strong>,
                 })}
@@ -95,9 +95,9 @@ function SelectionMode({onSelectPublic, onSelectPrivate, t}: Readonly<SelectionM
               <TbLock className={styles["lockIcon"]} />
             </div>
             <div className={styles["cardContent"]}>
-              <CardTitle className={styles["cardTitleBase"]}>{t((m) => m["IMS--Dialogs"].shareInvoiceDialog.selection.privateTitle)}</CardTitle>
+              <CardTitle className={styles["cardTitleBase"]}>{t((m) => m.dialogs.invoices.shareInvoiceDialog.selection.privateTitle)}</CardTitle>
               <CardDescription className={styles["cardDescSm"]}>
-                {t.rich((m) => m["IMS--Dialogs"].shareInvoiceDialog.selection.privateDescription, {
+                {t.rich((m) => m.dialogs.invoices.shareInvoiceDialog.selection.privateDescription, {
                   // eslint-disable-next-line react/no-unstable-nested-components -- single-call site
                   strong: (chunks) => <strong>{chunks}</strong>,
                 })}
@@ -111,8 +111,8 @@ function SelectionMode({onSelectPublic, onSelectPrivate, t}: Readonly<SelectionM
         variant='default'
         className={styles["alertMt"]}>
         <TbAlertTriangle className={styles["alertIcon"]} />
-        <AlertTitle>{t((m) => m["IMS--Dialogs"].shareInvoiceDialog.selection.privacyNoticeTitle)}</AlertTitle>
-        <AlertDescription className={styles["alertDescXs"]}>{t((m) => m["IMS--Dialogs"].shareInvoiceDialog.selection.privacyNoticeDescription)}</AlertDescription>
+        <AlertTitle>{t((m) => m.dialogs.invoices.shareInvoiceDialog.selection.privacyNoticeTitle)}</AlertTitle>
+        <AlertDescription className={styles["alertDescXs"]}>{t((m) => m.dialogs.invoices.shareInvoiceDialog.selection.privacyNoticeDescription)}</AlertDescription>
       </Alert>
     </div>
   );
@@ -226,9 +226,9 @@ export default function ShareInvoiceDialog(): React.JSX.Element {
     };
 
     toast.promise(copyLinkAction(), {
-      loading: isInvoicePublic ? t((m) => m["IMS--Dialogs"].shareInvoiceDialog.toasts.copyLink.loadingPublic) : t((m) => m["IMS--Dialogs"].shareInvoiceDialog.toasts.copyLink.loadingMakePublic),
-      success: isInvoicePublic ? t((m) => m["IMS--Dialogs"].shareInvoiceDialog.toasts.copyLink.successPublic) : t((m) => m["IMS--Dialogs"].shareInvoiceDialog.toasts.copyLink.successMadePublic),
-      error: (error: unknown) => t((m) => m["IMS--Dialogs"].shareInvoiceDialog.toasts.copyLink.error, {message: error instanceof Error ? error.message : String(error)}),
+      loading: isInvoicePublic ? t((m) => m.dialogs.invoices.shareInvoiceDialog.toasts.copyLink.loadingPublic) : t((m) => m.dialogs.invoices.shareInvoiceDialog.toasts.copyLink.loadingMakePublic),
+      success: isInvoicePublic ? t((m) => m.dialogs.invoices.shareInvoiceDialog.toasts.copyLink.successPublic) : t((m) => m.dialogs.invoices.shareInvoiceDialog.toasts.copyLink.successMadePublic),
+      error: (error: unknown) => t((m) => m.dialogs.invoices.shareInvoiceDialog.toasts.copyLink.error, {message: error instanceof Error ? error.message : String(error)}),
     });
   }, [invoice, isInvoicePublic, makeInvoicePublic, router, sharingMode, shareUrl, t]);
 
@@ -246,7 +246,7 @@ export default function ShareInvoiceDialog(): React.JSX.Element {
 
       const qrCodeElement = document.querySelector("#invoice-qr-code");
       if (!qrCodeElement) {
-        throw new Error(t((m) => m["IMS--Dialogs"].shareInvoiceDialog.errors.qrNotFound));
+        throw new Error(t((m) => m.dialogs.invoices.shareInvoiceDialog.errors.qrNotFound));
       }
 
       await copySvgToClipboard(qrCodeElement);
@@ -258,9 +258,9 @@ export default function ShareInvoiceDialog(): React.JSX.Element {
     };
 
     toast.promise(copyQRCodeAction(), {
-      loading: isInvoicePublic ? t((m) => m["IMS--Dialogs"].shareInvoiceDialog.toasts.copyQr.loadingPublic) : t((m) => m["IMS--Dialogs"].shareInvoiceDialog.toasts.copyQr.loadingMakePublic),
-      success: isInvoicePublic ? t((m) => m["IMS--Dialogs"].shareInvoiceDialog.toasts.copyQr.successPublic) : t((m) => m["IMS--Dialogs"].shareInvoiceDialog.toasts.copyQr.successMadePublic),
-      error: (error: unknown) => t((m) => m["IMS--Dialogs"].shareInvoiceDialog.toasts.copyQr.error, {message: error instanceof Error ? error.message : String(error)}),
+      loading: isInvoicePublic ? t((m) => m.dialogs.invoices.shareInvoiceDialog.toasts.copyQr.loadingPublic) : t((m) => m.dialogs.invoices.shareInvoiceDialog.toasts.copyQr.loadingMakePublic),
+      success: isInvoicePublic ? t((m) => m.dialogs.invoices.shareInvoiceDialog.toasts.copyQr.successPublic) : t((m) => m.dialogs.invoices.shareInvoiceDialog.toasts.copyQr.successMadePublic),
+      error: (error: unknown) => t((m) => m.dialogs.invoices.shareInvoiceDialog.toasts.copyQr.error, {message: error instanceof Error ? error.message : String(error)}),
     });
   }, [invoice, isInvoicePublic, makeInvoicePublic, router, sharingMode, t]);
 
@@ -300,9 +300,9 @@ export default function ShareInvoiceDialog(): React.JSX.Element {
       toast.promise(
         sendEmailAction().finally(() => setIsSendingEmail(false)),
         {
-          loading: t((m) => m["IMS--Dialogs"].shareInvoiceDialog.toasts.sendEmail.loading, {email}),
-          success: t((m) => m["IMS--Dialogs"].shareInvoiceDialog.toasts.sendEmail.success, {email}),
-          error: (error: unknown) => t((m) => m["IMS--Dialogs"].shareInvoiceDialog.toasts.sendEmail.error, {message: error instanceof Error ? error.message : String(error)}),
+          loading: t((m) => m.dialogs.invoices.shareInvoiceDialog.toasts.sendEmail.loading, {email}),
+          success: t((m) => m.dialogs.invoices.shareInvoiceDialog.toasts.sendEmail.success, {email}),
+          error: (error: unknown) => t((m) => m.dialogs.invoices.shareInvoiceDialog.toasts.sendEmail.error, {message: error instanceof Error ? error.message : String(error)}),
         },
       );
     },
@@ -337,9 +337,9 @@ export default function ShareInvoiceDialog(): React.JSX.Element {
     toast.promise(
       revokeAction().finally(() => setIsRevoking(false)),
       {
-        loading: t((m) => m["IMS--Dialogs"].shareInvoiceDialog.toasts.revoke.loading),
-        success: t((m) => m["IMS--Dialogs"].shareInvoiceDialog.toasts.revoke.success),
-        error: (error: unknown) => t((m) => m["IMS--Dialogs"].shareInvoiceDialog.toasts.revoke.error, {message: error instanceof Error ? error.message : String(error)}),
+        loading: t((m) => m.dialogs.invoices.shareInvoiceDialog.toasts.revoke.loading),
+        success: t((m) => m.dialogs.invoices.shareInvoiceDialog.toasts.revoke.success),
+        error: (error: unknown) => t((m) => m.dialogs.invoices.shareInvoiceDialog.toasts.revoke.error, {message: error instanceof Error ? error.message : String(error)}),
       },
     );
   }, [invoice, router, handleClose, t]);
@@ -371,15 +371,15 @@ export default function ShareInvoiceDialog(): React.JSX.Element {
   /** Get the dialog description based on current state */
   const getDialogDescription = (): string => {
     if (isInvoicePublic) {
-      return t((m) => m["IMS--Dialogs"].shareInvoiceDialog.dialogDescription.currentlyPublic, {invoiceName: invoice.name});
+      return t((m) => m.dialogs.invoices.shareInvoiceDialog.dialogDescription.currentlyPublic, {invoiceName: invoice.name});
     }
     switch (sharingMode) {
       case "selection":
-        return t((m) => m["IMS--Dialogs"].shareInvoiceDialog.dialogDescription.selection, {invoiceName: invoice.name});
+        return t((m) => m.dialogs.invoices.shareInvoiceDialog.dialogDescription.selection, {invoiceName: invoice.name});
       case "public":
-        return t((m) => m["IMS--Dialogs"].shareInvoiceDialog.dialogDescription.public, {invoiceName: invoice.name});
+        return t((m) => m.dialogs.invoices.shareInvoiceDialog.dialogDescription.public, {invoiceName: invoice.name});
       case "private":
-        return t((m) => m["IMS--Dialogs"].shareInvoiceDialog.dialogDescription.private, {invoiceName: invoice.name});
+        return t((m) => m.dialogs.invoices.shareInvoiceDialog.dialogDescription.private, {invoiceName: invoice.name});
       default:
         return "";
     }
@@ -391,7 +391,7 @@ export default function ShareInvoiceDialog(): React.JSX.Element {
       onOpenChange={handleOpenChange}>
       <DialogContent className={styles["dialogContentMd"]}>
         <DialogHeader>
-          <DialogTitle>{t((m) => m["IMS--Dialogs"].shareInvoiceDialog.title)}</DialogTitle>
+          <DialogTitle>{t((m) => m.dialogs.invoices.shareInvoiceDialog.title)}</DialogTitle>
           <DialogDescription>{getDialogDescription()}</DialogDescription>
         </DialogHeader>
 

--- a/sites/arolariu.ro/src/app/domains/invoices/create-invoice/_components/InvoiceDetailsForm.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/create-invoice/_components/InvoiceDetailsForm.tsx
@@ -50,7 +50,7 @@ function ScanThumbnail({scan}: Readonly<{scan: {name: string; blobUrl: string; s
     <Card className={styles["thumbnailCard"]}>
       <CardContent className={styles["thumbnailContent"]}>
         <div className={styles["thumbnailHeader"]}>
-          <h3 className={styles["thumbnailTitle"]}>{t((m) => m["IMS--Create"].detailsForm.scanPreview.title)}</h3>
+          <h3 className={styles["thumbnailTitle"]}>{t((m) => m.forms.invoices.createInvoice.detailsForm.scanPreview.title)}</h3>
           <span className={styles["scanName"]}>{scan.name}</span>
         </div>
         <div className={styles["thumbnailImageWrapper"]}>
@@ -129,8 +129,8 @@ export default function InvoiceDetailsForm(): React.JSX.Element {
   return (
     <div className={styles["container"]}>
       <div className={styles["header"]}>
-        <h2 className={styles["title"]}>{t((m) => m["IMS--Create"].detailsForm.title)}</h2>
-        <p className={styles["subtitle"]}>{t((m) => m["IMS--Create"].detailsForm.subtitle)}</p>
+        <h2 className={styles["title"]}>{t((m) => m.forms.invoices.createInvoice.detailsForm.title)}</h2>
+        <p className={styles["subtitle"]}>{t((m) => m.forms.invoices.createInvoice.detailsForm.subtitle)}</p>
       </div>
 
       <div className={styles["contentWrapper"]}>
@@ -146,62 +146,62 @@ export default function InvoiceDetailsForm(): React.JSX.Element {
           <CardContent className={styles["formContent"]}>
             {/* Invoice Name */}
             <div className={styles["formField"]}>
-              <Label htmlFor='invoice-name'>{t((m) => m["IMS--Create"].detailsForm.fields.name.label)}</Label>
+              <Label htmlFor='invoice-name'>{t((m) => m.forms.invoices.createInvoice.detailsForm.fields.name.label)}</Label>
               <Input
                 id='invoice-name'
                 type='text'
-                placeholder={t((m) => m["IMS--Create"].detailsForm.fields.name.placeholder)}
+                placeholder={t((m) => m.forms.invoices.createInvoice.detailsForm.fields.name.placeholder)}
                 value={invoiceDetails.name}
                 onChange={handleNameChange}
                 required
               />
-              <p className={styles["fieldHint"]}>{t((m) => m["IMS--Create"].detailsForm.fields.name.hint)}</p>
+              <p className={styles["fieldHint"]}>{t((m) => m.forms.invoices.createInvoice.detailsForm.fields.name.hint)}</p>
             </div>
 
             {/* Category */}
             <div className={styles["formField"]}>
-              <Label htmlFor='invoice-category'>{t((m) => m["IMS--Create"].detailsForm.fields.category.label)}</Label>
+              <Label htmlFor='invoice-category'>{t((m) => m.forms.invoices.createInvoice.detailsForm.fields.category.label)}</Label>
               <Select
                 value={invoiceDetails.category.toString()}
                 onValueChange={handleCategoryChange}>
                 <SelectTrigger id='invoice-category'>
-                  <SelectValue placeholder={t((m) => m["IMS--Create"].detailsForm.fields.category.placeholder)} />
+                  <SelectValue placeholder={t((m) => m.forms.invoices.createInvoice.detailsForm.fields.category.placeholder)} />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value={InvoiceCategory.NOT_DEFINED.toString()}>{t((m) => m["IMS--Create"].detailsForm.fields.category.options.notDefined)}</SelectItem>
-                  <SelectItem value={InvoiceCategory.GROCERY.toString()}>{t((m) => m["IMS--Create"].detailsForm.fields.category.options.grocery)}</SelectItem>
-                  <SelectItem value={InvoiceCategory.FAST_FOOD.toString()}>{t((m) => m["IMS--Create"].detailsForm.fields.category.options.fastFood)}</SelectItem>
-                  <SelectItem value={InvoiceCategory.HOME_CLEANING.toString()}>{t((m) => m["IMS--Create"].detailsForm.fields.category.options.homeCleaning)}</SelectItem>
-                  <SelectItem value={InvoiceCategory.CAR_AUTO.toString()}>{t((m) => m["IMS--Create"].detailsForm.fields.category.options.carAuto)}</SelectItem>
-                  <SelectItem value={InvoiceCategory.OTHER.toString()}>{t((m) => m["IMS--Create"].detailsForm.fields.category.options.other)}</SelectItem>
+                  <SelectItem value={InvoiceCategory.NOT_DEFINED.toString()}>{t((m) => m.forms.invoices.createInvoice.detailsForm.fields.category.options.notDefined)}</SelectItem>
+                  <SelectItem value={InvoiceCategory.GROCERY.toString()}>{t((m) => m.forms.invoices.createInvoice.detailsForm.fields.category.options.grocery)}</SelectItem>
+                  <SelectItem value={InvoiceCategory.FAST_FOOD.toString()}>{t((m) => m.forms.invoices.createInvoice.detailsForm.fields.category.options.fastFood)}</SelectItem>
+                  <SelectItem value={InvoiceCategory.HOME_CLEANING.toString()}>{t((m) => m.forms.invoices.createInvoice.detailsForm.fields.category.options.homeCleaning)}</SelectItem>
+                  <SelectItem value={InvoiceCategory.CAR_AUTO.toString()}>{t((m) => m.forms.invoices.createInvoice.detailsForm.fields.category.options.carAuto)}</SelectItem>
+                  <SelectItem value={InvoiceCategory.OTHER.toString()}>{t((m) => m.forms.invoices.createInvoice.detailsForm.fields.category.options.other)}</SelectItem>
                 </SelectContent>
               </Select>
             </div>
 
             {/* Payment Type */}
             <div className={styles["formField"]}>
-              <Label htmlFor='payment-type'>{t((m) => m["IMS--Create"].detailsForm.fields.paymentType.label)}</Label>
+              <Label htmlFor='payment-type'>{t((m) => m.forms.invoices.createInvoice.detailsForm.fields.paymentType.label)}</Label>
               <Select
                 value={invoiceDetails.paymentType.toString()}
                 onValueChange={handlePaymentTypeChange}>
                 <SelectTrigger id='payment-type'>
-                  <SelectValue placeholder={t((m) => m["IMS--Create"].detailsForm.fields.paymentType.placeholder)} />
+                  <SelectValue placeholder={t((m) => m.forms.invoices.createInvoice.detailsForm.fields.paymentType.placeholder)} />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value={PaymentType.Unknown.toString()}>{t((m) => m["IMS--Create"].detailsForm.fields.paymentType.options.unknown)}</SelectItem>
-                  <SelectItem value={PaymentType.Cash.toString()}>{t((m) => m["IMS--Create"].detailsForm.fields.paymentType.options.cash)}</SelectItem>
-                  <SelectItem value={PaymentType.Card.toString()}>{t((m) => m["IMS--Create"].detailsForm.fields.paymentType.options.card)}</SelectItem>
-                  <SelectItem value={PaymentType.Transfer.toString()}>{t((m) => m["IMS--Create"].detailsForm.fields.paymentType.options.transfer)}</SelectItem>
-                  <SelectItem value={PaymentType.MobilePayment.toString()}>{t((m) => m["IMS--Create"].detailsForm.fields.paymentType.options.mobilePayment)}</SelectItem>
-                  <SelectItem value={PaymentType.Voucher.toString()}>{t((m) => m["IMS--Create"].detailsForm.fields.paymentType.options.voucher)}</SelectItem>
-                  <SelectItem value={PaymentType.Other.toString()}>{t((m) => m["IMS--Create"].detailsForm.fields.paymentType.options.other)}</SelectItem>
+                  <SelectItem value={PaymentType.Unknown.toString()}>{t((m) => m.forms.invoices.createInvoice.detailsForm.fields.paymentType.options.unknown)}</SelectItem>
+                  <SelectItem value={PaymentType.Cash.toString()}>{t((m) => m.forms.invoices.createInvoice.detailsForm.fields.paymentType.options.cash)}</SelectItem>
+                  <SelectItem value={PaymentType.Card.toString()}>{t((m) => m.forms.invoices.createInvoice.detailsForm.fields.paymentType.options.card)}</SelectItem>
+                  <SelectItem value={PaymentType.Transfer.toString()}>{t((m) => m.forms.invoices.createInvoice.detailsForm.fields.paymentType.options.transfer)}</SelectItem>
+                  <SelectItem value={PaymentType.MobilePayment.toString()}>{t((m) => m.forms.invoices.createInvoice.detailsForm.fields.paymentType.options.mobilePayment)}</SelectItem>
+                  <SelectItem value={PaymentType.Voucher.toString()}>{t((m) => m.forms.invoices.createInvoice.detailsForm.fields.paymentType.options.voucher)}</SelectItem>
+                  <SelectItem value={PaymentType.Other.toString()}>{t((m) => m.forms.invoices.createInvoice.detailsForm.fields.paymentType.options.other)}</SelectItem>
                 </SelectContent>
               </Select>
             </div>
 
             {/* Transaction Date */}
             <div className={styles["formField"]}>
-              <Label htmlFor='transaction-date'>{t((m) => m["IMS--Create"].detailsForm.fields.transactionDate.label)}</Label>
+              <Label htmlFor='transaction-date'>{t((m) => m.forms.invoices.createInvoice.detailsForm.fields.transactionDate.label)}</Label>
               <Popover>
                 <PopoverTrigger asChild>
                   <Button
@@ -227,16 +227,16 @@ export default function InvoiceDetailsForm(): React.JSX.Element {
 
             {/* Description */}
             <div className={styles["formField"]}>
-              <Label htmlFor='invoice-description'>{t((m) => m["IMS--Create"].detailsForm.fields.description.label)}</Label>
+              <Label htmlFor='invoice-description'>{t((m) => m.forms.invoices.createInvoice.detailsForm.fields.description.label)}</Label>
               <Textarea
                 id='invoice-description'
-                placeholder={t((m) => m["IMS--Create"].detailsForm.fields.description.placeholder)}
+                placeholder={t((m) => m.forms.invoices.createInvoice.detailsForm.fields.description.placeholder)}
                 value={invoiceDetails.description}
                 onChange={handleDescriptionChange}
                 rows={4}
                 className={styles["descriptionTextarea"]}
               />
-              <p className={styles["fieldHint"]}>{t((m) => m["IMS--Create"].detailsForm.fields.description.hint)}</p>
+              <p className={styles["fieldHint"]}>{t((m) => m.forms.invoices.createInvoice.detailsForm.fields.description.hint)}</p>
             </div>
           </CardContent>
         </Card>

--- a/sites/arolariu.ro/src/app/domains/invoices/create-invoice/_components/ReviewStep.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/create-invoice/_components/ReviewStep.tsx
@@ -56,8 +56,8 @@ export default function ReviewStep(): React.JSX.Element {
   return (
     <div className={styles["container"]}>
       <div className={styles["header"]}>
-        <h2 className={styles["title"]}>{t((m) => m["IMS--Create"].reviewStep.title)}</h2>
-        <p className={styles["subtitle"]}>{t((m) => m["IMS--Create"].reviewStep.subtitle)}</p>
+        <h2 className={styles["title"]}>{t((m) => m.forms.invoices.createInvoice.reviewStep.title)}</h2>
+        <p className={styles["subtitle"]}>{t((m) => m.forms.invoices.createInvoice.reviewStep.subtitle)}</p>
       </div>
 
       {/* Selected Scans */}
@@ -65,7 +65,7 @@ export default function ReviewStep(): React.JSX.Element {
         <CardHeader>
           <CardTitle className={styles["sectionTitle"]}>
             <TbPhoto />
-            {t((m) => m["IMS--Create"].reviewStep.sections.scans.title)}
+            {t((m) => m.forms.invoices.createInvoice.reviewStep.sections.scans.title)}
             <Badge variant='secondary'>{selectedScans.length}</Badge>
           </CardTitle>
         </CardHeader>
@@ -102,14 +102,14 @@ export default function ReviewStep(): React.JSX.Element {
         <CardHeader>
           <CardTitle className={styles["sectionTitle"]}>
             <TbFileInvoice />
-            {t((m) => m["IMS--Create"].reviewStep.sections.details.title)}
+            {t((m) => m.forms.invoices.createInvoice.reviewStep.sections.details.title)}
           </CardTitle>
         </CardHeader>
         <CardContent className={styles["detailsContent"]}>
           <div className={styles["detailRow"]}>
             <div className={styles["detailLabel"]}>
               <TbFileDescription />
-              {t((m) => m["IMS--Create"].reviewStep.sections.details.name)}
+              {t((m) => m.forms.invoices.createInvoice.reviewStep.sections.details.name)}
             </div>
             <div className={styles["detailValue"]}>{invoiceDetails.name}</div>
           </div>
@@ -117,27 +117,27 @@ export default function ReviewStep(): React.JSX.Element {
           <div className={styles["detailRow"]}>
             <div className={styles["detailLabel"]}>
               <TbCategory />
-              {t((m) => m["IMS--Create"].reviewStep.sections.details.category)}
+              {t((m) => m.forms.invoices.createInvoice.reviewStep.sections.details.category)}
             </div>
             <div className={styles["detailValue"]}>
-              <Badge variant='outline'>{t(selectorFromPath(`IMS--Create.reviewStep.categories.${CATEGORY_KEYS[invoiceDetails.category] ?? "notDefined"}`))}</Badge>
+              <Badge variant='outline'>{t(selectorFromPath(`forms.invoices.createInvoice.reviewStep.categories.${CATEGORY_KEYS[invoiceDetails.category] ?? "notDefined"}`))}</Badge>
             </div>
           </div>
 
           <div className={styles["detailRow"]}>
             <div className={styles["detailLabel"]}>
               <TbCreditCard />
-              {t((m) => m["IMS--Create"].reviewStep.sections.details.paymentType)}
+              {t((m) => m.forms.invoices.createInvoice.reviewStep.sections.details.paymentType)}
             </div>
             <div className={styles["detailValue"]}>
-              <Badge variant='outline'>{t(selectorFromPath(`IMS--Create.reviewStep.paymentTypes.${PAYMENT_TYPE_KEYS[invoiceDetails.paymentType] ?? "unknown"}`))}</Badge>
+              <Badge variant='outline'>{t(selectorFromPath(`forms.invoices.createInvoice.reviewStep.paymentTypes.${PAYMENT_TYPE_KEYS[invoiceDetails.paymentType] ?? "unknown"}`))}</Badge>
             </div>
           </div>
 
           <div className={styles["detailRow"]}>
             <div className={styles["detailLabel"]}>
               <TbCalendar />
-              {t((m) => m["IMS--Create"].reviewStep.sections.details.transactionDate)}
+              {t((m) => m.forms.invoices.createInvoice.reviewStep.sections.details.transactionDate)}
             </div>
             <div className={styles["detailValue"]}>{format.dateTime(invoiceDetails.transactionDate, {dateStyle: "long"})}</div>
           </div>
@@ -146,7 +146,7 @@ export default function ReviewStep(): React.JSX.Element {
             <div className={styles["detailRow"]}>
               <div className={styles["detailLabel"]}>
                 <TbFileDescription />
-                {t((m) => m["IMS--Create"].reviewStep.sections.details.description)}
+                {t((m) => m.forms.invoices.createInvoice.reviewStep.sections.details.description)}
               </div>
               <div className={styles["detailValue"]}>{invoiceDetails.description}</div>
             </div>
@@ -164,16 +164,16 @@ export default function ReviewStep(): React.JSX.Element {
           {isCreating ? (
             <>
               <Spinner className={styles["spinner"]} />
-              {t((m) => m["IMS--Create"].reviewStep.actions.creating)}
+              {t((m) => m.forms.invoices.createInvoice.reviewStep.actions.creating)}
             </>
           ) : (
             <>
               <TbSparkles />
-              {t((m) => m["IMS--Create"].reviewStep.actions.create)}
+              {t((m) => m.forms.invoices.createInvoice.reviewStep.actions.create)}
             </>
           )}
         </Button>
-        <p className={styles["createHint"]}>{t((m) => m["IMS--Create"].reviewStep.actions.hint)}</p>
+        <p className={styles["createHint"]}>{t((m) => m.forms.invoices.createInvoice.reviewStep.actions.hint)}</p>
       </div>
     </div>
   );

--- a/sites/arolariu.ro/src/app/domains/invoices/create-invoice/_components/ScanSelector.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/create-invoice/_components/ScanSelector.tsx
@@ -91,8 +91,8 @@ export default function ScanSelector(): React.JSX.Element {
       {/* Header with actions */}
       <div className={styles["header"]}>
         <div className={styles["headerInfo"]}>
-          <h2 className={styles["title"]}>{t((m) => m["IMS--Create"].scanSelector.title)}</h2>
-          <p className={styles["subtitle"]}>{t((m) => m["IMS--Create"].scanSelector.subtitle)}</p>
+          <h2 className={styles["title"]}>{t((m) => m.forms.invoices.createInvoice.scanSelector.title)}</h2>
+          <p className={styles["subtitle"]}>{t((m) => m.forms.invoices.createInvoice.scanSelector.subtitle)}</p>
         </div>
 
         <div className={styles["actions"]}>
@@ -100,7 +100,7 @@ export default function ScanSelector(): React.JSX.Element {
             <Badge
               variant='secondary'
               className={styles["selectedBadge"]}>
-              {t((m) => m["IMS--Create"].scanSelector.selectedCount, {count: String(selectedScans.length)})}
+              {t((m) => m.forms.invoices.createInvoice.scanSelector.selectedCount, {count: String(selectedScans.length)})}
             </Badge>
           ) : null}
 
@@ -111,7 +111,7 @@ export default function ScanSelector(): React.JSX.Element {
                 size='sm'
                 onClick={clearSelection}>
                 <TbX />
-                {t((m) => m["IMS--Create"].scanSelector.clearAll)}
+                {t((m) => m.forms.invoices.createInvoice.scanSelector.clearAll)}
               </Button>
             ) : (
               <Button
@@ -120,7 +120,7 @@ export default function ScanSelector(): React.JSX.Element {
                 onClick={selectAllScans}
                 disabled={readyScans.length > 5}>
                 <TbCheck />
-                {t((m) => m["IMS--Create"].scanSelector.selectAll)}
+                {t((m) => m.forms.invoices.createInvoice.scanSelector.selectAll)}
               </Button>
             )
           ) : null}
@@ -150,17 +150,17 @@ export default function ScanSelector(): React.JSX.Element {
                 onClick={handlePreviousPage}
                 disabled={page === 0}>
                 <TbChevronLeft />
-                {t((m) => m["IMS--Create"].scanSelector.previous)}
+                {t((m) => m.forms.invoices.createInvoice.scanSelector.previous)}
               </Button>
               <span className={styles["pageInfo"]}>
-                {page + 1} / {totalPages} ({readyScans.length} {t((m) => m["IMS--Create"].scanSelector.scansCount)})
+                {page + 1} / {totalPages} ({readyScans.length} {t((m) => m.forms.invoices.createInvoice.scanSelector.scansCount)})
               </span>
               <Button
                 variant='outline'
                 size='sm'
                 onClick={handleNextPage}
                 disabled={page >= totalPages - 1}>
-                {t((m) => m["IMS--Create"].scanSelector.next)}
+                {t((m) => m.forms.invoices.createInvoice.scanSelector.next)}
                 <TbChevronRight />
               </Button>
             </div>
@@ -169,7 +169,7 @@ export default function ScanSelector(): React.JSX.Element {
       ) : (
         <div className={styles["emptyState"]}>
           <TbPhoto className={styles["emptyIcon"]} />
-          <p className={styles["emptyText"]}>{t((m) => m["IMS--Create"].scanSelector.noScans)}</p>
+          <p className={styles["emptyText"]}>{t((m) => m.forms.invoices.createInvoice.scanSelector.noScans)}</p>
         </div>
       )}
     </div>

--- a/sites/arolariu.ro/src/app/domains/invoices/create-invoice/_components/StepIndicator.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/create-invoice/_components/StepIndicator.tsx
@@ -58,8 +58,8 @@ function StepItem({
   return (
     <div className={styles["stepItem"]}>
       <div className={circleClassName}>{isCompleted ? <TbCheck className={styles["stepCheckIcon"]} /> : step.icon}</div>
-      <span className={labelClassName}>{t(selectorFromPath(`IMS--Create.steps.${step.labelKey}`))}</span>
-      <span className={styles["stepDescription"]}>{t(selectorFromPath(`IMS--Create.steps.${step.descriptionKey}`))}</span>
+      <span className={labelClassName}>{t(selectorFromPath(`forms.invoices.createInvoice.steps.${step.labelKey}`))}</span>
+      <span className={styles["stepDescription"]}>{t(selectorFromPath(`forms.invoices.createInvoice.steps.${step.descriptionKey}`))}</span>
     </div>
   );
 }

--- a/sites/arolariu.ro/src/app/domains/invoices/create-invoice/island.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/create-invoice/island.tsx
@@ -83,7 +83,7 @@ function WizardNavigation(): React.JSX.Element {
           onClick={goBack}
           disabled={isCreating}>
           <TbArrowLeft />
-          {t((m) => m["IMS--Create"].navigation.back)}
+          {t((m) => m.forms.invoices.createInvoice.navigation.back)}
         </Button>
       ) : null}
 
@@ -92,7 +92,7 @@ function WizardNavigation(): React.JSX.Element {
           onClick={goNext}
           disabled={!canGoNext || isCreating}
           className={styles["nextButton"]}>
-          {t((m) => m["IMS--Create"].navigation.next)}
+          {t((m) => m.forms.invoices.createInvoice.navigation.next)}
         </Button>
       ) : null}
     </div>
@@ -109,14 +109,14 @@ function EmptyState(): React.JSX.Element {
     <Card className={styles["emptyState"]}>
       <CardContent className={styles["emptyStateContent"]}>
         <div className={styles["emptyStateIcon"]}>📄</div>
-        <h2 className={styles["emptyStateTitle"]}>{t((m) => m["IMS--Create"].emptyState.title)}</h2>
-        <p className={styles["emptyStateDescription"]}>{t((m) => m["IMS--Create"].emptyState.description)}</p>
+        <h2 className={styles["emptyStateTitle"]}>{t((m) => m.forms.invoices.createInvoice.emptyState.title)}</h2>
+        <p className={styles["emptyStateDescription"]}>{t((m) => m.forms.invoices.createInvoice.emptyState.description)}</p>
         <div className={styles["emptyStateActions"]}>
           <Link href='/domains/invoices/upload-scans'>
-            <Button>{t((m) => m["IMS--Create"].emptyState.uploadButton)}</Button>
+            <Button>{t((m) => m.forms.invoices.createInvoice.emptyState.uploadButton)}</Button>
           </Link>
           <Link href='/domains/invoices/view-scans'>
-            <Button variant='outline'>{t((m) => m["IMS--Create"].emptyState.viewScansButton)}</Button>
+            <Button variant='outline'>{t((m) => m.forms.invoices.createInvoice.emptyState.viewScansButton)}</Button>
           </Link>
         </div>
       </CardContent>
@@ -143,10 +143,10 @@ function CreateInvoiceWizard(): React.JSX.Element {
           href='/domains/invoices'
           className={styles["backLink"]}>
           <TbArrowLeft />
-          {t((m) => m["IMS--Create"].header.backToInvoices)}
+          {t((m) => m.forms.invoices.createInvoice.header.backToInvoices)}
         </Link>
-        <h1 className={styles["title"]}>{t((m) => m["IMS--Create"].header.title)}</h1>
-        <p className={styles["subtitle"]}>{t((m) => m["IMS--Create"].header.subtitle)}</p>
+        <h1 className={styles["title"]}>{t((m) => m.forms.invoices.createInvoice.header.title)}</h1>
+        <p className={styles["subtitle"]}>{t((m) => m.forms.invoices.createInvoice.header.subtitle)}</p>
       </div>
 
       {/* Step Indicator */}

--- a/sites/arolariu.ro/src/app/domains/invoices/create-invoice/page.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/create-invoice/page.tsx
@@ -17,8 +17,8 @@ export async function generateMetadata(): Promise<Metadata> {
   const locale = await getLocale();
   return createMetadata({
     locale,
-    title: t((m) => m["IMS--Create"].metadata.title),
-    description: t((m) => m["IMS--Create"].metadata.description),
+    title: t((m) => m.forms.invoices.createInvoice.metadata.title),
+    description: t((m) => m.forms.invoices.createInvoice.metadata.description),
   });
 }
 

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/ChangeHistory.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/ChangeHistory.tsx
@@ -106,7 +106,7 @@ export default function ChangeHistory(): React.JSX.Element {
       items.push({
         id: "pending-name",
         type: "pending",
-        title: t((m) => m["IMS--Edit"].changeHistory.changes.nameChanged),
+        title: t((m) => m.pages.invoices.editInvoice.changeHistory.changes.nameChanged),
         description: `"${invoice.name}" → "${pendingChanges.name}"`,
         timestamp: new Date(), // "Just now"
         icon: <TbFileText className={styles["timelineIcon"]} />,
@@ -119,7 +119,7 @@ export default function ChangeHistory(): React.JSX.Element {
       items.push({
         id: "pending-category",
         type: "pending",
-        title: t((m) => m["IMS--Edit"].changeHistory.changes.categoryUpdated),
+        title: t((m) => m.pages.invoices.editInvoice.changeHistory.changes.categoryUpdated),
         description: `${oldCategory} → ${newCategory}`,
         timestamp: new Date(),
         icon: <TbTag className={styles["timelineIcon"]} />,
@@ -130,7 +130,7 @@ export default function ChangeHistory(): React.JSX.Element {
       items.push({
         id: "pending-description",
         type: "pending",
-        title: t((m) => m["IMS--Edit"].changeHistory.changes.descriptionChanged),
+        title: t((m) => m.pages.invoices.editInvoice.changeHistory.changes.descriptionChanged),
         description: pendingChanges.description.length > 50 ? `${pendingChanges.description.slice(0, 50)}...` : pendingChanges.description,
         timestamp: new Date(),
         icon: <TbFileText className={styles["timelineIcon"]} />,
@@ -141,7 +141,7 @@ export default function ChangeHistory(): React.JSX.Element {
       items.push({
         id: "pending-payment",
         type: "pending",
-        title: t((m) => m["IMS--Edit"].changeHistory.changes.paymentTypeChanged),
+        title: t((m) => m.pages.invoices.editInvoice.changeHistory.changes.paymentTypeChanged),
         description: String(pendingChanges.paymentType),
         timestamp: new Date(),
         icon: <TbWallet className={styles["timelineIcon"]} />,
@@ -152,7 +152,7 @@ export default function ChangeHistory(): React.JSX.Element {
       items.push({
         id: "pending-date",
         type: "pending",
-        title: t((m) => m["IMS--Edit"].changeHistory.changes.transactionDateChanged),
+        title: t((m) => m.pages.invoices.editInvoice.changeHistory.changes.transactionDateChanged),
         description: pendingChanges.transactionDate.toLocaleDateString(),
         timestamp: new Date(),
         icon: <TbCalendar className={styles["timelineIcon"]} />,
@@ -163,10 +163,10 @@ export default function ChangeHistory(): React.JSX.Element {
       items.push({
         id: "pending-important",
         type: "pending",
-        title: t((m) => m["IMS--Edit"].changeHistory.changes.importanceChanged),
+        title: t((m) => m.pages.invoices.editInvoice.changeHistory.changes.importanceChanged),
         description: pendingChanges.isImportant
-          ? t((m) => m["IMS--Edit"].changeHistory.changes.markedImportant)
-          : t((m) => m["IMS--Edit"].changeHistory.changes.unmarkedImportant),
+          ? t((m) => m.pages.invoices.editInvoice.changeHistory.changes.markedImportant)
+          : t((m) => m.pages.invoices.editInvoice.changeHistory.changes.unmarkedImportant),
         timestamp: new Date(),
         icon: <TbCheck className={styles["timelineIcon"]} />,
       });
@@ -177,7 +177,7 @@ export default function ChangeHistory(): React.JSX.Element {
       items.push({
         id: "modified",
         type: "modified",
-        title: t((m) => m["IMS--Edit"].changeHistory.modified),
+        title: t((m) => m.pages.invoices.editInvoice.changeHistory.modified),
         timestamp: invoice.lastUpdatedAt,
         icon: <TbClock className={styles["timelineIcon"]} />,
       });
@@ -187,7 +187,7 @@ export default function ChangeHistory(): React.JSX.Element {
     items.push({
       id: "created",
       type: "created",
-      title: t((m) => m["IMS--Edit"].changeHistory.created),
+      title: t((m) => m.pages.invoices.editInvoice.changeHistory.created),
       timestamp: invoice.createdAt,
       icon: <TbCircleDot className={styles["timelineIcon"]} />,
     });
@@ -198,12 +198,12 @@ export default function ChangeHistory(): React.JSX.Element {
   return (
     <div className={styles["container"]}>
       <div className={styles["header"]}>
-        <h3 className={styles["title"]}>{t((m) => m["IMS--Edit"].changeHistory.title)}</h3>
+        <h3 className={styles["title"]}>{t((m) => m.pages.invoices.editInvoice.changeHistory.title)}</h3>
         {historyItems.some((item) => item.type === "pending") && (
           <Badge
             variant='secondary'
             className={styles["pendingBadge"]}>
-            {t((m) => m["IMS--Edit"].changeHistory.unsavedChanges)}
+            {t((m) => m.pages.invoices.editInvoice.changeHistory.unsavedChanges)}
           </Badge>
         )}
       </div>
@@ -220,7 +220,7 @@ export default function ChangeHistory(): React.JSX.Element {
             <div className={styles["timelineContent"]}>
               <div className={styles["changeHeader"]}>
                 <p className={styles["changeTitle"]}>{item.title}</p>
-                {item.type === "pending" && <span className={styles["pendingIndicator"]}>{t((m) => m["IMS--Edit"].changeHistory.pending)}</span>}
+                {item.type === "pending" && <span className={styles["pendingIndicator"]}>{t((m) => m.pages.invoices.editInvoice.changeHistory.pending)}</span>}
               </div>
               {item.description ? <p className={styles["changeDescription"]}>{item.description}</p> : null}
               <p className={styles["changeTimestamp"]}>{formatRelativeTime(item.timestamp)}</p>

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/GuidedEditBanner.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/GuidedEditBanner.tsx
@@ -130,15 +130,15 @@ export default function GuidedEditBanner({items, onReviewAll}: Props): React.JSX
     const parts: string[] = [];
 
     if (analysis.uncategorized.length > 0) {
-      parts.push(t((m) => m["IMS--Edit"].guidedEditBanner.summary.uncategorized, {count: analysis.uncategorized.length}));
+      parts.push(t((m) => m.pages.invoices.editInvoice.guidedEditBanner.summary.uncategorized, {count: analysis.uncategorized.length}));
     }
 
     if (analysis.lowConfidence.length > 0) {
-      parts.push(t((m) => m["IMS--Edit"].guidedEditBanner.summary.lowConfidence, {count: analysis.lowConfidence.length}));
+      parts.push(t((m) => m.pages.invoices.editInvoice.guidedEditBanner.summary.lowConfidence, {count: analysis.lowConfidence.length}));
     }
 
     if (analysis.missingName.length > 0) {
-      parts.push(t((m) => m["IMS--Edit"].guidedEditBanner.summary.missingName, {count: analysis.missingName.length}));
+      parts.push(t((m) => m.pages.invoices.editInvoice.guidedEditBanner.summary.missingName, {count: analysis.missingName.length}));
     }
 
     return parts.join(", ");
@@ -157,13 +157,13 @@ export default function GuidedEditBanner({items, onReviewAll}: Props): React.JSX
         <TbAlertCircle className={styles["alertIcon"]} />
         <div className={styles["content"]}>
           <div className={styles["header"]}>
-            <AlertTitle className={styles["title"]}>{t((m) => m["IMS--Edit"].guidedEditBanner.title, {count: analysis.totalIssues})}</AlertTitle>
+            <AlertTitle className={styles["title"]}>{t((m) => m.pages.invoices.editInvoice.guidedEditBanner.title, {count: analysis.totalIssues})}</AlertTitle>
             <Button
               variant='ghost'
               size='sm'
               onClick={handleDismiss}
               className={styles["dismissButton"]}
-              aria-label={t((m) => m["IMS--Edit"].guidedEditBanner.actions.dismiss)}>
+              aria-label={t((m) => m.pages.invoices.editInvoice.guidedEditBanner.actions.dismiss)}>
               <TbX className={styles["dismissIcon"]} />
             </Button>
           </div>
@@ -178,7 +178,7 @@ export default function GuidedEditBanner({items, onReviewAll}: Props): React.JSX
                 onClick={onReviewAll}
                 className={styles["reviewButton"]}>
                 <TbChevronDown className={styles["reviewIcon"]} />
-                {t((m) => m["IMS--Edit"].guidedEditBanner.actions.reviewAll)}
+                {t((m) => m.pages.invoices.editInvoice.guidedEditBanner.actions.reviewAll)}
               </Button>
             ) : null}
 
@@ -188,21 +188,21 @@ export default function GuidedEditBanner({items, onReviewAll}: Props): React.JSX
                 <Badge
                   variant='secondary'
                   className={styles["badge"]}>
-                  {t((m) => m["IMS--Edit"].guidedEditBanner.badges.uncategorized, {count: analysis.uncategorized.length})}
+                  {t((m) => m.pages.invoices.editInvoice.guidedEditBanner.badges.uncategorized, {count: analysis.uncategorized.length})}
                 </Badge>
               )}
               {analysis.lowConfidence.length > 0 && (
                 <Badge
                   variant='secondary'
                   className={styles["badge"]}>
-                  {t((m) => m["IMS--Edit"].guidedEditBanner.badges.lowConfidence, {count: analysis.lowConfidence.length})}
+                  {t((m) => m.pages.invoices.editInvoice.guidedEditBanner.badges.lowConfidence, {count: analysis.lowConfidence.length})}
                 </Badge>
               )}
               {analysis.missingName.length > 0 && (
                 <Badge
                   variant='secondary'
                   className={styles["badge"]}>
-                  {t((m) => m["IMS--Edit"].guidedEditBanner.badges.missingName, {count: analysis.missingName.length})}
+                  {t((m) => m.pages.invoices.editInvoice.guidedEditBanner.badges.missingName, {count: analysis.missingName.length})}
                 </Badge>
               )}
             </div>

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/InvoiceHeader.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/InvoiceHeader.tsx
@@ -105,12 +105,12 @@ export default function InvoiceHeader(): React.JSX.Element {
                       onClick={handleSave}
                       disabled={isSaving}>
                       <TbDeviceFloppy className={styles["buttonIcon"]} />
-                      {isSaving ? t((m) => m["IMS--Common"].invoiceHeader.buttons.saving) : t((m) => m["IMS--Common"].invoiceHeader.buttons.save)}
+                      {isSaving ? t((m) => m.shared.invoices.invoiceHeader.buttons.saving) : t((m) => m.shared.invoices.invoiceHeader.buttons.save)}
                     </Button>
                   }
                 />
                 <TooltipContent>
-                  <p>{t((m) => m["IMS--Common"].invoiceHeader.tooltips.saveAllPendingChanges)}</p>
+                  <p>{t((m) => m.shared.invoices.invoiceHeader.tooltips.saveAllPendingChanges)}</p>
                 </TooltipContent>
               </Tooltip>
               <Tooltip>
@@ -122,12 +122,12 @@ export default function InvoiceHeader(): React.JSX.Element {
                       onClick={handleDiscard}
                       disabled={isSaving}>
                       <TbX className={styles["buttonIcon"]} />
-                      {t((m) => m["IMS--Common"].invoiceHeader.buttons.discard)}
+                      {t((m) => m.shared.invoices.invoiceHeader.buttons.discard)}
                     </Button>
                   }
                 />
                 <TooltipContent>
-                  <p>{t((m) => m["IMS--Common"].invoiceHeader.tooltips.discardAllPendingChanges)}</p>
+                  <p>{t((m) => m.shared.invoices.invoiceHeader.tooltips.discardAllPendingChanges)}</p>
                 </TooltipContent>
               </Tooltip>
             </>
@@ -140,12 +140,12 @@ export default function InvoiceHeader(): React.JSX.Element {
                   size='sm'
                   onClick={handleInvoicePrint}>
                   <TbPrinter className={styles["buttonIcon"]} />
-                  {t((m) => m["IMS--Common"].invoiceHeader.buttons.print)}
+                  {t((m) => m.shared.invoices.invoiceHeader.buttons.print)}
                 </Button>
               }
             />
             <TooltipContent>
-              <p>{t((m) => m["IMS--Common"].invoiceHeader.tooltips.printInvoiceWithAllDetails)}</p>
+              <p>{t((m) => m.shared.invoices.invoiceHeader.tooltips.printInvoiceWithAllDetails)}</p>
             </TooltipContent>
           </Tooltip>
           {Boolean(canAnalyze) && (
@@ -157,12 +157,12 @@ export default function InvoiceHeader(): React.JSX.Element {
                     variant='outline'
                     size='sm'>
                     <TbScanEye className={styles["buttonIcon"]} />
-                    {t((m) => m["IMS--Common"].invoiceHeader.buttons.analyzeWithAi)}
+                    {t((m) => m.shared.invoices.invoiceHeader.buttons.analyzeWithAi)}
                   </Button>
                 }
               />
               <TooltipContent>
-                <p>{t((m) => m["IMS--Common"].invoiceHeader.tooltips.analyzeSpendingPatterns)}</p>
+                <p>{t((m) => m.shared.invoices.invoiceHeader.tooltips.analyzeSpendingPatterns)}</p>
               </TooltipContent>
             </Tooltip>
           )}
@@ -174,12 +174,12 @@ export default function InvoiceHeader(): React.JSX.Element {
                   variant='destructive'
                   size='sm'>
                   <TbTrash className={styles["buttonIcon"]} />
-                  {t((m) => m["IMS--Common"].invoiceHeader.buttons.delete)}
+                  {t((m) => m.shared.invoices.invoiceHeader.buttons.delete)}
                 </Button>
               }
             />
             <TooltipContent>
-              <p>{t((m) => m["IMS--Common"].invoiceHeader.tooltips.deleteInvoicePermanently)}</p>
+              <p>{t((m) => m.shared.invoices.invoiceHeader.tooltips.deleteInvoicePermanently)}</p>
             </TooltipContent>
           </Tooltip>
         </TooltipProvider>

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/TriviaTips.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/TriviaTips.tsx
@@ -1,4 +1,6 @@
-"use client";`r`n`r`nimport type {MessageSelector} from "next-intl-selector";
+"use client";
+
+import type {MessageSelector} from "next-intl-selector";
 
 import {formatCurrency} from "@/lib/utils.generic";
 import {Invoice, InvoiceCategory, Merchant} from "@/types/invoices";

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/TriviaTips.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/TriviaTips.tsx
@@ -173,8 +173,8 @@ export default function TriviaTipsCard({merchant, invoice}: Readonly<Props>) {
     if (invoice.items.length === 0 && !dismissedTips.includes("noItems")) {
       tips.push({
         id: "noItems",
-        messageSelector: (m) => m["IMS--Edit"].triviaTips.contextTips.noItems,
-        actionSelector: (m) => m["IMS--Edit"].triviaTips.contextActions.analyze,
+        messageSelector: (m) => m.pages.invoices.editInvoice.triviaTips.contextTips.noItems,
+        actionSelector: (m) => m.pages.invoices.editInvoice.triviaTips.contextActions.analyze,
         action: () => {
           // TODO: Open AnalyzeDialog when connected to island
           console.log("Open AnalyzeDialog");
@@ -187,8 +187,8 @@ export default function TriviaTipsCard({merchant, invoice}: Readonly<Props>) {
     if (invoice.description.length === 0 && !dismissedTips.includes("noDescription")) {
       tips.push({
         id: "noDescription",
-        messageSelector: (m) => m["IMS--Edit"].triviaTips.contextTips.noDescription,
-        actionSelector: (m) => m["IMS--Edit"].triviaTips.contextActions.addDescription,
+        messageSelector: (m) => m.pages.invoices.editInvoice.triviaTips.contextTips.noDescription,
+        actionSelector: (m) => m.pages.invoices.editInvoice.triviaTips.contextActions.addDescription,
         action: () => {
           // Focus description field
           const descriptionInput = document.querySelector<HTMLTextAreaElement>('textarea[name="description"]');
@@ -203,8 +203,8 @@ export default function TriviaTipsCard({merchant, invoice}: Readonly<Props>) {
     if (invoice.category === InvoiceCategory.NOT_DEFINED && !dismissedTips.includes("noCategory")) {
       tips.push({
         id: "noCategory",
-        messageSelector: (m) => m["IMS--Edit"].triviaTips.contextTips.noCategory,
-        actionSelector: (m) => m["IMS--Edit"].triviaTips.contextActions.setCategory,
+        messageSelector: (m) => m.pages.invoices.editInvoice.triviaTips.contextTips.noCategory,
+        actionSelector: (m) => m.pages.invoices.editInvoice.triviaTips.contextActions.setCategory,
         action: () => {
           // Focus category select
           const categorySelect = document.querySelector<HTMLButtonElement>('button[role="combobox"]');
@@ -219,8 +219,8 @@ export default function TriviaTipsCard({merchant, invoice}: Readonly<Props>) {
     if (invoice.possibleRecipes.length === 0 && invoice.items.length > 0 && !dismissedTips.includes("noRecipes")) {
       tips.push({
         id: "noRecipes",
-        messageSelector: (m) => m["IMS--Edit"].triviaTips.contextTips.noRecipes,
-        actionSelector: (m) => m["IMS--Edit"].triviaTips.contextActions.analyze,
+        messageSelector: (m) => m.pages.invoices.editInvoice.triviaTips.contextTips.noRecipes,
+        actionSelector: (m) => m.pages.invoices.editInvoice.triviaTips.contextActions.analyze,
         action: () => {
           // TODO: Open AnalyzeDialog when connected to island
           console.log("Open AnalyzeDialog");
@@ -255,24 +255,24 @@ export default function TriviaTipsCard({merchant, invoice}: Readonly<Props>) {
   const savingsTips = [
     {
       id: 1,
-      title: t((m) => m["IMS--Edit"].triviaTips.tips.loyaltyProgram.title),
-      description: t((m) => m["IMS--Edit"].triviaTips.tips.loyaltyProgram.description, {merchantName: merchant?.name ?? ""}),
+      title: t((m) => m.pages.invoices.editInvoice.triviaTips.tips.loyaltyProgram.title),
+      description: t((m) => m.pages.invoices.editInvoice.triviaTips.tips.loyaltyProgram.description, {merchantName: merchant?.name ?? ""}),
       potentialSavings: invoice.paymentInformation?.totalCostAmount! * 0.05,
       difficulty: "easy",
       icon: <TbPigMoney className={styles["tipIcon"]} />,
     },
     {
       id: 2,
-      title: t((m) => m["IMS--Edit"].triviaTips.tips.bulkPurchase.title),
-      description: t((m) => m["IMS--Edit"].triviaTips.tips.bulkPurchase.description),
+      title: t((m) => m.pages.invoices.editInvoice.triviaTips.tips.bulkPurchase.title),
+      description: t((m) => m.pages.invoices.editInvoice.triviaTips.tips.bulkPurchase.description),
       potentialSavings: invoice.paymentInformation?.totalCostAmount! * 0.1,
       difficulty: "medium",
       icon: <TbPercentage className={styles["tipIcon"]} />,
     },
     {
       id: 3,
-      title: t((m) => m["IMS--Edit"].triviaTips.tips.digitalCoupons.title),
-      description: t((m) => m["IMS--Edit"].triviaTips.tips.digitalCoupons.description, {merchantName: merchant?.name ?? ""}),
+      title: t((m) => m.pages.invoices.editInvoice.triviaTips.tips.digitalCoupons.title),
+      description: t((m) => m.pages.invoices.editInvoice.triviaTips.tips.digitalCoupons.description, {merchantName: merchant?.name ?? ""}),
       potentialSavings: invoice.paymentInformation?.totalCostAmount! * 0.08,
       difficulty: "easy",
       icon: <TbBulb className={styles["tipIcon"]} />,
@@ -287,14 +287,14 @@ export default function TriviaTipsCard({merchant, invoice}: Readonly<Props>) {
       <CardHeader className={styles["cardHeader"]}>
         <CardTitle className={styles["cardTitle"]}>
           <TbSparkles className={styles["sparklesIcon"]} />
-          <span>{t((m) => m["IMS--Edit"].triviaTips.title)}</span>
+          <span>{t((m) => m.pages.invoices.editInvoice.triviaTips.title)}</span>
         </CardTitle>
       </CardHeader>
       <CardContent className={styles["cardContent"]}>
         {/* Completeness Progress Bar */}
         <div className={styles["completenessSection"]}>
           <div className={styles["completenessHeader"]}>
-            <p className={styles["completenessLabel"]}>{t((m) => m["IMS--Edit"].triviaTips.completeness, {percentage: String(percentage)})}</p>
+            <p className={styles["completenessLabel"]}>{t((m) => m.pages.invoices.editInvoice.triviaTips.completeness, {percentage: String(percentage)})}</p>
             <p className={styles["completenessScore"]}>
               {completenessScore} / {maxScore}
             </p>
@@ -306,7 +306,7 @@ export default function TriviaTipsCard({merchant, invoice}: Readonly<Props>) {
           {percentage === 100 ? (
             <div className={styles["completeLabel"]}>
               <TbCheck className={styles["completeIcon"]} />
-              <span>{t((m) => m["IMS--Edit"].triviaTips.completeLabel)}</span>
+              <span>{t((m) => m.pages.invoices.editInvoice.triviaTips.completeLabel)}</span>
             </div>
           ) : null}
         </div>
@@ -356,12 +356,12 @@ export default function TriviaTipsCard({merchant, invoice}: Readonly<Props>) {
           whileHover={{scale: 1.02}}
           transition={{type: "spring", stiffness: 400, damping: 10}}>
           <div className={styles["savingsBannerInner"]}>
-            <p className={styles["savingsLabel"]}>{t((m) => m["IMS--Edit"].triviaTips.banner.potentialSavingsLabel)}</p>
+            <p className={styles["savingsLabel"]}>{t((m) => m.pages.invoices.editInvoice.triviaTips.banner.potentialSavingsLabel)}</p>
             <p className={styles["savingsAmount"]}>
               {formatCurrency(totalPotentialSavings, {currencyCode: invoice.paymentInformation.currency.code, locale: "en"})}
             </p>
           </div>
-          <p className={styles["savingsHint"]}>{t((m) => m["IMS--Edit"].triviaTips.banner.hint, {merchantName: merchant?.name ?? ""})}</p>
+          <p className={styles["savingsHint"]}>{t((m) => m.pages.invoices.editInvoice.triviaTips.banner.hint, {merchantName: merchant?.name ?? ""})}</p>
         </motion.div>
 
         <Separator />
@@ -385,7 +385,7 @@ export default function TriviaTipsCard({merchant, invoice}: Readonly<Props>) {
                       <Badge
                         variant={tip.difficulty === "easy" ? "default" : "secondary"}
                         className={styles["difficultyBadge"]}>
-                        {tip.difficulty === "easy" ? t((m) => m["IMS--Edit"].triviaTips.difficulty.easy) : t((m) => m["IMS--Edit"].triviaTips.difficulty.medium)}
+                        {tip.difficulty === "easy" ? t((m) => m.pages.invoices.editInvoice.triviaTips.difficulty.easy) : t((m) => m.pages.invoices.editInvoice.triviaTips.difficulty.medium)}
                       </Badge>
                     </div>
                     <TooltipProvider>
@@ -404,7 +404,7 @@ export default function TriviaTipsCard({merchant, invoice}: Readonly<Props>) {
                           }
                         />
                         <TooltipContent>
-                          <p>{t((m) => m["IMS--Edit"].triviaTips.tooltips.estimatedSavings)}</p>
+                          <p>{t((m) => m.pages.invoices.editInvoice.triviaTips.tooltips.estimatedSavings)}</p>
                         </TooltipContent>
                       </Tooltip>
                     </TooltipProvider>
@@ -420,14 +420,14 @@ export default function TriviaTipsCard({merchant, invoice}: Readonly<Props>) {
           <Button
             variant='outline'
             className={styles["moreButton"]}>
-            <span>{t((m) => m["IMS--Edit"].triviaTips.buttons.viewMoreSavingsTips)}</span>
+            <span>{t((m) => m.pages.invoices.editInvoice.triviaTips.buttons.viewMoreSavingsTips)}</span>
             <TbArrowRight className={styles["arrowIcon"]} />
           </Button>
         </div>
 
         <div className={styles["disclaimer"]}>
           <TbAlertCircle className={styles["alertCircleIcon"]} />
-          <span>{t((m) => m["IMS--Edit"].triviaTips.disclaimer)}</span>
+          <span>{t((m) => m.pages.invoices.editInvoice.triviaTips.disclaimer)}</span>
         </div>
       </CardContent>
     </Card>

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/cards/ImageCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/cards/ImageCard.tsx
@@ -101,7 +101,7 @@ export default function ImageCard({invoice}: Readonly<Props>): React.JSX.Element
       <Card className={styles["card"]}>
         <CardHeader className={styles["cardHeader"]}>
           <CardTitle className={styles["cardTitle"]}>
-            {totalScans > 1 ? t((m) => m["IMS--Cards"].imageCard.titleWithIndex, {current: String(currentScanIndex + 1), total: String(totalScans)}) : t((m) => m["IMS--Cards"].imageCard.title)}
+            {totalScans > 1 ? t((m) => m.cards.invoices.imageCard.titleWithIndex, {current: String(currentScanIndex + 1), total: String(totalScans)}) : t((m) => m.cards.invoices.imageCard.title)}
           </CardTitle>
         </CardHeader>
         <CardContent className={styles["cardContent"]}>
@@ -112,12 +112,12 @@ export default function ImageCard({invoice}: Readonly<Props>): React.JSX.Element
               variant='ghost'
               className={styles["imageButton"]}
               onClick={handleOpenZoom}
-              aria-label={t((m) => m["IMS--Cards"].imageCard.aria.expandImage)}>
+              aria-label={t((m) => m.cards.invoices.imageCard.aria.expandImage)}>
               {/* Plain <img> with direct HTTP GET — bypasses next/image optimization. */}
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img
                 src={currentScanSrc}
-                alt={t((m) => m["IMS--Cards"].imageCard.scanAlt, {index: String(currentScanIndex + 1)})}
+                alt={t((m) => m.cards.invoices.imageCard.scanAlt, {index: String(currentScanIndex + 1)})}
                 width={400}
                 height={600}
                 loading='lazy'
@@ -132,8 +132,8 @@ export default function ImageCard({invoice}: Readonly<Props>): React.JSX.Element
               <DialogHeader>
                 <DialogTitle>
                   {totalScans > 1
-                    ? t((m) => m["IMS--Cards"].imageCard.dialogTitleWithIndex, {current: String(currentScanIndex + 1), total: String(totalScans)})
-                    : t((m) => m["IMS--Cards"].imageCard.dialogTitle)}
+                    ? t((m) => m.cards.invoices.imageCard.dialogTitleWithIndex, {current: String(currentScanIndex + 1), total: String(totalScans)})
+                    : t((m) => m.cards.invoices.imageCard.dialogTitle)}
                 </DialogTitle>
               </DialogHeader>
               <div className={styles["zoomContainer"]}>
@@ -141,7 +141,7 @@ export default function ImageCard({invoice}: Readonly<Props>): React.JSX.Element
                 {/* eslint-disable-next-line @next/next/no-img-element */}
                 <img
                   src={currentScanSrc}
-                  alt={t((m) => m["IMS--Cards"].imageCard.scanAltFullSize, {index: String(currentScanIndex + 1)})}
+                  alt={t((m) => m.cards.invoices.imageCard.scanAltFullSize, {index: String(currentScanIndex + 1)})}
                   width={800}
                   height={1200}
                   loading='lazy'
@@ -162,12 +162,12 @@ export default function ImageCard({invoice}: Readonly<Props>): React.JSX.Element
                   className={styles["fullWidthButton"]}
                   onClick={handleOpenZoom}>
                   <TbZoomIn className={styles["buttonIcon"]} />
-                  {t((m) => m["IMS--Cards"].imageCard.buttons.expand)}
+                  {t((m) => m.cards.invoices.imageCard.buttons.expand)}
                 </Button>
               }
             />
             <TooltipContent>
-              <p>{t((m) => m["IMS--Cards"].imageCard.tooltips.expand)}</p>
+              <p>{t((m) => m.cards.invoices.imageCard.tooltips.expand)}</p>
             </TooltipContent>
           </Tooltip>
 
@@ -183,12 +183,12 @@ export default function ImageCard({invoice}: Readonly<Props>): React.JSX.Element
                         className={styles["navButton"]}
                         onClick={handlePreviousScan}>
                         <TbChevronLeft className={styles["chevronIcon"]} />
-                        {t((m) => m["IMS--Cards"].imageCard.buttons.previous)}
+                        {t((m) => m.cards.invoices.imageCard.buttons.previous)}
                       </Button>
                     }
                   />
                   <TooltipContent>
-                    <p>{t((m) => m["IMS--Cards"].imageCard.tooltips.previous)}</p>
+                    <p>{t((m) => m.cards.invoices.imageCard.tooltips.previous)}</p>
                   </TooltipContent>
                 </Tooltip>
               )}
@@ -200,13 +200,13 @@ export default function ImageCard({invoice}: Readonly<Props>): React.JSX.Element
                         variant='secondary'
                         className={styles["navButton"]}
                         onClick={handleNextScan}>
-                        {t((m) => m["IMS--Cards"].imageCard.buttons.next)}
+                        {t((m) => m.cards.invoices.imageCard.buttons.next)}
                         <TbChevronRight className={styles["chevronIconRight"]} />
                       </Button>
                     }
                   />
                   <TooltipContent>
-                    <p>{t((m) => m["IMS--Cards"].imageCard.tooltips.next)}</p>
+                    <p>{t((m) => m.cards.invoices.imageCard.tooltips.next)}</p>
                   </TooltipContent>
                 </Tooltip>
               )}
@@ -223,12 +223,12 @@ export default function ImageCard({invoice}: Readonly<Props>): React.JSX.Element
                     className={styles["navButton"]}
                     onClick={openAddScan}>
                     <TbPlus className={styles["chevronIcon"]} />
-                    {t((m) => m["IMS--Cards"].imageCard.buttons.addScan)}
+                    {t((m) => m.cards.invoices.imageCard.buttons.addScan)}
                   </Button>
                 }
               />
               <TooltipContent>
-                <p>{t((m) => m["IMS--Cards"].imageCard.tooltips.addScan)}</p>
+                <p>{t((m) => m.cards.invoices.imageCard.tooltips.addScan)}</p>
               </TooltipContent>
             </Tooltip>
             <Tooltip>
@@ -240,12 +240,12 @@ export default function ImageCard({invoice}: Readonly<Props>): React.JSX.Element
                     onClick={openRemoveScan}
                     disabled={totalScans === 0}>
                     <TbTrash className={styles["chevronIcon"]} />
-                    {t((m) => m["IMS--Cards"].imageCard.buttons.remove)}
+                    {t((m) => m.cards.invoices.imageCard.buttons.remove)}
                   </Button>
                 }
               />
               <TooltipContent>
-                <p>{t((m) => m["IMS--Cards"].imageCard.tooltips.remove)}</p>
+                <p>{t((m) => m.cards.invoices.imageCard.tooltips.remove)}</p>
               </TooltipContent>
             </Tooltip>
           </div>

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/cards/InvoiceCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/cards/InvoiceCard.tsx
@@ -178,7 +178,7 @@ export default function InvoiceCard(): React.JSX.Element {
       <Card className={styles["card"]}>
         <CardHeader className={styles["cardHeader"]}>
           <div className={styles["headerRow"]}>
-            <CardTitle>{t((m) => m["IMS--Cards"].invoiceCard.title)}</CardTitle>
+            <CardTitle>{t((m) => m.cards.invoices.invoiceCard.title)}</CardTitle>
             <TooltipProvider>
               <Tooltip>
                 <TooltipTrigger
@@ -188,23 +188,23 @@ export default function InvoiceCard(): React.JSX.Element {
                       className={styles["importantBadge"]}
                       onClick={handleImportantToggle}>
                       <TbHeart className={currentIsImportant ? styles["heartIconFilled"] : styles["heartIcon"]} />
-                      {currentIsImportant ? t((m) => m["IMS--Cards"].invoiceCard.importantBadge) : t((m) => m["IMS--Cards"].invoiceCard.markImportant)}
+                      {currentIsImportant ? t((m) => m.cards.invoices.invoiceCard.importantBadge) : t((m) => m.cards.invoices.invoiceCard.markImportant)}
                     </Badge>
                   }
                 />
                 <TooltipContent>
-                  <span>{currentIsImportant ? t((m) => m["IMS--Cards"].invoiceCard.tooltips.unmarkFavorite) : t((m) => m["IMS--Cards"].invoiceCard.tooltips.markFavorite)}</span>
+                  <span>{currentIsImportant ? t((m) => m.cards.invoices.invoiceCard.tooltips.unmarkFavorite) : t((m) => m.cards.invoices.invoiceCard.tooltips.markFavorite)}</span>
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>
           </div>
           <CardDescription>
-            {t((m) => m["IMS--Cards"].invoiceCard.fromMerchant, {merchant: merchant?.name ?? ""})}
+            {t((m) => m.cards.invoices.invoiceCard.fromMerchant, {merchant: merchant?.name ?? ""})}
             <Separator className={styles["separatorSmall"]} />
             <Textarea
               value={currentDescription}
               onChange={handleDescriptionChange}
-              placeholder={t((m) => m["IMS--Cards"].invoiceCard.descriptionPlaceholder)}
+              placeholder={t((m) => m.cards.invoices.invoiceCard.descriptionPlaceholder)}
               className={styles["descriptionTextarea"]}
               rows={3}
             />
@@ -215,7 +215,7 @@ export default function InvoiceCard(): React.JSX.Element {
             <motion.div
               whileHover={{scale: 1.02}}
               transition={{type: "spring", stiffness: 400, damping: 10}}>
-              <h3 className={styles["detailLabel"]}>{t((m) => m["IMS--Cards"].invoiceCard.labels.dateUtc)}</h3>
+              <h3 className={styles["detailLabel"]}>{t((m) => m.cards.invoices.invoiceCard.labels.dateUtc)}</h3>
               <div className={styles["dateRow"]}>
                 <TbCalendar className={styles["mutedIcon"]} />
                 <Popover>
@@ -247,7 +247,7 @@ export default function InvoiceCard(): React.JSX.Element {
                         <Label
                           htmlFor='hours'
                           className={styles["timeLabel"]}>
-                          {t((m) => m["IMS--Cards"].invoiceCard.labels.hours)}
+                          {t((m) => m.cards.invoices.invoiceCard.labels.hours)}
                         </Label>
                         <Input
                           id='hours'
@@ -264,7 +264,7 @@ export default function InvoiceCard(): React.JSX.Element {
                         <Label
                           htmlFor='minutes'
                           className={styles["timeLabel"]}>
-                          {t((m) => m["IMS--Cards"].invoiceCard.labels.minutes)}
+                          {t((m) => m.cards.invoices.invoiceCard.labels.minutes)}
                         </Label>
                         <Input
                           id='minutes'
@@ -276,7 +276,7 @@ export default function InvoiceCard(): React.JSX.Element {
                           className={styles["timeInput"]}
                         />
                       </div>
-                      <span className={styles["timeUtc"]}>{t((m) => m["IMS--Cards"].invoiceCard.labels.utc)}</span>
+                      <span className={styles["timeUtc"]}>{t((m) => m.cards.invoices.invoiceCard.labels.utc)}</span>
                     </div>
                   </PopoverContent>
                 </Popover>
@@ -285,14 +285,14 @@ export default function InvoiceCard(): React.JSX.Element {
             <motion.div
               whileHover={{scale: 1.02}}
               transition={{type: "spring", stiffness: 400, damping: 10}}>
-              <h3 className={styles["detailLabel"]}>{t((m) => m["IMS--Cards"].invoiceCard.labels.category)}</h3>
+              <h3 className={styles["detailLabel"]}>{t((m) => m.cards.invoices.invoiceCard.labels.category)}</h3>
               <div className={styles["categoryRow"]}>
                 <TbTag className={styles["mutedIcon"]} />
                 <Select
                   value={String(currentCategory)}
                   onValueChange={handleCategoryChange}>
                   <SelectTrigger className={styles["categoryTrigger"]}>
-                    <SelectValue placeholder={t((m) => m["IMS--Cards"].invoiceCard.placeholders.selectCategory)}>{currentCategoryLabel}</SelectValue>
+                    <SelectValue placeholder={t((m) => m.cards.invoices.invoiceCard.placeholders.selectCategory)}>{currentCategoryLabel}</SelectValue>
                   </SelectTrigger>
                   <SelectContent>
                     {categoryOptions.map((option) => (
@@ -309,14 +309,14 @@ export default function InvoiceCard(): React.JSX.Element {
             <motion.div
               whileHover={{scale: 1.02}}
               transition={{type: "spring", stiffness: 400, damping: 10}}>
-              <h3 className={styles["detailLabel"]}>{t((m) => m["IMS--Cards"].invoiceCard.labels.paymentMethod)}</h3>
+              <h3 className={styles["detailLabel"]}>{t((m) => m.cards.invoices.invoiceCard.labels.paymentMethod)}</h3>
               <div className={styles["paymentRow"]}>
                 <TbCreditCard className={styles["mutedIcon"]} />
                 <Select
                   value={String(currentPaymentType)}
                   onValueChange={handlePaymentTypeChange}>
                   <SelectTrigger className={styles["paymentTrigger"]}>
-                    <SelectValue placeholder={t((m) => m["IMS--Cards"].invoiceCard.placeholders.selectPaymentType)}>{currentPaymentTypeLabel}</SelectValue>
+                    <SelectValue placeholder={t((m) => m.cards.invoices.invoiceCard.placeholders.selectPaymentType)}>{currentPaymentTypeLabel}</SelectValue>
                   </SelectTrigger>
                   <SelectContent>
                     {paymentTypeOptions.map((option) => (
@@ -333,7 +333,7 @@ export default function InvoiceCard(): React.JSX.Element {
             <motion.div
               whileHover={{scale: 1.02}}
               transition={{type: "spring", stiffness: 400, damping: 10}}>
-              <h3 className={styles["detailLabel"]}>{t((m) => m["IMS--Cards"].invoiceCard.labels.totalAmount)}</h3>
+              <h3 className={styles["detailLabel"]}>{t((m) => m.cards.invoices.invoiceCard.labels.totalAmount)}</h3>
               <p className={styles["totalAmount"]}>
                 {formatCurrency(paymentInformation.totalCostAmount, {currencyCode: paymentInformation.currency.code, locale})}
               </p>

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/cards/MerchantCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/cards/MerchantCard.tsx
@@ -82,10 +82,10 @@ export default function MerchantCard({merchant}: Readonly<Props>): React.JSX.Ele
     return (
       <Card className={styles["card"]}>
         <CardHeader>
-          <CardTitle>{t((m) => m["IMS--Cards"].merchantCard.title)}</CardTitle>
+          <CardTitle>{t((m) => m.cards.invoices.merchantCard.title)}</CardTitle>
         </CardHeader>
         <CardContent className={styles["cardContent"]}>
-          <p className={styles["noMerchantText"]}>{t((m) => m["IMS--Cards"].merchantCard.noMerchantLinked)}</p>
+          <p className={styles["noMerchantText"]}>{t((m) => m.cards.invoices.merchantCard.noMerchantLinked)}</p>
         </CardContent>
       </Card>
     );
@@ -94,7 +94,7 @@ export default function MerchantCard({merchant}: Readonly<Props>): React.JSX.Ele
   return (
     <Card className={styles["card"]}>
       <CardHeader>
-        <CardTitle>{t((m) => m["IMS--Cards"].merchantCard.title)}</CardTitle>
+        <CardTitle>{t((m) => m.cards.invoices.merchantCard.title)}</CardTitle>
       </CardHeader>
       <CardContent className={styles["cardContent"]}>
         <div className={styles["merchantInfo"]}>
@@ -103,7 +103,7 @@ export default function MerchantCard({merchant}: Readonly<Props>): React.JSX.Ele
           </div>
           <div>
             <p className={styles["merchantName"]}>{merchant.name}</p>
-            <p className={styles["merchantAddress"]}>{t((m) => m["IMS--Cards"].merchantCard.addressLabel, {address: merchant.address.address})}</p>
+            <p className={styles["merchantAddress"]}>{t((m) => m.cards.invoices.merchantCard.addressLabel, {address: merchant.address.address})}</p>
           </div>
         </div>
         <div className={styles["actions"]}>
@@ -116,13 +116,13 @@ export default function MerchantCard({merchant}: Readonly<Props>): React.JSX.Ele
                     className={styles["actionButton"]}
                     // eslint-disable-next-line react/jsx-no-bind -- merchant is narrowed non-null here
                     onClick={handleOpenMerchantDialog}>
-                    <span>{t((m) => m["IMS--Cards"].merchantCard.buttons.viewMerchantDetails)}</span>
+                    <span>{t((m) => m.cards.invoices.merchantCard.buttons.viewMerchantDetails)}</span>
                     <TbArrowRight className={styles["arrowIcon"]} />
                   </Button>
                 }
               />
               <TooltipContent>
-                <p>{t((m) => m["IMS--Cards"].merchantCard.tooltips.viewMerchantDetails)}</p>
+                <p>{t((m) => m.cards.invoices.merchantCard.tooltips.viewMerchantDetails)}</p>
               </TooltipContent>
             </Tooltip>
           </TooltipProvider>
@@ -137,13 +137,13 @@ export default function MerchantCard({merchant}: Readonly<Props>): React.JSX.Ele
                     // eslint-disable-next-line react/jsx-no-bind -- merchant is narrowed non-null here
                     onClick={handleOpenMerchantReceiptsDialog}>
                     <TbShoppingBag className={styles["buttonIcon"]} />
-                    <span>{t((m) => m["IMS--Cards"].merchantCard.buttons.viewAllReceipts)}</span>
+                    <span>{t((m) => m.cards.invoices.merchantCard.buttons.viewAllReceipts)}</span>
                     <TbArrowRight className={styles["arrowIcon"]} />
                   </Button>
                 }
               />
               <TooltipContent side='bottom'>
-                <p>{t((m) => m["IMS--Cards"].merchantCard.tooltips.viewAllReceipts)}</p>
+                <p>{t((m) => m.cards.invoices.merchantCard.tooltips.viewAllReceipts)}</p>
               </TooltipContent>
             </Tooltip>
           </TooltipProvider>

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/cards/RecipeCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/cards/RecipeCard.tsx
@@ -84,10 +84,10 @@ export default function RecipeCard({recipe}: Readonly<Props>): React.JSX.Element
   const {name, complexity, description, ingredients, preparationTime, cookingTime} = recipe;
 
   const complexityLabelMap: Readonly<Record<RecipeComplexity, string>> = {
-    [RecipeComplexity.Unknown]: t((m) => m["IMS--Cards"].recipeCard.complexity.unknown),
-    [RecipeComplexity.Easy]: t((m) => m["IMS--Cards"].recipeCard.complexity.easy),
-    [RecipeComplexity.Normal]: t((m) => m["IMS--Cards"].recipeCard.complexity.normal),
-    [RecipeComplexity.Hard]: t((m) => m["IMS--Cards"].recipeCard.complexity.hard),
+    [RecipeComplexity.Unknown]: t((m) => m.cards.invoices.recipeCard.complexity.unknown),
+    [RecipeComplexity.Easy]: t((m) => m.cards.invoices.recipeCard.complexity.easy),
+    [RecipeComplexity.Normal]: t((m) => m.cards.invoices.recipeCard.complexity.normal),
+    [RecipeComplexity.Hard]: t((m) => m.cards.invoices.recipeCard.complexity.hard),
   };
 
   const getBadgeVariant = () => {
@@ -133,30 +133,30 @@ export default function RecipeCard({recipe}: Readonly<Props>): React.JSX.Element
                 className={styles["menuItem"]}
                 onClick={openViewDialog}>
                 <TbEdit className={styles["menuIcon"]} />
-                {t((m) => m["IMS--Cards"].recipeCard.dropdown.view)}
+                {t((m) => m.cards.invoices.recipeCard.dropdown.view)}
               </DropdownMenuItem>
               <DropdownMenuItem
                 className={styles["menuItem"]}
                 onClick={openEditDialog}>
                 <TbEdit className={styles["menuIcon"]} />
-                {t((m) => m["IMS--Cards"].recipeCard.dropdown.edit)}
+                {t((m) => m.cards.invoices.recipeCard.dropdown.edit)}
               </DropdownMenuItem>
               <DropdownMenuItem
                 className={styles["menuItemDestructive"]}
                 onClick={openDeleteDialog}>
                 <TbTrash className={styles["menuIcon"]} />
-                {t((m) => m["IMS--Cards"].recipeCard.dropdown.delete)}
+                {t((m) => m.cards.invoices.recipeCard.dropdown.delete)}
               </DropdownMenuItem>
               <DropdownMenuItem
                 className={styles["menuItemAccent"]}
                 onClick={openShareDialog}>
                 <TbShare className={styles["menuIcon"]} />
-                {t((m) => m["IMS--Cards"].recipeCard.dropdown.share)}
+                {t((m) => m.cards.invoices.recipeCard.dropdown.share)}
               </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuItem className={styles["menuItemMuted"]}>
                 <TbHeart className={styles["menuIcon"]} />
-                {t((m) => m["IMS--Cards"].recipeCard.dropdown.markAsFavorite)}
+                {t((m) => m.cards.invoices.recipeCard.dropdown.markAsFavorite)}
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
@@ -166,7 +166,7 @@ export default function RecipeCard({recipe}: Readonly<Props>): React.JSX.Element
         <p className={styles["description"]}>{description}</p>
 
         <div className={styles["ingredientsSection"]}>
-          <h4 className={styles["ingredientsLabel"]}>{t((m) => m["IMS--Cards"].recipeCard.ingredients.label)}</h4>
+          <h4 className={styles["ingredientsLabel"]}>{t((m) => m.cards.invoices.recipeCard.ingredients.label)}</h4>
           <ul className={styles["ingredientsList"]}>
             {ingredients.slice(0, 3).map((ingredient) => (
               <li key={ingredient}>{ingredient}</li>
@@ -175,10 +175,10 @@ export default function RecipeCard({recipe}: Readonly<Props>): React.JSX.Element
               <TooltipProvider>
                 <Tooltip>
                   <TooltipTrigger
-                    render={<li className={styles["moreIngredients"]}>{t((m) => m["IMS--Cards"].recipeCard.ingredients.more, {count: String(ingredients.length - 3)})}</li>}
+                    render={<li className={styles["moreIngredients"]}>{t((m) => m.cards.invoices.recipeCard.ingredients.more, {count: String(ingredients.length - 3)})}</li>}
                   />
                   <TooltipContent className={styles["tooltipContent"]}>
-                    <p className={styles["tooltipTitle"]}>{t((m) => m["IMS--Cards"].recipeCard.ingredients.additionalLabel)}</p>
+                    <p className={styles["tooltipTitle"]}>{t((m) => m.cards.invoices.recipeCard.ingredients.additionalLabel)}</p>
                     <ul className={styles["tooltipIngredientsList"]}>
                       {ingredients.slice(3).map((ingredient, index) => (
                         <li key={`${ingredient}-${index + 3}`}>{ingredient}</li>
@@ -199,12 +199,12 @@ export default function RecipeCard({recipe}: Readonly<Props>): React.JSX.Element
                 render={
                   <div className={styles["timeItem"]}>
                     <TbClock className={styles["timeIcon"]} />
-                    {t((m) => m["IMS--Cards"].recipeCard.timing.prepLabel, {minutes: String(preparationTime)})}
+                    {t((m) => m.cards.invoices.recipeCard.timing.prepLabel, {minutes: String(preparationTime)})}
                   </div>
                 }
               />
               <TooltipContent side='bottom'>
-                <p>{t((m) => m["IMS--Cards"].recipeCard.timing.prepTooltip, {minutes: String(preparationTime)})}</p>
+                <p>{t((m) => m.cards.invoices.recipeCard.timing.prepTooltip, {minutes: String(preparationTime)})}</p>
               </TooltipContent>
             </Tooltip>
             <Tooltip>
@@ -212,12 +212,12 @@ export default function RecipeCard({recipe}: Readonly<Props>): React.JSX.Element
                 render={
                   <div className={styles["timeItem"]}>
                     <TbToolsKitchen className={styles["timeIcon"]} />
-                    {t((m) => m["IMS--Cards"].recipeCard.timing.cookLabel, {minutes: String(cookingTime)})}
+                    {t((m) => m.cards.invoices.recipeCard.timing.cookLabel, {minutes: String(cookingTime)})}
                   </div>
                 }
               />
               <TooltipContent side='bottom'>
-                <p>{t((m) => m["IMS--Cards"].recipeCard.timing.cookTooltip, {minutes: String(cookingTime)})}</p>
+                <p>{t((m) => m.cards.invoices.recipeCard.timing.cookTooltip, {minutes: String(cookingTime)})}</p>
               </TooltipContent>
             </Tooltip>
           </TooltipProvider>
@@ -228,14 +228,14 @@ export default function RecipeCard({recipe}: Readonly<Props>): React.JSX.Element
         <Button
           variant='ghost'
           size='sm'>
-          {t((m) => m["IMS--Cards"].recipeCard.buttons.visitReference)}
+          {t((m) => m.cards.invoices.recipeCard.buttons.visitReference)}
           <TbExternalLink className={styles["externalLinkIcon"]} />
         </Button>
         <Button
           variant='default'
           size='sm'
           onClick={openViewDialog}>
-          {t((m) => m["IMS--Cards"].recipeCard.buttons.viewRecipe)}
+          {t((m) => m.cards.invoices.recipeCard.buttons.viewRecipe)}
           <TbLayoutBottombarExpand />
         </Button>
       </CardFooter>

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/cards/SharingCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/cards/SharingCard.tsx
@@ -90,8 +90,8 @@ export default function SharingCard({invoice}: Readonly<Props>): React.JSX.Eleme
 
   const handleRemoveAccess = useCallback(() => {
     // TODO: Implement remove access functionality for specific user
-    toast(t((m) => m["IMS--Cards"].sharingCard.toasts.removeAccessComingSoon.title), {
-      description: t((m) => m["IMS--Cards"].sharingCard.toasts.removeAccessComingSoon.description),
+    toast(t((m) => m.cards.invoices.sharingCard.toasts.removeAccessComingSoon.title), {
+      description: t((m) => m.cards.invoices.sharingCard.toasts.removeAccessComingSoon.description),
     });
   }, [t]);
 
@@ -122,9 +122,9 @@ export default function SharingCard({invoice}: Readonly<Props>): React.JSX.Eleme
     toast.promise(
       markPrivateAction().finally(() => setIsMarkingPrivate(false)),
       {
-        loading: t((m) => m["IMS--Cards"].sharingCard.toasts.revoke.loading),
-        success: t((m) => m["IMS--Cards"].sharingCard.toasts.revoke.success),
-        error: (error: unknown) => t((m) => m["IMS--Cards"].sharingCard.toasts.revoke.error, {message: error instanceof Error ? error.message : String(error)}),
+        loading: t((m) => m.cards.invoices.sharingCard.toasts.revoke.loading),
+        success: t((m) => m.cards.invoices.sharingCard.toasts.revoke.success),
+        error: (error: unknown) => t((m) => m.cards.invoices.sharingCard.toasts.revoke.error, {message: error instanceof Error ? error.message : String(error)}),
       },
     );
   }, [invoice.id, invoice.sharedWith, router, t]);
@@ -132,7 +132,7 @@ export default function SharingCard({invoice}: Readonly<Props>): React.JSX.Eleme
   return (
     <Card className={styles["card"]}>
       <CardHeader>
-        <CardTitle>{t((m) => m["IMS--Cards"].sharingCard.title)}</CardTitle>
+        <CardTitle>{t((m) => m.cards.invoices.sharingCard.title)}</CardTitle>
       </CardHeader>
       <CardContent className={styles["cardContent"]}>
         <div className={styles["ownerRow"]}>
@@ -140,7 +140,7 @@ export default function SharingCard({invoice}: Readonly<Props>): React.JSX.Eleme
             {userInformation?.user?.imageUrl ? (
               <Image
                 src={userInformation?.user?.imageUrl!}
-                alt={t((m) => m["IMS--Cards"].sharingCard.ownerAvatarAlt)}
+                alt={t((m) => m.cards.invoices.sharingCard.ownerAvatarAlt)}
                 width={40}
                 height={40}
                 className={styles["ownerImage"]}
@@ -151,7 +151,7 @@ export default function SharingCard({invoice}: Readonly<Props>): React.JSX.Eleme
             )}
           </div>
           <div>
-            <p className={styles["ownerName"]}>{t((m) => m["IMS--Cards"].sharingCard.owner)}</p>
+            <p className={styles["ownerName"]}>{t((m) => m.cards.invoices.sharingCard.owner)}</p>
             <p className={styles["ownerUsername"]}>{userInformation?.user?.username}</p>
           </div>
           <div className={styles["manageArea"]}>
@@ -164,12 +164,12 @@ export default function SharingCard({invoice}: Readonly<Props>): React.JSX.Eleme
                       className={styles["manageButton"]}
                       onClick={handleManageSharing}>
                       <TbLockCog className={styles["buttonIcon"]} />
-                      <span>{t((m) => m["IMS--Cards"].sharingCard.buttons.manageSharing)}</span>
+                      <span>{t((m) => m.cards.invoices.sharingCard.buttons.manageSharing)}</span>
                     </Button>
                   }
                 />
                 <TooltipContent>
-                  <p>{t((m) => m["IMS--Cards"].sharingCard.tooltips.manageSharing)}</p>
+                  <p>{t((m) => m.cards.invoices.sharingCard.tooltips.manageSharing)}</p>
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>
@@ -183,13 +183,13 @@ export default function SharingCard({invoice}: Readonly<Props>): React.JSX.Eleme
             variant='destructive'
             className={styles["publicAlert"]}>
             <TbGlobe className={styles["globeIcon"]} />
-            <AlertTitle className={styles["publicAlertTitle"]}>{t((m) => m["IMS--Cards"].sharingCard.publicInvoice.title)}</AlertTitle>
-            <AlertDescription className={styles["publicAlertDescription"]}>{t((m) => m["IMS--Cards"].sharingCard.publicInvoice.description)}</AlertDescription>
+            <AlertTitle className={styles["publicAlertTitle"]}>{t((m) => m.cards.invoices.sharingCard.publicInvoice.title)}</AlertTitle>
+            <AlertDescription className={styles["publicAlertDescription"]}>{t((m) => m.cards.invoices.sharingCard.publicInvoice.description)}</AlertDescription>
           </Alert>
         )}
 
         <div>
-          <h3 className={styles["sharedTitle"]}>{t((m) => m["IMS--Cards"].sharingCard.sharedWith)}</h3>
+          <h3 className={styles["sharedTitle"]}>{t((m) => m.cards.invoices.sharingCard.sharedWith)}</h3>
           {sharedUsers.length > 0 ? (
             <div className={styles["sharedList"]}>
               {sharedUsers.map((userId, index) => (
@@ -203,7 +203,7 @@ export default function SharingCard({invoice}: Readonly<Props>): React.JSX.Eleme
                   <div className={styles["sharedUserAvatar"]}>
                     <TbUser className={styles["sharedUserIcon"]} />
                   </div>
-                  <span className={styles["sharedUserName"]}>{t((m) => m["IMS--Cards"].sharingCard.userWithId, {id: userId})}</span>
+                  <span className={styles["sharedUserName"]}>{t((m) => m.cards.invoices.sharingCard.userWithId, {id: userId})}</span>
                   <TooltipProvider>
                     <Tooltip>
                       <TooltipTrigger
@@ -217,7 +217,7 @@ export default function SharingCard({invoice}: Readonly<Props>): React.JSX.Eleme
                         }
                       />
                       <TooltipContent>
-                        <p>{t((m) => m["IMS--Cards"].sharingCard.tooltips.removeAccess)}</p>
+                        <p>{t((m) => m.cards.invoices.sharingCard.tooltips.removeAccess)}</p>
                       </TooltipContent>
                     </Tooltip>
                   </TooltipProvider>
@@ -225,7 +225,7 @@ export default function SharingCard({invoice}: Readonly<Props>): React.JSX.Eleme
               ))}
             </div>
           ) : (
-            <p className={styles["emptyShared"]}>{isInvoicePublic ? t((m) => m["IMS--Cards"].sharingCard.emptyShared.public) : t((m) => m["IMS--Cards"].sharingCard.emptyShared.private)}</p>
+            <p className={styles["emptyShared"]}>{isInvoicePublic ? t((m) => m.cards.invoices.sharingCard.emptyShared.public) : t((m) => m.cards.invoices.sharingCard.emptyShared.private)}</p>
           )}
         </div>
       </CardContent>
@@ -239,13 +239,13 @@ export default function SharingCard({invoice}: Readonly<Props>): React.JSX.Eleme
                   className={styles["fullWidthButton"]}
                   onClick={open}>
                   <TbShare2 className={styles["buttonIcon"]} />
-                  <span>{t((m) => m["IMS--Cards"].sharingCard.buttons.shareInvoice)}</span>
+                  <span>{t((m) => m.cards.invoices.sharingCard.buttons.shareInvoice)}</span>
                   <TbArrowRight className={styles["arrowIcon"]} />
                 </Button>
               }
             />
             <TooltipContent>
-              <p>{t((m) => m["IMS--Cards"].sharingCard.tooltips.shareInvoice)}</p>
+              <p>{t((m) => m.cards.invoices.sharingCard.tooltips.shareInvoice)}</p>
             </TooltipContent>
           </Tooltip>
 
@@ -258,13 +258,13 @@ export default function SharingCard({invoice}: Readonly<Props>): React.JSX.Eleme
                     className={styles["fullWidthButton"]}
                     disabled={isMarkingPrivate}
                     onClick={handleMarkPrivate}>
-                    <span>{isMarkingPrivate ? t((m) => m["IMS--Cards"].sharingCard.buttons.revokingAccess) : t((m) => m["IMS--Cards"].sharingCard.buttons.markAsPrivate)}</span>
+                    <span>{isMarkingPrivate ? t((m) => m.cards.invoices.sharingCard.buttons.revokingAccess) : t((m) => m.cards.invoices.sharingCard.buttons.markAsPrivate)}</span>
                     <TbLock className={styles["arrowIcon"]} />
                   </Button>
                 }
               />
               <TooltipContent side='bottom'>
-                <p>{t((m) => m["IMS--Cards"].sharingCard.tooltips.markAsPrivate)}</p>
+                <p>{t((m) => m.cards.invoices.sharingCard.tooltips.markAsPrivate)}</p>
               </TooltipContent>
             </Tooltip>
           )}

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/AddScanDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/AddScanDialog.tsx
@@ -19,7 +19,7 @@ import {
   SelectValue,
   toast,
 } from "@arolariu/components";
-import {useTranslations} from "next-intl-selector";
+import {selectorFromPath, useTranslations} from "next-intl-selector";
 import {useRouter} from "next/navigation";
 import {useCallback, useState} from "react";
 import {useDropzone} from "react-dropzone";
@@ -155,7 +155,7 @@ export default function AddScanDialog(): React.JSX.Element {
       const {status, blobUrl} = createScanResult.data;
 
       if (status !== 201) {
-        throw new Error(t((m) => m.dialogs.invoices.addScanDialog.errors.uploadStorageFailed));
+        throw new Error(t(selectorFromPath("dialogs.invoices.addScanDialog.errors.uploadStorageFailed")));
       }
 
       // Step 4: Attach scan to invoice
@@ -171,8 +171,8 @@ export default function AddScanDialog(): React.JSX.Element {
         },
       });
 
-      toast.success(t((m) => m.dialogs.invoices.addScanDialog.toasts.scanAddedTitle), {
-        description: t((m) => m.dialogs.invoices.addScanDialog.toasts.scanAddedDescription),
+      toast.success(t(selectorFromPath("dialogs.invoices.addScanDialog.toasts.scanAddedTitle")), {
+        description: t(selectorFromPath("dialogs.invoices.addScanDialog.toasts.scanAddedDescription")),
       });
 
       // Reset state and close dialog
@@ -182,9 +182,9 @@ export default function AddScanDialog(): React.JSX.Element {
       // Refresh the page to show new scan
       router.refresh();
     } catch (error) {
-      console.error(t((m) => m.dialogs.invoices.addScanDialog.console.uploadError), error);
-      toast.error(t((m) => m.dialogs.invoices.addScanDialog.toasts.scanFailedTitle), {
-        description: error instanceof Error ? error.message : t((m) => m.dialogs.invoices.addScanDialog.errors.unknown),
+      console.error(t(selectorFromPath("dialogs.invoices.addScanDialog.console.uploadError")), error);
+      toast.error(t(selectorFromPath("dialogs.invoices.addScanDialog.toasts.scanFailedTitle")), {
+        description: error instanceof Error ? error.message : t(selectorFromPath("dialogs.invoices.addScanDialog.errors.unknown")),
       });
     } finally {
       setIsUploading(false);

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/AddScanDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/AddScanDialog.tsx
@@ -94,8 +94,8 @@ export default function AddScanDialog(): React.JSX.Element {
       // Validate file size (max 10MB)
       const maxSize = 10 * 1024 * 1024;
       if (selectedFile.size > maxSize) {
-        toast.error(t((m) => m["IMS--Dialogs"].addScanDialog.toasts.fileTooLargeTitle), {
-          description: t((m) => m["IMS--Dialogs"].addScanDialog.toasts.fileTooLargeDescription),
+        toast.error(t((m) => m.dialogs.invoices.addScanDialog.toasts.fileTooLargeTitle), {
+          description: t((m) => m.dialogs.invoices.addScanDialog.toasts.fileTooLargeDescription),
         });
         return;
       }
@@ -155,7 +155,7 @@ export default function AddScanDialog(): React.JSX.Element {
       const {status, blobUrl} = createScanResult.data;
 
       if (status !== 201) {
-        throw new Error(t((m) => m["IMS--Dialogs"].addScanDialog.errors.uploadStorageFailed));
+        throw new Error(t((m) => m.dialogs.invoices.addScanDialog.errors.uploadStorageFailed));
       }
 
       // Step 4: Attach scan to invoice
@@ -171,8 +171,8 @@ export default function AddScanDialog(): React.JSX.Element {
         },
       });
 
-      toast.success(t((m) => m["IMS--Dialogs"].addScanDialog.toasts.scanAddedTitle), {
-        description: t((m) => m["IMS--Dialogs"].addScanDialog.toasts.scanAddedDescription),
+      toast.success(t((m) => m.dialogs.invoices.addScanDialog.toasts.scanAddedTitle), {
+        description: t((m) => m.dialogs.invoices.addScanDialog.toasts.scanAddedDescription),
       });
 
       // Reset state and close dialog
@@ -182,9 +182,9 @@ export default function AddScanDialog(): React.JSX.Element {
       // Refresh the page to show new scan
       router.refresh();
     } catch (error) {
-      console.error(t((m) => m["IMS--Dialogs"].addScanDialog.console.uploadError), error);
-      toast.error(t((m) => m["IMS--Dialogs"].addScanDialog.toasts.scanFailedTitle), {
-        description: error instanceof Error ? error.message : t((m) => m["IMS--Dialogs"].addScanDialog.errors.unknown),
+      console.error(t((m) => m.dialogs.invoices.addScanDialog.console.uploadError), error);
+      toast.error(t((m) => m.dialogs.invoices.addScanDialog.toasts.scanFailedTitle), {
+        description: error instanceof Error ? error.message : t((m) => m.dialogs.invoices.addScanDialog.errors.unknown),
       });
     } finally {
       setIsUploading(false);
@@ -214,8 +214,8 @@ export default function AddScanDialog(): React.JSX.Element {
       onOpenChange={handleOpenChange}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
-          <DialogTitle>{t((m) => m["IMS--Dialogs"].addScanDialog.title)}</DialogTitle>
-          <DialogDescription>{t((m) => m["IMS--Dialogs"].addScanDialog.description)}</DialogDescription>
+          <DialogTitle>{t((m) => m.dialogs.invoices.addScanDialog.title)}</DialogTitle>
+          <DialogDescription>{t((m) => m.dialogs.invoices.addScanDialog.description)}</DialogDescription>
         </DialogHeader>
 
         {/* eslint-disable react/jsx-props-no-spreading, react/jsx-handler-names -- react-dropzone library requires spread props */}
@@ -227,14 +227,14 @@ export default function AddScanDialog(): React.JSX.Element {
             <input {...getInputProps()} />
             <TbCloudUpload className={styles["uploadIcon"]} />
             {isDragActive ? (
-              <p className={styles["dropText"]}>{t((m) => m["IMS--Dialogs"].addScanDialog.dropzone.dropHere)}</p>
+              <p className={styles["dropText"]}>{t((m) => m.dialogs.invoices.addScanDialog.dropzone.dropHere)}</p>
             ) : (
               <>
-                <p className={styles["dropText"]}>{t((m) => m["IMS--Dialogs"].addScanDialog.dropzone.dragAndDrop)}</p>
-                <p className={styles["dropSubtext"]}>{t((m) => m["IMS--Dialogs"].addScanDialog.dropzone.orClickBrowse)}</p>
+                <p className={styles["dropText"]}>{t((m) => m.dialogs.invoices.addScanDialog.dropzone.dragAndDrop)}</p>
+                <p className={styles["dropSubtext"]}>{t((m) => m.dialogs.invoices.addScanDialog.dropzone.orClickBrowse)}</p>
               </>
             )}
-            <p className={styles["dropFormats"]}>{t((m) => m["IMS--Dialogs"].addScanDialog.dropzone.formats)}</p>
+            <p className={styles["dropFormats"]}>{t((m) => m.dialogs.invoices.addScanDialog.dropzone.formats)}</p>
           </div>
 
           {/* Selected file preview */}
@@ -262,19 +262,19 @@ export default function AddScanDialog(): React.JSX.Element {
           {/* Scan type selector */}
           {file ? (
             <div className={styles["scanTypeGrid"]}>
-              <Label htmlFor='scan-type'>{t((m) => m["IMS--Dialogs"].addScanDialog.scanType.label)}</Label>
+              <Label htmlFor='scan-type'>{t((m) => m.dialogs.invoices.addScanDialog.scanType.label)}</Label>
               <Select
                 value={String(scanType)}
                 onValueChange={handleScanTypeChange}
                 disabled={isUploading}>
                 <SelectTrigger id='scan-type'>
-                  <SelectValue placeholder={t((m) => m["IMS--Dialogs"].addScanDialog.scanType.placeholder)} />
+                  <SelectValue placeholder={t((m) => m.dialogs.invoices.addScanDialog.scanType.placeholder)} />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value={String(InvoiceScanType.JPEG)}>{t((m) => m["IMS--Dialogs"].addScanDialog.scanType.jpeg)}</SelectItem>
-                  <SelectItem value={String(InvoiceScanType.PNG)}>{t((m) => m["IMS--Dialogs"].addScanDialog.scanType.png)}</SelectItem>
-                  <SelectItem value={String(InvoiceScanType.PDF)}>{t((m) => m["IMS--Dialogs"].addScanDialog.scanType.pdf)}</SelectItem>
-                  <SelectItem value={String(InvoiceScanType.OTHER)}>{t((m) => m["IMS--Dialogs"].addScanDialog.scanType.other)}</SelectItem>
+                  <SelectItem value={String(InvoiceScanType.JPEG)}>{t((m) => m.dialogs.invoices.addScanDialog.scanType.jpeg)}</SelectItem>
+                  <SelectItem value={String(InvoiceScanType.PNG)}>{t((m) => m.dialogs.invoices.addScanDialog.scanType.png)}</SelectItem>
+                  <SelectItem value={String(InvoiceScanType.PDF)}>{t((m) => m.dialogs.invoices.addScanDialog.scanType.pdf)}</SelectItem>
+                  <SelectItem value={String(InvoiceScanType.OTHER)}>{t((m) => m.dialogs.invoices.addScanDialog.scanType.other)}</SelectItem>
                 </SelectContent>
               </Select>
             </div>
@@ -288,7 +288,7 @@ export default function AddScanDialog(): React.JSX.Element {
             variant='outline'
             onClick={handleClose}
             disabled={isUploading}>
-            {t((m) => m["IMS--Dialogs"].addScanDialog.buttons.cancel)}
+            {t((m) => m.dialogs.invoices.addScanDialog.buttons.cancel)}
           </Button>
           <Button
             type='button'
@@ -297,12 +297,12 @@ export default function AddScanDialog(): React.JSX.Element {
             {isUploading ? (
               <>
                 <TbLoader2 className={styles["spinnerIcon"]} />
-                {t((m) => m["IMS--Dialogs"].addScanDialog.buttons.uploading)}
+                {t((m) => m.dialogs.invoices.addScanDialog.buttons.uploading)}
               </>
             ) : (
               <>
                 <TbUpload className={styles["uploadButtonIcon"]} />
-                {t((m) => m["IMS--Dialogs"].addScanDialog.buttons.upload)}
+                {t((m) => m.dialogs.invoices.addScanDialog.buttons.upload)}
               </>
             )}
           </Button>

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/AllergenDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/AllergenDialog.tsx
@@ -129,26 +129,26 @@ export default function AllergenDialog(): React.JSX.Element {
     (name: string) => {
       const trimmedName = name.trim();
       if (!trimmedName) {
-        toast.error(t((m) => m["IMS--Dialogs"].allergenDialog.errors.emptyName));
+        toast.error(t((m) => m.dialogs.invoices.allergenDialog.errors.emptyName));
         return;
       }
 
       // Check for duplicates (case-insensitive)
       const isDuplicate = allergens.some((a) => a.name.toLowerCase() === trimmedName.toLowerCase());
       if (isDuplicate) {
-        toast.warning(t((m) => m["IMS--Dialogs"].allergenDialog.errors.duplicate, {name: trimmedName}));
+        toast.warning(t((m) => m.dialogs.invoices.allergenDialog.errors.duplicate, {name: trimmedName}));
         return;
       }
 
       const newAllergen: Allergen = {
         name: trimmedName,
-        description: t((m) => m["IMS--Dialogs"].allergenDialog.defaultDescription, {name: trimmedName}),
+        description: t((m) => m.dialogs.invoices.allergenDialog.defaultDescription, {name: trimmedName}),
         learnMoreAddress: "",
       };
 
       setAllergens((prev) => [...prev, newAllergen]);
       setCustomAllergen("");
-      toast.success(t((m) => m["IMS--Dialogs"].allergenDialog.success.added, {name: trimmedName}));
+      toast.success(t((m) => m.dialogs.invoices.allergenDialog.success.added, {name: trimmedName}));
     },
     [allergens, t],
   );
@@ -163,7 +163,7 @@ export default function AllergenDialog(): React.JSX.Element {
       const allergenName = allergens[index]?.name;
       setAllergens((prev) => prev.filter((_, i) => i !== index));
       if (allergenName) {
-        toast.success(t((m) => m["IMS--Dialogs"].allergenDialog.success.removed, {name: allergenName}));
+        toast.success(t((m) => m.dialogs.invoices.allergenDialog.success.removed, {name: allergenName}));
       }
     },
     [allergens, t],
@@ -219,7 +219,7 @@ export default function AllergenDialog(): React.JSX.Element {
    */
   const handleSave = useCallback(async () => {
     if (!invoice || !product || productIndex === undefined) {
-      toast.error(t((m) => m["IMS--Dialogs"].allergenDialog.errors.missingData));
+      toast.error(t((m) => m.dialogs.invoices.allergenDialog.errors.missingData));
       return;
     }
 
@@ -239,17 +239,17 @@ export default function AllergenDialog(): React.JSX.Element {
       });
 
       if (result.success) {
-        toast.success(t((m) => m["IMS--Dialogs"].allergenDialog.success.saved));
+        toast.success(t((m) => m.dialogs.invoices.allergenDialog.success.saved));
         close();
         // Trigger page refresh to show updated data
         globalThis.window.location.reload();
       } else {
         console.error("Failed to save allergens:", result.error);
-        toast.error(t((m) => m["IMS--Dialogs"].allergenDialog.errors.saveFailed));
+        toast.error(t((m) => m.dialogs.invoices.allergenDialog.errors.saveFailed));
       }
     } catch (error) {
       console.error("Failed to save allergens:", error);
-      toast.error(t((m) => m["IMS--Dialogs"].allergenDialog.errors.saveFailed));
+      toast.error(t((m) => m.dialogs.invoices.allergenDialog.errors.saveFailed));
     } finally {
       setIsSaving(false);
     }
@@ -265,16 +265,16 @@ export default function AllergenDialog(): React.JSX.Element {
       onOpenChange={close}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
-          <DialogTitle>{t((m) => m["IMS--Dialogs"].allergenDialog.title)}</DialogTitle>
-          <DialogDescription>{t((m) => m["IMS--Dialogs"].allergenDialog.description, {productName: product.name})}</DialogDescription>
+          <DialogTitle>{t((m) => m.dialogs.invoices.allergenDialog.title)}</DialogTitle>
+          <DialogDescription>{t((m) => m.dialogs.invoices.allergenDialog.description, {productName: product.name})}</DialogDescription>
         </DialogHeader>
 
         <div className={styles["content"]}>
           {/* Current Allergens */}
           <div className={styles["section"]}>
-            <Label className={styles["sectionLabel"]}>{t((m) => m["IMS--Dialogs"].allergenDialog.labels.currentAllergens)}</Label>
+            <Label className={styles["sectionLabel"]}>{t((m) => m.dialogs.invoices.allergenDialog.labels.currentAllergens)}</Label>
             {allergens.length === 0 ? (
-              <p className={styles["emptyText"]}>{t((m) => m["IMS--Dialogs"].allergenDialog.empty.noAllergens)}</p>
+              <p className={styles["emptyText"]}>{t((m) => m.dialogs.invoices.allergenDialog.empty.noAllergens)}</p>
             ) : (
               <div className={styles["allergenList"]}>
                 {allergens.map((allergen, index) => (
@@ -287,7 +287,7 @@ export default function AllergenDialog(): React.JSX.Element {
                       type='button'
                       onClick={createRemoveAllergenHandler(index)}
                       className={styles["removeButton"]}
-                      aria-label={t((m) => m["IMS--Dialogs"].allergenDialog.aria.removeAllergen, {name: allergen.name})}>
+                      aria-label={t((m) => m.dialogs.invoices.allergenDialog.aria.removeAllergen, {name: allergen.name})}>
                       <TbX className={styles["removeIcon"]} />
                     </button>
                   </Badge>
@@ -298,7 +298,7 @@ export default function AllergenDialog(): React.JSX.Element {
 
           {/* Quick Add Common Allergens */}
           <div className={styles["section"]}>
-            <Label className={styles["sectionLabel"]}>{t((m) => m["IMS--Dialogs"].allergenDialog.labels.quickAdd)}</Label>
+            <Label className={styles["sectionLabel"]}>{t((m) => m.dialogs.invoices.allergenDialog.labels.quickAdd)}</Label>
             <div className={styles["quickAddGrid"]}>
               {COMMON_ALLERGENS.map((allergenName) => {
                 const isAdded = allergens.some((a) => a.name.toLowerCase() === allergenName.toLowerCase());
@@ -322,7 +322,7 @@ export default function AllergenDialog(): React.JSX.Element {
             <Label
               htmlFor='custom-allergen'
               className={styles["sectionLabel"]}>
-              {t((m) => m["IMS--Dialogs"].allergenDialog.labels.customAllergen)}
+              {t((m) => m.dialogs.invoices.allergenDialog.labels.customAllergen)}
             </Label>
             <div className={styles["inputRow"]}>
               <Input
@@ -331,7 +331,7 @@ export default function AllergenDialog(): React.JSX.Element {
                 value={customAllergen}
                 onChange={handleCustomAllergenChange}
                 onKeyDown={handleKeyDown}
-                placeholder={t((m) => m["IMS--Dialogs"].allergenDialog.placeholders.customAllergen)}
+                placeholder={t((m) => m.dialogs.invoices.allergenDialog.placeholders.customAllergen)}
                 className={styles["customInput"]}
               />
               <Button
@@ -341,7 +341,7 @@ export default function AllergenDialog(): React.JSX.Element {
                 disabled={!customAllergen.trim()}
                 className={styles["addButton"]}>
                 <TbPlus className={styles["addIcon"]} />
-                {t((m) => m["IMS--Dialogs"].allergenDialog.buttons.add)}
+                {t((m) => m.dialogs.invoices.allergenDialog.buttons.add)}
               </Button>
             </div>
           </div>
@@ -352,12 +352,12 @@ export default function AllergenDialog(): React.JSX.Element {
             variant='outline'
             onClick={close}
             disabled={isSaving}>
-            {t((m) => m["IMS--Dialogs"].allergenDialog.buttons.cancel)}
+            {t((m) => m.dialogs.invoices.allergenDialog.buttons.cancel)}
           </Button>
           <Button
             onClick={handleSave}
             disabled={isSaving}>
-            {isSaving ? t((m) => m["IMS--Dialogs"].allergenDialog.buttons.saving) : t((m) => m["IMS--Dialogs"].allergenDialog.buttons.save)}
+            {isSaving ? t((m) => m.dialogs.invoices.allergenDialog.buttons.saving) : t((m) => m.dialogs.invoices.allergenDialog.buttons.save)}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/AnalyzeDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/AnalyzeDialog.tsx
@@ -98,55 +98,55 @@ export default function AnalyzeDialog(): React.JSX.Element {
   const analysisOptions: AnalysisOptionConfig[] = [
     {
       id: InvoiceAnalysisOptions.CompleteAnalysis,
-      title: t((m) => m["IMS--Dialogs"].analyzeDialog.options.completeAnalysis.title),
-      description: t((m) => m["IMS--Dialogs"].analyzeDialog.options.completeAnalysis.description),
+      title: t((m) => m.dialogs.invoices.analyzeDialog.options.completeAnalysis.title),
+      description: t((m) => m.dialogs.invoices.analyzeDialog.options.completeAnalysis.description),
       icon: <TbBrain className={styles["optionIcon"]} />,
-      estimatedTime: t((m) => m["IMS--Dialogs"].analyzeDialog.options.completeAnalysis.estimatedTime),
+      estimatedTime: t((m) => m.dialogs.invoices.analyzeDialog.options.completeAnalysis.estimatedTime),
       features: [
-        t((m) => m["IMS--Dialogs"].analyzeDialog.options.completeAnalysis.features.ocrExtraction),
-        t((m) => m["IMS--Dialogs"].analyzeDialog.options.completeAnalysis.features.itemCategorization),
-        t((m) => m["IMS--Dialogs"].analyzeDialog.options.completeAnalysis.features.merchantIdentification),
-        t((m) => m["IMS--Dialogs"].analyzeDialog.options.completeAnalysis.features.priceAnalysis),
-        t((m) => m["IMS--Dialogs"].analyzeDialog.options.completeAnalysis.features.receiptValidation),
+        t((m) => m.dialogs.invoices.analyzeDialog.options.completeAnalysis.features.ocrExtraction),
+        t((m) => m.dialogs.invoices.analyzeDialog.options.completeAnalysis.features.itemCategorization),
+        t((m) => m.dialogs.invoices.analyzeDialog.options.completeAnalysis.features.merchantIdentification),
+        t((m) => m.dialogs.invoices.analyzeDialog.options.completeAnalysis.features.priceAnalysis),
+        t((m) => m.dialogs.invoices.analyzeDialog.options.completeAnalysis.features.receiptValidation),
       ],
       recommended: true,
     },
     {
       id: InvoiceAnalysisOptions.InvoiceOnly,
-      title: t((m) => m["IMS--Dialogs"].analyzeDialog.options.invoiceOnly.title),
-      description: t((m) => m["IMS--Dialogs"].analyzeDialog.options.invoiceOnly.description),
+      title: t((m) => m.dialogs.invoices.analyzeDialog.options.invoiceOnly.title),
+      description: t((m) => m.dialogs.invoices.analyzeDialog.options.invoiceOnly.description),
       icon: <TbReceipt className={styles["optionIcon"]} />,
-      estimatedTime: t((m) => m["IMS--Dialogs"].analyzeDialog.options.invoiceOnly.estimatedTime),
+      estimatedTime: t((m) => m.dialogs.invoices.analyzeDialog.options.invoiceOnly.estimatedTime),
       features: [
-        t((m) => m["IMS--Dialogs"].analyzeDialog.options.invoiceOnly.features.totalExtraction),
-        t((m) => m["IMS--Dialogs"].analyzeDialog.options.invoiceOnly.features.dateParsing),
-        t((m) => m["IMS--Dialogs"].analyzeDialog.options.invoiceOnly.features.paymentMethodDetection),
+        t((m) => m.dialogs.invoices.analyzeDialog.options.invoiceOnly.features.totalExtraction),
+        t((m) => m.dialogs.invoices.analyzeDialog.options.invoiceOnly.features.dateParsing),
+        t((m) => m.dialogs.invoices.analyzeDialog.options.invoiceOnly.features.paymentMethodDetection),
       ],
     },
     {
       id: InvoiceAnalysisOptions.InvoiceItemsOnly,
-      title: t((m) => m["IMS--Dialogs"].analyzeDialog.options.itemsOnly.title),
-      description: t((m) => m["IMS--Dialogs"].analyzeDialog.options.itemsOnly.description),
+      title: t((m) => m.dialogs.invoices.analyzeDialog.options.itemsOnly.title),
+      description: t((m) => m.dialogs.invoices.analyzeDialog.options.itemsOnly.description),
       icon: <TbShoppingCart className={styles["optionIcon"]} />,
-      estimatedTime: t((m) => m["IMS--Dialogs"].analyzeDialog.options.itemsOnly.estimatedTime),
+      estimatedTime: t((m) => m.dialogs.invoices.analyzeDialog.options.itemsOnly.estimatedTime),
       features: [
-        t((m) => m["IMS--Dialogs"].analyzeDialog.options.itemsOnly.features.itemExtraction),
-        t((m) => m["IMS--Dialogs"].analyzeDialog.options.itemsOnly.features.categoryAssignment),
-        t((m) => m["IMS--Dialogs"].analyzeDialog.options.itemsOnly.features.pricePerItem),
-        t((m) => m["IMS--Dialogs"].analyzeDialog.options.itemsOnly.features.quantityDetection),
+        t((m) => m.dialogs.invoices.analyzeDialog.options.itemsOnly.features.itemExtraction),
+        t((m) => m.dialogs.invoices.analyzeDialog.options.itemsOnly.features.categoryAssignment),
+        t((m) => m.dialogs.invoices.analyzeDialog.options.itemsOnly.features.pricePerItem),
+        t((m) => m.dialogs.invoices.analyzeDialog.options.itemsOnly.features.quantityDetection),
       ],
     },
     {
       id: InvoiceAnalysisOptions.InvoiceMerchantOnly,
-      title: t((m) => m["IMS--Dialogs"].analyzeDialog.options.merchantOnly.title),
-      description: t((m) => m["IMS--Dialogs"].analyzeDialog.options.merchantOnly.description),
+      title: t((m) => m.dialogs.invoices.analyzeDialog.options.merchantOnly.title),
+      description: t((m) => m.dialogs.invoices.analyzeDialog.options.merchantOnly.description),
       icon: <TbBuildingStore className={styles["optionIcon"]} />,
-      estimatedTime: t((m) => m["IMS--Dialogs"].analyzeDialog.options.merchantOnly.estimatedTime),
+      estimatedTime: t((m) => m.dialogs.invoices.analyzeDialog.options.merchantOnly.estimatedTime),
       features: [
-        t((m) => m["IMS--Dialogs"].analyzeDialog.options.merchantOnly.features.merchantIdentification),
-        t((m) => m["IMS--Dialogs"].analyzeDialog.options.merchantOnly.features.locationExtraction),
-        t((m) => m["IMS--Dialogs"].analyzeDialog.options.merchantOnly.features.businessCategory),
-        t((m) => m["IMS--Dialogs"].analyzeDialog.options.merchantOnly.features.contactInfo),
+        t((m) => m.dialogs.invoices.analyzeDialog.options.merchantOnly.features.merchantIdentification),
+        t((m) => m.dialogs.invoices.analyzeDialog.options.merchantOnly.features.locationExtraction),
+        t((m) => m.dialogs.invoices.analyzeDialog.options.merchantOnly.features.businessCategory),
+        t((m) => m.dialogs.invoices.analyzeDialog.options.merchantOnly.features.contactInfo),
       ],
     },
   ];
@@ -154,20 +154,20 @@ export default function AnalyzeDialog(): React.JSX.Element {
   const analysisEnhancements: AnalysisEnhancement[] = [
     {
       id: "priceComparison",
-      label: t((m) => m["IMS--Dialogs"].analyzeDialog.enhancements.priceComparison.label),
-      description: t((m) => m["IMS--Dialogs"].analyzeDialog.enhancements.priceComparison.description),
+      label: t((m) => m.dialogs.invoices.analyzeDialog.enhancements.priceComparison.label),
+      description: t((m) => m.dialogs.invoices.analyzeDialog.enhancements.priceComparison.description),
       icon: <TbChartBar className={styles["enhancementSmallIcon"]} />,
     },
     {
       id: "savingsTips",
-      label: t((m) => m["IMS--Dialogs"].analyzeDialog.enhancements.savingsTips.label),
-      description: t((m) => m["IMS--Dialogs"].analyzeDialog.enhancements.savingsTips.description),
+      label: t((m) => m.dialogs.invoices.analyzeDialog.enhancements.savingsTips.label),
+      description: t((m) => m.dialogs.invoices.analyzeDialog.enhancements.savingsTips.description),
       icon: <TbSparkles className={styles["enhancementSmallIcon"]} />,
     },
     {
       id: "quickExtract",
-      label: t((m) => m["IMS--Dialogs"].analyzeDialog.enhancements.quickExtract.label),
-      description: t((m) => m["IMS--Dialogs"].analyzeDialog.enhancements.quickExtract.description),
+      label: t((m) => m.dialogs.invoices.analyzeDialog.enhancements.quickExtract.label),
+      description: t((m) => m.dialogs.invoices.analyzeDialog.enhancements.quickExtract.description),
       icon: <TbBolt className={styles["enhancementSmallIcon"]} />,
     },
   ];
@@ -195,11 +195,11 @@ export default function AnalyzeDialog(): React.JSX.Element {
       });
 
     const steps = [
-      t((m) => m["IMS--Dialogs"].analyzeDialog.analysisSteps.preparingDocument),
-      t((m) => m["IMS--Dialogs"].analyzeDialog.analysisSteps.runningOcrExtraction),
-      t((m) => m["IMS--Dialogs"].analyzeDialog.analysisSteps.analyzingWithAi),
-      t((m) => m["IMS--Dialogs"].analyzeDialog.analysisSteps.categorizingItems),
-      t((m) => m["IMS--Dialogs"].analyzeDialog.analysisSteps.finalizingResults),
+      t((m) => m.dialogs.invoices.analyzeDialog.analysisSteps.preparingDocument),
+      t((m) => m.dialogs.invoices.analyzeDialog.analysisSteps.runningOcrExtraction),
+      t((m) => m.dialogs.invoices.analyzeDialog.analysisSteps.analyzingWithAi),
+      t((m) => m.dialogs.invoices.analyzeDialog.analysisSteps.categorizingItems),
+      t((m) => m.dialogs.invoices.analyzeDialog.analysisSteps.finalizingResults),
     ];
 
     try {
@@ -225,7 +225,7 @@ export default function AnalyzeDialog(): React.JSX.Element {
           const settled = await Promise.race([analysisSettledPromise, delay(0).then(() => false)]);
           if (settled) return;
 
-          setCurrentStep(steps[i] ?? t((m) => m["IMS--Dialogs"].analyzeDialog.analysisSteps.processing));
+          setCurrentStep(steps[i] ?? t((m) => m.dialogs.invoices.analyzeDialog.analysisSteps.processing));
           setProgress(((i + 1) / steps.length) * 95);
 
           // Wait briefly before advancing steps, but don't block completion.
@@ -246,18 +246,18 @@ export default function AnalyzeDialog(): React.JSX.Element {
         enhancements: selectedEnhancements,
       });
 
-      setCurrentStep(t((m) => m["IMS--Dialogs"].analyzeDialog.analysisSteps.finalizingResults));
+      setCurrentStep(t((m) => m.dialogs.invoices.analyzeDialog.analysisSteps.finalizingResults));
       setProgress(100);
 
-      toast(t((m) => m["IMS--Dialogs"].analyzeDialog.toasts.analysisComplete.title), {
-        description: t((m) => m["IMS--Dialogs"].analyzeDialog.toasts.analysisComplete.description),
+      toast(t((m) => m.dialogs.invoices.analyzeDialog.toasts.analysisComplete.title), {
+        description: t((m) => m.dialogs.invoices.analyzeDialog.toasts.analysisComplete.description),
       });
 
       close();
     } catch (error) {
       console.error("Error analyzing invoice:", error);
-      toast(t((m) => m["IMS--Dialogs"].analyzeDialog.toasts.analysisFailed.title), {
-        description: t((m) => m["IMS--Dialogs"].analyzeDialog.toasts.analysisFailed.description),
+      toast(t((m) => m.dialogs.invoices.analyzeDialog.toasts.analysisFailed.title), {
+        description: t((m) => m.dialogs.invoices.analyzeDialog.toasts.analysisFailed.description),
       });
     } finally {
       setIsAnalyzing(false);
@@ -279,10 +279,10 @@ export default function AnalyzeDialog(): React.JSX.Element {
         <DialogHeader>
           <DialogTitle className={styles["dialogTitle"]}>
             <TbScanEye className={styles["scanIcon"]} />
-            {t((m) => m["IMS--Dialogs"].analyzeDialog.header.title)}
+            {t((m) => m.dialogs.invoices.analyzeDialog.header.title)}
           </DialogTitle>
           <DialogDescription>
-            {t((m) => m["IMS--Dialogs"].analyzeDialog.header.description)} <span className={styles["invoiceIdSnippet"]}>{invoice.id.slice(0, 8)}...</span>
+            {t((m) => m.dialogs.invoices.analyzeDialog.header.description)} <span className={styles["invoiceIdSnippet"]}>{invoice.id.slice(0, 8)}...</span>
           </DialogDescription>
         </DialogHeader>
 
@@ -301,7 +301,7 @@ export default function AnalyzeDialog(): React.JSX.Element {
                   className={styles["spinnerIcon"]}>
                   <TbLoader2 className={styles["spinnerLargeIcon"]} />
                 </motion.div>
-                <h3 className={styles["analyzingTitle"]}>{t((m) => m["IMS--Dialogs"].analyzeDialog.analyzing.title)}</h3>
+                <h3 className={styles["analyzingTitle"]}>{t((m) => m.dialogs.invoices.analyzeDialog.analyzing.title)}</h3>
                 <p className={styles["analyzingStep"]}>{currentStep}</p>
               </div>
               <div className={styles["progressWrapper"]}>
@@ -309,7 +309,7 @@ export default function AnalyzeDialog(): React.JSX.Element {
                   value={progress}
                   className={styles["progressBar"]}
                 />
-                <p className={styles["progressText"]}>{t((m) => m["IMS--Dialogs"].analyzeDialog.analyzing.progressComplete, {progress: String(Math.round(progress))})}</p>
+                <p className={styles["progressText"]}>{t((m) => m.dialogs.invoices.analyzeDialog.analyzing.progressComplete, {progress: String(Math.round(progress))})}</p>
               </div>
             </motion.div>
           ) : (
@@ -321,7 +321,7 @@ export default function AnalyzeDialog(): React.JSX.Element {
               className={styles["optionsSection"]}>
               {/* Analysis Type Selection */}
               <div className={styles["sectionLabel"]}>
-                <Label className={styles["sectionLabelLarge"]}>{t((m) => m["IMS--Dialogs"].analyzeDialog.sections.analysisType)}</Label>
+                <Label className={styles["sectionLabelLarge"]}>{t((m) => m.dialogs.invoices.analyzeDialog.sections.analysisType)}</Label>
                 <div className={styles["optionsGrid"]}>
                   {analysisOptions.map((option) => (
                     <Card
@@ -339,7 +339,7 @@ export default function AnalyzeDialog(): React.JSX.Element {
                               <Badge
                                 variant='secondary'
                                 className={styles["recommendedBadge"]}>
-                                {t((m) => m["IMS--Dialogs"].analyzeDialog.badges.recommended)}
+                                {t((m) => m.dialogs.invoices.analyzeDialog.badges.recommended)}
                               </Badge>
                             ) : null}
                             {selectedOption === option.id && <TbCheck className={styles["checkIcon"]} />}
@@ -365,7 +365,7 @@ export default function AnalyzeDialog(): React.JSX.Element {
                   initial={{opacity: 0, height: 0}}
                   animate={{opacity: 1, height: "auto"}}
                   className={styles["featuresSection"]}>
-                  <Label className={styles["sectionLabelText"]}>{t((m) => m["IMS--Dialogs"].analyzeDialog.sections.includedFeatures)}</Label>
+                  <Label className={styles["sectionLabelText"]}>{t((m) => m.dialogs.invoices.analyzeDialog.sections.includedFeatures)}</Label>
                   <div className={styles["featuresList"]}>
                     {selectedConfig.features.map((feature) => (
                       <Badge
@@ -384,7 +384,7 @@ export default function AnalyzeDialog(): React.JSX.Element {
 
               {/* Analysis Enhancements */}
               <div className={styles["enhancementsSection"]}>
-                <Label className={styles["sectionLabelLarge"]}>{t((m) => m["IMS--Dialogs"].analyzeDialog.sections.enhancementsOptional)}</Label>
+                <Label className={styles["sectionLabelLarge"]}>{t((m) => m.dialogs.invoices.analyzeDialog.sections.enhancementsOptional)}</Label>
                 <div className={styles["enhancementsSection"]}>
                   {analysisEnhancements.map((enhancement) => (
                     <div
@@ -422,13 +422,13 @@ export default function AnalyzeDialog(): React.JSX.Element {
                       <p className={styles["summaryTitle"]}>{selectedConfig?.title}</p>
                       <p className={styles["summarySubtext"]}>
                         {selectedEnhancements.length > 0
-                          ? t((m) => m["IMS--Dialogs"].analyzeDialog.summary.enhancementsSelected, {count: String(selectedEnhancements.length)})
-                          : t((m) => m["IMS--Dialogs"].analyzeDialog.summary.noEnhancementsSelected)}
+                          ? t((m) => m.dialogs.invoices.analyzeDialog.summary.enhancementsSelected, {count: String(selectedEnhancements.length)})
+                          : t((m) => m.dialogs.invoices.analyzeDialog.summary.noEnhancementsSelected)}
                       </p>
                     </div>
                   </div>
                   <div className={styles["summaryRight"]}>
-                    <p className={styles["summaryTimeLabel"]}>{t((m) => m["IMS--Dialogs"].analyzeDialog.summary.estimatedTime)}</p>
+                    <p className={styles["summaryTimeLabel"]}>{t((m) => m.dialogs.invoices.analyzeDialog.summary.estimatedTime)}</p>
                     <p className={styles["summaryTimeValue"]}>{selectedConfig?.estimatedTime}</p>
                   </div>
                 </CardContent>
@@ -443,7 +443,7 @@ export default function AnalyzeDialog(): React.JSX.Element {
             variant='outline'
             onClick={close}
             disabled={isAnalyzing}>
-            {t((m) => m["IMS--Dialogs"].analyzeDialog.buttons.cancel)}
+            {t((m) => m.dialogs.invoices.analyzeDialog.buttons.cancel)}
           </Button>
           <Button
             type='button'
@@ -453,12 +453,12 @@ export default function AnalyzeDialog(): React.JSX.Element {
             {isAnalyzing ? (
               <>
                 <TbLoader2 className={styles["buttonSpinner"]} />
-                {t((m) => m["IMS--Dialogs"].analyzeDialog.buttons.analyzing)}
+                {t((m) => m.dialogs.invoices.analyzeDialog.buttons.analyzing)}
               </>
             ) : (
               <>
                 <TbScanEye className={styles["buttonScanIcon"]} />
-                {t((m) => m["IMS--Dialogs"].analyzeDialog.buttons.startAnalysis)}
+                {t((m) => m.dialogs.invoices.analyzeDialog.buttons.startAnalysis)}
               </>
             )}
           </Button>

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/BulkCategoryDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/BulkCategoryDialog.tsx
@@ -140,12 +140,12 @@ export default function BulkCategoryDialog(): React.JSX.Element {
    */
   const handleSave = useCallback(async () => {
     if (!invoice || !selectedProducts || !selectedIndices || selectedCategory === null) {
-      toast.error(t((m) => m["IMS--Dialogs"].bulkCategoryDialog.errors.missingData));
+      toast.error(t((m) => m.dialogs.invoices.bulkCategoryDialog.errors.missingData));
       return;
     }
 
     if (selectedProducts.length === 0) {
-      toast.error(t((m) => m["IMS--Dialogs"].bulkCategoryDialog.errors.noProducts));
+      toast.error(t((m) => m.dialogs.invoices.bulkCategoryDialog.errors.noProducts));
       return;
     }
 
@@ -188,24 +188,24 @@ export default function BulkCategoryDialog(): React.JSX.Element {
 
       // Show summary toast
       if (errors.length === 0) {
-        toast.success(t((m) => m["IMS--Dialogs"].bulkCategoryDialog.success.saved, {count: successCount}));
+        toast.success(t((m) => m.dialogs.invoices.bulkCategoryDialog.success.saved, {count: successCount}));
         close();
         router.refresh();
       } else if (successCount > 0) {
         toast.warning(
-          t((m) => m["IMS--Dialogs"].bulkCategoryDialog.success.partialSuccess, {
+          t((m) => m.dialogs.invoices.bulkCategoryDialog.success.partialSuccess, {
             success: String(successCount),
             failed: String(errors.length),
           }),
         );
         console.error("Some products failed to update:", errors);
       } else {
-        toast.error(t((m) => m["IMS--Dialogs"].bulkCategoryDialog.errors.allFailed));
+        toast.error(t((m) => m.dialogs.invoices.bulkCategoryDialog.errors.allFailed));
         console.error("All products failed to update:", errors);
       }
     } catch (error) {
       console.error("Failed to update categories:", error);
-      toast.error(t((m) => m["IMS--Dialogs"].bulkCategoryDialog.errors.saveFailed));
+      toast.error(t((m) => m.dialogs.invoices.bulkCategoryDialog.errors.saveFailed));
     } finally {
       setIsSaving(false);
       setUpdateProgress(null);
@@ -222,14 +222,14 @@ export default function BulkCategoryDialog(): React.JSX.Element {
       onOpenChange={close}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
-          <DialogTitle>{t((m) => m["IMS--Dialogs"].bulkCategoryDialog.title)}</DialogTitle>
-          <DialogDescription>{t((m) => m["IMS--Dialogs"].bulkCategoryDialog.description, {count: selectedProducts.length})}</DialogDescription>
+          <DialogTitle>{t((m) => m.dialogs.invoices.bulkCategoryDialog.title)}</DialogTitle>
+          <DialogDescription>{t((m) => m.dialogs.invoices.bulkCategoryDialog.description, {count: selectedProducts.length})}</DialogDescription>
         </DialogHeader>
 
         <div className={styles["content"]}>
           {/* Selected Products Preview */}
           <div className={styles["section"]}>
-            <Label className={styles["sectionLabel"]}>{t((m) => m["IMS--Dialogs"].bulkCategoryDialog.labels.selectedProducts)}</Label>
+            <Label className={styles["sectionLabel"]}>{t((m) => m.dialogs.invoices.bulkCategoryDialog.labels.selectedProducts)}</Label>
             <div className={styles["productList"]}>
               {selectedProducts.slice(0, 5).map((product) => (
                 <div
@@ -239,7 +239,7 @@ export default function BulkCategoryDialog(): React.JSX.Element {
                 </div>
               ))}
               {selectedProducts.length > 5 && (
-                <div className={styles["moreText"]}>{t((m) => m["IMS--Dialogs"].bulkCategoryDialog.labels.andMore, {count: String(selectedProducts.length - 5)})}</div>
+                <div className={styles["moreText"]}>{t((m) => m.dialogs.invoices.bulkCategoryDialog.labels.andMore, {count: String(selectedProducts.length - 5)})}</div>
               )}
             </div>
           </div>
@@ -250,7 +250,7 @@ export default function BulkCategoryDialog(): React.JSX.Element {
               htmlFor='category-select'
               className={styles["sectionLabel"]}>
               <TbTag className={styles["labelIcon"]} />
-              {t((m) => m["IMS--Dialogs"].bulkCategoryDialog.labels.newCategory)}
+              {t((m) => m.dialogs.invoices.bulkCategoryDialog.labels.newCategory)}
             </Label>
             <Select
               value={selectedCategory === null ? undefined : String(selectedCategory)}
@@ -258,7 +258,7 @@ export default function BulkCategoryDialog(): React.JSX.Element {
               <SelectTrigger
                 id='category-select'
                 className={styles["categoryTrigger"]}>
-                <SelectValue placeholder={t((m) => m["IMS--Dialogs"].bulkCategoryDialog.placeholders.selectCategory)} />
+                <SelectValue placeholder={t((m) => m.dialogs.invoices.bulkCategoryDialog.placeholders.selectCategory)} />
               </SelectTrigger>
               <SelectContent>
                 {categoryOptions.map((option) => (
@@ -275,9 +275,9 @@ export default function BulkCategoryDialog(): React.JSX.Element {
           {/* Progress Indicator */}
           {updateProgress ? (
             <div className={styles["section"]}>
-              <Label className={styles["sectionLabel"]}>{t((m) => m["IMS--Dialogs"].bulkCategoryDialog.labels.progress)}</Label>
+              <Label className={styles["sectionLabel"]}>{t((m) => m.dialogs.invoices.bulkCategoryDialog.labels.progress)}</Label>
               <p className={styles["progressText"]}>
-                {t((m) => m["IMS--Dialogs"].bulkCategoryDialog.progress.updating, {
+                {t((m) => m.dialogs.invoices.bulkCategoryDialog.progress.updating, {
                   current: String(updateProgress.current),
                   total: String(updateProgress.total),
                 })}
@@ -291,12 +291,12 @@ export default function BulkCategoryDialog(): React.JSX.Element {
             variant='outline'
             onClick={close}
             disabled={isSaving}>
-            {t((m) => m["IMS--Dialogs"].bulkCategoryDialog.buttons.cancel)}
+            {t((m) => m.dialogs.invoices.bulkCategoryDialog.buttons.cancel)}
           </Button>
           <Button
             onClick={handleSave}
             disabled={isSaving || selectedCategory === null}>
-            {isSaving ? t((m) => m["IMS--Dialogs"].bulkCategoryDialog.buttons.saving) : t((m) => m["IMS--Dialogs"].bulkCategoryDialog.buttons.save)}
+            {isSaving ? t((m) => m.dialogs.invoices.bulkCategoryDialog.buttons.saving) : t((m) => m.dialogs.invoices.bulkCategoryDialog.buttons.save)}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/FeedbackDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/FeedbackDialog.tsx
@@ -72,12 +72,12 @@ export default function FeedbackDialog(): React.JSX.Element {
 
   const {invoice, merchant} = payload;
   const features = [
-    t((m) => m["IMS--Dialogs"].feedbackDialog.features.spendingTrends),
-    t((m) => m["IMS--Dialogs"].feedbackDialog.features.priceComparisons),
-    t((m) => m["IMS--Dialogs"].feedbackDialog.features.savingsTips),
-    t((m) => m["IMS--Dialogs"].feedbackDialog.features.merchantAnalysis),
-    t((m) => m["IMS--Dialogs"].feedbackDialog.features.visualCharts),
-    t((m) => m["IMS--Dialogs"].feedbackDialog.features.categoryBreakdown),
+    t((m) => m.dialogs.invoices.feedbackDialog.features.spendingTrends),
+    t((m) => m.dialogs.invoices.feedbackDialog.features.priceComparisons),
+    t((m) => m.dialogs.invoices.feedbackDialog.features.savingsTips),
+    t((m) => m.dialogs.invoices.feedbackDialog.features.merchantAnalysis),
+    t((m) => m.dialogs.invoices.feedbackDialog.features.visualCharts),
+    t((m) => m.dialogs.invoices.feedbackDialog.features.categoryBreakdown),
   ];
 
   // Stable handlers to avoid inline arrow functions in JSX
@@ -104,15 +104,15 @@ export default function FeedbackDialog(): React.JSX.Element {
       e.preventDefault();
 
       // Show loading toast
-      const loadingToast = toast(t((m) => m["IMS--Dialogs"].feedbackDialog.toasts.sending.title), {
-        description: t((m) => m["IMS--Dialogs"].feedbackDialog.toasts.sending.description),
+      const loadingToast = toast(t((m) => m.dialogs.invoices.feedbackDialog.toasts.sending.title), {
+        description: t((m) => m.dialogs.invoices.feedbackDialog.toasts.sending.description),
         className: "z-100",
       });
 
       if (rating === 0) {
         toast.dismiss(loadingToast);
-        toast(t((m) => m["IMS--Dialogs"].feedbackDialog.toasts.ratingRequired.title), {
-          description: t((m) => m["IMS--Dialogs"].feedbackDialog.toasts.ratingRequired.description),
+        toast(t((m) => m.dialogs.invoices.feedbackDialog.toasts.ratingRequired.title), {
+          description: t((m) => m.dialogs.invoices.feedbackDialog.toasts.ratingRequired.description),
         });
         return;
       }
@@ -137,8 +137,8 @@ export default function FeedbackDialog(): React.JSX.Element {
         }
 
         toast.dismiss(loadingToast);
-        toast(t((m) => m["IMS--Dialogs"].feedbackDialog.toasts.success.title), {
-          description: t((m) => m["IMS--Dialogs"].feedbackDialog.toasts.success.description),
+        toast(t((m) => m.dialogs.invoices.feedbackDialog.toasts.success.title), {
+          description: t((m) => m.dialogs.invoices.feedbackDialog.toasts.success.description),
           className: "z-100",
         });
         setRating(0);
@@ -148,8 +148,8 @@ export default function FeedbackDialog(): React.JSX.Element {
       } catch (error: unknown) {
         console.error(">>> Failed to send feedback:", error);
         toast.dismiss(loadingToast);
-        toast(t((m) => m["IMS--Dialogs"].feedbackDialog.toasts.error.title), {
-          description: t((m) => m["IMS--Dialogs"].feedbackDialog.toasts.error.description),
+        toast(t((m) => m.dialogs.invoices.feedbackDialog.toasts.error.title), {
+          description: t((m) => m.dialogs.invoices.feedbackDialog.toasts.error.description),
         });
       } finally {
         close();
@@ -179,14 +179,14 @@ export default function FeedbackDialog(): React.JSX.Element {
       }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
-          <DialogTitle>{t((m) => m["IMS--Dialogs"].feedbackDialog.title)}</DialogTitle>
-          <DialogDescription>{t((m) => m["IMS--Dialogs"].feedbackDialog.description, {merchant: merchant?.name ?? ""})}</DialogDescription>
+          <DialogTitle>{t((m) => m.dialogs.invoices.feedbackDialog.title)}</DialogTitle>
+          <DialogDescription>{t((m) => m.dialogs.invoices.feedbackDialog.description, {merchant: merchant?.name ?? ""})}</DialogDescription>
         </DialogHeader>
 
         <div className={styles["body"]}>
           {/* Star Rating */}
           <div className={styles["section"]}>
-            <h4 className={styles["sectionHeading"]}>{t((m) => m["IMS--Dialogs"].feedbackDialog.sections.rating)}</h4>
+            <h4 className={styles["sectionHeading"]}>{t((m) => m.dialogs.invoices.feedbackDialog.sections.rating)}</h4>
             <div className={styles["starRow"]}>
               {[1, 2, 3, 4, 5].map((star) => (
                 <Button
@@ -205,7 +205,7 @@ export default function FeedbackDialog(): React.JSX.Element {
 
           {/* Feature Selection */}
           <div className={styles["section"]}>
-            <h4 className={styles["sectionHeading"]}>{t((m) => m["IMS--Dialogs"].feedbackDialog.sections.features)}</h4>
+            <h4 className={styles["sectionHeading"]}>{t((m) => m.dialogs.invoices.feedbackDialog.sections.features)}</h4>
             <div className={styles["featuresWrap"]}>
               {features.map((feature) => (
                 <Badge
@@ -222,9 +222,9 @@ export default function FeedbackDialog(): React.JSX.Element {
 
           {/* Written Feedback */}
           <div className={styles["section"]}>
-            <h4 className={styles["sectionHeading"]}>{t((m) => m["IMS--Dialogs"].feedbackDialog.sections.comments)}</h4>
+            <h4 className={styles["sectionHeading"]}>{t((m) => m.dialogs.invoices.feedbackDialog.sections.comments)}</h4>
             <Textarea
-              placeholder={t((m) => m["IMS--Dialogs"].feedbackDialog.commentsPlaceholder)}
+              placeholder={t((m) => m.dialogs.invoices.feedbackDialog.commentsPlaceholder)}
               value={feedback}
               onChange={handleFeedbackChange}
               rows={4}
@@ -239,9 +239,9 @@ export default function FeedbackDialog(): React.JSX.Element {
             <Button
               variant='outline'
               onClick={close}>
-              {t((m) => m["IMS--Dialogs"].feedbackDialog.buttons.cancel)}
+              {t((m) => m.dialogs.invoices.feedbackDialog.buttons.cancel)}
             </Button>
-            <Button type='submit'>{t((m) => m["IMS--Dialogs"].feedbackDialog.buttons.submit)}</Button>
+            <Button type='submit'>{t((m) => m.dialogs.invoices.feedbackDialog.buttons.submit)}</Button>
           </form>
         </DialogFooter>
       </DialogContent>

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/ImageDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/ImageDialog.tsx
@@ -60,12 +60,12 @@ export default function ImageDialog(): React.JSX.Element {
       }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
-          <DialogTitle>{t((m) => m["IMS--Dialogs"].imageDialog.title, {image})}</DialogTitle>
+          <DialogTitle>{t((m) => m.dialogs.invoices.imageDialog.title, {image})}</DialogTitle>
           <div className={styles["imageContainer"]}>
             <Image
               src={image}
               fill
-              alt={t((m) => m["IMS--Dialogs"].imageDialog.imageAlt)}
+              alt={t((m) => m.dialogs.invoices.imageDialog.imageAlt)}
               className={styles["receiptImage"]}
             />
           </div>

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/ItemsDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/ItemsDialog.tsx
@@ -191,8 +191,8 @@ export default function ItemsDialog(): React.JSX.Element {
       }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
-          <DialogTitle>{t((m) => m["IMS--Dialogs"].itemsDialog.title)}</DialogTitle>
-          <DialogDescription>{t((m) => m["IMS--Dialogs"].itemsDialog.description)}</DialogDescription>
+          <DialogTitle>{t((m) => m.dialogs.invoices.itemsDialog.title)}</DialogTitle>
+          <DialogDescription>{t((m) => m.dialogs.invoices.itemsDialog.description)}</DialogDescription>
         </DialogHeader>
 
         <div className={styles["body"]}>
@@ -200,12 +200,12 @@ export default function ItemsDialog(): React.JSX.Element {
             <Table className={styles["table"]}>
               <TableHeader>
                 <TableRow className={styles["headerRow"]}>
-                  <TableHead className={styles["tableHeader"]}>{t((m) => m["IMS--Dialogs"].itemsDialog.table.item)}</TableHead>
-                  <TableHead className={styles["tableHeaderCenter"]}>{t((m) => m["IMS--Dialogs"].itemsDialog.table.quantity)}</TableHead>
-                  <TableHead className={styles["tableHeaderCenter"]}>{t((m) => m["IMS--Dialogs"].itemsDialog.table.unit)}</TableHead>
-                  <TableHead className={styles["tableHeaderRight"]}>{t((m) => m["IMS--Dialogs"].itemsDialog.table.price)}</TableHead>
-                  <TableHead className={styles["tableHeaderRight"]}>{t((m) => m["IMS--Dialogs"].itemsDialog.table.total)}</TableHead>
-                  <TableHead className={styles["tableHeaderCenter"]}>{t((m) => m["IMS--Dialogs"].itemsDialog.table.actions)}</TableHead>
+                  <TableHead className={styles["tableHeader"]}>{t((m) => m.dialogs.invoices.itemsDialog.table.item)}</TableHead>
+                  <TableHead className={styles["tableHeaderCenter"]}>{t((m) => m.dialogs.invoices.itemsDialog.table.quantity)}</TableHead>
+                  <TableHead className={styles["tableHeaderCenter"]}>{t((m) => m.dialogs.invoices.itemsDialog.table.unit)}</TableHead>
+                  <TableHead className={styles["tableHeaderRight"]}>{t((m) => m.dialogs.invoices.itemsDialog.table.price)}</TableHead>
+                  <TableHead className={styles["tableHeaderRight"]}>{t((m) => m.dialogs.invoices.itemsDialog.table.total)}</TableHead>
+                  <TableHead className={styles["tableHeaderCenter"]}>{t((m) => m.dialogs.invoices.itemsDialog.table.actions)}</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody className={styles["tableBody"]}>
@@ -260,7 +260,7 @@ export default function ItemsDialog(): React.JSX.Element {
                         <Button
                           variant='ghost'
                           size='icon'
-                          aria-label={t((m) => m["IMS--Dialogs"].itemsDialog.aria.deleteItem, {name: item.name || t((m) => m["IMS--Dialogs"].itemsDialog.aria.unnamedItem)})}
+                          aria-label={t((m) => m.dialogs.invoices.itemsDialog.aria.deleteItem, {name: item.name || t((m) => m.dialogs.invoices.itemsDialog.aria.unnamedItem)})}
                           onClick={handleDeleteItem(item)}>
                           <TbTrash className={styles["trashIcon"]} />
                         </Button>
@@ -278,7 +278,7 @@ export default function ItemsDialog(): React.JSX.Element {
                       role='status'
                       aria-live='polite'
                       aria-atomic='true'>
-                      {t((m) => m["IMS--Dialogs"].itemsDialog.footer.itemsFound, {total: String(editableItems.length), shown: String(paginatedItems.length)})}
+                      {t((m) => m.dialogs.invoices.itemsDialog.footer.itemsFound, {total: String(editableItems.length), shown: String(paginatedItems.length)})}
                     </span>
                   </TableHead>
                   <TableHead
@@ -288,7 +288,7 @@ export default function ItemsDialog(): React.JSX.Element {
                       role='status'
                       aria-live='polite'
                       aria-atomic='true'>
-                      {t((m) => m["IMS--Dialogs"].itemsDialog.footer.page, {current: String(currentPage), total: String(totalPages)})}
+                      {t((m) => m.dialogs.invoices.itemsDialog.footer.page, {current: String(currentPage), total: String(totalPages)})}
                     </span>
                   </TableHead>
                   <TableHead
@@ -297,20 +297,20 @@ export default function ItemsDialog(): React.JSX.Element {
                     <Button
                       variant='ghost'
                       size='sm'
-                      aria-label={t((m) => m["IMS--Dialogs"].itemsDialog.aria.previousPage, {page: String(currentPage - 1)})}
+                      aria-label={t((m) => m.dialogs.invoices.itemsDialog.aria.previousPage, {page: String(currentPage - 1)})}
                       // eslint-disable-next-line react-compiler/react-compiler -- inputs always change - ok usage.
                       onClick={handlePreviousPage}
                       disabled={currentPage === 1}>
-                      {t((m) => m["IMS--Dialogs"].itemsDialog.buttons.previous)}
+                      {t((m) => m.dialogs.invoices.itemsDialog.buttons.previous)}
                     </Button>
                     <Button
                       variant='ghost'
                       size='sm'
-                      aria-label={t((m) => m["IMS--Dialogs"].itemsDialog.aria.nextPage, {page: String(currentPage + 1)})}
+                      aria-label={t((m) => m.dialogs.invoices.itemsDialog.aria.nextPage, {page: String(currentPage + 1)})}
                       // eslint-disable-next-line react-compiler/react-compiler -- inputs always change - ok usage.
                       onClick={handleNextPage}
                       disabled={currentPage === totalPages}>
-                      {t((m) => m["IMS--Dialogs"].itemsDialog.buttons.next)}
+                      {t((m) => m.dialogs.invoices.itemsDialog.buttons.next)}
                     </Button>
                   </TableHead>
                 </TableRow>
@@ -323,16 +323,16 @@ export default function ItemsDialog(): React.JSX.Element {
             <Button
               type='button'
               variant='outline'
-              aria-label={t((m) => m["IMS--Dialogs"].itemsDialog.aria.addItem)}
+              aria-label={t((m) => m.dialogs.invoices.itemsDialog.aria.addItem)}
               onClick={handleAddNewItem}>
               <TbPlus className={styles["buttonIcon"]} />
-              {t((m) => m["IMS--Dialogs"].itemsDialog.buttons.addItem)}
+              {t((m) => m.dialogs.invoices.itemsDialog.buttons.addItem)}
             </Button>
             <div
               className={styles["itemCount"]}
               role='status'
               aria-live='polite'>
-              {t((m) => m["IMS--Dialogs"].itemsDialog.footer.itemsTotal, {count: items.length})}
+              {t((m) => m.dialogs.invoices.itemsDialog.footer.itemsTotal, {count: items.length})}
             </div>
           </div>
         </div>
@@ -340,15 +340,15 @@ export default function ItemsDialog(): React.JSX.Element {
         <DialogFooter>
           <Button
             variant='outline'
-            aria-label={t((m) => m["IMS--Dialogs"].itemsDialog.aria.cancel)}
+            aria-label={t((m) => m.dialogs.invoices.itemsDialog.aria.cancel)}
             onClick={close}>
-            {t((m) => m["IMS--Dialogs"].itemsDialog.buttons.cancel)}
+            {t((m) => m.dialogs.invoices.itemsDialog.buttons.cancel)}
           </Button>
           <Button
-            aria-label={t((m) => m["IMS--Dialogs"].itemsDialog.aria.save)}
+            aria-label={t((m) => m.dialogs.invoices.itemsDialog.aria.save)}
             onClick={handleSaveChanges}>
             <TbDisc className={styles["buttonIcon"]} />
-            {t((m) => m["IMS--Dialogs"].itemsDialog.buttons.saveChanges)}
+            {t((m) => m.dialogs.invoices.itemsDialog.buttons.saveChanges)}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/MerchantDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/MerchantDialog.tsx
@@ -79,8 +79,8 @@ export default function MerchantDialog(): React.JSX.Element {
       }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader className={styles["dialogHeader"]}>
-          <DialogTitle>{t((m) => m["IMS--Dialogs"].merchantDialog.title)}</DialogTitle>
-          <DialogDescription>{t((m) => m["IMS--Dialogs"].merchantDialog.description, {merchantName: merchant.name})}</DialogDescription>
+          <DialogTitle>{t((m) => m.dialogs.invoices.merchantDialog.title)}</DialogTitle>
+          <DialogDescription>{t((m) => m.dialogs.invoices.merchantDialog.description, {merchantName: merchant.name})}</DialogDescription>
         </DialogHeader>
         <div className={styles["body"]}>
           <div className={styles["merchantProfile"]}>
@@ -103,7 +103,7 @@ export default function MerchantDialog(): React.JSX.Element {
                 <TableCell className={styles["labelCell"]}>
                   <div className={styles["detailRow"]}>
                     <TbMapPin className={styles["mutedIcon"]} />
-                    <span className={styles["detailLabel"]}>{t((m) => m["IMS--Dialogs"].merchantDialog.fields.address)}</span>
+                    <span className={styles["detailLabel"]}>{t((m) => m.dialogs.invoices.merchantDialog.fields.address)}</span>
                   </div>
                 </TableCell>
                 <TableCell className={styles["valueCell"]}>{merchant.address.address}</TableCell>
@@ -112,7 +112,7 @@ export default function MerchantDialog(): React.JSX.Element {
                 <TableCell className={styles["labelCell"]}>
                   <div className={styles["detailRow"]}>
                     <TbPhone className={styles["mutedIcon"]} />
-                    <span className={styles["detailLabel"]}>{t((m) => m["IMS--Dialogs"].merchantDialog.fields.phone)}</span>
+                    <span className={styles["detailLabel"]}>{t((m) => m.dialogs.invoices.merchantDialog.fields.phone)}</span>
                   </div>
                 </TableCell>
                 <TableCell className={styles["valueCell"]}>{merchant.address.phoneNumber}</TableCell>
@@ -121,7 +121,7 @@ export default function MerchantDialog(): React.JSX.Element {
                 <TableCell className={styles["labelCell"]}>
                   <div className={styles["detailRow"]}>
                     <TbBuildingStore className={styles["mutedIcon"]} />
-                    <span className={styles["detailLabel"]}>{t((m) => m["IMS--Dialogs"].merchantDialog.fields.parentCompany)}</span>
+                    <span className={styles["detailLabel"]}>{t((m) => m.dialogs.invoices.merchantDialog.fields.parentCompany)}</span>
                   </div>
                 </TableCell>
                 <TableCell className={styles["valueCell"]}>{merchant.parentCompanyId}</TableCell>
@@ -134,7 +134,7 @@ export default function MerchantDialog(): React.JSX.Element {
           <Button
             type='button'
             className={styles["mapsButton"]}>
-            {t((m) => m["IMS--Dialogs"].merchantDialog.buttons.openInMaps)}
+            {t((m) => m.dialogs.invoices.merchantDialog.buttons.openInMaps)}
           </Button>
         </div>
       </DialogContent>

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/MerchantReceiptsDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/MerchantReceiptsDialog.tsx
@@ -142,8 +142,8 @@ export default function MerchantReceiptsDialog(): React.JSX.Element {
       }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
-          <DialogTitle>{t((m) => m["IMS--Dialogs"].merchantReceiptsDialog.title, {merchant: merchant.name})}</DialogTitle>
-          <DialogDescription>{t((m) => m["IMS--Dialogs"].merchantReceiptsDialog.description)}</DialogDescription>
+          <DialogTitle>{t((m) => m.dialogs.invoices.merchantReceiptsDialog.title, {merchant: merchant.name})}</DialogTitle>
+          <DialogDescription>{t((m) => m.dialogs.invoices.merchantReceiptsDialog.description)}</DialogDescription>
         </DialogHeader>
 
         <div className={styles["body"]}>
@@ -151,7 +151,7 @@ export default function MerchantReceiptsDialog(): React.JSX.Element {
             <div className={styles["searchWrapper"]}>
               <TbSearch className={styles["searchIcon"]} />
               <Input
-                placeholder={t((m) => m["IMS--Dialogs"].merchantReceiptsDialog.searchPlaceholder)}
+                placeholder={t((m) => m.dialogs.invoices.merchantReceiptsDialog.searchPlaceholder)}
                 className={styles["searchInput"]}
                 value={searchQuery}
                 onChange={handleSearchQueryChange}
@@ -162,13 +162,13 @@ export default function MerchantReceiptsDialog(): React.JSX.Element {
                 <Select onValueChange={handleDateFilterChange}>
                   <SelectTrigger>
                     <TbCalendar className={styles["filterIcon"]} />
-                    <SelectValue placeholder={t((m) => m["IMS--Dialogs"].merchantReceiptsDialog.filters.date)} />
+                    <SelectValue placeholder={t((m) => m.dialogs.invoices.merchantReceiptsDialog.filters.date)} />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value='all'>{t((m) => m["IMS--Dialogs"].merchantReceiptsDialog.dateOptions.allTime)}</SelectItem>
-                    <SelectItem value='30days'>{t((m) => m["IMS--Dialogs"].merchantReceiptsDialog.dateOptions.last30Days)}</SelectItem>
-                    <SelectItem value='90days'>{t((m) => m["IMS--Dialogs"].merchantReceiptsDialog.dateOptions.last90Days)}</SelectItem>
-                    <SelectItem value='thisYear'>{t((m) => m["IMS--Dialogs"].merchantReceiptsDialog.dateOptions.thisYear)}</SelectItem>
+                    <SelectItem value='all'>{t((m) => m.dialogs.invoices.merchantReceiptsDialog.dateOptions.allTime)}</SelectItem>
+                    <SelectItem value='30days'>{t((m) => m.dialogs.invoices.merchantReceiptsDialog.dateOptions.last30Days)}</SelectItem>
+                    <SelectItem value='90days'>{t((m) => m.dialogs.invoices.merchantReceiptsDialog.dateOptions.last90Days)}</SelectItem>
+                    <SelectItem value='thisYear'>{t((m) => m.dialogs.invoices.merchantReceiptsDialog.dateOptions.thisYear)}</SelectItem>
                   </SelectContent>
                 </Select>
               </div>
@@ -176,11 +176,11 @@ export default function MerchantReceiptsDialog(): React.JSX.Element {
                 <Select onValueChange={handleSortChange}>
                   <SelectTrigger>
                     <TbArrowsUpDown className={styles["filterIcon"]} />
-                    <SelectValue placeholder={t((m) => m["IMS--Dialogs"].merchantReceiptsDialog.filters.sort)} />
+                    <SelectValue placeholder={t((m) => m.dialogs.invoices.merchantReceiptsDialog.filters.sort)} />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value='date-desc'>{t((m) => m["IMS--Dialogs"].merchantReceiptsDialog.sortOptions.newest)}</SelectItem>
-                    <SelectItem value='date-asc'>{t((m) => m["IMS--Dialogs"].merchantReceiptsDialog.sortOptions.oldest)}</SelectItem>
+                    <SelectItem value='date-desc'>{t((m) => m.dialogs.invoices.merchantReceiptsDialog.sortOptions.newest)}</SelectItem>
+                    <SelectItem value='date-asc'>{t((m) => m.dialogs.invoices.merchantReceiptsDialog.sortOptions.oldest)}</SelectItem>
                   </SelectContent>
                 </Select>
               </div>
@@ -192,10 +192,10 @@ export default function MerchantReceiptsDialog(): React.JSX.Element {
               <Table>
                 <TableHeader>
                   <TableRow className={styles["headerRow"]}>
-                    <TableHead className={styles["tableHeader"]}>{t((m) => m["IMS--Dialogs"].merchantReceiptsDialog.table.receipt)}</TableHead>
-                    <TableHead className={styles["tableHeader"]}>{t((m) => m["IMS--Dialogs"].merchantReceiptsDialog.table.date)}</TableHead>
-                    <TableHead className={styles["tableHeaderRight"]}>{t((m) => m["IMS--Dialogs"].merchantReceiptsDialog.table.itemsCount)}</TableHead>
-                    <TableHead className={styles["tableHeaderRight"]}>{t((m) => m["IMS--Dialogs"].merchantReceiptsDialog.table.actions)}</TableHead>
+                    <TableHead className={styles["tableHeader"]}>{t((m) => m.dialogs.invoices.merchantReceiptsDialog.table.receipt)}</TableHead>
+                    <TableHead className={styles["tableHeader"]}>{t((m) => m.dialogs.invoices.merchantReceiptsDialog.table.date)}</TableHead>
+                    <TableHead className={styles["tableHeaderRight"]}>{t((m) => m.dialogs.invoices.merchantReceiptsDialog.table.itemsCount)}</TableHead>
+                    <TableHead className={styles["tableHeaderRight"]}>{t((m) => m.dialogs.invoices.merchantReceiptsDialog.table.actions)}</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody className={styles["tableBody"]}>
@@ -213,7 +213,7 @@ export default function MerchantReceiptsDialog(): React.JSX.Element {
                             variant='ghost'
                             size='sm'>
                             <TbDownload className={styles["downloadIcon"]} />
-                            {t((m) => m["IMS--Dialogs"].merchantReceiptsDialog.table.view)}
+                            {t((m) => m.dialogs.invoices.merchantReceiptsDialog.table.view)}
                           </Button>
                         </TableCell>
                       </TableRow>
@@ -223,12 +223,12 @@ export default function MerchantReceiptsDialog(): React.JSX.Element {
                 <TableFooter>
                   <TableRow>
                     <TableHead className={styles["tableHeader"]}>
-                      {t((m) => m["IMS--Dialogs"].merchantReceiptsDialog.footer.receiptsFound, {count: String(receipts.length), showing: String(paginatedItems.length)})}
+                      {t((m) => m.dialogs.invoices.merchantReceiptsDialog.footer.receiptsFound, {count: String(receipts.length), showing: String(paginatedItems.length)})}
                     </TableHead>
                     <TableCell
                       className={styles["tableHeaderRight"]}
                       colSpan={2}>
-                      {t((m) => m["IMS--Dialogs"].merchantReceiptsDialog.footer.page, {current: String(currentPage), total: String(totalPages)})}
+                      {t((m) => m.dialogs.invoices.merchantReceiptsDialog.footer.page, {current: String(currentPage), total: String(totalPages)})}
                     </TableCell>
                     <TableCell
                       className={styles["tableHeaderRight"]}
@@ -238,14 +238,14 @@ export default function MerchantReceiptsDialog(): React.JSX.Element {
                         size='sm'
                         onClick={handlePreviousPage}
                         disabled={currentPage === 1}>
-                        {t((m) => m["IMS--Dialogs"].merchantReceiptsDialog.buttons.previous)}
+                        {t((m) => m.dialogs.invoices.merchantReceiptsDialog.buttons.previous)}
                       </Button>
                       <Button
                         variant='ghost'
                         size='sm'
                         onClick={handleNextPage}
                         disabled={currentPage === totalPages}>
-                        {t((m) => m["IMS--Dialogs"].merchantReceiptsDialog.buttons.next)}
+                        {t((m) => m.dialogs.invoices.merchantReceiptsDialog.buttons.next)}
                       </Button>
                     </TableCell>
                   </TableRow>

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/MetadataDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/MetadataDialog.tsx
@@ -61,30 +61,30 @@ const AddDialog = () => {
       }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
-          <DialogTitle>{t((m) => m["IMS--Dialogs"].metadataDialog.add.title)}</DialogTitle>
-          <DialogDescription>{t((m) => m["IMS--Dialogs"].metadataDialog.add.description)}</DialogDescription>
+          <DialogTitle>{t((m) => m.dialogs.invoices.metadataDialog.add.title)}</DialogTitle>
+          <DialogDescription>{t((m) => m.dialogs.invoices.metadataDialog.add.description)}</DialogDescription>
         </DialogHeader>
 
         <div className={styles["formBody"]}>
           <div className={styles["fieldGroup"]}>
-            <Label htmlFor='key'>{t((m) => m["IMS--Dialogs"].metadataDialog.fields.keyLabel)}</Label>
+            <Label htmlFor='key'>{t((m) => m.dialogs.invoices.metadataDialog.fields.keyLabel)}</Label>
             <Input
               id='key'
               name='key'
               value={addedMetadata.key}
               onChange={handleChange}
-              placeholder={t((m) => m["IMS--Dialogs"].metadataDialog.fields.keyPlaceholder)}
+              placeholder={t((m) => m.dialogs.invoices.metadataDialog.fields.keyPlaceholder)}
             />
           </div>
 
           <div className={styles["fieldGroup"]}>
-            <Label htmlFor='value'>{t((m) => m["IMS--Dialogs"].metadataDialog.fields.valueLabel)}</Label>
+            <Label htmlFor='value'>{t((m) => m.dialogs.invoices.metadataDialog.fields.valueLabel)}</Label>
             <Input
               id='value'
               name='value'
               value={addedMetadata.value}
               onChange={handleChange}
-              placeholder={t((m) => m["IMS--Dialogs"].metadataDialog.fields.valuePlaceholder)}
+              placeholder={t((m) => m.dialogs.invoices.metadataDialog.fields.valuePlaceholder)}
             />
           </div>
         </div>
@@ -94,13 +94,13 @@ const AddDialog = () => {
             type='button'
             variant='outline'
             onClick={close}>
-            {t((m) => m["IMS--Dialogs"].metadataDialog.buttons.cancel)}
+            {t((m) => m.dialogs.invoices.metadataDialog.buttons.cancel)}
           </Button>
           <Button
             type='button'
             onClick={handleSave}>
             <TbDiscFilled className={styles["saveIcon"]} />
-            {t((m) => m["IMS--Dialogs"].metadataDialog.buttons.save)}
+            {t((m) => m.dialogs.invoices.metadataDialog.buttons.save)}
           </Button>
         </DialogFooter>
       </DialogContent>
@@ -132,13 +132,13 @@ const UpdateDialog = ({metadata}: Readonly<{metadata: Record<string, string>}>) 
       }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
-          <DialogTitle>{t((m) => m["IMS--Dialogs"].metadataDialog.edit.title)}</DialogTitle>
-          <DialogDescription>{t((m) => m["IMS--Dialogs"].metadataDialog.edit.description)}</DialogDescription>
+          <DialogTitle>{t((m) => m.dialogs.invoices.metadataDialog.edit.title)}</DialogTitle>
+          <DialogDescription>{t((m) => m.dialogs.invoices.metadataDialog.edit.description)}</DialogDescription>
         </DialogHeader>
 
         <div className={styles["formBody"]}>
           <div className={styles["fieldGroup"]}>
-            <Label htmlFor='key'>{t((m) => m["IMS--Dialogs"].metadataDialog.edit.fieldLabel)}</Label>
+            <Label htmlFor='key'>{t((m) => m.dialogs.invoices.metadataDialog.edit.fieldLabel)}</Label>
             <Input
               id='key'
               value={editedMetadata["key"]}
@@ -147,12 +147,12 @@ const UpdateDialog = ({metadata}: Readonly<{metadata: Record<string, string>}>) 
           </div>
 
           <div className={styles["fieldGroup"]}>
-            <Label htmlFor='value'>{t((m) => m["IMS--Dialogs"].metadataDialog.fields.valueLabel)}</Label>
+            <Label htmlFor='value'>{t((m) => m.dialogs.invoices.metadataDialog.fields.valueLabel)}</Label>
             <Input
               id='value'
               value={editedMetadata["value"]}
               onChange={handleChange}
-              placeholder={t((m) => m["IMS--Dialogs"].metadataDialog.fields.valuePlaceholder)}
+              placeholder={t((m) => m.dialogs.invoices.metadataDialog.fields.valuePlaceholder)}
             />
           </div>
         </div>
@@ -162,13 +162,13 @@ const UpdateDialog = ({metadata}: Readonly<{metadata: Record<string, string>}>) 
             type='button'
             variant='outline'
             onClick={close}>
-            {t((m) => m["IMS--Dialogs"].metadataDialog.buttons.cancel)}
+            {t((m) => m.dialogs.invoices.metadataDialog.buttons.cancel)}
           </Button>
           <Button
             type='button'
             onClick={handleSave}>
             <TbDiscFilled className={styles["saveIcon"]} />
-            {t((m) => m["IMS--Dialogs"].metadataDialog.buttons.save)}
+            {t((m) => m.dialogs.invoices.metadataDialog.buttons.save)}
           </Button>
         </DialogFooter>
       </DialogContent>
@@ -195,8 +195,8 @@ const DeleteDialog = ({metadata}: Readonly<{metadata: Record<string, string>}>) 
       }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
-          <DialogTitle>{t((m) => m["IMS--Dialogs"].metadataDialog.delete.title)}</DialogTitle>
-          <DialogDescription>{t((m) => m["IMS--Dialogs"].metadataDialog.delete.description)}</DialogDescription>
+          <DialogTitle>{t((m) => m.dialogs.invoices.metadataDialog.delete.title)}</DialogTitle>
+          <DialogDescription>{t((m) => m.dialogs.invoices.metadataDialog.delete.description)}</DialogDescription>
         </DialogHeader>
 
         <DialogFooter>
@@ -204,13 +204,13 @@ const DeleteDialog = ({metadata}: Readonly<{metadata: Record<string, string>}>) 
             type='button'
             variant='outline'
             onClick={close}>
-            {t((m) => m["IMS--Dialogs"].metadataDialog.buttons.cancel)}
+            {t((m) => m.dialogs.invoices.metadataDialog.buttons.cancel)}
           </Button>
           <Button
             type='button'
             onClick={handleDelete}
             className={styles["deleteButton"]}>
-            {t((m) => m["IMS--Dialogs"].metadataDialog.buttons.delete)}
+            {t((m) => m.dialogs.invoices.metadataDialog.buttons.delete)}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/RecipeDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/RecipeDialog.tsx
@@ -125,15 +125,15 @@ const CreateDialog = () => {
       });
 
       if (result.success) {
-        toast.success(t((m) => m["IMS--Dialogs"].recipeDialog.create.success) ?? "Recipe created successfully");
+        toast.success(t((m) => m.dialogs.invoices.recipeDialog.create.success) ?? "Recipe created successfully");
         close();
         router.refresh();
       } else {
-        toast.error(result.error.message || t((m) => m["IMS--Dialogs"].recipeDialog.create.error) || "Failed to create recipe");
+        toast.error(result.error.message || t((m) => m.dialogs.invoices.recipeDialog.create.error) || "Failed to create recipe");
       }
     } catch (error) {
       console.error("Failed to create recipe:", error);
-      toast.error(t((m) => m["IMS--Dialogs"].recipeDialog.create.error) ?? "Failed to create recipe");
+      toast.error(t((m) => m.dialogs.invoices.recipeDialog.create.error) ?? "Failed to create recipe");
     } finally {
       setIsSaving(false);
     }
@@ -171,14 +171,14 @@ const CreateDialog = () => {
       onOpenChange={handleOpenChange}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
-          <DialogTitle>{t((m) => m["IMS--Dialogs"].recipeDialog.create.title)}</DialogTitle>
-          <DialogDescription>{t((m) => m["IMS--Dialogs"].recipeDialog.create.description)}</DialogDescription>
+          <DialogTitle>{t((m) => m.dialogs.invoices.recipeDialog.create.title)}</DialogTitle>
+          <DialogDescription>{t((m) => m.dialogs.invoices.recipeDialog.create.description)}</DialogDescription>
         </DialogHeader>
 
         <form className={styles["formBody"]}>
           <div className={styles["fieldGroup"]}>
             <div className={styles["fieldHeader"]}>
-              <Label htmlFor='name'>{t((m) => m["IMS--Dialogs"].recipeDialog.fields.recipeName)}</Label>
+              <Label htmlFor='name'>{t((m) => m.dialogs.invoices.recipeDialog.fields.recipeName)}</Label>
               <div>
                 <TooltipProvider>
                   <Tooltip>
@@ -191,12 +191,12 @@ const CreateDialog = () => {
                           onClick={handleGenerateName}
                           className={styles["generateButton"]}>
                           <TbSparkles className={styles["sparklesIcon"]} />
-                          {t((m) => m["IMS--Dialogs"].recipeDialog.actions.generateName)}
+                          {t((m) => m.dialogs.invoices.recipeDialog.actions.generateName)}
                         </Button>
                       }
                     />
                     <TooltipContent>
-                      <p className={styles["tooltipText"]}>{t((m) => m["IMS--Dialogs"].recipeDialog.tooltips.generateName)}</p>
+                      <p className={styles["tooltipText"]}>{t((m) => m.dialogs.invoices.recipeDialog.tooltips.generateName)}</p>
                     </TooltipContent>
                   </Tooltip>
                 </TooltipProvider>
@@ -207,32 +207,32 @@ const CreateDialog = () => {
               name='name'
               value={recipe.name}
               onChange={handleChange}
-              placeholder={t((m) => m["IMS--Dialogs"].recipeDialog.placeholders.recipeName)}
+              placeholder={t((m) => m.dialogs.invoices.recipeDialog.placeholders.recipeName)}
             />
           </div>
 
           {/* Add description field */}
           <div className={styles["fieldGroup"]}>
-            <Label htmlFor='description'>{t((m) => m["IMS--Dialogs"].recipeDialog.fields.description)}</Label>
+            <Label htmlFor='description'>{t((m) => m.dialogs.invoices.recipeDialog.fields.description)}</Label>
             <Textarea
               id='description'
               name='description'
               value={recipe.description} // updated from formData to recipe
               onChange={handleChange}
-              placeholder={t((m) => m["IMS--Dialogs"].recipeDialog.placeholders.description)}
+              placeholder={t((m) => m.dialogs.invoices.recipeDialog.placeholders.description)}
               rows={2}
             />
           </div>
 
           <div className={styles["fieldGroup"]}>
             <div className={styles["fieldHeader"]}>
-              <Label>{t((m) => m["IMS--Dialogs"].recipeDialog.fields.ingredients)}</Label>
+              <Label>{t((m) => m.dialogs.invoices.recipeDialog.fields.ingredients)}</Label>
               <Button
                 type='button'
                 variant='outline'
                 size='sm'>
                 <TbPlus className={styles["addIcon"]} />
-                {t((m) => m["IMS--Dialogs"].recipeDialog.buttons.add)}
+                {t((m) => m.dialogs.invoices.recipeDialog.buttons.add)}
               </Button>
             </div>
 
@@ -263,17 +263,17 @@ const CreateDialog = () => {
 
           {/* Add difficulty selector */}
           <div className={styles["fieldGroup"]}>
-            <Label htmlFor='difficulty'>{t((m) => m["IMS--Dialogs"].recipeDialog.fields.difficulty)}</Label>
+            <Label htmlFor='difficulty'>{t((m) => m.dialogs.invoices.recipeDialog.fields.difficulty)}</Label>
             <Select
               value={formatEnum(RecipeComplexity, recipe.complexity) || "Unknown"}
               onValueChange={handleDifficultyChange}>
               <SelectTrigger>
-                <SelectValue placeholder={t((m) => m["IMS--Dialogs"].recipeDialog.placeholders.selectDifficulty)} />
+                <SelectValue placeholder={t((m) => m.dialogs.invoices.recipeDialog.placeholders.selectDifficulty)} />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value='Easy'>{t((m) => m["IMS--Dialogs"].recipeDialog.difficulty.easy)}</SelectItem>
-                <SelectItem value='Normal'>{t((m) => m["IMS--Dialogs"].recipeDialog.difficulty.medium)}</SelectItem>
-                <SelectItem value='Hard'>{t((m) => m["IMS--Dialogs"].recipeDialog.difficulty.hard)}</SelectItem>
+                <SelectItem value='Easy'>{t((m) => m.dialogs.invoices.recipeDialog.difficulty.easy)}</SelectItem>
+                <SelectItem value='Normal'>{t((m) => m.dialogs.invoices.recipeDialog.difficulty.medium)}</SelectItem>
+                <SelectItem value='Hard'>{t((m) => m.dialogs.invoices.recipeDialog.difficulty.hard)}</SelectItem>
               </SelectContent>
             </Select>
           </div>
@@ -281,7 +281,7 @@ const CreateDialog = () => {
           {/* Add instructions field */}
           <div className={styles["fieldGroup"]}>
             <div className={styles["fieldHeader"]}>
-              <Label htmlFor='instructions'>{t((m) => m["IMS--Dialogs"].recipeDialog.fields.instructions)}</Label>
+              <Label htmlFor='instructions'>{t((m) => m.dialogs.invoices.recipeDialog.fields.instructions)}</Label>
               <TooltipProvider>
                 <Tooltip>
                   <TooltipTrigger
@@ -292,12 +292,12 @@ const CreateDialog = () => {
                         size='sm'
                         onClick={handleEnhanceInstructions}>
                         <TbWand className={styles["addIcon"]} />
-                        {t((m) => m["IMS--Dialogs"].recipeDialog.actions.enhanceInstructions)}
+                        {t((m) => m.dialogs.invoices.recipeDialog.actions.enhanceInstructions)}
                       </Button>
                     }
                   />
                   <TooltipContent>
-                    <p>{t((m) => m["IMS--Dialogs"].recipeDialog.tooltips.enhanceInstructions)}</p>
+                    <p>{t((m) => m.dialogs.invoices.recipeDialog.tooltips.enhanceInstructions)}</p>
                   </TooltipContent>
                 </Tooltip>
               </TooltipProvider>
@@ -307,7 +307,7 @@ const CreateDialog = () => {
               name='instructions'
               value={recipe.instructions}
               onChange={handleChange}
-              placeholder={t((m) => m["IMS--Dialogs"].recipeDialog.placeholders.instructions)}
+              placeholder={t((m) => m.dialogs.invoices.recipeDialog.placeholders.instructions)}
               rows={4}
             />
           </div>
@@ -315,7 +315,7 @@ const CreateDialog = () => {
           {/* Add preparation time field */}
           <div className={styles["timeGrid"]}>
             <div className={styles["fieldGroup"]}>
-              <Label htmlFor='preparationTime'>{t((m) => m["IMS--Dialogs"].recipeDialog.fields.prepTime)}</Label>
+              <Label htmlFor='preparationTime'>{t((m) => m.dialogs.invoices.recipeDialog.fields.prepTime)}</Label>
               <div className={styles["timeRow"]}>
                 <TbClock className={styles["mutedIcon"]} />
                 <Input
@@ -324,14 +324,14 @@ const CreateDialog = () => {
                   type='number'
                   value={recipe.preparationTime}
                   onChange={handleChange}
-                  placeholder={t((m) => m["IMS--Dialogs"].recipeDialog.placeholders.prepTime)}
+                  placeholder={t((m) => m.dialogs.invoices.recipeDialog.placeholders.prepTime)}
                 />
               </div>
             </div>
 
             {/* Add cooking time field */}
             <div className={styles["fieldGroup"]}>
-              <Label htmlFor='cookingTime'>{t((m) => m["IMS--Dialogs"].recipeDialog.fields.cookTime)}</Label>
+              <Label htmlFor='cookingTime'>{t((m) => m.dialogs.invoices.recipeDialog.fields.cookTime)}</Label>
               <div className={styles["timeRow"]}>
                 <TbToolsKitchen className={styles["mutedIcon"]} />
                 <Input
@@ -340,7 +340,7 @@ const CreateDialog = () => {
                   type='number'
                   value={recipe.cookingTime}
                   onChange={handleChange}
-                  placeholder={t((m) => m["IMS--Dialogs"].recipeDialog.placeholders.cookTime)}
+                  placeholder={t((m) => m.dialogs.invoices.recipeDialog.placeholders.cookTime)}
                 />
               </div>
             </div>
@@ -349,11 +349,11 @@ const CreateDialog = () => {
           {/* Display total duration */}
           {(Number(recipe.preparationTime) > 0 || Number(recipe.cookingTime) > 0) && (
             <div className={styles["fieldGroup"]}>
-              <Label>{t((m) => m["IMS--Dialogs"].recipeDialog.fields.totalDuration) ?? "Total Duration"}</Label>
+              <Label>{t((m) => m.dialogs.invoices.recipeDialog.fields.totalDuration) ?? "Total Duration"}</Label>
               <div className={styles["timeRow"]}>
                 <TbToolsKitchen3 className={styles["mutedIcon"]} />
                 <span>
-                  {Number(recipe.preparationTime) + Number(recipe.cookingTime)} {t((m) => m["IMS--Dialogs"].recipeDialog.minutes) ?? "minutes"}
+                  {Number(recipe.preparationTime) + Number(recipe.cookingTime)} {t((m) => m.dialogs.invoices.recipeDialog.minutes) ?? "minutes"}
                 </span>
               </div>
             </div>
@@ -367,14 +367,14 @@ const CreateDialog = () => {
               variant='outline'
               onClick={close}
               disabled={isSaving}>
-              {t((m) => m["IMS--Dialogs"].recipeDialog.buttons.cancel)}
+              {t((m) => m.dialogs.invoices.recipeDialog.buttons.cancel)}
             </Button>
             <Button
               type='button'
               onClick={handleCreate}
               disabled={isSaving}>
               <TbDisc className={styles["saveIcon"]} />
-              {isSaving ? (t((m) => m["IMS--Dialogs"].recipeDialog.buttons.saving) ?? "Saving...") : t((m) => m["IMS--Dialogs"].recipeDialog.buttons.save)}
+              {isSaving ? (t((m) => m.dialogs.invoices.recipeDialog.buttons.saving) ?? "Saving...") : t((m) => m.dialogs.invoices.recipeDialog.buttons.save)}
             </Button>
           </div>
         </DialogFooter>
@@ -402,18 +402,18 @@ const ReadDialog = ({recipe}: Readonly<{recipe: Recipe}>) => {
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
           <DialogTitle>{recipe.name}</DialogTitle>
-          <DialogDescription>{t((m) => m["IMS--Dialogs"].recipeDialog.read.description)}</DialogDescription>
+          <DialogDescription>{t((m) => m.dialogs.invoices.recipeDialog.read.description)}</DialogDescription>
         </DialogHeader>
 
         <div className={styles["formBody"]}>
           {/* Add description field */}
           <div className={styles["fieldGroup"]}>
-            <Label htmlFor='description'>{t((m) => m["IMS--Dialogs"].recipeDialog.fields.description)}</Label>
-            <p className={styles["readText"]}>{recipe?.description || t((m) => m["IMS--Dialogs"].recipeDialog.read.noDescription)}</p>
+            <Label htmlFor='description'>{t((m) => m.dialogs.invoices.recipeDialog.fields.description)}</Label>
+            <p className={styles["readText"]}>{recipe?.description || t((m) => m.dialogs.invoices.recipeDialog.read.noDescription)}</p>
           </div>
 
           <div className={styles["fieldGroup"]}>
-            <Label>{t((m) => m["IMS--Dialogs"].recipeDialog.fields.ingredients)}</Label>
+            <Label>{t((m) => m.dialogs.invoices.recipeDialog.fields.ingredients)}</Label>
             <ul className={styles["ingredientReadList"]}>
               {recipe?.ingredients.map((ingredient, idx) => (
                 <li
@@ -426,7 +426,7 @@ const ReadDialog = ({recipe}: Readonly<{recipe: Recipe}>) => {
           </div>
 
           <div className={styles["fieldGroup"]}>
-            <Label htmlFor='complexity'>{t((m) => m["IMS--Dialogs"].recipeDialog.fields.complexity)}</Label>
+            <Label htmlFor='complexity'>{t((m) => m.dialogs.invoices.recipeDialog.fields.complexity)}</Label>
             <Badge
               variant={
                 recipe?.complexity === RecipeComplexity.Easy
@@ -435,24 +435,24 @@ const ReadDialog = ({recipe}: Readonly<{recipe: Recipe}>) => {
                     ? "secondary"
                     : "outline"
               }>
-              {recipe?.complexity || t((m) => m["IMS--Dialogs"].recipeDialog.difficulty.medium).toUpperCase()}
+              {recipe?.complexity || t((m) => m.dialogs.invoices.recipeDialog.difficulty.medium).toUpperCase()}
             </Badge>
           </div>
 
           <div className={styles["fieldGroup"]}>
-            <Label htmlFor='instructions'>{t((m) => m["IMS--Dialogs"].recipeDialog.fields.instructions)}</Label>
+            <Label htmlFor='instructions'>{t((m) => m.dialogs.invoices.recipeDialog.fields.instructions)}</Label>
 
             <div className={styles["timeGrid"]}>
-              <Label htmlFor='preparationTime'>{t((m) => m["IMS--Dialogs"].recipeDialog.fields.prepTime)}</Label>
+              <Label htmlFor='preparationTime'>{t((m) => m.dialogs.invoices.recipeDialog.fields.prepTime)}</Label>
               <TbClock className={styles["mutedIcon"]} />
-              <span>{recipe?.preparationTime || t((m) => m["IMS--Dialogs"].recipeDialog.read.notSpecified)}</span>
+              <span>{recipe?.preparationTime || t((m) => m.dialogs.invoices.recipeDialog.read.notSpecified)}</span>
             </div>
           </div>
 
           <div className={styles["fieldGroup"]}>
-            <Label htmlFor='cookingTime'>{t((m) => m["IMS--Dialogs"].recipeDialog.fields.cookTime)}</Label>
+            <Label htmlFor='cookingTime'>{t((m) => m.dialogs.invoices.recipeDialog.fields.cookTime)}</Label>
             <TbToolsKitchen3 className={styles["mutedIcon"]} />
-            <span>{recipe?.cookingTime || t((m) => m["IMS--Dialogs"].recipeDialog.read.notSpecified)}</span>
+            <span>{recipe?.cookingTime || t((m) => m.dialogs.invoices.recipeDialog.read.notSpecified)}</span>
           </div>
         </div>
 
@@ -460,7 +460,7 @@ const ReadDialog = ({recipe}: Readonly<{recipe: Recipe}>) => {
           <Button
             type='button'
             onClick={close}>
-            {t((m) => m["IMS--Dialogs"].recipeDialog.buttons.close)}
+            {t((m) => m.dialogs.invoices.recipeDialog.buttons.close)}
           </Button>
         </DialogFooter>
       </DialogContent>
@@ -518,14 +518,14 @@ const UpdateDialog = ({recipe}: Readonly<{recipe: Recipe}>) => {
       onOpenChange={handleOpenChange}>
       <DialogContent className={styles["dialogContentWide"]}>
         <DialogHeader>
-          <DialogTitle>{t((m) => m["IMS--Dialogs"].recipeDialog.update.title)}</DialogTitle>
-          <DialogDescription>{t((m) => m["IMS--Dialogs"].recipeDialog.update.description)}</DialogDescription>
+          <DialogTitle>{t((m) => m.dialogs.invoices.recipeDialog.update.title)}</DialogTitle>
+          <DialogDescription>{t((m) => m.dialogs.invoices.recipeDialog.update.description)}</DialogDescription>
         </DialogHeader>
 
         <form className={styles["formBody"]}>
           <div className={styles["fieldGroup"]}>
             <div className={styles["fieldHeader"]}>
-              <Label htmlFor='name'>{t((m) => m["IMS--Dialogs"].recipeDialog.fields.recipeName)}</Label>
+              <Label htmlFor='name'>{t((m) => m.dialogs.invoices.recipeDialog.fields.recipeName)}</Label>
               <div>
                 <TooltipProvider>
                   <Tooltip>
@@ -538,12 +538,12 @@ const UpdateDialog = ({recipe}: Readonly<{recipe: Recipe}>) => {
                           onClick={generateName}
                           className={styles["generateButton"]}>
                           <TbSparkles className={styles["sparklesIcon"]} />
-                          {t((m) => m["IMS--Dialogs"].recipeDialog.actions.generateName)}
+                          {t((m) => m.dialogs.invoices.recipeDialog.actions.generateName)}
                         </Button>
                       }
                     />
                     <TooltipContent>
-                      <p className={styles["tooltipText"]}>{t((m) => m["IMS--Dialogs"].recipeDialog.tooltips.generateName)}</p>
+                      <p className={styles["tooltipText"]}>{t((m) => m.dialogs.invoices.recipeDialog.tooltips.generateName)}</p>
                     </TooltipContent>
                   </Tooltip>
                 </TooltipProvider>
@@ -554,19 +554,19 @@ const UpdateDialog = ({recipe}: Readonly<{recipe: Recipe}>) => {
               name='name'
               value={recipeDetails.name}
               onChange={handleChange}
-              placeholder={t((m) => m["IMS--Dialogs"].recipeDialog.placeholders.recipeName)}
+              placeholder={t((m) => m.dialogs.invoices.recipeDialog.placeholders.recipeName)}
             />
           </div>
 
           {/* Add description field */}
           <div className={styles["fieldGroup"]}>
-            <Label htmlFor='description'>{t((m) => m["IMS--Dialogs"].recipeDialog.fields.description)}</Label>
+            <Label htmlFor='description'>{t((m) => m.dialogs.invoices.recipeDialog.fields.description)}</Label>
             <Textarea
               id='description'
               name='description'
               value={recipeDetails.description} // updated from formData to recipe
               onChange={handleChange}
-              placeholder={t((m) => m["IMS--Dialogs"].recipeDialog.placeholders.description)}
+              placeholder={t((m) => m.dialogs.invoices.recipeDialog.placeholders.description)}
               rows={2}
             />
           </div>
@@ -574,13 +574,13 @@ const UpdateDialog = ({recipe}: Readonly<{recipe: Recipe}>) => {
           {/* Add ingredients field */}
           <div className={styles["fieldGroup"]}>
             <div className={styles["fieldHeader"]}>
-              <Label>{t((m) => m["IMS--Dialogs"].recipeDialog.fields.ingredients)}</Label>
+              <Label>{t((m) => m.dialogs.invoices.recipeDialog.fields.ingredients)}</Label>
               <Button
                 type='button'
                 variant='outline'
                 size='sm'>
                 <TbPlus className={styles["addIcon"]} />
-                {t((m) => m["IMS--Dialogs"].recipeDialog.buttons.add)}
+                {t((m) => m.dialogs.invoices.recipeDialog.buttons.add)}
               </Button>
             </div>
 
@@ -611,17 +611,17 @@ const UpdateDialog = ({recipe}: Readonly<{recipe: Recipe}>) => {
 
           {/* Add difficulty selector */}
           <div className={styles["fieldGroup"]}>
-            <Label htmlFor='difficulty'>{t((m) => m["IMS--Dialogs"].recipeDialog.fields.difficulty)}</Label>
+            <Label htmlFor='difficulty'>{t((m) => m.dialogs.invoices.recipeDialog.fields.difficulty)}</Label>
             <Select
               value={formatEnum(RecipeComplexity, recipe.complexity) || "Unknown"}
               onValueChange={handleDifficultyChange}>
               <SelectTrigger>
-                <SelectValue placeholder={t((m) => m["IMS--Dialogs"].recipeDialog.placeholders.selectDifficulty)} />
+                <SelectValue placeholder={t((m) => m.dialogs.invoices.recipeDialog.placeholders.selectDifficulty)} />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value='EASY'>{t((m) => m["IMS--Dialogs"].recipeDialog.difficulty.easy)}</SelectItem>
-                <SelectItem value='MEDIUM'>{t((m) => m["IMS--Dialogs"].recipeDialog.difficulty.medium)}</SelectItem>
-                <SelectItem value='HARD'>{t((m) => m["IMS--Dialogs"].recipeDialog.difficulty.hard)}</SelectItem>
+                <SelectItem value='EASY'>{t((m) => m.dialogs.invoices.recipeDialog.difficulty.easy)}</SelectItem>
+                <SelectItem value='MEDIUM'>{t((m) => m.dialogs.invoices.recipeDialog.difficulty.medium)}</SelectItem>
+                <SelectItem value='HARD'>{t((m) => m.dialogs.invoices.recipeDialog.difficulty.hard)}</SelectItem>
               </SelectContent>
             </Select>
           </div>
@@ -629,7 +629,7 @@ const UpdateDialog = ({recipe}: Readonly<{recipe: Recipe}>) => {
           {/* Add instructions field */}
           <div className={styles["fieldGroup"]}>
             <div className={styles["fieldHeader"]}>
-              <Label htmlFor='instructions'>{t((m) => m["IMS--Dialogs"].recipeDialog.fields.instructions)}</Label>
+              <Label htmlFor='instructions'>{t((m) => m.dialogs.invoices.recipeDialog.fields.instructions)}</Label>
               <TooltipProvider>
                 <Tooltip>
                   <TooltipTrigger
@@ -640,12 +640,12 @@ const UpdateDialog = ({recipe}: Readonly<{recipe: Recipe}>) => {
                         size='sm'
                         onClick={enhanceInstructions}>
                         <TbWand className={styles["addIcon"]} />
-                        {t((m) => m["IMS--Dialogs"].recipeDialog.actions.enhanceInstructions)}
+                        {t((m) => m.dialogs.invoices.recipeDialog.actions.enhanceInstructions)}
                       </Button>
                     }
                   />
                   <TooltipContent>
-                    <p>{t((m) => m["IMS--Dialogs"].recipeDialog.tooltips.enhanceInstructions)}</p>
+                    <p>{t((m) => m.dialogs.invoices.recipeDialog.tooltips.enhanceInstructions)}</p>
                   </TooltipContent>
                 </Tooltip>
               </TooltipProvider>
@@ -655,7 +655,7 @@ const UpdateDialog = ({recipe}: Readonly<{recipe: Recipe}>) => {
               name='instructions'
               value={recipeDetails.instructions}
               onChange={handleChange}
-              placeholder={t((m) => m["IMS--Dialogs"].recipeDialog.placeholders.instructions)}
+              placeholder={t((m) => m.dialogs.invoices.recipeDialog.placeholders.instructions)}
               rows={4}
             />
           </div>
@@ -663,7 +663,7 @@ const UpdateDialog = ({recipe}: Readonly<{recipe: Recipe}>) => {
           {/* Add preparation time field */}
           <div className={styles["timeGrid"]}>
             <div className={styles["fieldGroup"]}>
-              <Label htmlFor='prepTime'>{t((m) => m["IMS--Dialogs"].recipeDialog.fields.prepTime)}</Label>
+              <Label htmlFor='prepTime'>{t((m) => m.dialogs.invoices.recipeDialog.fields.prepTime)}</Label>
               <div className={styles["timeRow"]}>
                 <TbClock className={styles["mutedIcon"]} />
                 <Input
@@ -671,14 +671,14 @@ const UpdateDialog = ({recipe}: Readonly<{recipe: Recipe}>) => {
                   name='prepTime'
                   value={recipeDetails.preparationTime}
                   onChange={handleChange}
-                  placeholder={t((m) => m["IMS--Dialogs"].recipeDialog.placeholders.prepTime)}
+                  placeholder={t((m) => m.dialogs.invoices.recipeDialog.placeholders.prepTime)}
                 />
               </div>
             </div>
 
             {/* Add cooking time field */}
             <div className={styles["fieldGroup"]}>
-              <Label htmlFor='cookTime'>{t((m) => m["IMS--Dialogs"].recipeDialog.fields.cookTime)}</Label>
+              <Label htmlFor='cookTime'>{t((m) => m.dialogs.invoices.recipeDialog.fields.cookTime)}</Label>
               <div className={styles["timeRow"]}>
                 <TbToolsKitchen className={styles["mutedIcon"]} />
                 <Input
@@ -686,7 +686,7 @@ const UpdateDialog = ({recipe}: Readonly<{recipe: Recipe}>) => {
                   name='cookTime'
                   value={recipeDetails.cookingTime}
                   onChange={handleChange}
-                  placeholder={t((m) => m["IMS--Dialogs"].recipeDialog.placeholders.cookTime)}
+                  placeholder={t((m) => m.dialogs.invoices.recipeDialog.placeholders.cookTime)}
                 />
               </div>
             </div>
@@ -699,13 +699,13 @@ const UpdateDialog = ({recipe}: Readonly<{recipe: Recipe}>) => {
               type='button'
               variant='outline'
               onClick={close}>
-              {t((m) => m["IMS--Dialogs"].recipeDialog.buttons.cancel)}
+              {t((m) => m.dialogs.invoices.recipeDialog.buttons.cancel)}
             </Button>
             <Button
               type='button'
               onClick={handleCreate}>
               <TbDisc className={styles["saveIcon"]} />
-              {t((m) => m["IMS--Dialogs"].recipeDialog.buttons.save)}
+              {t((m) => m.dialogs.invoices.recipeDialog.buttons.save)}
             </Button>
           </div>
         </DialogFooter>
@@ -737,15 +737,15 @@ const DeleteDialog = ({recipe}: Readonly<{recipe: Recipe}>) => {
       onOpenChange={handleOpenChange}>
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogTitle>{t((m) => m["IMS--Dialogs"].recipeDialog.delete.title)}</AlertDialogTitle>
-          <AlertDialogDescription>{t.rich((m) => m["IMS--Dialogs"].recipeDialog.delete.description, {name: recipe.name, strong: RichTextStrong})}</AlertDialogDescription>
+          <AlertDialogTitle>{t((m) => m.dialogs.invoices.recipeDialog.delete.title)}</AlertDialogTitle>
+          <AlertDialogDescription>{t.rich((m) => m.dialogs.invoices.recipeDialog.delete.description, {name: recipe.name, strong: RichTextStrong})}</AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <AlertDialogCancel>{t((m) => m["IMS--Dialogs"].recipeDialog.buttons.cancel)}</AlertDialogCancel>
+          <AlertDialogCancel>{t((m) => m.dialogs.invoices.recipeDialog.buttons.cancel)}</AlertDialogCancel>
           <AlertDialogAction
             onClick={handleDelete}
             className={styles["deleteAction"]}>
-            {t((m) => m["IMS--Dialogs"].recipeDialog.buttons.delete)}
+            {t((m) => m.dialogs.invoices.recipeDialog.buttons.delete)}
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/RemoveScanDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/dialogs/RemoveScanDialog.tsx
@@ -53,8 +53,8 @@ export default function RemoveScanDialog(): React.JSX.Element {
     if (!invoice || !scan) return;
 
     if (isLastScan) {
-      toast.error(t((m) => m["IMS--Dialogs"].removeScanDialog.toasts.cannotDeleteLastTitle), {
-        description: t((m) => m["IMS--Dialogs"].removeScanDialog.toasts.cannotDeleteLastDescription),
+      toast.error(t((m) => m.dialogs.invoices.removeScanDialog.toasts.cannotDeleteLastTitle), {
+        description: t((m) => m.dialogs.invoices.removeScanDialog.toasts.cannotDeleteLastDescription),
       });
       return;
     }
@@ -66,8 +66,8 @@ export default function RemoveScanDialog(): React.JSX.Element {
         scanLocation: scan.location,
       });
 
-      toast.success(t((m) => m["IMS--Dialogs"].removeScanDialog.toasts.removedTitle), {
-        description: t((m) => m["IMS--Dialogs"].removeScanDialog.toasts.removedDescription),
+      toast.success(t((m) => m.dialogs.invoices.removeScanDialog.toasts.removedTitle), {
+        description: t((m) => m.dialogs.invoices.removeScanDialog.toasts.removedDescription),
       });
 
       close();
@@ -75,9 +75,9 @@ export default function RemoveScanDialog(): React.JSX.Element {
       // Refresh the page to reflect the change
       router.refresh();
     } catch (error) {
-      console.error(t((m) => m["IMS--Dialogs"].removeScanDialog.console.deleteError), error);
-      toast.error(t((m) => m["IMS--Dialogs"].removeScanDialog.toasts.removeFailedTitle), {
-        description: error instanceof Error ? error.message : t((m) => m["IMS--Dialogs"].removeScanDialog.errors.unknown),
+      console.error(t((m) => m.dialogs.invoices.removeScanDialog.console.deleteError), error);
+      toast.error(t((m) => m.dialogs.invoices.removeScanDialog.toasts.removeFailedTitle), {
+        description: error instanceof Error ? error.message : t((m) => m.dialogs.invoices.removeScanDialog.errors.unknown),
       });
     } finally {
       setIsDeleting(false);
@@ -100,10 +100,10 @@ export default function RemoveScanDialog(): React.JSX.Element {
         <DialogHeader>
           <DialogTitle className={styles["dialogTitle"]}>
             <TbAlertTriangle className={styles["alertIcon"]} />
-            {t((m) => m["IMS--Dialogs"].removeScanDialog.title)}
+            {t((m) => m.dialogs.invoices.removeScanDialog.title)}
           </DialogTitle>
           <DialogDescription>
-            {isLastScan ? t((m) => m["IMS--Dialogs"].removeScanDialog.descriptionLastScan) : t((m) => m["IMS--Dialogs"].removeScanDialog.description, {current: String(currentScanNumber), total: String(totalScans)})}
+            {isLastScan ? t((m) => m.dialogs.invoices.removeScanDialog.descriptionLastScan) : t((m) => m.dialogs.invoices.removeScanDialog.description, {current: String(currentScanNumber), total: String(totalScans)})}
           </DialogDescription>
         </DialogHeader>
 
@@ -112,20 +112,20 @@ export default function RemoveScanDialog(): React.JSX.Element {
             <div className={styles["previewImage"]}>
               <Image
                 src={scan.location}
-                alt={t((m) => m["IMS--Dialogs"].removeScanDialog.scanAlt, {index: String(currentScanNumber)})}
+                alt={t((m) => m.dialogs.invoices.removeScanDialog.scanAlt, {index: String(currentScanNumber)})}
                 width={400}
                 height={300}
                 className={styles["scanPreviewImage"]}
               />
             </div>
-            <p className={styles["previewCaption"]}>{t((m) => m["IMS--Dialogs"].removeScanDialog.scanCaption, {index: String(currentScanNumber)})}</p>
+            <p className={styles["previewCaption"]}>{t((m) => m.dialogs.invoices.removeScanDialog.scanCaption, {index: String(currentScanNumber)})}</p>
           </div>
         ) : null}
 
         {isLastScan ? (
           <div className={styles["warningBox"]}>
-            <p className={styles["warningTitle"]}>{t((m) => m["IMS--Dialogs"].removeScanDialog.warning.title)}</p>
-            <p className={styles["warningText"]}>{t((m) => m["IMS--Dialogs"].removeScanDialog.warning.description)}</p>
+            <p className={styles["warningTitle"]}>{t((m) => m.dialogs.invoices.removeScanDialog.warning.title)}</p>
+            <p className={styles["warningText"]}>{t((m) => m.dialogs.invoices.removeScanDialog.warning.description)}</p>
           </div>
         ) : null}
 
@@ -135,7 +135,7 @@ export default function RemoveScanDialog(): React.JSX.Element {
             variant='outline'
             onClick={close}
             disabled={isDeleting}>
-            {t((m) => m["IMS--Dialogs"].removeScanDialog.buttons.cancel)}
+            {t((m) => m.dialogs.invoices.removeScanDialog.buttons.cancel)}
           </Button>
           <Button
             type='button'
@@ -145,12 +145,12 @@ export default function RemoveScanDialog(): React.JSX.Element {
             {isDeleting ? (
               <>
                 <TbLoader2 className={styles["spinnerIcon"]} />
-                {t((m) => m["IMS--Dialogs"].removeScanDialog.buttons.removing)}
+                {t((m) => m.dialogs.invoices.removeScanDialog.buttons.removing)}
               </>
             ) : (
               <>
                 <TbTrash className={styles["trashIcon"]} />
-                {t((m) => m["IMS--Dialogs"].removeScanDialog.buttons.remove)}
+                {t((m) => m.dialogs.invoices.removeScanDialog.buttons.remove)}
               </>
             )}
           </Button>

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/tables/ItemsTable.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/tables/ItemsTable.tsx
@@ -293,7 +293,7 @@ export default function ItemsTable({invoice}: Readonly<Props>) {
     });
 
     setEditingCell(null);
-    toast.success(t((m) => m["IMS--Edit"].itemsTable.editing.saved));
+    toast.success(t((m) => m.pages.invoices.editInvoice.itemsTable.editing.saved));
   }, [editingCell, editValues, sortedItems, t]);
 
   // Handle cancel edit (Escape)
@@ -348,14 +348,14 @@ export default function ItemsTable({invoice}: Readonly<Props>) {
 
     setSelectedIndices(new Set());
     setShowDeleteDialog(false);
-    toast.success(t((m) => m["IMS--Edit"].itemsTable.deleteConfirm.success, {count: itemsToDelete.length}));
+    toast.success(t((m) => m.pages.invoices.editInvoice.itemsTable.deleteConfirm.success, {count: itemsToDelete.length}));
   }, [selectedIndices, sortedItems, t]);
 
   // Handle add new item
   const handleAddItem = useCallback(() => {
     const uniqueSuffix = `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
     const newItem: Product = {
-      name: `${t((m) => m["IMS--Edit"].itemsTable.newItem.defaultName)}_${uniqueSuffix}`,
+      name: `${t((m) => m.pages.invoices.editInvoice.itemsTable.newItem.defaultName)}_${uniqueSuffix}`,
       category: ProductCategory.NOT_DEFINED,
       quantity: 1,
       quantityUnit: "pcs",
@@ -372,7 +372,7 @@ export default function ItemsTable({invoice}: Readonly<Props>) {
     };
 
     setLocalItems((prev) => [...prev, newItem]);
-    toast.success(t((m) => m["IMS--Edit"].itemsTable.newItem.added));
+    toast.success(t((m) => m.pages.invoices.editInvoice.itemsTable.newItem.added));
   }, [t]);
 
   /**
@@ -405,13 +405,13 @@ export default function ItemsTable({invoice}: Readonly<Props>) {
 
         if (result.success) {
           setLocalItems(updatedItems);
-          toast.success(t((m) => m["IMS--Edit"].itemsTable.softDelete.success, {name: product.name}));
+          toast.success(t((m) => m.pages.invoices.editInvoice.itemsTable.softDelete.success, {name: product.name}));
         } else {
-          toast.error(t((m) => m["IMS--Edit"].itemsTable.softDelete.error));
+          toast.error(t((m) => m.pages.invoices.editInvoice.itemsTable.softDelete.error));
         }
       } catch (error) {
         console.error("Failed to soft-delete product:", error);
-        toast.error(t((m) => m["IMS--Edit"].itemsTable.softDelete.error));
+        toast.error(t((m) => m.pages.invoices.editInvoice.itemsTable.softDelete.error));
       } finally {
         setIsSaving(false);
       }
@@ -449,13 +449,13 @@ export default function ItemsTable({invoice}: Readonly<Props>) {
 
         if (result.success) {
           setLocalItems(updatedItems);
-          toast.success(t((m) => m["IMS--Edit"].itemsTable.restore.success, {name: product.name}));
+          toast.success(t((m) => m.pages.invoices.editInvoice.itemsTable.restore.success, {name: product.name}));
         } else {
-          toast.error(t((m) => m["IMS--Edit"].itemsTable.restore.error));
+          toast.error(t((m) => m.pages.invoices.editInvoice.itemsTable.restore.error));
         }
       } catch (error) {
         console.error("Failed to restore product:", error);
-        toast.error(t((m) => m["IMS--Edit"].itemsTable.restore.error));
+        toast.error(t((m) => m.pages.invoices.editInvoice.itemsTable.restore.error));
       } finally {
         setIsSaving(false);
       }
@@ -485,7 +485,7 @@ export default function ItemsTable({invoice}: Readonly<Props>) {
    */
   const handleBulkCategoryChange = useCallback(() => {
     if (selectedIndices.size === 0) {
-      toast.warning(t((m) => m["IMS--Edit"].itemsTable.bulkCategory.noSelection));
+      toast.warning(t((m) => m.pages.invoices.editInvoice.itemsTable.bulkCategory.noSelection));
       return;
     }
 
@@ -587,7 +587,7 @@ export default function ItemsTable({invoice}: Readonly<Props>) {
   return (
     <div>
       <div className={styles["headerRow"]}>
-        <h3 className={styles["itemsLabel"]}>{t((m) => m["IMS--Edit"].itemsTable.title)}</h3>
+        <h3 className={styles["itemsLabel"]}>{t((m) => m.pages.invoices.editInvoice.itemsTable.title)}</h3>
         <div className={styles["headerActions"]}>
           <TooltipProvider>
             <Tooltip>
@@ -599,12 +599,12 @@ export default function ItemsTable({invoice}: Readonly<Props>) {
                     onClick={open}
                     className={styles["editButton"]}>
                     <TbEdit className={styles["editIcon"]} />
-                    {t((m) => m["IMS--Edit"].itemsTable.buttons.editItems)}
+                    {t((m) => m.pages.invoices.editInvoice.itemsTable.buttons.editItems)}
                   </Button>
                 }
               />
               <TooltipContent>
-                <p>{t((m) => m["IMS--Edit"].itemsTable.tooltips.editInvoiceItemsAndQuantities)}</p>
+                <p>{t((m) => m.pages.invoices.editInvoice.itemsTable.tooltips.editInvoiceItemsAndQuantities)}</p>
               </TooltipContent>
             </Tooltip>
           </TooltipProvider>
@@ -617,7 +617,7 @@ export default function ItemsTable({invoice}: Readonly<Props>) {
           <TbSearch className={styles["searchIcon"]} />
           <Input
             type='text'
-            placeholder={t((m) => m["IMS--Edit"].itemsTable.search.placeholder)}
+            placeholder={t((m) => m.pages.invoices.editInvoice.itemsTable.search.placeholder)}
             value={searchQuery}
             onChange={handleSearchChange}
             className={styles["searchInput"]}
@@ -625,14 +625,14 @@ export default function ItemsTable({invoice}: Readonly<Props>) {
         </div>
         {selectedIndices.size > 0 && (
           <div className={styles["bulkToolbar"]}>
-            <span className={styles["bulkToolbarText"]}>{t((m) => m["IMS--Edit"].itemsTable.bulkToolbar.selectedCount, {count: selectedIndices.size})}</span>
+            <span className={styles["bulkToolbarText"]}>{t((m) => m.pages.invoices.editInvoice.itemsTable.bulkToolbar.selectedCount, {count: selectedIndices.size})}</span>
             <Button
               variant='outline'
               size='sm'
               onClick={handleBulkCategoryChange}
               className={styles["categoryButton"]}>
               <TbTag className={styles["categoryIcon"]} />
-              {t((m) => m["IMS--Edit"].itemsTable.bulkToolbar.changeCategory)}
+              {t((m) => m.pages.invoices.editInvoice.itemsTable.bulkToolbar.changeCategory)}
             </Button>
             <Button
               variant='destructive'
@@ -640,7 +640,7 @@ export default function ItemsTable({invoice}: Readonly<Props>) {
               onClick={handleShowDeleteDialog}
               className={styles["deleteButton"]}>
               <TbTrash className={styles["deleteIcon"]} />
-              {t((m) => m["IMS--Edit"].itemsTable.bulkToolbar.deleteSelected)}
+              {t((m) => m.pages.invoices.editInvoice.itemsTable.bulkToolbar.deleteSelected)}
             </Button>
           </div>
         )}
@@ -655,30 +655,30 @@ export default function ItemsTable({invoice}: Readonly<Props>) {
                   nativeButton
                   checked={selectedIndices.size === sortedItems.length && sortedItems.length > 0}
                   onCheckedChange={handleSelectAll}
-                  aria-label={t((m) => m["IMS--Edit"].itemsTable.columns.selectAll)}
+                  aria-label={t((m) => m.pages.invoices.editInvoice.itemsTable.columns.selectAll)}
                   className={styles["selectCheckbox"]}
                 />
               </TableHead>
               <TableHead
                 className={styles["tableHeaderSortable"]}
                 onClick={handleSortByName}>
-                {t((m) => m["IMS--Edit"].itemsTable.columns.name)}
+                {t((m) => m.pages.invoices.editInvoice.itemsTable.columns.name)}
                 {sortField === "name" && <span className={styles["sortIndicator"]}>{sortDirection === "asc" ? " ▲" : " ▼"}</span>}
               </TableHead>
               <TableHead
                 className={styles["tableHeaderRightSortable"]}
                 onClick={handleSortByQuantity}>
-                {t((m) => m["IMS--Edit"].itemsTable.columns.quantity)}
+                {t((m) => m.pages.invoices.editInvoice.itemsTable.columns.quantity)}
                 {sortField === "quantity" ? <span className={styles["sortIndicator"]}>{sortDirection === "asc" ? " ▲" : " ▼"}</span> : null}
               </TableHead>
               <TableHead
                 className={styles["tableHeaderRightSortable"]}
                 onClick={handleSortByPrice}>
-                {t((m) => m["IMS--Edit"].itemsTable.columns.price)}
+                {t((m) => m.pages.invoices.editInvoice.itemsTable.columns.price)}
                 {sortField === "price" ? <span className={styles["sortIndicator"]}>{sortDirection === "asc" ? " ▲" : " ▼"}</span> : null}
               </TableHead>
-              <TableHead className={styles["tableHeaderRight"]}>{t((m) => m["IMS--Edit"].itemsTable.columns.total)}</TableHead>
-              <TableHead className={styles["tableHeaderCenter"]}>{t((m) => m["IMS--Edit"].itemsTable.columns.actions)}</TableHead>
+              <TableHead className={styles["tableHeaderRight"]}>{t((m) => m.pages.invoices.editInvoice.itemsTable.columns.total)}</TableHead>
+              <TableHead className={styles["tableHeaderCenter"]}>{t((m) => m.pages.invoices.editInvoice.itemsTable.columns.actions)}</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody className={styles["tableBody"]}>
@@ -714,7 +714,7 @@ export default function ItemsTable({invoice}: Readonly<Props>) {
                       nativeButton
                       checked={isSelected}
                       onCheckedChange={onSelectRow}
-                      aria-label={t((m) => m["IMS--Edit"].itemsTable.columns.selectRow, {name: item.name})}
+                      aria-label={t((m) => m.pages.invoices.editInvoice.itemsTable.columns.selectRow, {name: item.name})}
                       className={styles["selectCheckbox"]}
                       disabled={isSoftDeleted}
                     />
@@ -731,7 +731,7 @@ export default function ItemsTable({invoice}: Readonly<Props>) {
                           onChange={createEditChangeHandler(index, "name")}
                           onBlur={handleSaveEdit}
                           onKeyDown={handleEditKeyDown}
-                          aria-label={t((m) => m["IMS--Edit"].itemsTable.editing.fieldLabel, {field: t((m) => m["IMS--Edit"].itemsTable.columns.name), name: item.name})}
+                          aria-label={t((m) => m.pages.invoices.editInvoice.itemsTable.editing.fieldLabel, {field: t((m) => m.pages.invoices.editInvoice.itemsTable.columns.name), name: item.name})}
                           className={styles["editInput"]}
                         />
                       ) : (
@@ -746,12 +746,12 @@ export default function ItemsTable({invoice}: Readonly<Props>) {
                                       variant='outline'
                                       className={styles["editedBadge"]}>
                                       <TbPencil className={styles["editedIcon"]} />
-                                      {t((m) => m["IMS--Edit"].itemsTable.indicators.edited)}
+                                      {t((m) => m.pages.invoices.editInvoice.itemsTable.indicators.edited)}
                                     </Badge>
                                   }
                                 />
                                 <TooltipContent>
-                                  <p>{t((m) => m["IMS--Edit"].itemsTable.indicators.editedTooltip)}</p>
+                                  <p>{t((m) => m.pages.invoices.editInvoice.itemsTable.indicators.editedTooltip)}</p>
                                 </TooltipContent>
                               </Tooltip>
                             </TooltipProvider>
@@ -765,7 +765,7 @@ export default function ItemsTable({invoice}: Readonly<Props>) {
                                       variant='secondary'
                                       className={styles["allergenBadge"]}>
                                       <TbFlask className={styles["allergenIcon"]} />
-                                      {t((m) => m["IMS--Edit"].itemsTable.indicators.allergens, {count: item.detectedAllergens.length})}
+                                      {t((m) => m.pages.invoices.editInvoice.itemsTable.indicators.allergens, {count: item.detectedAllergens.length})}
                                     </Badge>
                                   }
                                 />
@@ -790,7 +790,7 @@ export default function ItemsTable({invoice}: Readonly<Props>) {
                         onChange={createEditChangeHandler(index, "quantity")}
                         onBlur={handleSaveEdit}
                         onKeyDown={handleEditKeyDown}
-                        aria-label={t((m) => m["IMS--Edit"].itemsTable.editing.fieldLabel, {field: t((m) => m["IMS--Edit"].itemsTable.columns.quantity), name: item.name})}
+                        aria-label={t((m) => m.pages.invoices.editInvoice.itemsTable.editing.fieldLabel, {field: t((m) => m.pages.invoices.editInvoice.itemsTable.columns.quantity), name: item.name})}
                         className={styles["editInput"]}
                       />
                     ) : (
@@ -809,7 +809,7 @@ export default function ItemsTable({invoice}: Readonly<Props>) {
                         onChange={(e) => handleEditChange(index, "price", e.target.value)}
                         onBlur={handleSaveEdit}
                         onKeyDown={handleEditKeyDown}
-                        aria-label={t((m) => m["IMS--Edit"].itemsTable.editing.fieldLabel, {field: t((m) => m["IMS--Edit"].itemsTable.columns.price), name: item.name})}
+                        aria-label={t((m) => m.pages.invoices.editInvoice.itemsTable.editing.fieldLabel, {field: t((m) => m.pages.invoices.editInvoice.itemsTable.columns.price), name: item.name})}
                         className={styles["editInput"]}
                       />
                     ) : (
@@ -837,7 +837,7 @@ export default function ItemsTable({invoice}: Readonly<Props>) {
                               }
                             />
                             <TooltipContent>
-                              <p>{t((m) => m["IMS--Edit"].itemsTable.actions.restore)}</p>
+                              <p>{t((m) => m.pages.invoices.editInvoice.itemsTable.actions.restore)}</p>
                             </TooltipContent>
                           </Tooltip>
                         </TooltipProvider>
@@ -858,7 +858,7 @@ export default function ItemsTable({invoice}: Readonly<Props>) {
                                 }
                               />
                               <TooltipContent>
-                                <p>{t((m) => m["IMS--Edit"].itemsTable.actions.editAllergens)}</p>
+                                <p>{t((m) => m.pages.invoices.editInvoice.itemsTable.actions.editAllergens)}</p>
                               </TooltipContent>
                             </Tooltip>
                           </TooltipProvider>
@@ -877,7 +877,7 @@ export default function ItemsTable({invoice}: Readonly<Props>) {
                                 }
                               />
                               <TooltipContent>
-                                <p>{t((m) => m["IMS--Edit"].itemsTable.actions.remove)}</p>
+                                <p>{t((m) => m.pages.invoices.editInvoice.itemsTable.actions.remove)}</p>
                               </TooltipContent>
                             </Tooltip>
                           </TooltipProvider>
@@ -910,7 +910,7 @@ export default function ItemsTable({invoice}: Readonly<Props>) {
               <TableHead
                 colSpan={3}
                 className={styles["footerLabel"]}>
-                {t((m) => m["IMS--Edit"].itemsTable.footer.total)}
+                {t((m) => m.pages.invoices.editInvoice.itemsTable.footer.total)}
               </TableHead>
               <TableHead className={styles["footerLabel"]}>
                 {formatCurrency(totalAmount, {currencyCode: invoice.paymentInformation.currency.code, locale})}
@@ -928,31 +928,31 @@ export default function ItemsTable({invoice}: Readonly<Props>) {
             onClick={handleAddItem}
             className={styles["addItemButton"]}>
             <TbPlus className={styles["addItemIcon"]} />
-            {t((m) => m["IMS--Edit"].itemsTable.buttons.addItem)}
+            {t((m) => m.pages.invoices.editInvoice.itemsTable.buttons.addItem)}
           </Button>
         </div>
 
         {/* Pagination controls - only show when more than one page */}
         {totalPages > 1 && (
           <div className={styles["paginationBar"]}>
-            <div className={styles["paginationInfo"]}>{t((m) => m["IMS--Edit"].itemsTable.pagination.totalItems, {count: sortedItems.length})}</div>
+            <div className={styles["paginationInfo"]}>{t((m) => m.pages.invoices.editInvoice.itemsTable.pagination.totalItems, {count: sortedItems.length})}</div>
             <div className={styles["paginationControls"]}>
               <Button
                 variant='outline'
                 className={styles["cursorPointer"]}
                 size='sm'
                 onClick={handlePreviousPage}>
-                {t((m) => m["IMS--Edit"].itemsTable.pagination.previous)}
+                {t((m) => m.pages.invoices.editInvoice.itemsTable.pagination.previous)}
               </Button>
               <span className={styles["paginationText"]}>
-                {t((m) => m["IMS--Edit"].itemsTable.pagination.pageOf, {currentPage: String(currentPage), totalPages: String(totalPages)})}
+                {t((m) => m.pages.invoices.editInvoice.itemsTable.pagination.pageOf, {currentPage: String(currentPage), totalPages: String(totalPages)})}
               </span>
               <Button
                 variant='outline'
                 className={styles["cursorPointer"]}
                 size='sm'
                 onClick={handleNextPage}>
-                {t((m) => m["IMS--Edit"].itemsTable.pagination.next)}
+                {t((m) => m.pages.invoices.editInvoice.itemsTable.pagination.next)}
               </Button>
             </div>
           </div>
@@ -965,12 +965,12 @@ export default function ItemsTable({invoice}: Readonly<Props>) {
         onOpenChange={setShowDeleteDialog}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>{t((m) => m["IMS--Edit"].itemsTable.deleteConfirm.title)}</AlertDialogTitle>
-            <AlertDialogDescription>{t((m) => m["IMS--Edit"].itemsTable.deleteConfirm.description, {count: selectedIndices.size})}</AlertDialogDescription>
+            <AlertDialogTitle>{t((m) => m.pages.invoices.editInvoice.itemsTable.deleteConfirm.title)}</AlertDialogTitle>
+            <AlertDialogDescription>{t((m) => m.pages.invoices.editInvoice.itemsTable.deleteConfirm.description, {count: selectedIndices.size})}</AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>{t((m) => m["IMS--Edit"].itemsTable.deleteConfirm.cancel)}</AlertDialogCancel>
-            <AlertDialogAction onClick={handleDeleteSelected}>{t((m) => m["IMS--Edit"].itemsTable.deleteConfirm.confirm)}</AlertDialogAction>
+            <AlertDialogCancel>{t((m) => m.pages.invoices.editInvoice.itemsTable.deleteConfirm.cancel)}</AlertDialogCancel>
+            <AlertDialogAction onClick={handleDeleteSelected}>{t((m) => m.pages.invoices.editInvoice.itemsTable.deleteConfirm.confirm)}</AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/tabs/MetadataTab.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/tabs/MetadataTab.tsx
@@ -77,8 +77,8 @@ export default function MetadataTab({metadata}: Readonly<Props>): React.JSX.Elem
       <Card className={styles["card"]}>
         <CardHeader className={styles["cardHeader"]}>
           <div>
-            <CardTitle>{t((m) => m["IMS--Edit"].metadataTab.header.title)}</CardTitle>
-            <CardDescription>{t((m) => m["IMS--Edit"].metadataTab.header.description)}</CardDescription>
+            <CardTitle>{t((m) => m.pages.invoices.editInvoice.metadataTab.header.title)}</CardTitle>
+            <CardDescription>{t((m) => m.pages.invoices.editInvoice.metadataTab.header.description)}</CardDescription>
           </div>
           <TooltipProvider>
             <Tooltip>
@@ -89,12 +89,12 @@ export default function MetadataTab({metadata}: Readonly<Props>): React.JSX.Elem
                     onClick={openAddDialog}
                     size='sm'>
                     <TbPlus className={styles["buttonIcon"]} />
-                    {t((m) => m["IMS--Edit"].metadataTab.buttons.addField)}
+                    {t((m) => m.pages.invoices.editInvoice.metadataTab.buttons.addField)}
                   </Button>
                 }
               />
               <TooltipContent>
-                <p>{t((m) => m["IMS--Edit"].metadataTab.tooltips.addCustomMetadata)}</p>
+                <p>{t((m) => m.pages.invoices.editInvoice.metadataTab.tooltips.addCustomMetadata)}</p>
               </TooltipContent>
             </Tooltip>
           </TooltipProvider>
@@ -115,7 +115,7 @@ export default function MetadataTab({metadata}: Readonly<Props>): React.JSX.Elem
                     <Badge
                       variant='outline'
                       className={styles["readonlyBadge"]}>
-                      {t((m) => m["IMS--Edit"].metadataTab.badges.readonly)}
+                      {t((m) => m.pages.invoices.editInvoice.metadataTab.badges.readonly)}
                     </Badge>
                   </div>
                   <span className={styles["fieldValue"]}>{String(value)}</span>
@@ -137,14 +137,14 @@ export default function MetadataTab({metadata}: Readonly<Props>): React.JSX.Elem
                           onClick={openEditDialog}
                           disabled>
                           <TbEdit className={styles["menuIcon"]} />
-                          {t((m) => m["IMS--Edit"].metadataTab.dropdown.edit)}
+                          {t((m) => m.pages.invoices.editInvoice.metadataTab.dropdown.edit)}
                         </DropdownMenuItem>
                         <DropdownMenuItem
                           onClick={openDeleteDialog}
                           className={styles["deleteMenuItem"]}
                           disabled>
                           <TbTrash className={styles["menuIcon"]} />
-                          {t((m) => m["IMS--Edit"].metadataTab.dropdown.delete)}
+                          {t((m) => m.pages.invoices.editInvoice.metadataTab.dropdown.delete)}
                         </DropdownMenuItem>
                       </DropdownMenuContent>
                     </DropdownMenu>
@@ -154,12 +154,12 @@ export default function MetadataTab({metadata}: Readonly<Props>): React.JSX.Elem
             </div>
           ) : (
             <div className={styles["emptyState"]}>
-              <p className={styles["emptyText"]}>{t((m) => m["IMS--Edit"].metadataTab.emptyState.noMetadataFields)}</p>
+              <p className={styles["emptyText"]}>{t((m) => m.pages.invoices.editInvoice.metadataTab.emptyState.noMetadataFields)}</p>
               <Button
                 onClick={openAddDialog}
                 variant='outline'>
                 <TbPlus className={styles["buttonIcon"]} />
-                {t((m) => m["IMS--Edit"].metadataTab.buttons.addFirstMetadataField)}
+                {t((m) => m.pages.invoices.editInvoice.metadataTab.buttons.addFirstMetadataField)}
               </Button>
             </div>
           )}

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/tabs/RecipesTab.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_components/tabs/RecipesTab.tsx
@@ -83,8 +83,8 @@ export default function RecipesTab({recipes}: Readonly<Props>): React.JSX.Elemen
 
   const handleGenerateRecipe = useCallback(() => {
     // TODO: Implement AI recipe generation
-    toast(t((m) => m["IMS--Edit"].recipesTab.toasts.aiGenerationComingSoon.title), {
-      description: t((m) => m["IMS--Edit"].recipesTab.toasts.aiGenerationComingSoon.description),
+    toast(t((m) => m.pages.invoices.editInvoice.recipesTab.toasts.aiGenerationComingSoon.title), {
+      description: t((m) => m.pages.invoices.editInvoice.recipesTab.toasts.aiGenerationComingSoon.description),
     });
   }, [t]);
 
@@ -101,8 +101,8 @@ export default function RecipesTab({recipes}: Readonly<Props>): React.JSX.Elemen
       <Card className={styles["card"]}>
         <CardHeader className={styles["cardHeader"]}>
           <div>
-            <CardTitle>{t((m) => m["IMS--Edit"].recipesTab.header.title)}</CardTitle>
-            <CardDescription>{t((m) => m["IMS--Edit"].recipesTab.header.description)}</CardDescription>
+            <CardTitle>{t((m) => m.pages.invoices.editInvoice.recipesTab.header.title)}</CardTitle>
+            <CardDescription>{t((m) => m.pages.invoices.editInvoice.recipesTab.header.description)}</CardDescription>
           </div>
           <TooltipProvider>
             <div className={styles["headerActions"]}>
@@ -115,12 +115,12 @@ export default function RecipesTab({recipes}: Readonly<Props>): React.JSX.Elemen
                       onClick={handleGenerateRecipe}
                       size='sm'>
                       <TbConfetti className={styles["buttonIcon"]} />
-                      {t((m) => m["IMS--Edit"].recipesTab.buttons.generate)}
+                      {t((m) => m.pages.invoices.editInvoice.recipesTab.buttons.generate)}
                     </Button>
                   }
                 />
                 <TooltipContent side='bottom'>
-                  <p>{t((m) => m["IMS--Edit"].recipesTab.tooltips.generateRecipeUsingAi)}</p>
+                  <p>{t((m) => m.pages.invoices.editInvoice.recipesTab.tooltips.generateRecipeUsingAi)}</p>
                 </TooltipContent>
               </Tooltip>
               <Tooltip>
@@ -131,12 +131,12 @@ export default function RecipesTab({recipes}: Readonly<Props>): React.JSX.Elemen
                       onClick={openAddDialog}
                       size='sm'>
                       <TbPlus className={styles["buttonIcon"]} />
-                      {t((m) => m["IMS--Edit"].recipesTab.buttons.addRecipe)}
+                      {t((m) => m.pages.invoices.editInvoice.recipesTab.buttons.addRecipe)}
                     </Button>
                   }
                 />
                 <TooltipContent>
-                  <p>{t((m) => m["IMS--Edit"].recipesTab.tooltips.createRecipeWithIngredients)}</p>
+                  <p>{t((m) => m.pages.invoices.editInvoice.recipesTab.tooltips.createRecipeWithIngredients)}</p>
                 </TooltipContent>
               </Tooltip>
             </div>
@@ -154,13 +154,13 @@ export default function RecipesTab({recipes}: Readonly<Props>): React.JSX.Elemen
             </div>
           ) : (
             <div className={styles["emptyState"]}>
-              <p className={styles["emptyText"]}>{t((m) => m["IMS--Edit"].recipesTab.emptyState.noRecipesAvailable)}</p>
+              <p className={styles["emptyText"]}>{t((m) => m.pages.invoices.editInvoice.recipesTab.emptyState.noRecipesAvailable)}</p>
               <Button
                 onClick={handleCreateFirstRecipe}
                 variant='outline'
                 className={styles["createButton"]}>
                 <TbPlus className={styles["buttonIcon"]} />
-                {t((m) => m["IMS--Edit"].recipesTab.buttons.createFirstRecipe)}
+                {t((m) => m.pages.invoices.editInvoice.recipesTab.buttons.createFirstRecipe)}
               </Button>
             </div>
           )}
@@ -171,17 +171,17 @@ export default function RecipesTab({recipes}: Readonly<Props>): React.JSX.Elemen
                 size='sm'
                 onClick={handlePreviousPage}
                 disabled={currentPage === 1}>
-                {t((m) => m["IMS--Edit"].recipesTab.pagination.previous)}
+                {t((m) => m.pages.invoices.editInvoice.recipesTab.pagination.previous)}
               </Button>
               <div className={styles["pageInfo"]}>
-                {t((m) => m["IMS--Edit"].recipesTab.pagination.pageOf, {currentPage: String(currentPage), totalPages: String(totalPages)})}
+                {t((m) => m.pages.invoices.editInvoice.recipesTab.pagination.pageOf, {currentPage: String(currentPage), totalPages: String(totalPages)})}
               </div>
               <Button
                 variant='ghost'
                 size='sm'
                 onClick={handleNextPage}
                 disabled={currentPage === totalPages}>
-                {t((m) => m["IMS--Edit"].recipesTab.pagination.next)}
+                {t((m) => m.pages.invoices.editInvoice.recipesTab.pagination.next)}
               </Button>
             </div>
           )}

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_context/EditInvoiceContext.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/_context/EditInvoiceContext.tsx
@@ -158,7 +158,7 @@ export function EditInvoiceContextProvider({invoice, merchant, children}: Readon
 
   const saveChanges = useCallback(async (): Promise<boolean> => {
     if (!hasChanges) {
-      toast.info(t((m) => m["IMS--Edit"].editInvoiceContext.toasts.noChanges));
+      toast.info(t((m) => m.pages.invoices.editInvoice.editInvoiceContext.toasts.noChanges));
       return true;
     }
 
@@ -201,18 +201,18 @@ export function EditInvoiceContextProvider({invoice, merchant, children}: Readon
       });
 
       if (result.success) {
-        toast.success(t((m) => m["IMS--Edit"].editInvoiceContext.toasts.updated));
+        toast.success(t((m) => m.pages.invoices.editInvoice.editInvoiceContext.toasts.updated));
         setPendingChanges({});
         // Trigger a page refresh to get the updated data
         globalThis.window.location.reload();
         return true;
       } else {
-        toast.error(t((m) => m["IMS--Edit"].editInvoiceContext.toasts.saveFailed));
+        toast.error(t((m) => m.pages.invoices.editInvoice.editInvoiceContext.toasts.saveFailed));
         return false;
       }
     } catch (error) {
-      console.error(t((m) => m["IMS--Edit"].editInvoiceContext.console.saveFailed), error);
-      toast.error(t((m) => m["IMS--Edit"].editInvoiceContext.toasts.saveFailed));
+      console.error(t((m) => m.pages.invoices.editInvoice.editInvoiceContext.console.saveFailed), error);
+      toast.error(t((m) => m.pages.invoices.editInvoice.editInvoiceContext.toasts.saveFailed));
       return false;
     } finally {
       setIsSaving(false);

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/not-found.test.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/not-found.test.tsx
@@ -5,13 +5,13 @@ import InvoiceNotFound from "./not-found";
 describe("edit-invoice/[id]/not-found.tsx", () => {
   it("renders the invoice-scoped not-found message", () => {
     render(<InvoiceNotFound />);
-    expect(screen.getByText("Errors.notFound.title")).toBeInTheDocument();
-    expect(screen.getByText("Errors.notFound.subtitle")).toBeInTheDocument();
+    expect(screen.getByText("app.errors.notFound.title")).toBeInTheDocument();
+    expect(screen.getByText("app.errors.notFound.subtitle")).toBeInTheDocument();
   });
 
   it("links back to the invoices listing", () => {
     render(<InvoiceNotFound />);
-    const link = screen.getByRole("link", {name: "Errors.notFound.buttons.returnButton"});
+    const link = screen.getByRole("link", {name: "app.errors.notFound.buttons.returnButton"});
     expect(link).toHaveAttribute("href", "/domains/invoices/view-invoices");
   });
 });

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/not-found.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/not-found.tsx
@@ -7,9 +7,9 @@ export default function InvoiceNotFound(): React.JSX.Element {
   const t = useTranslations();
   return (
     <section data-scope='edit-invoice'>
-      <h1>{t((m) => m.Errors.notFound.title)}</h1>
-      <p>{t((m) => m.Errors.notFound.subtitle)}</p>
-      <Link href='/domains/invoices/view-invoices'>{t((m) => m.Errors.notFound.buttons.returnButton)}</Link>
+      <h1>{t((m) => m.app.errors.notFound.title)}</h1>
+      <p>{t((m) => m.app.errors.notFound.subtitle)}</p>
+      <Link href='/domains/invoices/view-invoices'>{t((m) => m.app.errors.notFound.buttons.returnButton)}</Link>
     </section>
   );
 }

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/page.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/page.tsx
@@ -62,8 +62,8 @@ export async function generateMetadata(): Promise<Metadata> {
   const locale = await getLocale();
   return createMetadata({
     locale,
-    title: t((m) => m["IMS--Edit"].metadata.title),
-    description: t((m) => m["IMS--Edit"].metadata.description),
+    title: t((m) => m.pages.invoices.editInvoice.metadata.title),
+    description: t((m) => m.pages.invoices.editInvoice.metadata.description),
   });
 }
 

--- a/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/page.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/edit-invoice/[id]/page.tsx
@@ -19,7 +19,7 @@ import styles from "./page.module.scss";
  * **Execution Context**: Server-side metadata generation function (Next.js App Router).
  *
  * **Internationalization**: Retrieves localized title and description from the
- * translation key `IMS--Edit.metadata`. Falls back
+ * translation key `pages.invoices.editInvoice.metadata`. Falls back
  * to sensible defaults if translation keys are not yet defined.
  *
  * **SEO Optimization**: Uses the centralized `createMetadata` utility following RFC 1004

--- a/sites/arolariu.ro/src/app/domains/invoices/page.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/page.tsx
@@ -39,8 +39,8 @@ export async function generateMetadata(): Promise<Metadata> {
   const locale = await getLocale();
   return createMetadata({
     locale,
-    title: t((m) => m["IMS--Landing"].metadata.title),
-    description: t((m) => m["IMS--Landing"].metadata.description),
+    title: t((m) => m.pages.invoices.landing.metadata.title),
+    description: t((m) => m.pages.invoices.landing.metadata.description),
   });
 }
 

--- a/sites/arolariu.ro/src/app/domains/invoices/upload-scans/_components/PostUploadPrompt.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/upload-scans/_components/PostUploadPrompt.tsx
@@ -112,7 +112,7 @@ export default function PostUploadPrompt({
                   type='button'
                   onClick={onDismiss}
                   className={styles["dismissButton"]}
-                  aria-label={t((m) => m["IMS--UploadScans"].postUpload.dismiss)}>
+                  aria-label={t((m) => m.pages.invoices.uploadScans.postUpload.dismiss)}>
                   <TbX className={styles["dismissIcon"]} />
                 </button>
 
@@ -125,7 +125,7 @@ export default function PostUploadPrompt({
                     transition={{delay: 0.1, type: "spring", stiffness: 200, damping: 15}}>
                     <TbCheck className={styles["checkmarkIcon"]} />
                   </motion.div>
-                  <h2 className={styles["title"]}>{t((m) => m["IMS--UploadScans"].postUpload.title)}</h2>
+                  <h2 className={styles["title"]}>{t((m) => m.pages.invoices.uploadScans.postUpload.title)}</h2>
                 </div>
 
                 {/* Thumbnail preview row */}
@@ -164,7 +164,7 @@ export default function PostUploadPrompt({
                   initial={{opacity: 0}}
                   animate={{opacity: 1}}
                   transition={{delay: 0.4}}>
-                  {t((m) => m["IMS--UploadScans"].postUpload.subtitle, {count: completedScans.length})}
+                  {t((m) => m.pages.invoices.uploadScans.postUpload.subtitle, {count: completedScans.length})}
                 </motion.p>
 
                 {/* Action buttons */}
@@ -177,7 +177,7 @@ export default function PostUploadPrompt({
                     onClick={onCreateInvoice}
                     className={styles["primaryButton"]}
                     size='lg'>
-                    {t((m) => m["IMS--UploadScans"].postUpload.createInvoice)}
+                    {t((m) => m.pages.invoices.uploadScans.postUpload.createInvoice)}
                     <TbArrowRight className={styles["buttonIcon"]} />
                   </Button>
                   <Button
@@ -186,7 +186,7 @@ export default function PostUploadPrompt({
                     className={styles["secondaryButton"]}
                     size='lg'>
                     <TbEye className={styles["buttonIcon"]} />
-                    {t((m) => m["IMS--UploadScans"].postUpload.viewScans)}
+                    {t((m) => m.pages.invoices.uploadScans.postUpload.viewScans)}
                   </Button>
                 </motion.div>
               </CardContent>

--- a/sites/arolariu.ro/src/app/domains/invoices/upload-scans/_components/UploadArea.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/upload-scans/_components/UploadArea.tsx
@@ -228,7 +228,7 @@ export default function UploadArea(): React.JSX.Element {
           multiple
           onChange={handleFileChange}
           className={styles["hiddenInput"]}
-          aria-label={t((m) => m["IMS--UploadScans"].uploadArea.aria.uploadFiles)}
+          aria-label={t((m) => m.pages.invoices.uploadScans.uploadArea.aria.uploadFiles)}
         />
         <button
           type='button'
@@ -245,14 +245,14 @@ export default function UploadArea(): React.JSX.Element {
             <motion.div className={styles["iconCircle"]}>
               <TbUpload className={styles["iconCircleIcon"]} />
             </motion.div>
-            <h3 className={styles["dropzoneTitle"]}>{t((m) => m["IMS--UploadScans"].uploadArea.empty.title)}</h3>
+            <h3 className={styles["dropzoneTitle"]}>{t((m) => m.pages.invoices.uploadScans.uploadArea.empty.title)}</h3>
             <p className={styles["dropzoneSubtitle"]}>
-              {isDragActive ? t((m) => m["IMS--UploadScans"].uploadArea.empty.dropActive) : t((m) => m["IMS--UploadScans"].uploadArea.empty.dropInactive)}
+              {isDragActive ? t((m) => m.pages.invoices.uploadScans.uploadArea.empty.dropActive) : t((m) => m.pages.invoices.uploadScans.uploadArea.empty.dropInactive)}
             </p>
-            <p className={styles["dropzoneFormats"]}>{t((m) => m["IMS--UploadScans"].uploadArea.empty.formats)}</p>
-            <p className={styles["dropzoneNote"]}>{t((m) => m["IMS--UploadScans"].uploadArea.empty.note)}</p>
-            <p className={styles["dropzoneNote"]}>{t((m) => m["IMS--UploadScans"].uploadArea.empty.pasteHint)}</p>
-            <span className={styles["chooseFilesButton"]}>{t((m) => m["IMS--UploadScans"].uploadArea.empty.chooseFiles)}</span>
+            <p className={styles["dropzoneFormats"]}>{t((m) => m.pages.invoices.uploadScans.uploadArea.empty.formats)}</p>
+            <p className={styles["dropzoneNote"]}>{t((m) => m.pages.invoices.uploadScans.uploadArea.empty.note)}</p>
+            <p className={styles["dropzoneNote"]}>{t((m) => m.pages.invoices.uploadScans.uploadArea.empty.pasteHint)}</p>
+            <span className={styles["chooseFilesButton"]}>{t((m) => m.pages.invoices.uploadScans.uploadArea.empty.chooseFiles)}</span>
           </motion.div>
           {isDragActive && dragCount > 0 ? (
             <Badge
@@ -295,7 +295,7 @@ export default function UploadArea(): React.JSX.Element {
         multiple
         onChange={handleFileChange}
         className={styles["hiddenInput"]}
-        aria-label={t((m) => m["IMS--UploadScans"].uploadArea.aria.uploadFiles)}
+        aria-label={t((m) => m.pages.invoices.uploadScans.uploadArea.aria.uploadFiles)}
       />
       <button
         type='button'
@@ -312,9 +312,9 @@ export default function UploadArea(): React.JSX.Element {
           </div>
           <div className={styles["compactTextBlock"]}>
             <p className={styles["compactTitle"]}>
-              {isDragActive ? t((m) => m["IMS--UploadScans"].uploadArea.compact.dropActive) : t((m) => m["IMS--UploadScans"].uploadArea.compact.dropInactive)}
+              {isDragActive ? t((m) => m.pages.invoices.uploadScans.uploadArea.compact.dropActive) : t((m) => m.pages.invoices.uploadScans.uploadArea.compact.dropInactive)}
             </p>
-            <p className={styles["compactSubtitle"]}>{t((m) => m["IMS--UploadScans"].uploadArea.compact.subtitle)}</p>
+            <p className={styles["compactSubtitle"]}>{t((m) => m.pages.invoices.uploadScans.uploadArea.compact.subtitle)}</p>
           </div>
         </div>
       </button>
@@ -330,11 +330,11 @@ export default function UploadArea(): React.JSX.Element {
                   className={styles["clearButton"]}
                   type='button'
                   disabled={isUploading}>
-                  {t((m) => m["IMS--UploadScans"].uploadArea.actions.clearAll)}
+                  {t((m) => m.pages.invoices.uploadScans.uploadArea.actions.clearAll)}
                 </Button>
               }
             />
-            <TooltipContent>{t((m) => m["IMS--UploadScans"].uploadArea.tooltips.clearAll)}</TooltipContent>
+            <TooltipContent>{t((m) => m.pages.invoices.uploadScans.uploadArea.tooltips.clearAll)}</TooltipContent>
           </Tooltip>
         </TooltipProvider>
         <TooltipProvider>
@@ -346,11 +346,11 @@ export default function UploadArea(): React.JSX.Element {
                   className={styles["uploadButton"]}
                   type='button'
                   disabled={isUploading}>
-                  {isUploading ? t((m) => m["IMS--UploadScans"].uploadArea.actions.uploading) : t((m) => m["IMS--UploadScans"].uploadArea.actions.uploadScans)}
+                  {isUploading ? t((m) => m.pages.invoices.uploadScans.uploadArea.actions.uploading) : t((m) => m.pages.invoices.uploadScans.uploadArea.actions.uploadScans)}
                 </Button>
               }
             />
-            <TooltipContent>{t((m) => m["IMS--UploadScans"].uploadArea.tooltips.uploadScans)}</TooltipContent>
+            <TooltipContent>{t((m) => m.pages.invoices.uploadScans.uploadArea.tooltips.uploadScans)}</TooltipContent>
           </Tooltip>
         </TooltipProvider>
       </div>

--- a/sites/arolariu.ro/src/app/domains/invoices/upload-scans/_components/UploadPreview.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/upload-scans/_components/UploadPreview.tsx
@@ -117,11 +117,11 @@ function UploadCard({
                       <Badge
                         variant='secondary'
                         className={styles["badgePending"]}>
-                        {t((m) => m["IMS--UploadScans"].preview.status.pending)}
+                        {t((m) => m.pages.invoices.uploadScans.preview.status.pending)}
                       </Badge>
                     }
                   />
-                  <TooltipContent side='top'>{t((m) => m["IMS--UploadScans"].preview.pendingTooltip)}</TooltipContent>
+                  <TooltipContent side='top'>{t((m) => m.pages.invoices.uploadScans.preview.pendingTooltip)}</TooltipContent>
                 </Tooltip>
               </TooltipProvider>
             )}
@@ -129,28 +129,28 @@ function UploadCard({
               <Badge
                 variant='secondary'
                 className={styles["badgeUploading"]}>
-                {t((m) => m["IMS--UploadScans"].preview.status.uploading)}
+                {t((m) => m.pages.invoices.uploadScans.preview.status.uploading)}
               </Badge>
             )}
             {status === "retrying" && (
               <Badge
                 variant='secondary'
                 className={styles["badgeRetrying"]}>
-                {t((m) => m["IMS--UploadScans"].preview.status.retrying)}
+                {t((m) => m.pages.invoices.uploadScans.preview.status.retrying)}
               </Badge>
             )}
             {status === "completed" && (
               <Badge
                 variant='secondary'
                 className={styles["badgeCompleted"]}>
-                {t((m) => m["IMS--UploadScans"].preview.status.completed)}
+                {t((m) => m.pages.invoices.uploadScans.preview.status.completed)}
               </Badge>
             )}
             {status === "failed" && (
               <Badge
                 variant='secondary'
                 className={styles["badgeFailed"]}>
-                {t((m) => m["IMS--UploadScans"].preview.status.failed)}
+                {t((m) => m.pages.invoices.uploadScans.preview.status.failed)}
               </Badge>
             )}
           </div>
@@ -170,7 +170,7 @@ function UploadCard({
                     </Button>
                   }
                 />
-                <TooltipContent side='right'>{t((m) => m["IMS--UploadScans"].preview.removeTooltip)}</TooltipContent>
+                <TooltipContent side='right'>{t((m) => m.pages.invoices.uploadScans.preview.removeTooltip)}</TooltipContent>
               </Tooltip>
             </TooltipProvider>
           )}
@@ -195,7 +195,7 @@ function UploadCard({
               <p className={styles["fileSize"]}>{progress}%</p>
             </>
           )}
-          {status === "retrying" ? <p className={styles["fileError"]}>{t((m) => m["IMS--UploadScans"].preview.retryAttempt, {attempt: String(attempts)})}</p> : null}
+          {status === "retrying" ? <p className={styles["fileError"]}>{t((m) => m.pages.invoices.uploadScans.preview.retryAttempt, {attempt: String(attempts)})}</p> : null}
           {error ? <p className={styles["fileError"]}>{error}</p> : null}
         </div>
       </CardContent>
@@ -259,7 +259,7 @@ export default function UploadPreview(): React.JSX.Element | null {
   return (
     <div className={styles["container"]}>
       <div className={styles["header"]}>
-        <h2 className={styles["title"]}>{t((m) => m["IMS--UploadScans"].preview.title, {count: String(pendingUploads.length)})}</h2>
+        <h2 className={styles["title"]}>{t((m) => m.pages.invoices.uploadScans.preview.title, {count: String(pendingUploads.length)})}</h2>
       </div>
 
       <StaggerContainer
@@ -291,10 +291,10 @@ export default function UploadPreview(): React.JSX.Element | null {
             onClick={handlePreviousPage}
             disabled={page === 0}>
             <TbChevronLeft />
-            {t((m) => m["IMS--UploadScans"].preview.pagination.previous)}
+            {t((m) => m.pages.invoices.uploadScans.preview.pagination.previous)}
           </Button>
           <span className={styles["paginationInfo"]}>
-            {t((m) => m["IMS--UploadScans"].preview.pagination.pageInfo, {
+            {t((m) => m.pages.invoices.uploadScans.preview.pagination.pageInfo, {
               current: String(page + 1),
               total: String(totalPages),
               count: String(pendingUploads.length),
@@ -305,7 +305,7 @@ export default function UploadPreview(): React.JSX.Element | null {
             size='sm'
             onClick={handleNextPage}
             disabled={page >= totalPages - 1}>
-            {t((m) => m["IMS--UploadScans"].preview.pagination.next)}
+            {t((m) => m.pages.invoices.uploadScans.preview.pagination.next)}
             <TbChevronRight />
           </Button>
         </div>

--- a/sites/arolariu.ro/src/app/domains/invoices/upload-scans/island.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/upload-scans/island.tsx
@@ -137,7 +137,7 @@ function UploadContent(): React.JSX.Element {
           href='/domains/invoices'
           className={styles["breadcrumbLink"]}>
           <TbArrowLeft className={styles["breadcrumbIcon"]} />
-          {t((m) => m["IMS--UploadScans"].breadcrumb)}
+          {t((m) => m.pages.invoices.uploadScans.breadcrumb)}
         </Link>
       </div>
 
@@ -150,7 +150,7 @@ function UploadContent(): React.JSX.Element {
           <div className={styles["headerLeft"]}>
             <div>
               <div className={styles["titleRow"]}>
-                <h1 className={styles["headerTitle"]}>{t((m) => m["IMS--UploadScans"].header.title)}</h1>
+                <h1 className={styles["headerTitle"]}>{t((m) => m.pages.invoices.uploadScans.header.title)}</h1>
                 <TooltipProvider>
                   <Tooltip>
                     <TooltipTrigger
@@ -166,12 +166,12 @@ function UploadContent(): React.JSX.Element {
                     <TooltipContent
                       side='right'
                       className={styles["tooltipContent"]}>
-                      <p>{t((m) => m["IMS--UploadScans"].header.tooltip)}</p>
+                      <p>{t((m) => m.pages.invoices.uploadScans.header.tooltip)}</p>
                     </TooltipContent>
                   </Tooltip>
                 </TooltipProvider>
               </div>
-              <p className={styles["headerDescription"]}>{t((m) => m["IMS--UploadScans"].header.description)}</p>
+              <p className={styles["headerDescription"]}>{t((m) => m.pages.invoices.uploadScans.header.description)}</p>
             </div>
           </div>
 
@@ -186,14 +186,14 @@ function UploadContent(): React.JSX.Element {
                       render={
                         <Link href='/domains/invoices/view-scans'>
                           <TbEye className={styles["actionIcon"]} />
-                          <span className={styles["hiddenMobile"]}>{t((m) => m["IMS--UploadScans"].buttons.viewScans)}</span>
-                          <span className={styles["visibleMobile"]}>{t((m) => m["IMS--UploadScans"].buttons.viewScans).split(" ")[0]}</span>
+                          <span className={styles["hiddenMobile"]}>{t((m) => m.pages.invoices.uploadScans.buttons.viewScans)}</span>
+                          <span className={styles["visibleMobile"]}>{t((m) => m.pages.invoices.uploadScans.buttons.viewScans).split(" ")[0]}</span>
                         </Link>
                       }
                     />
                   }
                 />
-                <TooltipContent>{t((m) => m["IMS--UploadScans"].buttons.viewScans)}</TooltipContent>
+                <TooltipContent>{t((m) => m.pages.invoices.uploadScans.buttons.viewScans)}</TooltipContent>
               </Tooltip>
             </TooltipProvider>
 
@@ -207,14 +207,14 @@ function UploadContent(): React.JSX.Element {
                       render={
                         <Link href='/domains/invoices/view-invoices'>
                           <TbFileInvoice className={styles["actionIcon"]} />
-                          <span className={styles["hiddenMobile"]}>{t((m) => m["IMS--UploadScans"].buttons.myInvoices)}</span>
-                          <span className={styles["visibleMobile"]}>{t((m) => m["IMS--UploadScans"].buttons.myInvoices).split(" ")[0]}</span>
+                          <span className={styles["hiddenMobile"]}>{t((m) => m.pages.invoices.uploadScans.buttons.myInvoices)}</span>
+                          <span className={styles["visibleMobile"]}>{t((m) => m.pages.invoices.uploadScans.buttons.myInvoices).split(" ")[0]}</span>
                         </Link>
                       }
                     />
                   }
                 />
-                <TooltipContent>{t((m) => m["IMS--UploadScans"].buttons.myInvoices)}</TooltipContent>
+                <TooltipContent>{t((m) => m.pages.invoices.uploadScans.buttons.myInvoices)}</TooltipContent>
               </Tooltip>
             </TooltipProvider>
           </div>
@@ -234,33 +234,33 @@ function UploadContent(): React.JSX.Element {
           {/* Supported Formats */}
           <Card>
             <CardContent className={styles["sidebarCardContent"]}>
-              <h3 className={styles["sidebarTitle"]}>{t((m) => m["IMS--UploadScans"].sidebar.formats.title)}</h3>
+              <h3 className={styles["sidebarTitle"]}>{t((m) => m.pages.invoices.uploadScans.sidebar.formats.title)}</h3>
               <div className={styles["formatsList"]}>
                 <FileTypeCard
                   icon={<TbPhoto className={styles["fileTypeIconAccent"]} />}
-                  label={t((m) => m["IMS--UploadScans"].sidebar.formats.images)}
-                  extensions={t((m) => m["IMS--UploadScans"].sidebar.formats.imageExtensions)}
+                  label={t((m) => m.pages.invoices.uploadScans.sidebar.formats.images)}
+                  extensions={t((m) => m.pages.invoices.uploadScans.sidebar.formats.imageExtensions)}
                 />
                 <FileTypeCard
                   icon={<TbFileTypePdf className={styles["fileTypeIconRed"]} />}
-                  label={t((m) => m["IMS--UploadScans"].sidebar.formats.documents)}
-                  extensions={t((m) => m["IMS--UploadScans"].sidebar.formats.documentExtensions)}
+                  label={t((m) => m.pages.invoices.uploadScans.sidebar.formats.documents)}
+                  extensions={t((m) => m.pages.invoices.uploadScans.sidebar.formats.documentExtensions)}
                 />
               </div>
-              <p className={styles["maxSizeNote"]}>{t((m) => m["IMS--UploadScans"].sidebar.formats.maxSize)}</p>
+              <p className={styles["maxSizeNote"]}>{t((m) => m.pages.invoices.uploadScans.sidebar.formats.maxSize)}</p>
             </CardContent>
           </Card>
 
           {/* Tips */}
           <Card>
             <CardContent className={styles["sidebarCardContent"]}>
-              <h3 className={styles["sidebarTitle"]}>{t((m) => m["IMS--UploadScans"].sidebar.tips.title)}</h3>
+              <h3 className={styles["sidebarTitle"]}>{t((m) => m.pages.invoices.uploadScans.sidebar.tips.title)}</h3>
               <ul className={styles["tipsList"]}>
-                <TipItem>{t((m) => m["IMS--UploadScans"].sidebar.tips.tip1)}</TipItem>
-                <TipItem>{t((m) => m["IMS--UploadScans"].sidebar.tips.tip2)}</TipItem>
-                <TipItem>{t((m) => m["IMS--UploadScans"].sidebar.tips.tip3)}</TipItem>
-                <TipItem>{t((m) => m["IMS--UploadScans"].sidebar.tips.tip4)}</TipItem>
-                <TipItem>{t((m) => m["IMS--UploadScans"].sidebar.tips.tip5)}</TipItem>
+                <TipItem>{t((m) => m.pages.invoices.uploadScans.sidebar.tips.tip1)}</TipItem>
+                <TipItem>{t((m) => m.pages.invoices.uploadScans.sidebar.tips.tip2)}</TipItem>
+                <TipItem>{t((m) => m.pages.invoices.uploadScans.sidebar.tips.tip3)}</TipItem>
+                <TipItem>{t((m) => m.pages.invoices.uploadScans.sidebar.tips.tip4)}</TipItem>
+                <TipItem>{t((m) => m.pages.invoices.uploadScans.sidebar.tips.tip5)}</TipItem>
               </ul>
             </CardContent>
           </Card>
@@ -271,8 +271,8 @@ function UploadContent(): React.JSX.Element {
               <div className={styles["securityContent"]}>
                 <TbShieldCheck className={styles["securityIcon"]} />
                 <div>
-                  <h3 className={styles["securityTitle"]}>{t((m) => m["IMS--UploadScans"].sidebar.security.title)}</h3>
-                  <p className={styles["securityDescription"]}>{t((m) => m["IMS--UploadScans"].sidebar.security.description)}</p>
+                  <h3 className={styles["securityTitle"]}>{t((m) => m.pages.invoices.uploadScans.sidebar.security.title)}</h3>
+                  <p className={styles["securityDescription"]}>{t((m) => m.pages.invoices.uploadScans.sidebar.security.description)}</p>
                 </div>
               </div>
             </CardContent>
@@ -286,14 +286,14 @@ function UploadContent(): React.JSX.Element {
               transition={{delay: 0.3}}>
               <Card className={styles["nextStepsCard"]}>
                 <CardContent className={styles["sidebarCardContent"]}>
-                  <h3 className={styles["nextStepsTitle"]}>{t((m) => m["IMS--UploadScans"].sidebar.nextSteps.title)}</h3>
-                  <p className={styles["nextStepsDescription"]}>{t((m) => m["IMS--UploadScans"].sidebar.nextSteps.description)}</p>
+                  <h3 className={styles["nextStepsTitle"]}>{t((m) => m.pages.invoices.uploadScans.sidebar.nextSteps.title)}</h3>
+                  <p className={styles["nextStepsDescription"]}>{t((m) => m.pages.invoices.uploadScans.sidebar.nextSteps.description)}</p>
                   <Button
                     size='sm'
                     className={styles["nextStepsButton"]}
                     render={
                       <Link href='/domains/invoices/view-scans'>
-                        {t((m) => m["IMS--UploadScans"].sidebar.nextSteps.button)}
+                        {t((m) => m.pages.invoices.uploadScans.sidebar.nextSteps.button)}
                         <TbArrowRight className={styles["arrowIcon"]} />
                       </Link>
                     }

--- a/sites/arolariu.ro/src/app/domains/invoices/upload-scans/page.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/upload-scans/page.tsx
@@ -15,8 +15,8 @@ export async function generateMetadata(): Promise<Metadata> {
   const locale = await getLocale();
   return createMetadata({
     locale,
-    title: t((m) => m["IMS--UploadScans"].metadata.title),
-    description: t((m) => m["IMS--UploadScans"].metadata.description),
+    title: t((m) => m.pages.invoices.uploadScans.metadata.title),
+    description: t((m) => m.pages.invoices.uploadScans.metadata.description),
   });
 }
 

--- a/sites/arolariu.ro/src/app/domains/invoices/upload-scans/page.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/upload-scans/page.tsx
@@ -7,9 +7,7 @@ import {redirect} from "next/navigation";
 import RenderUploadScansScreen from "./island";
 import styles from "./page.module.scss";
 
-/**
- * Generates SEO metadata for the scan upload page.
- */
+/** Generates SEO metadata for the scan upload page. */
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations();
   const locale = await getLocale();

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/InvoiceAnalytics.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/InvoiceAnalytics.tsx
@@ -61,21 +61,21 @@ export function InvoiceAnalytics(): React.JSX.Element {
         <div className={styles["tabHeader"]}>
           <div className={styles["sectionTitle"]}>
             <TbChartBar className={styles["sectionIcon"]} />
-            <h2 className={styles["sectionTitleText"]}>{t((m) => m["IMS--View"].invoiceAnalytics.title)}</h2>
+            <h2 className={styles["sectionTitleText"]}>{t((m) => m.pages.invoices.viewInvoice.invoiceAnalytics.title)}</h2>
           </div>
           <TabsList className={styles["tabsList"]}>
             <TabsTrigger
               value='current'
               className={styles["tabsTrigger"]}>
               <TbChartBar className={styles["tabIcon"]} />
-              {t((m) => m["IMS--View"].invoiceAnalytics.tabs.current)}
+              {t((m) => m.pages.invoices.viewInvoice.invoiceAnalytics.tabs.current)}
             </TabsTrigger>
             {Boolean(isOwner) && (
               <TabsTrigger
                 value='compare'
                 className={styles["tabsTrigger"]}>
                 <TbTrendingUp className={styles["tabIcon"]} />
-                {t((m) => m["IMS--View"].invoiceAnalytics.tabs.compare)}
+                {t((m) => m.pages.invoices.viewInvoice.invoiceAnalytics.tabs.compare)}
               </TabsTrigger>
             )}
           </TabsList>
@@ -163,8 +163,8 @@ export function InvoiceAnalytics(): React.JSX.Element {
             ) : (
               <div className={styles["emptyState"]}>
                 <TbTrendingUp className={styles["emptyIcon"]} />
-                <h3 className={styles["emptyTitle"]}>{t((m) => m["IMS--View"].invoiceAnalytics.emptyState.title)}</h3>
-                <p className={styles["emptyDescription"]}>{t((m) => m["IMS--View"].invoiceAnalytics.emptyState.description)}</p>
+                <h3 className={styles["emptyTitle"]}>{t((m) => m.pages.invoices.viewInvoice.invoiceAnalytics.emptyState.title)}</h3>
+                <p className={styles["emptyDescription"]}>{t((m) => m.pages.invoices.viewInvoice.invoiceAnalytics.emptyState.description)}</p>
               </div>
             )}
           </TabsContent>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/InvoiceHeader.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/InvoiceHeader.tsx
@@ -30,12 +30,12 @@ export function InvoiceHeader(): React.JSX.Element {
               <Tooltip>
                 <TooltipTrigger render={<TbHeart className={styles["heartIcon"]} />} />
                 <TooltipContent>
-                  <p>{t((m) => m["IMS--Common"].invoiceHeader.tooltips.importantInvoice)}</p>
+                  <p>{t((m) => m.shared.invoices.invoiceHeader.tooltips.importantInvoice)}</p>
                 </TooltipContent>
               </Tooltip>
             )}
           </div>
-          <p className={styles["invoiceId"]}>{t((m) => m["IMS--Common"].invoiceHeader.id, {id: invoice.id})}</p>
+          <p className={styles["invoiceId"]}>{t((m) => m.shared.invoices.invoiceHeader.id, {id: invoice.id})}</p>
         </div>
         <div className={styles["actions"]}>
           {Boolean(isOwner) && (
@@ -48,13 +48,13 @@ export function InvoiceHeader(): React.JSX.Element {
                       className={styles["editLink"]}>
                       <Button>
                         <TbPencil className={styles["buttonIcon"]} />
-                        {t((m) => m["IMS--Common"].invoiceHeader.buttons.edit)}
+                        {t((m) => m.shared.invoices.invoiceHeader.buttons.edit)}
                       </Button>
                     </Link>
                   }
                 />
                 <TooltipContent>
-                  <p>{t((m) => m["IMS--Common"].invoiceHeader.tooltips.edit)}</p>
+                  <p>{t((m) => m.shared.invoices.invoiceHeader.tooltips.edit)}</p>
                 </TooltipContent>
               </Tooltip>
               <Tooltip>
@@ -64,12 +64,12 @@ export function InvoiceHeader(): React.JSX.Element {
                       variant='destructive'
                       onClick={openDeleteDialog}>
                       <TbTrash className={styles["buttonIcon"]} />
-                      {t((m) => m["IMS--Common"].invoiceHeader.buttons.delete)}
+                      {t((m) => m.shared.invoices.invoiceHeader.buttons.delete)}
                     </Button>
                   }
                 />
                 <TooltipContent>
-                  <p>{t((m) => m["IMS--Common"].invoiceHeader.tooltips.delete)}</p>
+                  <p>{t((m) => m.shared.invoices.invoiceHeader.tooltips.delete)}</p>
                 </TooltipContent>
               </Tooltip>
             </>
@@ -79,12 +79,12 @@ export function InvoiceHeader(): React.JSX.Element {
               render={
                 <Button variant='outline'>
                   <TbPrinter className={styles["buttonIcon"]} />
-                  {t((m) => m["IMS--Common"].invoiceHeader.buttons.print)}
+                  {t((m) => m.shared.invoices.invoiceHeader.buttons.print)}
                 </Button>
               }
             />
             <TooltipContent>
-              <p>{t((m) => m["IMS--Common"].invoiceHeader.tooltips.print)}</p>
+              <p>{t((m) => m.shared.invoices.invoiceHeader.tooltips.print)}</p>
             </TooltipContent>
           </Tooltip>
           <Tooltip>
@@ -94,12 +94,12 @@ export function InvoiceHeader(): React.JSX.Element {
                   variant='outline'
                   onClick={openExportDialog}>
                   <TbDownload className={styles["buttonIcon"]} />
-                  {t((m) => m["IMS--Common"].invoiceHeader.buttons.export)}
+                  {t((m) => m.shared.invoices.invoiceHeader.buttons.export)}
                 </Button>
               }
             />
             <TooltipContent>
-              <p>{t((m) => m["IMS--Common"].invoiceHeader.tooltips.export)}</p>
+              <p>{t((m) => m.shared.invoices.invoiceHeader.tooltips.export)}</p>
             </TooltipContent>
           </Tooltip>
         </div>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/PrintHeader.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/PrintHeader.tsx
@@ -55,28 +55,28 @@ export function PrintHeader(props: Readonly<PrintHeaderProps>): React.JSX.Elemen
         {/* Invoice Details Grid */}
         <div className={styles["detailsGrid"]}>
           <div className={styles["detailItem"]}>
-            <span className={styles["detailLabel"]}>{t((m) => m["IMS--View"].print.labels.date)}:</span>
+            <span className={styles["detailLabel"]}>{t((m) => m.pages.invoices.viewInvoice.print.labels.date)}:</span>
             <span className={styles["detailValue"]}>{invoiceDate}</span>
           </div>
 
           <div className={styles["detailItem"]}>
-            <span className={styles["detailLabel"]}>{t((m) => m["IMS--View"].print.labels.merchant)}:</span>
+            <span className={styles["detailLabel"]}>{t((m) => m.pages.invoices.viewInvoice.print.labels.merchant)}:</span>
             <span className={styles["detailValue"]}>{merchant?.name ?? ""}</span>
           </div>
 
           <div className={styles["detailItem"]}>
-            <span className={styles["detailLabel"]}>{t((m) => m["IMS--View"].print.labels.total)}:</span>
+            <span className={styles["detailLabel"]}>{t((m) => m.pages.invoices.viewInvoice.print.labels.total)}:</span>
             <span className={styles["detailValue"]}>{formattedTotal}</span>
           </div>
 
           <div className={styles["detailItem"]}>
-            <span className={styles["detailLabel"]}>{t((m) => m["IMS--View"].print.labels.items)}:</span>
+            <span className={styles["detailLabel"]}>{t((m) => m.pages.invoices.viewInvoice.print.labels.items)}:</span>
             <span className={styles["detailValue"]}>{invoice.items.length}</span>
           </div>
         </div>
 
         {/* Generated Timestamp */}
-        <div className={styles["generatedOn"]}>{t((m) => m["IMS--View"].print.generatedOn, {date: printDate})}</div>
+        <div className={styles["generatedOn"]}>{t((m) => m.pages.invoices.viewInvoice.print.generatedOn, {date: printDate})}</div>
       </div>
 
       {/* Bottom Border */}

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/banners/InvoiceGuestBanner.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/banners/InvoiceGuestBanner.tsx
@@ -12,8 +12,8 @@ export function InvoiceGuestBanner(): React.JSX.Element {
       variant='default'
       className={styles["alert"]}>
       <TbInfoCircle className={styles["infoIcon"]} />
-      <AlertTitle className={styles["alertTitle"]}>{t((m) => m["IMS--View"].invoiceGuestBanner.title)}</AlertTitle>
-      <AlertDescription className={styles["alertDescription"]}>{t((m) => m["IMS--View"].invoiceGuestBanner.description)}</AlertDescription>
+      <AlertTitle className={styles["alertTitle"]}>{t((m) => m.pages.invoices.viewInvoice.invoiceGuestBanner.title)}</AlertTitle>
+      <AlertDescription className={styles["alertDescription"]}>{t((m) => m.pages.invoices.viewInvoice.invoiceGuestBanner.description)}</AlertDescription>
     </Alert>
   );
 }

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/AnalysisPanel.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/AnalysisPanel.tsx
@@ -91,20 +91,20 @@ export function AnalysisPanel(): React.JSX.Element {
   const analysisOptions: readonly AnalysisOption[] = [
     {
       id: InvoiceAnalysisOptions.CompleteAnalysis,
-      label: t((m) => m["IMS--View"].analysisPanel.options.completeAnalysis),
-      description: t((m) => m["IMS--View"].analysisPanel.tooltips.completeAnalysis),
+      label: t((m) => m.pages.invoices.viewInvoice.analysisPanel.options.completeAnalysis),
+      description: t((m) => m.pages.invoices.viewInvoice.analysisPanel.tooltips.completeAnalysis),
       icon: <TbBrain className={styles["optionIcon"]} />,
     },
     {
       id: InvoiceAnalysisOptions.InvoiceOnly,
-      label: t((m) => m["IMS--View"].analysisPanel.options.invoiceOnly),
-      description: t((m) => m["IMS--View"].analysisPanel.tooltips.invoiceOnly),
+      label: t((m) => m.pages.invoices.viewInvoice.analysisPanel.options.invoiceOnly),
+      description: t((m) => m.pages.invoices.viewInvoice.analysisPanel.tooltips.invoiceOnly),
       icon: <TbRefreshAlert className={styles["optionIcon"]} />,
     },
     {
       id: InvoiceAnalysisOptions.InvoiceItemsOnly,
-      label: t((m) => m["IMS--View"].analysisPanel.options.itemsOnly),
-      description: t((m) => m["IMS--View"].analysisPanel.tooltips.itemsOnly),
+      label: t((m) => m.pages.invoices.viewInvoice.analysisPanel.options.itemsOnly),
+      description: t((m) => m.pages.invoices.viewInvoice.analysisPanel.tooltips.itemsOnly),
       icon: <TbShoppingCart className={styles["optionIcon"]} />,
     },
   ];
@@ -125,7 +125,7 @@ export function AnalysisPanel(): React.JSX.Element {
           setTimeout(resolve, ms);
         });
 
-      const steps = [t((m) => m["IMS--View"].analysisPanel.steps.preparing), t((m) => m["IMS--View"].analysisPanel.steps.extracting), t((m) => m["IMS--View"].analysisPanel.steps.analyzing), t((m) => m["IMS--View"].analysisPanel.steps.processing), t((m) => m["IMS--View"].analysisPanel.steps.finalizing)];
+      const steps = [t((m) => m.pages.invoices.viewInvoice.analysisPanel.steps.preparing), t((m) => m.pages.invoices.viewInvoice.analysisPanel.steps.extracting), t((m) => m.pages.invoices.viewInvoice.analysisPanel.steps.analyzing), t((m) => m.pages.invoices.viewInvoice.analysisPanel.steps.processing), t((m) => m.pages.invoices.viewInvoice.analysisPanel.steps.finalizing)];
 
       try {
         // Start analysis
@@ -146,7 +146,7 @@ export function AnalysisPanel(): React.JSX.Element {
             const settled = await Promise.race([analysisSettledPromise, delay(0).then(() => false)]);
             if (settled) return;
 
-            setCurrentStep(steps[i] ?? t((m) => m["IMS--View"].analysisPanel.steps.processing));
+            setCurrentStep(steps[i] ?? t((m) => m.pages.invoices.viewInvoice.analysisPanel.steps.processing));
             setProgress(((i + 1) / steps.length) * 95);
 
             const doneAfterDelay = await Promise.race([analysisSettledPromise, delay(stepDelayMs).then(() => false)]);
@@ -162,11 +162,11 @@ export function AnalysisPanel(): React.JSX.Element {
           throw new Error(result.error.message || "Analysis failed");
         }
 
-        setCurrentStep(t((m) => m["IMS--View"].analysisPanel.steps.complete));
+        setCurrentStep(t((m) => m.pages.invoices.viewInvoice.analysisPanel.steps.complete));
         setProgress(100);
 
-        toast(t((m) => m["IMS--View"].analysisPanel.toasts.success.title), {
-          description: t((m) => m["IMS--View"].analysisPanel.toasts.success.description),
+        toast(t((m) => m.pages.invoices.viewInvoice.analysisPanel.toasts.success.title), {
+          description: t((m) => m.pages.invoices.viewInvoice.analysisPanel.toasts.success.description),
         });
 
         // Wait briefly before refresh to show completion state
@@ -176,8 +176,8 @@ export function AnalysisPanel(): React.JSX.Element {
         router.refresh();
       } catch (error) {
         console.error("Error analyzing invoice:", error);
-        toast(t((m) => m["IMS--View"].analysisPanel.toasts.error.title), {
-          description: t((m) => m["IMS--View"].analysisPanel.toasts.error.description),
+        toast(t((m) => m.pages.invoices.viewInvoice.analysisPanel.toasts.error.title), {
+          description: t((m) => m.pages.invoices.viewInvoice.analysisPanel.toasts.error.description),
         });
       } finally {
         setIsAnalyzing(false);
@@ -213,9 +213,9 @@ export function AnalysisPanel(): React.JSX.Element {
         <div className={styles["headerContent"]}>
           <div className={styles["titleRow"]}>
             <TbSparkles className={styles["sparklesIcon"]} />
-            <CardTitle className={styles["title"]}>{t((m) => m["IMS--View"].analysisPanel.title)}</CardTitle>
+            <CardTitle className={styles["title"]}>{t((m) => m.pages.invoices.viewInvoice.analysisPanel.title)}</CardTitle>
           </div>
-          <CardDescription className={styles["description"]}>{t((m) => m["IMS--View"].analysisPanel.description)}</CardDescription>
+          <CardDescription className={styles["description"]}>{t((m) => m.pages.invoices.viewInvoice.analysisPanel.description)}</CardDescription>
         </div>
       </CardHeader>
 
@@ -231,7 +231,7 @@ export function AnalysisPanel(): React.JSX.Element {
               <div className={styles["spinnerWrapper"]}>
                 <Spinner className={styles["spinner"]} />
                 <div className={styles["statusText"]}>
-                  <p className={styles["statusTitle"]}>{t((m) => m["IMS--View"].analysisPanel.analyzing.title)}</p>
+                  <p className={styles["statusTitle"]}>{t((m) => m.pages.invoices.viewInvoice.analysisPanel.analyzing.title)}</p>
                   <p className={styles["statusStep"]}>{currentStep}</p>
                 </div>
               </div>
@@ -240,7 +240,7 @@ export function AnalysisPanel(): React.JSX.Element {
                 value={progress}
                 className={styles["progress"]}
               />
-              <p className={styles["progressText"]}>{t((m) => m["IMS--View"].analysisPanel.analyzing.progress, {progress: String(Math.round(progress))})}</p>
+              <p className={styles["progressText"]}>{t((m) => m.pages.invoices.viewInvoice.analysisPanel.analyzing.progress, {progress: String(Math.round(progress))})}</p>
             </motion.div>
           ) : (
             <motion.div
@@ -254,7 +254,7 @@ export function AnalysisPanel(): React.JSX.Element {
                 <div className={styles["lastAnalyzed"]}>
                   <div className={styles["infoRow"]}>
                     <TbClock className={styles["infoIcon"]} />
-                    <span className={styles["infoLabel"]}>{t((m) => m["IMS--View"].analysisPanel.labels.lastAnalyzed)}</span>
+                    <span className={styles["infoLabel"]}>{t((m) => m.pages.invoices.viewInvoice.analysisPanel.labels.lastAnalyzed)}</span>
                   </div>
                   <p className={styles["infoValue"]}>
                     {formatDate(invoice.lastUpdatedAt, {
@@ -265,7 +265,7 @@ export function AnalysisPanel(): React.JSX.Element {
                   </p>
                   {typeof invoice.numberOfUpdates === "number" && invoice.numberOfUpdates > 0 && (
                     <div className={styles["updatesBadge"]}>
-                      <Badge variant='outline'>{t((m) => m["IMS--View"].analysisPanel.labels.updates, {count: invoice.numberOfUpdates})}</Badge>
+                      <Badge variant='outline'>{t((m) => m.pages.invoices.viewInvoice.analysisPanel.labels.updates, {count: invoice.numberOfUpdates})}</Badge>
                     </div>
                   )}
                 </div>
@@ -280,13 +280,13 @@ export function AnalysisPanel(): React.JSX.Element {
                   variant='default'
                   size='default'>
                   <TbRefresh className={styles["buttonIcon"]} />
-                  {t((m) => m["IMS--View"].analysisPanel.buttons.reanalyze)}
+                  {t((m) => m.pages.invoices.viewInvoice.analysisPanel.buttons.reanalyze)}
                 </Button>
                 <TooltipProvider>
                   <Tooltip>
                     <TooltipTrigger render={<TbInfoCircle className={styles["infoIconButton"]} />} />
                     <TooltipContent>
-                      <p>{t((m) => m["IMS--View"].analysisPanel.tooltips.reanalyze)}</p>
+                      <p>{t((m) => m.pages.invoices.viewInvoice.analysisPanel.tooltips.reanalyze)}</p>
                     </TooltipContent>
                   </Tooltip>
                 </TooltipProvider>
@@ -295,7 +295,7 @@ export function AnalysisPanel(): React.JSX.Element {
               {/* Granular Analysis Options */}
               {invoice.items.length === 0 ? (
                 <div className={styles["optionsSection"]}>
-                  <p className={styles["optionsLabel"]}>{t((m) => m["IMS--View"].analysisPanel.labels.granularOptions)}</p>
+                  <p className={styles["optionsLabel"]}>{t((m) => m.pages.invoices.viewInvoice.analysisPanel.labels.granularOptions)}</p>
                   <div className={styles["optionsGrid"]}>
                     {analysisOptions.map((option) => (
                       <TooltipProvider key={option.id}>
@@ -325,14 +325,14 @@ export function AnalysisPanel(): React.JSX.Element {
               ) : (
                 <div className={styles["completionMessage"]}>
                   <TbCheck className={styles["completionIcon"]} />
-                  <p className={styles["completionText"]}>{t((m) => m["IMS--View"].analysisPanel.labels.analysisComplete)}</p>
+                  <p className={styles["completionText"]}>{t((m) => m.pages.invoices.viewInvoice.analysisPanel.labels.analysisComplete)}</p>
                 </div>
               )}
 
               {/* Quick Tip */}
               <div className={styles["tip"]}>
                 <TbBolt className={styles["tipIcon"]} />
-                <p className={styles["tipText"]}>{t((m) => m["IMS--View"].analysisPanel.tip)}</p>
+                <p className={styles["tipText"]}>{t((m) => m.pages.invoices.viewInvoice.analysisPanel.tip)}</p>
               </div>
             </motion.div>
           )}

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/BudgetImpactCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/BudgetImpactCard.tsx
@@ -32,7 +32,7 @@ export function BudgetImpactCard(): React.JSX.Element {
         <CardTitle>
           <span className={styles["titleRow"]}>
             <TbCreditCard className={styles["titleIcon"]} />
-            {t((m) => m["IMS--Cards"].budgetImpactCard.title, {month: monthName})}
+            {t((m) => m.cards.invoices.budgetImpactCard.title, {month: monthName})}
           </span>
         </CardTitle>
       </CardHeader>
@@ -41,36 +41,36 @@ export function BudgetImpactCard(): React.JSX.Element {
           {/* Budget progress */}
           <div className={styles["budgetSection"]}>
             <div className={styles["budgetRow"]}>
-              <span className={styles["budgetLabel"]}>{t((m) => m["IMS--Cards"].budgetImpactCard.monthlyBudget)}</span>
+              <span className={styles["budgetLabel"]}>{t((m) => m.cards.invoices.budgetImpactCard.monthlyBudget)}</span>
               <span className={styles["budgetValue"]}>{formatCurrency(monthlyBudget, {currencyCode: currency.code, locale})}</span>
             </div>
             <Progress value={Math.min(percentUsed, 100)} />
             <div className={styles["budgetMeta"]}>
-              <span>{t((m) => m["IMS--Cards"].budgetImpactCard.spent, {amount: formatCurrency(totalSpent, {currencyCode: currency.code, locale})})}</span>
+              <span>{t((m) => m.cards.invoices.budgetImpactCard.spent, {amount: formatCurrency(totalSpent, {currencyCode: currency.code, locale})})}</span>
               <span>{percentUsed.toFixed(0)}%</span>
             </div>
           </div>
 
           {/* This invoice impact */}
           <div className={styles["impactBox"]}>
-            <p className={styles["impactLabel"]}>{t((m) => m["IMS--Cards"].budgetImpactCard.invoiceUsed)}</p>
+            <p className={styles["impactLabel"]}>{t((m) => m.cards.invoices.budgetImpactCard.invoiceUsed)}</p>
             <p className={styles["impactPercent"]}>{thisInvoicePercent.toFixed(1)}%</p>
-            <p className={styles["impactDescription"]}>{t((m) => m["IMS--Cards"].budgetImpactCard.ofMonthlyBudget)}</p>
+            <p className={styles["impactDescription"]}>{t((m) => m.cards.invoices.budgetImpactCard.ofMonthlyBudget)}</p>
           </div>
 
           {/* Remaining stats */}
           <div className={styles["statsGrid"]}>
             <div className={styles["statItem"]}>
-              <p className={styles["statLabel"]}>{t((m) => m["IMS--Cards"].budgetImpactCard.remaining)}</p>
+              <p className={styles["statLabel"]}>{t((m) => m.cards.invoices.budgetImpactCard.remaining)}</p>
               <p className={`${styles["statValue"]} ${isOverBudget ? styles["overBudgetText"] : ""}`}>
                 {formatCurrency(Math.abs(remaining), {currencyCode: currency.code, locale})}
               </p>
-              {isOverBudget ? <p className={styles["overBudgetLabel"]}>{t((m) => m["IMS--Cards"].budgetImpactCard.overBudget)}</p> : null}
+              {isOverBudget ? <p className={styles["overBudgetLabel"]}>{t((m) => m.cards.invoices.budgetImpactCard.overBudget)}</p> : null}
             </div>
             <div className={styles["statItem"]}>
-              <p className={styles["statLabel"]}>{t((m) => m["IMS--Cards"].budgetImpactCard.daysLeft)}</p>
+              <p className={styles["statLabel"]}>{t((m) => m.cards.invoices.budgetImpactCard.daysLeft)}</p>
               <p className={styles["statValue"]}>{daysRemaining}</p>
-              <p className={styles["statLabel"]}>{t((m) => m["IMS--Cards"].budgetImpactCard.inMonth, {month: monthName})}</p>
+              <p className={styles["statLabel"]}>{t((m) => m.cards.invoices.budgetImpactCard.inMonth, {month: monthName})}</p>
             </div>
           </div>
 
@@ -78,9 +78,9 @@ export function BudgetImpactCard(): React.JSX.Element {
           {!isOverBudget && (
             <div className={styles["dailyAllowanceBox"]}>
               <div className={styles["dailyAllowanceContent"]}>
-                <p className={styles["dailyAllowanceLabel"]}>{t((m) => m["IMS--Cards"].budgetImpactCard.dailyAllowance)}</p>
+                <p className={styles["dailyAllowanceLabel"]}>{t((m) => m.cards.invoices.budgetImpactCard.dailyAllowance)}</p>
                 <p className={styles["dailyAllowanceValue"]}>
-                  {t((m) => m["IMS--Cards"].budgetImpactCard.dailyAllowanceValue, {amount: formatCurrency(dailyAllowance, {currencyCode: currency.code, locale})})}
+                  {t((m) => m.cards.invoices.budgetImpactCard.dailyAllowanceValue, {amount: formatCurrency(dailyAllowance, {currencyCode: currency.code, locale})})}
                 </p>
               </div>
               {getDailyAllowanceIcon()}

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/ComparisonStatsCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/ComparisonStatsCard.tsx
@@ -31,8 +31,8 @@ export function ComparisonStatsCard({stats, currency}: Readonly<Props>): React.J
     <div className={styles["card"]}>
       <Card>
         <CardHeader>
-          <CardTitle>{t((m) => m["IMS--Cards"].comparisonStatsCard.title)}</CardTitle>
-          <CardDescription>{t((m) => m["IMS--Cards"].comparisonStatsCard.subtitle, {count: String(stats.totalInvoices)})}</CardDescription>
+          <CardTitle>{t((m) => m.cards.invoices.comparisonStatsCard.title)}</CardTitle>
+          <CardDescription>{t((m) => m.cards.invoices.comparisonStatsCard.subtitle, {count: String(stats.totalInvoices)})}</CardDescription>
         </CardHeader>
         <CardContent>
           <div className={styles["contentSpaced"]}>
@@ -41,7 +41,7 @@ export function ComparisonStatsCard({stats, currency}: Readonly<Props>): React.J
               <div className={styles["row"]}>
                 <div className={styles["rowWithIcon"]}>
                   <TbTarget className={styles["iconMuted"]} />
-                  <span className={styles["label"]}>{t((m) => m["IMS--Cards"].comparisonStatsCard.vsAverage)}</span>
+                  <span className={styles["label"]}>{t((m) => m.cards.invoices.comparisonStatsCard.vsAverage)}</span>
                 </div>
                 <div className={styles["trendRow"]}>
                   {getTrendIcon(stats.percentageDiff)}
@@ -52,26 +52,26 @@ export function ComparisonStatsCard({stats, currency}: Readonly<Props>): React.J
                 </div>
               </div>
               <div className={styles["mutedRow"]}>
-                <span>{t((m) => m["IMS--Cards"].comparisonStatsCard.avgValue, {amount: stats.averageAmount.toFixed(2), currency})}</span>
-                <span>{t((m) => m["IMS--Cards"].comparisonStatsCard.thisValue, {amount: stats.currentAmount.toFixed(2), currency})}</span>
+                <span>{t((m) => m.cards.invoices.comparisonStatsCard.avgValue, {amount: stats.averageAmount.toFixed(2), currency})}</span>
+                <span>{t((m) => m.cards.invoices.comparisonStatsCard.thisValue, {amount: stats.currentAmount.toFixed(2), currency})}</span>
               </div>
             </div>
 
             {/* Spending Range Progress */}
             <div className={styles["section"]}>
               <div className={styles["mutedRow"]}>
-                <span>{t((m) => m["IMS--Cards"].comparisonStatsCard.minValue, {amount: stats.minAmount.toFixed(0)})}</span>
-                <span>{t((m) => m["IMS--Cards"].comparisonStatsCard.maxValue, {amount: stats.maxAmount.toFixed(0)})}</span>
+                <span>{t((m) => m.cards.invoices.comparisonStatsCard.minValue, {amount: stats.minAmount.toFixed(0)})}</span>
+                <span>{t((m) => m.cards.invoices.comparisonStatsCard.maxValue, {amount: stats.maxAmount.toFixed(0)})}</span>
               </div>
               <Progress value={percentageProgress} />
-              <p className={styles["positionLabel"]}>{t((m) => m["IMS--Cards"].comparisonStatsCard.positionInRange)}</p>
+              <p className={styles["positionLabel"]}>{t((m) => m.cards.invoices.comparisonStatsCard.positionInRange)}</p>
             </div>
 
             {/* Item Count Comparison */}
             <div className={styles["borderTopRow"]}>
               <div className={styles["rowWithIcon"]}>
                 <TbShoppingBag className={styles["iconMuted"]} />
-                <span className={styles["label"]}>{t((m) => m["IMS--Cards"].comparisonStatsCard.itemCount)}</span>
+                <span className={styles["label"]}>{t((m) => m.cards.invoices.comparisonStatsCard.itemCount)}</span>
               </div>
               <div className={styles["rightAlign"]}>
                 <div className={styles["trendRow"]}>
@@ -82,7 +82,7 @@ export function ComparisonStatsCard({stats, currency}: Readonly<Props>): React.J
                   </span>
                 </div>
                 <span className={styles["subLabel"]}>
-                  {t((m) => m["IMS--Cards"].comparisonStatsCard.itemCountComparison, {current: String(stats.currentItemCount), average: String(stats.averageItemCount)})}
+                  {t((m) => m.cards.invoices.comparisonStatsCard.itemCountComparison, {current: String(stats.currentItemCount), average: String(stats.averageItemCount)})}
                 </span>
               </div>
             </div>
@@ -91,7 +91,7 @@ export function ComparisonStatsCard({stats, currency}: Readonly<Props>): React.J
             <div className={styles["borderTopRow"]}>
               <div className={styles["rowWithIcon"]}>
                 <TbBuildingStore className={styles["iconMuted"]} />
-                <span className={styles["label"]}>{t((m) => m["IMS--Cards"].comparisonStatsCard.sameStore)}</span>
+                <span className={styles["label"]}>{t((m) => m.cards.invoices.comparisonStatsCard.sameStore)}</span>
               </div>
               <div className={styles["rightAlign"]}>
                 <div className={styles["trendRow"]}>
@@ -102,7 +102,7 @@ export function ComparisonStatsCard({stats, currency}: Readonly<Props>): React.J
                   </span>
                 </div>
                 <span className={styles["subLabel"]}>
-                  {t((m) => m["IMS--Cards"].comparisonStatsCard.sameStoreComparison, {average: stats.sameMerchantAvg.toFixed(0), currency})}
+                  {t((m) => m.cards.invoices.comparisonStatsCard.sameStoreComparison, {average: stats.sameMerchantAvg.toFixed(0), currency})}
                 </span>
               </div>
             </div>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/InvoiceDetailsCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/InvoiceDetailsCard.tsx
@@ -87,7 +87,7 @@ export function InvoiceDetailsCard(): React.JSX.Element {
           <div className={styles["headerInfo"]}>
             <CardTitle>
               <span className={styles["titleRow"]}>
-                {t((m) => m["IMS--Cards"].invoiceDetailsCard.title)}
+                {t((m) => m.cards.invoices.invoiceDetailsCard.title)}
                 {Boolean(invoice.isImportant) && <TbHeart className={styles["heartIcon"]} />}
               </span>
             </CardTitle>
@@ -104,7 +104,7 @@ export function InvoiceDetailsCard(): React.JSX.Element {
             <div className={styles["infoItem"]}>
               <div className={styles["infoLabel"]}>
                 <TbCalendar className={styles["iconSm"]} />
-                <span>{t((m) => m["IMS--Cards"].invoiceDetailsCard.labels.dateUtc)}</span>
+                <span>{t((m) => m.cards.invoices.invoiceDetailsCard.labels.dateUtc)}</span>
               </div>
               <p className={styles["infoValue"]}>
                 {formatDate(invoice.paymentInformation.transactionDate, {
@@ -116,18 +116,18 @@ export function InvoiceDetailsCard(): React.JSX.Element {
               </p>
             </div>
             <div className={styles["infoItem"]}>
-              <p className={styles["infoLabelPlain"]}>{t((m) => m["IMS--Cards"].invoiceDetailsCard.labels.category)}</p>
+              <p className={styles["infoLabelPlain"]}>{t((m) => m.cards.invoices.invoiceDetailsCard.labels.category)}</p>
               <Badge variant='outline'>{formatEnum(ProductCategory, invoice.category)}</Badge>
             </div>
             <div className={styles["infoItem"]}>
               <div className={styles["infoLabel"]}>
                 <TbCreditCard className={styles["iconSm"]} />
-                <span>{t((m) => m["IMS--Cards"].invoiceDetailsCard.labels.payment)}</span>
+                <span>{t((m) => m.cards.invoices.invoiceDetailsCard.labels.payment)}</span>
               </div>
               <p className={styles["infoValue"]}>{formatEnum(PaymentType, invoice.paymentInformation.paymentType)}</p>
             </div>
             <div className={styles["infoItem"]}>
-              <p className={styles["infoLabelPlain"]}>{t((m) => m["IMS--Cards"].invoiceDetailsCard.labels.totalAmount)}</p>
+              <p className={styles["infoLabelPlain"]}>{t((m) => m.cards.invoices.invoiceDetailsCard.labels.totalAmount)}</p>
               <p className={styles["totalAmount"]}>
                 {formatCurrency(invoice.paymentInformation.totalCostAmount, {
                   currencyCode: invoice.paymentInformation.currency.code,
@@ -139,7 +139,7 @@ export function InvoiceDetailsCard(): React.JSX.Element {
             {/* Receipt Type Badge - New DI v4.0 field */}
             {invoice.receiptType ? (
               <div className={styles["infoItem"]}>
-                <p className={styles["infoLabelPlain"]}>{t((m) => m["IMS--Cards"].invoiceDetailsCard.labels.receiptType)}</p>
+                <p className={styles["infoLabelPlain"]}>{t((m) => m.cards.invoices.invoiceDetailsCard.labels.receiptType)}</p>
                 <Badge variant='secondary'>
                   <TbReceipt className={styles["iconSm"]} />
                   <span>
@@ -152,7 +152,7 @@ export function InvoiceDetailsCard(): React.JSX.Element {
             {/* Country/Region - New DI v4.0 field */}
             {invoice.countryRegion ? (
               <div className={styles["infoItem"]}>
-                <p className={styles["infoLabelPlain"]}>{t((m) => m["IMS--Cards"].invoiceDetailsCard.labels.countryRegion)}</p>
+                <p className={styles["infoLabelPlain"]}>{t((m) => m.cards.invoices.invoiceDetailsCard.labels.countryRegion)}</p>
                 <Badge variant='outline'>
                   <TbFlag3 className={styles["iconSm"]} />
                   <span>{invoice.countryRegion}</span>
@@ -163,7 +163,7 @@ export function InvoiceDetailsCard(): React.JSX.Element {
             {/* Subtotal Amount - New DI v4.0 field */}
             {invoice.paymentInformation.subtotalAmount > 0 && (
               <div className={styles["infoItem"]}>
-                <p className={styles["infoLabelPlain"]}>{t((m) => m["IMS--Cards"].invoiceDetailsCard.labels.subtotal)}</p>
+                <p className={styles["infoLabelPlain"]}>{t((m) => m.cards.invoices.invoiceDetailsCard.labels.subtotal)}</p>
                 <p className={styles["infoValue"]}>
                   {formatCurrency(invoice.paymentInformation.subtotalAmount, {
                     currencyCode: invoice.paymentInformation.currency.code,
@@ -176,7 +176,7 @@ export function InvoiceDetailsCard(): React.JSX.Element {
             {/* Tip Amount - New DI v4.0 field */}
             {invoice.paymentInformation.tipAmount > 0 && (
               <div className={styles["infoItem"]}>
-                <p className={styles["infoLabelPlain"]}>{t((m) => m["IMS--Cards"].invoiceDetailsCard.labels.tip)}</p>
+                <p className={styles["infoLabelPlain"]}>{t((m) => m.cards.invoices.invoiceDetailsCard.labels.tip)}</p>
                 <p className={styles["infoValue"]}>
                   {formatCurrency(invoice.paymentInformation.tipAmount, {
                     currencyCode: invoice.paymentInformation.currency.code,
@@ -189,7 +189,7 @@ export function InvoiceDetailsCard(): React.JSX.Element {
             {/* RON Equivalent for non-RON currencies - Enhancement for multi-currency */}
             {ronEquivalent ? (
               <div className={styles["infoItem"]}>
-                <p className={styles["infoLabelPlain"]}>{t((m) => m["IMS--Cards"].invoiceDetailsCard.labels.ronEquivalent)}</p>
+                <p className={styles["infoLabelPlain"]}>{t((m) => m.cards.invoices.invoiceDetailsCard.labels.ronEquivalent)}</p>
                 <TooltipProvider>
                   <Tooltip>
                     <TooltipTrigger
@@ -202,7 +202,7 @@ export function InvoiceDetailsCard(): React.JSX.Element {
                     />
                     <TooltipContent>
                       <p>
-                        {t((m) => m["IMS--Cards"].invoiceDetailsCard.tooltips.exchangeRate, {
+                        {t((m) => m.cards.invoices.invoiceDetailsCard.tooltips.exchangeRate, {
                           fromCurrency: invoice.paymentInformation.currency.code,
                           rate: ronEquivalent.rateUsed.toFixed(4),
                           year: ronEquivalent.rateYear.toString(),
@@ -221,7 +221,7 @@ export function InvoiceDetailsCard(): React.JSX.Element {
           {invoice.payments && invoice.payments.length > 0 ? (
             <>
               <div className={styles["paymentsSection"]}>
-                <h3 className={styles["sectionTitle"]}>{t((m) => m["IMS--Cards"].invoiceDetailsCard.sections.paymentMethods)}</h3>
+                <h3 className={styles["sectionTitle"]}>{t((m) => m.cards.invoices.invoiceDetailsCard.sections.paymentMethods)}</h3>
                 <div className={styles["paymentsList"]}>
                   {invoice.payments.map((payment) => (
                     <div
@@ -246,7 +246,7 @@ export function InvoiceDetailsCard(): React.JSX.Element {
           {invoice.taxDetails && invoice.taxDetails.length > 0 ? (
             <>
               <div className={styles["taxSection"]}>
-                <h3 className={styles["sectionTitle"]}>{t((m) => m["IMS--Cards"].invoiceDetailsCard.sections.taxBreakdown)}</h3>
+                <h3 className={styles["sectionTitle"]}>{t((m) => m.cards.invoices.invoiceDetailsCard.sections.taxBreakdown)}</h3>
                 <div className={styles["taxTable"]}>
                   {invoice.taxDetails.map((taxDetail) => (
                     <div
@@ -258,14 +258,14 @@ export function InvoiceDetailsCard(): React.JSX.Element {
                       </div>
                       <div className={styles["taxAmounts"]}>
                         <span className={styles["taxNetAmount"]}>
-                          {t((m) => m["IMS--Cards"].invoiceDetailsCard.taxLabels.net)}:{" "}
+                          {t((m) => m.cards.invoices.invoiceDetailsCard.taxLabels.net)}:{" "}
                           {formatCurrency(taxDetail.netAmount, {
                             currencyCode: invoice.paymentInformation.currency.code,
                             locale,
                           })}
                         </span>
                         <span className={styles["taxAmount"]}>
-                          {t((m) => m["IMS--Cards"].invoiceDetailsCard.taxLabels.tax)}:{" "}
+                          {t((m) => m.cards.invoices.invoiceDetailsCard.taxLabels.tax)}:{" "}
                           {formatCurrency(taxDetail.amount, {
                             currencyCode: invoice.paymentInformation.currency.code,
                             locale,
@@ -282,16 +282,16 @@ export function InvoiceDetailsCard(): React.JSX.Element {
 
           {/* Items Table */}
           <div className={styles["itemsSection"]}>
-            <h3 className={styles["itemsTitle"]}>{t((m) => m["IMS--Cards"].invoiceDetailsCard.itemsTitle, {count: String(invoice.items.length)})}</h3>
+            <h3 className={styles["itemsTitle"]}>{t((m) => m.cards.invoices.invoiceDetailsCard.itemsTitle, {count: String(invoice.items.length)})}</h3>
             <div className={styles["tableContainer"]}>
               <Table>
                 <TableHeader>
                   <TableRow>
-                    <TableHead>{t((m) => m["IMS--Cards"].invoiceDetailsCard.table.item)}</TableHead>
-                    <TableHead>{t((m) => m["IMS--Cards"].invoiceDetailsCard.table.qty)}</TableHead>
-                    <TableHead>{t((m) => m["IMS--Cards"].invoiceDetailsCard.table.unit)}</TableHead>
-                    <TableHead>{t((m) => m["IMS--Cards"].invoiceDetailsCard.table.price)}</TableHead>
-                    <TableHead>{t((m) => m["IMS--Cards"].invoiceDetailsCard.table.total)}</TableHead>
+                    <TableHead>{t((m) => m.cards.invoices.invoiceDetailsCard.table.item)}</TableHead>
+                    <TableHead>{t((m) => m.cards.invoices.invoiceDetailsCard.table.qty)}</TableHead>
+                    <TableHead>{t((m) => m.cards.invoices.invoiceDetailsCard.table.unit)}</TableHead>
+                    <TableHead>{t((m) => m.cards.invoices.invoiceDetailsCard.table.price)}</TableHead>
+                    <TableHead>{t((m) => m.cards.invoices.invoiceDetailsCard.table.total)}</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
@@ -327,7 +327,7 @@ export function InvoiceDetailsCard(): React.JSX.Element {
                 </TableBody>
                 <TableFooter>
                   <TableRow>
-                    <TableCell colSpan={4}>{t((m) => m["IMS--Cards"].invoiceDetailsCard.table.grandTotal)}</TableCell>
+                    <TableCell colSpan={4}>{t((m) => m.cards.invoices.invoiceDetailsCard.table.grandTotal)}</TableCell>
                     <TableCell>
                       {formatCurrency(invoice.paymentInformation.totalCostAmount, {
                         currencyCode: invoice.paymentInformation.currency.code,
@@ -343,7 +343,7 @@ export function InvoiceDetailsCard(): React.JSX.Element {
             {totalPages > 1 && (
               <div className={styles["pagination"]}>
                 <p className={styles["paginationText"]}>
-                  {t((m) => m["IMS--Cards"].invoiceDetailsCard.pagination.pageOf, {current: String(currentPage), total: String(totalPages)})}
+                  {t((m) => m.cards.invoices.invoiceDetailsCard.pagination.pageOf, {current: String(currentPage), total: String(totalPages)})}
                 </p>
                 <div className={styles["paginationButtons"]}>
                   <Button
@@ -352,14 +352,14 @@ export function InvoiceDetailsCard(): React.JSX.Element {
                     onClick={handlePreviousPage}
                     disabled={currentPage === 1}>
                     <TbChevronLeft className={styles["navIcon"]} />
-                    {t((m) => m["IMS--Cards"].invoiceDetailsCard.pagination.previous)}
+                    {t((m) => m.cards.invoices.invoiceDetailsCard.pagination.previous)}
                   </Button>
                   <Button
                     variant='outline'
                     size='sm'
                     onClick={handleNextPage}
                     disabled={currentPage === totalPages}>
-                    {t((m) => m["IMS--Cards"].invoiceDetailsCard.pagination.next)}
+                    {t((m) => m.cards.invoices.invoiceDetailsCard.pagination.next)}
                     <TbChevronRight className={styles["navIcon"]} />
                   </Button>
                 </div>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/InvoiceHealthScore.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/InvoiceHealthScore.tsx
@@ -375,8 +375,8 @@ export function InvoiceHealthScore(): React.JSX.Element {
   return (
     <Card className={styles["card"]}>
       <CardHeader>
-        <CardTitle className={styles["cardTitle"]}>{t((m) => m["IMS--View"].healthScore.title)}</CardTitle>
-        <CardDescription className={styles["cardDescription"]}>{t((m) => m["IMS--View"].healthScore.subtitle)}</CardDescription>
+        <CardTitle className={styles["cardTitle"]}>{t((m) => m.pages.invoices.viewInvoice.healthScore.title)}</CardTitle>
+        <CardDescription className={styles["cardDescription"]}>{t((m) => m.pages.invoices.viewInvoice.healthScore.subtitle)}</CardDescription>
       </CardHeader>
       <CardContent className={styles["cardContent"]}>
         {/* Circular Progress */}
@@ -418,18 +418,18 @@ export function InvoiceHealthScore(): React.JSX.Element {
         </div>
 
         {/* Status label */}
-        <div className={`${styles["statusLabel"]} ${styles[status.color]}`}>{t(selectorFromPath(`IMS--View.healthScore.status.${status.key}`))}</div>
+        <div className={`${styles["statusLabel"]} ${styles[status.color]}`}>{t(selectorFromPath(`pages.invoices.viewInvoice.healthScore.status.${status.key}`))}</div>
 
         {/* Score breakdown */}
         <div className={styles["scoreBreakdown"]}>
-          {score} / {maxScore} {t((m) => m["IMS--View"].healthScore.points)}
+          {score} / {maxScore} {t((m) => m.pages.invoices.viewInvoice.healthScore.points)}
         </div>
 
         {/* Improvement Suggestions */}
         {suggestions.length > 0 && showSuggestions ? (
           <div className={styles["suggestionsContainer"]}>
             <div className={styles["suggestionsHeader"]}>
-              <h4 className={styles["suggestionsTitle"]}>{t((m) => m["IMS--View"].healthScore.suggestions.title)}</h4>
+              <h4 className={styles["suggestionsTitle"]}>{t((m) => m.pages.invoices.viewInvoice.healthScore.suggestions.title)}</h4>
               <Button
                 variant='ghost'
                 size='sm'
@@ -446,12 +446,12 @@ export function InvoiceHealthScore(): React.JSX.Element {
                   <suggestion.icon className={styles["suggestionIcon"]} />
                   <span className={styles["suggestionText"]}>
                     {suggestion.params
-                      ? t.rich(selectorFromPath(`IMS--View.healthScore.${`suggestions.${suggestion.key}` as "suggestions.incompleteProducts"}`), {
+                      ? t.rich(selectorFromPath(`pages.invoices.viewInvoice.healthScore.suggestions.${suggestion.key}`), {
                           count: String(suggestion.params["count"] ?? ""),
                           // eslint-disable-next-line react/no-unstable-nested-components -- single-call site
                           strong: (chunks) => <strong>{chunks}</strong>,
                         })
-                      : t(selectorFromPath(`IMS--View.healthScore.${`suggestions.${suggestion.key}` as "suggestions.noProducts"}`))}
+                      : t(selectorFromPath(`pages.invoices.viewInvoice.healthScore.suggestions.${suggestion.key}`))}
                   </span>
                   {suggestion.link ? (
                     <Button
@@ -461,7 +461,7 @@ export function InvoiceHealthScore(): React.JSX.Element {
                       className={styles["suggestionAction"]}>
                       <Link href={suggestion.link}>
                         <TbExternalLink className={styles["actionIcon"]} />
-                        {t((m) => m["IMS--View"].healthScore.suggestions.fix)}
+                        {t((m) => m.pages.invoices.viewInvoice.healthScore.suggestions.fix)}
                       </Link>
                     </Button>
                   ) : null}
@@ -481,7 +481,7 @@ export function InvoiceHealthScore(): React.JSX.Element {
                 variant='ghost'
                 className={styles["toggleButton"]}>
                 {isExpanded ? <TbChevronUp className={styles["chevronIcon"]} /> : <TbChevronDown className={styles["chevronIcon"]} />}
-                {isExpanded ? t((m) => m["IMS--View"].healthScore.hideDetails) : t((m) => m["IMS--View"].healthScore.showDetails)}
+                {isExpanded ? t((m) => m.pages.invoices.viewInvoice.healthScore.hideDetails) : t((m) => m.pages.invoices.viewInvoice.healthScore.showDetails)}
               </Button>
             }
           />
@@ -496,7 +496,7 @@ export function InvoiceHealthScore(): React.JSX.Element {
                   </div>
                   <div className={styles["factorContent"]}>
                     <span className={factor.achieved ? styles["achievedText"] : styles["missingText"]}>
-                      {t(selectorFromPath(`IMS--View.healthScore.factors.${factor.key}`))}
+                      {t(selectorFromPath(`pages.invoices.viewInvoice.healthScore.factors.${factor.key}`))}
                       {factor.detail ? <span className={styles["factorDetail"]}> ({factor.detail})</span> : null}
                     </span>
                     <span className={styles["factorPoints"]}>
@@ -518,7 +518,7 @@ export function InvoiceHealthScore(): React.JSX.Element {
               className={styles["ctaButton"]}>
               <Link href={`/domains/invoices/edit-invoice/${invoice.id}`}>
                 <TbSparkles className={styles["ctaIcon"]} />
-                {t((m) => m["IMS--View"].healthScore.cta.edit)}
+                {t((m) => m.pages.invoices.viewInvoice.healthScore.cta.edit)}
               </Link>
             </Button>
           </div>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/InvoiceTimelineCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/InvoiceTimelineCard.tsx
@@ -25,7 +25,7 @@ export function InvoiceTimelineCard({invoice}: Readonly<Props>): React.JSX.Eleme
         <CardTitle>
           <span className={styles["titleRow"]}>
             <TbCalendar className={styles["titleIcon"]} />
-            {t((m) => m["IMS--View"].invoiceTimeline.title)}
+            {t((m) => m.pages.invoices.viewInvoice.invoiceTimeline.title)}
           </span>
         </CardTitle>
       </CardHeader>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/ItemAnalyticsCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/ItemAnalyticsCard.tsx
@@ -319,14 +319,14 @@ export function ItemAnalyticsCard(): React.JSX.Element {
         <CardHeader>
           <CardTitle className={styles["titleRow"]}>
             <TbShoppingCart className={styles["iconTitle"]} />
-            {t((m) => m["IMS--View"].itemAnalytics.title)}
+            {t((m) => m.pages.invoices.viewInvoice.itemAnalytics.title)}
           </CardTitle>
         </CardHeader>
         <CardContent>
           <div className={styles["emptyState"]}>
             <TbShoppingCart className={styles["emptyIcon"]} />
-            <h3 className={styles["emptyTitle"]}>{t((m) => m["IMS--View"].itemAnalytics.empty.title)}</h3>
-            <p className={styles["emptySubtitle"]}>{t((m) => m["IMS--View"].itemAnalytics.empty.subtitle)}</p>
+            <h3 className={styles["emptyTitle"]}>{t((m) => m.pages.invoices.viewInvoice.itemAnalytics.empty.title)}</h3>
+            <p className={styles["emptySubtitle"]}>{t((m) => m.pages.invoices.viewInvoice.itemAnalytics.empty.subtitle)}</p>
           </div>
         </CardContent>
       </Card>
@@ -342,7 +342,7 @@ export function ItemAnalyticsCard(): React.JSX.Element {
         <CardHeader>
           <CardTitle className={styles["titleRow"]}>
             <TbShoppingCart className={styles["iconTitle"]} />
-            {t((m) => m["IMS--View"].itemAnalytics.title)} ({invoice.items.length})
+            {t((m) => m.pages.invoices.viewInvoice.itemAnalytics.title)} ({invoice.items.length})
           </CardTitle>
         </CardHeader>
         <CardContent>
@@ -353,7 +353,7 @@ export function ItemAnalyticsCard(): React.JSX.Element {
                 <TbSearch className={styles["searchIcon"]} />
                 <Input
                   type='text'
-                  placeholder={t((m) => m["IMS--View"].itemAnalytics.searchPlaceholder)}
+                  placeholder={t((m) => m.pages.invoices.viewInvoice.itemAnalytics.searchPlaceholder)}
                   value={searchQuery}
                   onChange={handleSearchQueryChange}
                   className={styles["searchInput"]}
@@ -372,7 +372,7 @@ export function ItemAnalyticsCard(): React.JSX.Element {
                           type='button'
                           onClick={handleSortByName}
                           className={styles["sortButton"]}>
-                          {t((m) => m["IMS--View"].itemAnalytics.columns.name)}
+                          {t((m) => m.pages.invoices.viewInvoice.itemAnalytics.columns.name)}
                           <TbArrowsSort className={styles["sortIcon"]} />
                         </button>
                       </TableHead>
@@ -381,7 +381,7 @@ export function ItemAnalyticsCard(): React.JSX.Element {
                           type='button'
                           onClick={handleSortByCategory}
                           className={styles["sortButton"]}>
-                          {t((m) => m["IMS--View"].itemAnalytics.columns.category)}
+                          {t((m) => m.pages.invoices.viewInvoice.itemAnalytics.columns.category)}
                           <TbArrowsSort className={styles["sortIcon"]} />
                         </button>
                       </TableHead>
@@ -390,7 +390,7 @@ export function ItemAnalyticsCard(): React.JSX.Element {
                           type='button'
                           onClick={handleSortByPrice}
                           className={styles["sortButton"]}>
-                          {t((m) => m["IMS--View"].itemAnalytics.columns.price)}
+                          {t((m) => m.pages.invoices.viewInvoice.itemAnalytics.columns.price)}
                           <TbArrowsSort className={styles["sortIcon"]} />
                         </button>
                       </TableHead>
@@ -399,11 +399,11 @@ export function ItemAnalyticsCard(): React.JSX.Element {
                           type='button'
                           onClick={handleSortByQuantity}
                           className={styles["sortButton"]}>
-                          {t((m) => m["IMS--View"].itemAnalytics.columns.quantity)}
+                          {t((m) => m.pages.invoices.viewInvoice.itemAnalytics.columns.quantity)}
                           <TbArrowsSort className={styles["sortIcon"]} />
                         </button>
                       </TableHead>
-                      <TableHead>{t((m) => m["IMS--View"].itemAnalytics.columns.total)}</TableHead>
+                      <TableHead>{t((m) => m.pages.invoices.viewInvoice.itemAnalytics.columns.total)}</TableHead>
                     </TableRow>
                   </TableHeader>
                   <TableBody>
@@ -426,13 +426,13 @@ export function ItemAnalyticsCard(): React.JSX.Element {
                                             : "destructive"
                                       }
                                       className={styles["confidenceBadge"]}
-                                      aria-label={t((m) => m["IMS--View"].itemAnalytics.confidence.ariaLabel, {
+                                      aria-label={t((m) => m.pages.invoices.viewInvoice.itemAnalytics.confidence.ariaLabel, {
                                         level:
                                           item.metadata.confidence >= 0.9
-                                            ? t((m) => m["IMS--View"].itemAnalytics.confidence.high)
+                                            ? t((m) => m.pages.invoices.viewInvoice.itemAnalytics.confidence.high)
                                             : item.metadata.confidence >= 0.7
-                                              ? t((m) => m["IMS--View"].itemAnalytics.confidence.medium)
-                                              : t((m) => m["IMS--View"].itemAnalytics.confidence.low),
+                                              ? t((m) => m.pages.invoices.viewInvoice.itemAnalytics.confidence.medium)
+                                              : t((m) => m.pages.invoices.viewInvoice.itemAnalytics.confidence.low),
                                         percent: (item.metadata.confidence * 100).toFixed(0),
                                       })}>
                                       {item.metadata.confidence >= 0.9 ? "✓" : item.metadata.confidence >= 0.7 ? "~" : "!"}
@@ -440,10 +440,10 @@ export function ItemAnalyticsCard(): React.JSX.Element {
                                   </TooltipTrigger>
                                   <TooltipContent>
                                     <p className={styles["confidenceTooltip"]}>
-                                      {t((m) => m["IMS--View"].itemAnalytics.confidence.label)}: {(item.metadata.confidence * 100).toFixed(0)}%
+                                      {t((m) => m.pages.invoices.viewInvoice.itemAnalytics.confidence.label)}: {(item.metadata.confidence * 100).toFixed(0)}%
                                     </p>
                                     {item.metadata.confidence < 0.7 && (
-                                      <p className={styles["confidenceWarning"]}>{t((m) => m["IMS--View"].itemAnalytics.confidence.lowWarning)}</p>
+                                      <p className={styles["confidenceWarning"]}>{t((m) => m.pages.invoices.viewInvoice.itemAnalytics.confidence.lowWarning)}</p>
                                     )}
                                   </TooltipContent>
                                 </Tooltip>
@@ -496,7 +496,7 @@ export function ItemAnalyticsCard(): React.JSX.Element {
 
             {/* Total Row */}
             <div className={styles["totalRow"]}>
-              <div className={styles["totalLabel"]}>{t((m) => m["IMS--View"].itemAnalytics.totalLabel)}</div>
+              <div className={styles["totalLabel"]}>{t((m) => m.pages.invoices.viewInvoice.itemAnalytics.totalLabel)}</div>
               <div className={styles["totalValues"]}>
                 <div className={styles["totalQuantity"]}>{totals.quantity}</div>
                 <div className={styles["totalPrice"]}>{totals.price.toFixed(2)}</div>
@@ -505,24 +505,24 @@ export function ItemAnalyticsCard(): React.JSX.Element {
 
             {/* Summary Section */}
             <div className={styles["summarySection"]}>
-              <h4 className={styles["summaryTitle"]}>📊 {t((m) => m["IMS--View"].itemAnalytics.summary.title)}</h4>
+              <h4 className={styles["summaryTitle"]}>📊 {t((m) => m.pages.invoices.viewInvoice.itemAnalytics.summary.title)}</h4>
               <ul className={styles["summaryList"]}>
                 {summary.mostExpensive ? (
                   <li className={styles["summaryItem"]}>
-                    • {t((m) => m["IMS--View"].itemAnalytics.summary.mostExpensive)}: <strong>{summary.mostExpensive.name}</strong> (
+                    • {t((m) => m.pages.invoices.viewInvoice.itemAnalytics.summary.mostExpensive)}: <strong>{summary.mostExpensive.name}</strong> (
                     {summary.mostExpensive.totalPrice.toFixed(2)})
                   </li>
                 ) : null}
                 {summary.cheapest ? (
                   <li className={styles["summaryItem"]}>
-                    • {t((m) => m["IMS--View"].itemAnalytics.summary.cheapest)}: <strong>{summary.cheapest.name}</strong> ({summary.cheapest.totalPrice.toFixed(2)})
+                    • {t((m) => m.pages.invoices.viewInvoice.itemAnalytics.summary.cheapest)}: <strong>{summary.cheapest.name}</strong> ({summary.cheapest.totalPrice.toFixed(2)})
                   </li>
                 ) : null}
                 <li className={styles["summaryItem"]}>
-                  • {summary.categoryCount} {t((m) => m["IMS--View"].itemAnalytics.summary.categories, {count: String(summary.categoryCount)})}
+                  • {summary.categoryCount} {t((m) => m.pages.invoices.viewInvoice.itemAnalytics.summary.categories, {count: String(summary.categoryCount)})}
                 </li>
                 <li className={styles["summaryItem"]}>
-                  • {summary.allergenCount} {t((m) => m["IMS--View"].itemAnalytics.summary.allergens, {count: String(summary.allergenCount)})}
+                  • {summary.allergenCount} {t((m) => m.pages.invoices.viewInvoice.itemAnalytics.summary.allergens, {count: String(summary.allergenCount)})}
                 </li>
               </ul>
             </div>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/MerchantInfoCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/MerchantInfoCard.tsx
@@ -108,11 +108,11 @@ export function MerchantInfoCard(): React.JSX.Element {
     return (
       <Card>
         <CardHeader>
-          <CardTitle>{t((m) => m["IMS--Cards"].merchantInfoCard.title)}</CardTitle>
+          <CardTitle>{t((m) => m.cards.invoices.merchantInfoCard.title)}</CardTitle>
         </CardHeader>
         <CardContent>
           <div className={styles["emptyState"]}>
-            <p className={styles["emptyStateText"]}>{t((m) => m["IMS--Cards"].merchantInfoCard.noMerchantLinked)}</p>
+            <p className={styles["emptyStateText"]}>{t((m) => m.cards.invoices.merchantInfoCard.noMerchantLinked)}</p>
           </div>
         </CardContent>
       </Card>
@@ -252,7 +252,7 @@ export function MerchantInfoCard(): React.JSX.Element {
             <div className={styles["section"]}>
               <div className={styles["sectionHeader"]}>
                 <TbChartBar className={styles["iconMuted"]} />
-                <span className={styles["sectionTitle"]}>{t((m) => m["IMS--Cards"].merchantInfoCard.spendingHistory)}</span>
+                <span className={styles["sectionTitle"]}>{t((m) => m.cards.invoices.merchantInfoCard.spendingHistory)}</span>
               </div>
               <div className={styles["sparklineContainer"]}>
                 <ResponsiveContainer
@@ -299,17 +299,17 @@ export function MerchantInfoCard(): React.JSX.Element {
               <div className={styles["statBadge"]}>
                 <TbShoppingBag className={styles["statIcon"]} />
                 <span className={styles["statValue"]}>{visitStats.count}</span>
-                <span className={styles["statLabel"]}>{t((m) => m["IMS--Cards"].merchantInfoCard.stats.visits)}</span>
+                <span className={styles["statLabel"]}>{t((m) => m.cards.invoices.merchantInfoCard.stats.visits)}</span>
               </div>
               <div className={styles["statBadge"]}>
                 <TbReceipt className={styles["statIcon"]} />
                 <span className={styles["statValue"]}>{formatAmount(visitStats.avgSpend)}</span>
-                <span className={styles["statLabel"]}>{t((m) => m["IMS--Cards"].merchantInfoCard.stats.avgSpend)}</span>
+                <span className={styles["statLabel"]}>{t((m) => m.cards.invoices.merchantInfoCard.stats.avgSpend)}</span>
               </div>
               <div className={styles["statBadge"]}>
                 <TbCalendar className={styles["statIcon"]} />
                 <span className={styles["statValue"]}>{visitStats.daysAgo}</span>
-                <span className={styles["statLabel"]}>{t((m) => m["IMS--Cards"].merchantInfoCard.stats.daysAgo)}</span>
+                <span className={styles["statLabel"]}>{t((m) => m.cards.invoices.merchantInfoCard.stats.daysAgo)}</span>
               </div>
             </div>
           )}
@@ -318,7 +318,7 @@ export function MerchantInfoCard(): React.JSX.Element {
           {categoryDistribution.length > 1 && (
             <div className={styles["section"]}>
               <div className={styles["sectionHeader"]}>
-                <span className={styles["sectionTitle"]}>{t((m) => m["IMS--Cards"].merchantInfoCard.categoryDistribution)}</span>
+                <span className={styles["sectionTitle"]}>{t((m) => m.cards.invoices.merchantInfoCard.categoryDistribution)}</span>
               </div>
               <div className={styles["categoryBar"]}>
                 {categoryDistribution.map((cat) => (
@@ -356,7 +356,7 @@ export function MerchantInfoCard(): React.JSX.Element {
                 target='_blank'
                 rel='noopener noreferrer'>
                 <TbMapPin className={styles["buttonIcon"]} />
-                {t((m) => m["IMS--Cards"].merchantInfoCard.viewOnMap)}
+                {t((m) => m.cards.invoices.merchantInfoCard.viewOnMap)}
               </a>
             </Button>
           ) : null}
@@ -367,7 +367,7 @@ export function MerchantInfoCard(): React.JSX.Element {
           variant='outline'
           asChild
           className={styles["fullWidth"]}>
-          <Link href={viewAllInvoicesUrl}>{t((m) => m["IMS--Cards"].merchantInfoCard.viewAllInvoices)}</Link>
+          <Link href={viewAllInvoicesUrl}>{t((m) => m.cards.invoices.merchantInfoCard.viewAllInvoices)}</Link>
         </Button>
       </CardFooter>
     </Card>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/ReceiptScanCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/ReceiptScanCard.tsx
@@ -159,7 +159,7 @@ export function ReceiptScanCard(): React.JSX.Element {
       <Card className={styles["card"]}>
         <CardHeader>
           <CardTitle className={styles["cardTitle"]}>
-            {totalScans > 1 ? t((m) => m["IMS--Cards"].receiptScanCard.titleWithIndex, {current: String(currentScanIndex + 1), total: String(totalScans)}) : t((m) => m["IMS--Cards"].receiptScanCard.title)}
+            {totalScans > 1 ? t((m) => m.cards.invoices.receiptScanCard.titleWithIndex, {current: String(currentScanIndex + 1), total: String(totalScans)}) : t((m) => m.cards.invoices.receiptScanCard.title)}
           </CardTitle>
         </CardHeader>
         <CardContent>
@@ -183,7 +183,7 @@ export function ReceiptScanCard(): React.JSX.Element {
                     {/* eslint-disable-next-line @next/next/no-img-element */}
                     <img
                       src={currentScanSrc}
-                      alt={t((m) => m["IMS--Cards"].receiptScanCard.scanAlt, {index: String(currentScanIndex + 1)})}
+                      alt={t((m) => m.cards.invoices.receiptScanCard.scanAlt, {index: String(currentScanIndex + 1)})}
                       width={400}
                       height={600}
                       loading='lazy'
@@ -198,8 +198,8 @@ export function ReceiptScanCard(): React.JSX.Element {
               <DialogHeader>
                 <DialogTitle>
                   {totalScans > 1
-                    ? t((m) => m["IMS--Cards"].receiptScanCard.dialogTitleWithIndex, {current: String(currentScanIndex + 1), total: String(totalScans)})
-                    : t((m) => m["IMS--Cards"].receiptScanCard.dialogTitle)}
+                    ? t((m) => m.cards.invoices.receiptScanCard.dialogTitleWithIndex, {current: String(currentScanIndex + 1), total: String(totalScans)})
+                    : t((m) => m.cards.invoices.receiptScanCard.dialogTitle)}
                 </DialogTitle>
               </DialogHeader>
               <div className={styles["dialogImageContainer"]}>
@@ -214,13 +214,13 @@ export function ReceiptScanCard(): React.JSX.Element {
                   onMouseMove={handleDialogMouseMove}
                   role='button'
                   tabIndex={0}
-                  aria-label={t((m) => m["IMS--Cards"].receiptScanCard.controls.toggleZoom)}
+                  aria-label={t((m) => m.cards.invoices.receiptScanCard.controls.toggleZoom)}
                   onKeyDown={handleDialogImageKeyDown}>
                   {/* Plain <img> with direct HTTP GET — bypasses next/image optimization. */}
                   {/* eslint-disable-next-line @next/next/no-img-element */}
                   <img
                     src={currentScanSrc}
-                    alt={t((m) => m["IMS--Cards"].receiptScanCard.scanAltFullSize, {index: String(currentScanIndex + 1)})}
+                    alt={t((m) => m.cards.invoices.receiptScanCard.scanAltFullSize, {index: String(currentScanIndex + 1)})}
                     width={800}
                     height={1200}
                     loading='lazy'
@@ -241,12 +241,12 @@ export function ReceiptScanCard(): React.JSX.Element {
                           onClick={handleDialogResetZoom}
                           disabled={dialogZoomLevel === 1}>
                           <TbZoomReset className={styles["controlIcon"]} />
-                          <span className={styles["controlLabelDesktop"]}>{t((m) => m["IMS--Cards"].receiptScanCard.controls.reset)}</span>
+                          <span className={styles["controlLabelDesktop"]}>{t((m) => m.cards.invoices.receiptScanCard.controls.reset)}</span>
                         </Button>
                       }
                     />
                     <TooltipContent>
-                      <p>{t((m) => m["IMS--Cards"].receiptScanCard.controls.reset)}</p>
+                      <p>{t((m) => m.cards.invoices.receiptScanCard.controls.reset)}</p>
                     </TooltipContent>
                   </Tooltip>
                   <Tooltip>
@@ -257,12 +257,12 @@ export function ReceiptScanCard(): React.JSX.Element {
                           size='sm'
                           onClick={handleDialogRotate}>
                           <TbRotateClockwise className={styles["controlIcon"]} />
-                          <span className={styles["controlLabelDesktop"]}>{t((m) => m["IMS--Cards"].receiptScanCard.controls.rotate)}</span>
+                          <span className={styles["controlLabelDesktop"]}>{t((m) => m.cards.invoices.receiptScanCard.controls.rotate)}</span>
                         </Button>
                       }
                     />
                     <TooltipContent>
-                      <p>{t((m) => m["IMS--Cards"].receiptScanCard.controls.rotate)}</p>
+                      <p>{t((m) => m.cards.invoices.receiptScanCard.controls.rotate)}</p>
                     </TooltipContent>
                   </Tooltip>
                   <Tooltip>
@@ -273,12 +273,12 @@ export function ReceiptScanCard(): React.JSX.Element {
                           size='sm'
                           onClick={handleDownload}>
                           <TbDownload className={styles["controlIcon"]} />
-                          <span className={styles["controlLabelDesktop"]}>{t((m) => m["IMS--Cards"].receiptScanCard.controls.download)}</span>
+                          <span className={styles["controlLabelDesktop"]}>{t((m) => m.cards.invoices.receiptScanCard.controls.download)}</span>
                         </Button>
                       }
                     />
                     <TooltipContent>
-                      <p>{t((m) => m["IMS--Cards"].receiptScanCard.controls.download)}</p>
+                      <p>{t((m) => m.cards.invoices.receiptScanCard.controls.download)}</p>
                     </TooltipContent>
                   </Tooltip>
                 </div>
@@ -290,17 +290,17 @@ export function ReceiptScanCard(): React.JSX.Element {
                       onClick={handlePreviousScan}
                       disabled={currentScanIndex === 0}>
                       <TbArrowLeft className={styles["controlIcon"]} />
-                      <span className={styles["controlLabelDesktop"]}>{t((m) => m["IMS--Cards"].receiptScanCard.navigation.previous)}</span>
+                      <span className={styles["controlLabelDesktop"]}>{t((m) => m.cards.invoices.receiptScanCard.navigation.previous)}</span>
                     </Button>
                     <span className={styles["scanCounter"]}>
-                      {currentScanIndex + 1} {t((m) => m["IMS--Cards"].receiptScanCard.navigation.of)} {totalScans}
+                      {currentScanIndex + 1} {t((m) => m.cards.invoices.receiptScanCard.navigation.of)} {totalScans}
                     </span>
                     <Button
                       variant='secondary'
                       size='sm'
                       onClick={handleNextScan}
                       disabled={currentScanIndex === totalScans - 1}>
-                      <span className={styles["controlLabelDesktop"]}>{t((m) => m["IMS--Cards"].receiptScanCard.navigation.next)}</span>
+                      <span className={styles["controlLabelDesktop"]}>{t((m) => m.cards.invoices.receiptScanCard.navigation.next)}</span>
                       <TbArrowRight className={styles["controlIcon"]} />
                     </Button>
                   </div>
@@ -325,7 +325,7 @@ export function ReceiptScanCard(): React.JSX.Element {
                   }
                 />
                 <TooltipContent>
-                  <p>{t((m) => m["IMS--Cards"].receiptScanCard.controls.zoomIn)}</p>
+                  <p>{t((m) => m.cards.invoices.receiptScanCard.controls.zoomIn)}</p>
                 </TooltipContent>
               </Tooltip>
               <Tooltip>
@@ -341,7 +341,7 @@ export function ReceiptScanCard(): React.JSX.Element {
                   }
                 />
                 <TooltipContent>
-                  <p>{t((m) => m["IMS--Cards"].receiptScanCard.controls.zoomOut)}</p>
+                  <p>{t((m) => m.cards.invoices.receiptScanCard.controls.zoomOut)}</p>
                 </TooltipContent>
               </Tooltip>
               <Tooltip>
@@ -357,7 +357,7 @@ export function ReceiptScanCard(): React.JSX.Element {
                   }
                 />
                 <TooltipContent>
-                  <p>{t((m) => m["IMS--Cards"].receiptScanCard.controls.reset)}</p>
+                  <p>{t((m) => m.cards.invoices.receiptScanCard.controls.reset)}</p>
                 </TooltipContent>
               </Tooltip>
               <Tooltip>
@@ -372,7 +372,7 @@ export function ReceiptScanCard(): React.JSX.Element {
                   }
                 />
                 <TooltipContent>
-                  <p>{t((m) => m["IMS--Cards"].receiptScanCard.controls.rotate)}</p>
+                  <p>{t((m) => m.cards.invoices.receiptScanCard.controls.rotate)}</p>
                 </TooltipContent>
               </Tooltip>
               <Tooltip>
@@ -387,7 +387,7 @@ export function ReceiptScanCard(): React.JSX.Element {
                   }
                 />
                 <TooltipContent>
-                  <p>{t((m) => m["IMS--Cards"].receiptScanCard.controls.download)}</p>
+                  <p>{t((m) => m.cards.invoices.receiptScanCard.controls.download)}</p>
                 </TooltipContent>
               </Tooltip>
             </div>
@@ -405,12 +405,12 @@ export function ReceiptScanCard(): React.JSX.Element {
                         className={styles["navButton"]}
                         onClick={handlePreviousScan}>
                         <TbArrowLeft className={styles["navIcon"]} />
-                        {t((m) => m["IMS--Cards"].receiptScanCard.buttons.previousScan)}
+                        {t((m) => m.cards.invoices.receiptScanCard.buttons.previousScan)}
                       </Button>
                     }
                   />
                   <TooltipContent>
-                    <p>{t((m) => m["IMS--Cards"].receiptScanCard.tooltips.previousScan)}</p>
+                    <p>{t((m) => m.cards.invoices.receiptScanCard.tooltips.previousScan)}</p>
                   </TooltipContent>
                 </Tooltip>
               )}
@@ -422,13 +422,13 @@ export function ReceiptScanCard(): React.JSX.Element {
                         variant='secondary'
                         className={styles["navButton"]}
                         onClick={handleNextScan}>
-                        {t((m) => m["IMS--Cards"].receiptScanCard.buttons.nextScan)}
+                        {t((m) => m.cards.invoices.receiptScanCard.buttons.nextScan)}
                         <TbArrowRight className={styles["navIcon"]} />
                       </Button>
                     }
                   />
                   <TooltipContent>
-                    <p>{t((m) => m["IMS--Cards"].receiptScanCard.tooltips.nextScan)}</p>
+                    <p>{t((m) => m.cards.invoices.receiptScanCard.tooltips.nextScan)}</p>
                   </TooltipContent>
                 </Tooltip>
               )}

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/RelatedInvoicesCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/RelatedInvoicesCard.tsx
@@ -209,8 +209,8 @@ export function RelatedInvoicesCard(): React.JSX.Element | null {
         <CardHeader>
           <div className={styles["header"]}>
             <div>
-              <CardTitle>{t((m) => m["IMS--View"].relatedInvoices.title)}</CardTitle>
-              <p className={styles["subtitle"]}>{t((m) => m["IMS--View"].relatedInvoices.subtitle)}</p>
+              <CardTitle>{t((m) => m.pages.invoices.viewInvoice.relatedInvoices.title)}</CardTitle>
+              <p className={styles["subtitle"]}>{t((m) => m.pages.invoices.viewInvoice.relatedInvoices.subtitle)}</p>
             </div>
             <TbReceipt className={styles["headerIcon"]} />
           </div>
@@ -275,7 +275,7 @@ function RelatedInvoiceMiniCard({invoice, relationType}: Readonly<RelatedInvoice
 
   const amount = `${invoice.paymentInformation.currency.symbol}${formatAmount(invoice.paymentInformation.totalCostAmount)}`;
 
-  const relationTypeBadge = t(selectorFromPath(`IMS--View.relatedInvoices.${relationType}`));
+  const relationTypeBadge = t(selectorFromPath(`pages.invoices.viewInvoice.relatedInvoices.${relationType}`));
 
   return (
     <Link
@@ -311,7 +311,7 @@ function RelatedInvoiceMiniCard({invoice, relationType}: Readonly<RelatedInvoice
 
         {/* View Arrow */}
         <div className={styles["viewAction"]}>
-          <span className={styles["viewText"]}>{t((m) => m["IMS--View"].relatedInvoices.viewInvoice)}</span>
+          <span className={styles["viewText"]}>{t((m) => m.pages.invoices.viewInvoice.relatedInvoices.viewInvoice)}</span>
           <TbArrowRight className={styles["arrowIcon"]} />
         </div>
       </div>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/SeasonalInsightsCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/SeasonalInsightsCard.tsx
@@ -181,7 +181,7 @@ export function SeasonalInsightsCard(): React.JSX.Element {
   const locale = useLocale();
   const t = useTranslations();
   const translate = useMemo<SeasonalTranslateFn>(
-    () => (key, values) => t(selectorFromPath(`IMS--Cards.seasonalInsightsCard.${key}`), values),
+    () => (key, values) => t(selectorFromPath(`cards.invoices.seasonalInsightsCard.${key}`), values),
     [t],
   );
   const {invoice} = useInvoiceContext();
@@ -240,7 +240,7 @@ export function SeasonalInsightsCard(): React.JSX.Element {
         <CardTitle>
           <span className={styles["titleRow"]}>
             <TbSparkles className={styles["titleIcon"]} />
-            {t((m) => m["IMS--Cards"].seasonalInsightsCard.title)}
+            {t((m) => m.cards.invoices.seasonalInsightsCard.title)}
           </span>
         </CardTitle>
       </CardHeader>
@@ -253,8 +253,8 @@ export function SeasonalInsightsCard(): React.JSX.Element {
                   <TbBulb className={styles["iconSm"]} />
                 </div>
                 <div className={styles["insightContent"]}>
-                  <p className={styles["insightTitle"]}>{t((m) => m["IMS--Cards"].seasonalInsightsCard.insights.insufficientData.title)}</p>
-                  <p className={styles["insightDescription"]}>{t((m) => m["IMS--Cards"].seasonalInsightsCard.insights.insufficientData.description)}</p>
+                  <p className={styles["insightTitle"]}>{t((m) => m.cards.invoices.seasonalInsightsCard.insights.insufficientData.title)}</p>
+                  <p className={styles["insightDescription"]}>{t((m) => m.cards.invoices.seasonalInsightsCard.insights.insufficientData.description)}</p>
                 </div>
               </div>
             </div>
@@ -264,7 +264,7 @@ export function SeasonalInsightsCard(): React.JSX.Element {
             {/* Month comparison */}
             <div className={styles["monthSection"]}>
               <div className={styles["monthRow"]}>
-                <span className={styles["monthLabel"]}>{t((m) => m["IMS--Cards"].seasonalInsightsCard.month.spendingSoFar, {month: monthName})}</span>
+                <span className={styles["monthLabel"]}>{t((m) => m.cards.invoices.seasonalInsightsCard.month.spendingSoFar, {month: monthName})}</span>
                 <span className={styles["monthValue"]}>
                   {formatCurrency(seasonalData.currentAmount, {currencyCode: currency.code, locale})}
                 </span>
@@ -272,7 +272,7 @@ export function SeasonalInsightsCard(): React.JSX.Element {
               <Progress value={seasonalData.percentOfAverage} />
               <div className={styles["monthMeta"]}>
                 <span>
-                  {t((m) => m["IMS--Cards"].seasonalInsightsCard.month.vsAverage, {
+                  {t((m) => m.cards.invoices.seasonalInsightsCard.month.vsAverage, {
                     month: monthName,
                     amount: formatCurrency(seasonalData.monthAverage, {currencyCode: currency.code, locale}),
                   })}

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/ShareCollaborateCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/ShareCollaborateCard.tsx
@@ -195,15 +195,15 @@ export function ShareCollaborateCard(): React.JSX.Element {
         .then((result) => {
           if (result.success) {
             setInvoice(result.data);
-            toast.success(t((m) => (isCurrentlyPublic ? m["IMS--View"].shareCollaborate.madePrivate : m["IMS--View"].shareCollaborate.madePublic)));
+            toast.success(t((m) => (isCurrentlyPublic ? m.pages.invoices.viewInvoice.shareCollaborate.madePrivate : m.pages.invoices.viewInvoice.shareCollaborate.madePublic)));
             return;
           }
-          toast.error(t((m) => m["IMS--View"].shareCollaborate.toggleError));
+          toast.error(t((m) => m.pages.invoices.viewInvoice.shareCollaborate.toggleError));
           return;
         })
         .catch((error) => {
           console.error("Failed to toggle public status:", error);
-          toast.error(t((m) => m["IMS--View"].shareCollaborate.toggleError));
+          toast.error(t((m) => m.pages.invoices.viewInvoice.shareCollaborate.toggleError));
         });
     });
   }, [sharingStatus, invoice, setInvoice, t]);
@@ -225,7 +225,7 @@ export function ShareCollaborateCard(): React.JSX.Element {
       <CardHeader>
         <CardTitle className={styles["cardTitle"]}>
           <TbShare className={styles["titleIcon"]} />
-          {t((m) => m["IMS--View"].shareCollaborate.title)}
+          {t((m) => m.pages.invoices.viewInvoice.shareCollaborate.title)}
         </CardTitle>
       </CardHeader>
 
@@ -237,7 +237,7 @@ export function ShareCollaborateCard(): React.JSX.Element {
               htmlFor='public-toggle'
               className={styles["toggleLabel"]}>
               <TbWorld className={styles["toggleIcon"]} />
-              {t((m) => m["IMS--View"].shareCollaborate.publicAccess)}
+              {t((m) => m.pages.invoices.viewInvoice.shareCollaborate.publicAccess)}
             </Label>
             <Switch
               nativeButton
@@ -247,7 +247,7 @@ export function ShareCollaborateCard(): React.JSX.Element {
               disabled={isPending}
             />
           </div>
-          <p className={styles["toggleDescription"]}>{t((m) => m["IMS--View"].shareCollaborate.publicAccessDescription)}</p>
+          <p className={styles["toggleDescription"]}>{t((m) => m.pages.invoices.viewInvoice.shareCollaborate.publicAccessDescription)}</p>
         </div>
 
         {/* Sharing Status Section */}
@@ -258,13 +258,13 @@ export function ShareCollaborateCard(): React.JSX.Element {
               variant={badgeVariant}
               className={styles["statusBadge"]}>
               <StatusIcon className={styles["badgeIcon"]} />
-              {t(selectorFromPath(`IMS--View.shareCollaborate.${sharingStatus}`))}
+              {t(selectorFromPath(`pages.invoices.viewInvoice.shareCollaborate.${sharingStatus}`))}
             </Badge>
           </div>
 
           {sharingStatus !== "private" && (
             <div className={styles["sharedWithRow"]}>
-              <span className={styles["sharedWithLabel"]}>{t((m) => m["IMS--View"].shareCollaborate.sharedWith)}:</span>
+              <span className={styles["sharedWithLabel"]}>{t((m) => m.pages.invoices.viewInvoice.shareCollaborate.sharedWith)}:</span>
               <span className={styles["sharedWithCount"]}>{sharedWithCount} people</span>
             </div>
           )}
@@ -272,10 +272,10 @@ export function ShareCollaborateCard(): React.JSX.Element {
 
         {/* Activity Summary Section */}
         <div className={styles["activitySection"]}>
-          <h4 className={styles["activityTitle"]}>{t((m) => m["IMS--View"].shareCollaborate.activity.title)}:</h4>
+          <h4 className={styles["activityTitle"]}>{t((m) => m.pages.invoices.viewInvoice.shareCollaborate.activity.title)}:</h4>
           <ul className={styles["activityList"]}>
-            <li className={styles["activityItem"]}>• {t((m) => m["IMS--View"].shareCollaborate.activity.created, {time: formatRelativeTime(invoice.createdAt)})}</li>
-            <li className={styles["activityItem"]}>• {t((m) => m["IMS--View"].shareCollaborate.activity.modified, {time: formatRelativeTime(invoice.lastUpdatedAt)})}</li>
+            <li className={styles["activityItem"]}>• {t((m) => m.pages.invoices.viewInvoice.shareCollaborate.activity.created, {time: formatRelativeTime(invoice.createdAt)})}</li>
+            <li className={styles["activityItem"]}>• {t((m) => m.pages.invoices.viewInvoice.shareCollaborate.activity.modified, {time: formatRelativeTime(invoice.lastUpdatedAt)})}</li>
           </ul>
         </div>
 
@@ -285,7 +285,7 @@ export function ShareCollaborateCard(): React.JSX.Element {
           size='sm'
           onClick={handleManageSharing}
           className={styles["manageButton"]}>
-          {t((m) => m["IMS--View"].shareCollaborate.manageSharing)} →
+          {t((m) => m.pages.invoices.viewInvoice.shareCollaborate.manageSharing)} →
         </Button>
       </CardContent>
     </Card>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/ShoppingCalendarCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/ShoppingCalendarCard.tsx
@@ -97,7 +97,7 @@ function InvoiceNamesList({data}: Readonly<{data: DayData}>): React.JSX.Element 
         );
       })}
       {data.invoiceNames.length > 3 && (
-        <p className={styles["moreText"]}>{t((m) => m["IMS--Cards"].shoppingCalendarCard.tooltip.more, {count: String(data.invoiceNames.length - 3)})}</p>
+        <p className={styles["moreText"]}>{t((m) => m.cards.invoices.shoppingCalendarCard.tooltip.more, {count: String(data.invoiceNames.length - 3)})}</p>
       )}
     </div>
   );
@@ -113,7 +113,7 @@ function HistoricalComparisonSection({historicalData}: Readonly<{historicalData:
     <div className={styles["historicalRow"]}>
       <ArrowIcon className={`${styles["iconXs"]} ${colorClass}`} />
       <span className={colorClass}>{Math.abs(historicalData.percentageDiff).toFixed(0)}%</span>
-      <span className={styles["moreText"]}>{t((m) => m["IMS--Cards"].shoppingCalendarCard.tooltip.vsAverage, {years: String(historicalData.yearsWithData)})}</span>
+      <span className={styles["moreText"]}>{t((m) => m.cards.invoices.shoppingCalendarCard.tooltip.vsAverage, {years: String(historicalData.yearsWithData)})}</span>
     </div>
   );
 }
@@ -129,11 +129,11 @@ function DayTooltipContent(props: DayTooltipContentProps): React.JSX.Element {
       className={styles["dayTooltip"]}>
       <div>
         <p className={styles["tooltipLabel"]}>{formatCurrency(amount, {currencyCode: currency.code, locale})}</p>
-        <p className={styles["tooltipCount"]}>{t((m) => m["IMS--Cards"].shoppingCalendarCard.tooltip.invoiceCount, {count: String(count)})}</p>
+        <p className={styles["tooltipCount"]}>{t((m) => m.cards.invoices.shoppingCalendarCard.tooltip.invoiceCount, {count: String(count)})}</p>
       </div>
       {data ? <InvoiceNamesList data={data} /> : null}
       {historicalData ? <HistoricalComparisonSection historicalData={historicalData} /> : null}
-      {isCurrentInvoiceDate ? <Badge className={styles["badgeMt"]}>{t((m) => m["IMS--Cards"].shoppingCalendarCard.tooltip.currentInvoice)}</Badge> : null}
+      {isCurrentInvoiceDate ? <Badge className={styles["badgeMt"]}>{t((m) => m.cards.invoices.shoppingCalendarCard.tooltip.currentInvoice)}</Badge> : null}
     </TooltipContent>
   );
 }
@@ -250,15 +250,15 @@ export function ShoppingCalendarCard(): React.JSX.Element {
           <CardHeader className={styles["cardHeader"]}>
             <CardTitle className={styles["titleRow"]}>
               <TbCalendar className={styles["titleIcon"]} />
-              {t((m) => m["IMS--Cards"].shoppingCalendarCard.title)}
+              {t((m) => m.cards.invoices.shoppingCalendarCard.title)}
               <Tooltip>
                 <TooltipTrigger render={<TbInfoCircle className={styles["infoIcon"]} />} />
                 <TooltipContent
                   side='top'
                   className={styles["tooltipXs"]}>
                   {hasHydrated && invoices.length > 1
-                    ? t((m) => m["IMS--Cards"].shoppingCalendarCard.tooltip.basedOnCachedInvoices, {count: String(invoices.length)})
-                    : t((m) => m["IMS--Cards"].shoppingCalendarCard.tooltip.currentInvoiceOnly)}
+                    ? t((m) => m.cards.invoices.shoppingCalendarCard.tooltip.basedOnCachedInvoices, {count: String(invoices.length)})
+                    : t((m) => m.cards.invoices.shoppingCalendarCard.tooltip.currentInvoiceOnly)}
                 </TooltipContent>
               </Tooltip>
             </CardTitle>
@@ -280,7 +280,7 @@ export function ShoppingCalendarCard(): React.JSX.Element {
 
             {/* Legend */}
             <div className={styles["legend"]}>
-              <span>{t((m) => m["IMS--Cards"].shoppingCalendarCard.legend.less)}</span>
+              <span>{t((m) => m.cards.invoices.shoppingCalendarCard.legend.less)}</span>
               <div className={styles["legendBlocks"]}>
                 <div className={`${styles["legendBlock"]} ${styles["legendBlock1"]}`} />
                 <div className={`${styles["legendBlock"]} ${styles["legendBlock2"]}`} />
@@ -288,7 +288,7 @@ export function ShoppingCalendarCard(): React.JSX.Element {
                 <div className={`${styles["legendBlock"]} ${styles["legendBlock4"]}`} />
                 <div className={`${styles["legendBlock"]} ${styles["legendBlock5"]}`} />
               </div>
-              <span>{t((m) => m["IMS--Cards"].shoppingCalendarCard.legend.more)}</span>
+              <span>{t((m) => m.cards.invoices.shoppingCalendarCard.legend.more)}</span>
             </div>
 
             <Separator />
@@ -298,14 +298,14 @@ export function ShoppingCalendarCard(): React.JSX.Element {
               <div className={styles["statBox"]}>
                 <TbShoppingCart className={styles["iconMutedShrink"]} />
                 <div>
-                  <p className={styles["statLabel"]}>{t((m) => m["IMS--Cards"].shoppingCalendarCard.stats.monthTotal)}</p>
+                  <p className={styles["statLabel"]}>{t((m) => m.cards.invoices.shoppingCalendarCard.stats.monthTotal)}</p>
                   <p className={styles["statValue"]}>{formatCurrency(patterns.monthTotal, {currencyCode: currency.code, locale})}</p>
                 </div>
               </div>
               <div className={styles["statBox"]}>
                 <TbCalendar className={styles["iconMutedShrink"]} />
                 <div>
-                  <p className={styles["statLabel"]}>{t((m) => m["IMS--Cards"].shoppingCalendarCard.stats.shoppingDays)}</p>
+                  <p className={styles["statLabel"]}>{t((m) => m.cards.invoices.shoppingCalendarCard.stats.shoppingDays)}</p>
                   <p className={styles["statValue"]}>{patterns.shoppingDaysCount}</p>
                 </div>
               </div>
@@ -316,16 +316,16 @@ export function ShoppingCalendarCard(): React.JSX.Element {
               <div className={styles["insightBox"]}>
                 <TbTrendingUp className={styles["iconMutedShrink"]} />
                 <p className={styles["insightText"]}>
-                  {t((m) => m["IMS--Cards"].shoppingCalendarCard.insights.shopEveryPrefix)}{" "}
-                  <span className={styles["insightHighlight"]}>{t((m) => m["IMS--Cards"].shoppingCalendarCard.insights.days, {count: patterns.avgDaysBetween.toFixed(0)})}</span>{" "}
-                  {t((m) => m["IMS--Cards"].shoppingCalendarCard.insights.onAverage)}
+                  {t((m) => m.cards.invoices.shoppingCalendarCard.insights.shopEveryPrefix)}{" "}
+                  <span className={styles["insightHighlight"]}>{t((m) => m.cards.invoices.shoppingCalendarCard.insights.days, {count: patterns.avgDaysBetween.toFixed(0)})}</span>{" "}
+                  {t((m) => m.cards.invoices.shoppingCalendarCard.insights.onAverage)}
                   {patterns.avgPerTrip > 0 ? (
                     <>
-                      {t((m) => m["IMS--Cards"].shoppingCalendarCard.insights.spendingPrefix)}{" "}
+                      {t((m) => m.cards.invoices.shoppingCalendarCard.insights.spendingPrefix)}{" "}
                       <span className={styles["insightHighlight"]}>
                         {formatCurrency(patterns.avgPerTrip, {currencyCode: currency.code, locale})}
                       </span>
-                      {t((m) => m["IMS--Cards"].shoppingCalendarCard.insights.perTrip)}
+                      {t((m) => m.cards.invoices.shoppingCalendarCard.insights.perTrip)}
                     </>
                   ) : null}
                 </p>
@@ -337,9 +337,9 @@ export function ShoppingCalendarCard(): React.JSX.Element {
               <div className={styles["insightBox"]}>
                 <TbCalendar className={styles["iconMutedShrink"]} />
                 <p className={styles["insightText"]}>
-                  {t((m) => m["IMS--Cards"].shoppingCalendarCard.insights.mostActiveOn)}{" "}
+                  {t((m) => m.cards.invoices.shoppingCalendarCard.insights.mostActiveOn)}{" "}
                   <span className={styles["insightHighlight"]}>
-                    {t((m) => m["IMS--Cards"].shoppingCalendarCard.insights.weekdayLabel, {weekday: getWeekdayName(patterns.mostActiveWeekday, locale)})}
+                    {t((m) => m.cards.invoices.shoppingCalendarCard.insights.weekdayLabel, {weekday: getWeekdayName(patterns.mostActiveWeekday, locale)})}
                   </span>
                 </p>
               </div>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/SummaryStatsCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/SummaryStatsCard.tsx
@@ -18,28 +18,28 @@ export function SummaryStatsCard({summary, currency}: Readonly<Props>): React.JS
   const t = useTranslations();
   const stats = [
     {
-      label: t((m) => m["IMS--Cards"].summaryStatsCard.stats.totalItems.label),
+      label: t((m) => m.cards.invoices.summaryStatsCard.stats.totalItems.label),
       value: summary.totalItems.toString(),
       icon: TbPackage,
-      description: t((m) => m["IMS--Cards"].summaryStatsCard.stats.totalItems.description),
+      description: t((m) => m.cards.invoices.summaryStatsCard.stats.totalItems.description),
     },
     {
-      label: t((m) => m["IMS--Cards"].summaryStatsCard.stats.categories.label),
+      label: t((m) => m.cards.invoices.summaryStatsCard.stats.categories.label),
       value: summary.uniqueCategories.toString(),
       icon: TbGrid3X3,
-      description: t((m) => m["IMS--Cards"].summaryStatsCard.stats.categories.description),
+      description: t((m) => m.cards.invoices.summaryStatsCard.stats.categories.description),
     },
     {
-      label: t((m) => m["IMS--Cards"].summaryStatsCard.stats.averagePrice.label),
+      label: t((m) => m.cards.invoices.summaryStatsCard.stats.averagePrice.label),
       value: `${formatAmount(summary.averageItemPrice)}`,
       icon: TbReceipt,
-      description: t((m) => m["IMS--Cards"].summaryStatsCard.stats.averagePrice.description, {currency}),
+      description: t((m) => m.cards.invoices.summaryStatsCard.stats.averagePrice.description, {currency}),
     },
     {
-      label: t((m) => m["IMS--Cards"].summaryStatsCard.stats.taxRate.label),
+      label: t((m) => m.cards.invoices.summaryStatsCard.stats.taxRate.label),
       value: `${formatAmount(summary.taxPercentage, locale, 1)}%`,
       icon: TbPercentage,
-      description: t((m) => m["IMS--Cards"].summaryStatsCard.stats.taxRate.description, {amount: formatAmount(summary.taxAmount), currency}),
+      description: t((m) => m.cards.invoices.summaryStatsCard.stats.taxRate.description, {amount: formatAmount(summary.taxAmount), currency}),
     },
   ];
 
@@ -47,8 +47,8 @@ export function SummaryStatsCard({summary, currency}: Readonly<Props>): React.JS
     <div className={styles["card"]}>
       <Card>
         <CardHeader>
-          <CardTitle>{t((m) => m["IMS--Cards"].summaryStatsCard.title)}</CardTitle>
-          <CardDescription>{t((m) => m["IMS--Cards"].summaryStatsCard.description)}</CardDescription>
+          <CardTitle>{t((m) => m.cards.invoices.summaryStatsCard.title)}</CardTitle>
+          <CardDescription>{t((m) => m.cards.invoices.summaryStatsCard.description)}</CardDescription>
         </CardHeader>
         <CardContent>
           <div className={styles["statsGrid"]}>
@@ -70,7 +70,7 @@ export function SummaryStatsCard({summary, currency}: Readonly<Props>): React.JS
             <div className={styles["extremeRow"]}>
               <div className={styles["extremeLabel"]}>
                 <TbTrendingUp className={styles["iconEmerald"]} />
-                <span className={styles["extremeLabelText"]}>{t((m) => m["IMS--Cards"].summaryStatsCard.extremes.highest)}</span>
+                <span className={styles["extremeLabelText"]}>{t((m) => m.cards.invoices.summaryStatsCard.extremes.highest)}</span>
               </div>
               <div className={styles["extremeRight"]}>
                 <p className={styles["extremePrice"]}>
@@ -83,7 +83,7 @@ export function SummaryStatsCard({summary, currency}: Readonly<Props>): React.JS
             <div className={styles["extremeRow"]}>
               <div className={styles["extremeLabel"]}>
                 <TbTrendingDown className={styles["iconBlue"]} />
-                <span className={styles["extremeLabelText"]}>{t((m) => m["IMS--Cards"].summaryStatsCard.extremes.lowest)}</span>
+                <span className={styles["extremeLabelText"]}>{t((m) => m.cards.invoices.summaryStatsCard.extremes.lowest)}</span>
               </div>
               <div className={styles["extremeRight"]}>
                 <p className={styles["extremePrice"]}>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/insights/CategorySuggestionCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/insights/CategorySuggestionCard.tsx
@@ -61,14 +61,14 @@ export function CategorySuggestionCard(): React.JSX.Element {
         <CardTitle>
           <span className={styles["titleRow"]}>
             <TbHelpCircle className={styles["titleIcon"]} />
-            {t((m) => m["IMS--Cards"].categorySuggestionCard.title)}
+            {t((m) => m.cards.invoices.categorySuggestionCard.title)}
           </span>
         </CardTitle>
       </CardHeader>
       <CardContent>
         <div className={styles["contentSpaced"]}>
           {/* Explanation */}
-          <p className={styles["description"]}>{t((m) => m["IMS--Cards"].categorySuggestionCard.description)}</p>
+          <p className={styles["description"]}>{t((m) => m.cards.invoices.categorySuggestionCard.description)}</p>
 
           {/* Main Categories Grid */}
           <div className={styles["mainGrid"]}>
@@ -85,7 +85,7 @@ export function CategorySuggestionCard(): React.JSX.Element {
 
           {/* More Categories Grid */}
           <div className={styles["moreSection"]}>
-            <p className={styles["moreLabel"]}>{t((m) => m["IMS--Cards"].categorySuggestionCard.moreCategories)}</p>
+            <p className={styles["moreLabel"]}>{t((m) => m.cards.invoices.categorySuggestionCard.moreCategories)}</p>
             <div className={styles["moreGrid"]}>
               {extendedCategories.map((category) => (
                 <CategoryButton
@@ -103,7 +103,7 @@ export function CategorySuggestionCard(): React.JSX.Element {
           <div className={styles["gamificationBox"]}>
             <div className={styles["gamificationHeader"]}>
               <TbGift className={styles["gamificationGiftIcon"]} />
-              <span className={styles["gamificationLabel"]}>{t((m) => m["IMS--Cards"].categorySuggestionCard.gamification, {goal: String(goal)})}</span>
+              <span className={styles["gamificationLabel"]}>{t((m) => m.cards.invoices.categorySuggestionCard.gamification, {goal: String(goal)})}</span>
             </div>
             <div className={styles["gamificationProgress"]}>
               <Progress value={(categorizedCount / goal) * 100} />

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/insights/DiningCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/insights/DiningCard.tsx
@@ -34,9 +34,9 @@ export function DiningCard(): React.JSX.Element {
 
   // Determine sodium level based on total amount spent
   const getSodiumLevel = (): string => {
-    if (totalAmount > 50) return t((m) => m["IMS--Cards"].diningCard.sodium.high);
-    if (totalAmount > 30) return t((m) => m["IMS--Cards"].diningCard.sodium.medium);
-    return t((m) => m["IMS--Cards"].diningCard.sodium.low);
+    if (totalAmount > 50) return t((m) => m.cards.invoices.diningCard.sodium.high);
+    if (totalAmount > 30) return t((m) => m.cards.invoices.diningCard.sodium.medium);
+    return t((m) => m.cards.invoices.diningCard.sodium.low);
   };
   const sodiumLevel = getSodiumLevel();
 
@@ -50,9 +50,9 @@ export function DiningCard(): React.JSX.Element {
 
   // Healthier swaps
   const swaps = [
-    {id: "grilled", swap: t((m) => m["IMS--Cards"].diningCard.swaps.grilled), calSaved: 200},
-    {id: "water", swap: t((m) => m["IMS--Cards"].diningCard.swaps.water), calSaved: 150, moneySaved: 8},
-    {id: "salad", swap: t((m) => m["IMS--Cards"].diningCard.swaps.salad), calSaved: 280},
+    {id: "grilled", swap: t((m) => m.cards.invoices.diningCard.swaps.grilled), calSaved: 200},
+    {id: "water", swap: t((m) => m.cards.invoices.diningCard.swaps.water), calSaved: 150, moneySaved: 8},
+    {id: "salad", swap: t((m) => m.cards.invoices.diningCard.swaps.salad), calSaved: 280},
   ];
 
   // Challenge
@@ -64,7 +64,7 @@ export function DiningCard(): React.JSX.Element {
         <CardTitle>
           <span className={styles["titleRow"]}>
             <TbToolsKitchen className={styles["titleIcon"]} />
-            {t((m) => m["IMS--Cards"].diningCard.title)}
+            {t((m) => m.cards.invoices.diningCard.title)}
           </span>
         </CardTitle>
       </CardHeader>
@@ -72,37 +72,37 @@ export function DiningCard(): React.JSX.Element {
         <div className={styles["contentSpaced"]}>
           {/* Estimated Nutrition */}
           <div>
-            <h4 className={styles["sectionTitle"]}>{t((m) => m["IMS--Cards"].diningCard.estimatedNutrition.title)}</h4>
+            <h4 className={styles["sectionTitle"]}>{t((m) => m.cards.invoices.diningCard.estimatedNutrition.title)}</h4>
             <div className={styles["nutritionGrid"]}>
               <div className={styles["nutritionItem"]}>
                 <TbFlame className={styles["iconOrange"]} />
                 <div>
-                  <p className={styles["nutritionLabel"]}>{t((m) => m["IMS--Cards"].diningCard.estimatedNutrition.calories)}</p>
-                  <p className={styles["nutritionValue"]}>{t((m) => m["IMS--Cards"].diningCard.estimatedNutrition.caloriesValue, {value: String(estimatedCalories)})}</p>
+                  <p className={styles["nutritionLabel"]}>{t((m) => m.cards.invoices.diningCard.estimatedNutrition.calories)}</p>
+                  <p className={styles["nutritionValue"]}>{t((m) => m.cards.invoices.diningCard.estimatedNutrition.caloriesValue, {value: String(estimatedCalories)})}</p>
                 </div>
               </div>
               <div className={styles["nutritionItem"]}>
                 <TbMeat className={styles["iconRed"]} />
                 <div>
-                  <p className={styles["nutritionLabel"]}>{t((m) => m["IMS--Cards"].diningCard.estimatedNutrition.protein)}</p>
-                  <p className={styles["nutritionValue"]}>{t((m) => m["IMS--Cards"].diningCard.estimatedNutrition.proteinValue, {value: String(estimatedProtein)})}</p>
+                  <p className={styles["nutritionLabel"]}>{t((m) => m.cards.invoices.diningCard.estimatedNutrition.protein)}</p>
+                  <p className={styles["nutritionValue"]}>{t((m) => m.cards.invoices.diningCard.estimatedNutrition.proteinValue, {value: String(estimatedProtein)})}</p>
                 </div>
               </div>
               <div className={styles["nutritionItem"]}>
-                <TbAlertTriangle className={sodiumLevel === t((m) => m["IMS--Cards"].diningCard.sodium.high) ? styles["iconRed"] : styles["iconAmber"]} />
+                <TbAlertTriangle className={sodiumLevel === t((m) => m.cards.invoices.diningCard.sodium.high) ? styles["iconRed"] : styles["iconAmber"]} />
                 <div>
-                  <p className={styles["nutritionLabel"]}>{t((m) => m["IMS--Cards"].diningCard.estimatedNutrition.sodium)}</p>
+                  <p className={styles["nutritionLabel"]}>{t((m) => m.cards.invoices.diningCard.estimatedNutrition.sodium)}</p>
                   <p className={styles["nutritionValue"]}>
                     {sodiumLevel}
-                    {sodiumLevel === t((m) => m["IMS--Cards"].diningCard.sodium.high) && <span className={styles["sodiumWarning"]}>!</span>}
+                    {sodiumLevel === t((m) => m.cards.invoices.diningCard.sodium.high) && <span className={styles["sodiumWarning"]}>!</span>}
                   </p>
                 </div>
               </div>
               <div className={styles["nutritionItem"]}>
                 <TbCookie className={styles["iconAmber"]} />
                 <div>
-                  <p className={styles["nutritionLabel"]}>{t((m) => m["IMS--Cards"].diningCard.estimatedNutrition.carbs)}</p>
-                  <p className={styles["nutritionValue"]}>{t((m) => m["IMS--Cards"].diningCard.estimatedNutrition.carbsValue, {value: String(estimatedCarbs)})}</p>
+                  <p className={styles["nutritionLabel"]}>{t((m) => m.cards.invoices.diningCard.estimatedNutrition.carbs)}</p>
+                  <p className={styles["nutritionValue"]}>{t((m) => m.cards.invoices.diningCard.estimatedNutrition.carbsValue, {value: String(estimatedCarbs)})}</p>
                 </div>
               </div>
             </div>
@@ -110,17 +110,17 @@ export function DiningCard(): React.JSX.Element {
 
           {/* Fast Food Habits */}
           <div>
-            <h4 className={styles["sectionTitle"]}>{t((m) => m["IMS--Cards"].diningCard.habits.title)}</h4>
+            <h4 className={styles["sectionTitle"]}>{t((m) => m.cards.invoices.diningCard.habits.title)}</h4>
             <div className={styles["habitsGrid"]}>
               <div className={styles["habitCard"]}>
                 <TbCalendar className={`${styles["habitIconWrapper"]} ${styles["iconBlue"]}`} />
-                <p className={styles["habitLabel"]}>{t((m) => m["IMS--Cards"].diningCard.habits.frequency)}</p>
-                <p className={styles["habitValue"]}>{t((m) => m["IMS--Cards"].diningCard.habits.frequencyValue, {count: String(fastFoodFrequency)})}</p>
-                <p className={styles["habitSub"]}>{t((m) => m["IMS--Cards"].diningCard.habits.frequencyDiff)}</p>
+                <p className={styles["habitLabel"]}>{t((m) => m.cards.invoices.diningCard.habits.frequency)}</p>
+                <p className={styles["habitValue"]}>{t((m) => m.cards.invoices.diningCard.habits.frequencyValue, {count: String(fastFoodFrequency)})}</p>
+                <p className={styles["habitSub"]}>{t((m) => m.cards.invoices.diningCard.habits.frequencyDiff)}</p>
               </div>
               <div className={styles["habitCard"]}>
                 <TbUserDollar className={`${styles["habitIconWrapper"]} ${styles["iconGreen"]}`} />
-                <p className={styles["habitLabel"]}>{t((m) => m["IMS--Cards"].diningCard.habits.avgSpend)}</p>
+                <p className={styles["habitLabel"]}>{t((m) => m.cards.invoices.diningCard.habits.avgSpend)}</p>
                 <p className={styles["habitValue"]}>{formatCurrency(avgSpend, {currencyCode: currency.code, locale})}</p>
                 <p className={`${styles["habitSub"]} ${spendDiff > 0 ? styles["spendDiffRed"] : styles["spendDiffGreen"]}`}>
                   {spendDiff > 0 ? "+" : ""}
@@ -129,9 +129,9 @@ export function DiningCard(): React.JSX.Element {
               </div>
               <div className={styles["habitCard"]}>
                 <TbMapPin className={`${styles["habitIconWrapper"]} ${styles["iconRed"]}`} />
-                <p className={styles["habitLabel"]}>{t((m) => m["IMS--Cards"].diningCard.habits.favorite)}</p>
+                <p className={styles["habitLabel"]}>{t((m) => m.cards.invoices.diningCard.habits.favorite)}</p>
                 <p className={styles["habitValue"]}>{favoritePlace}</p>
-                <p className={styles["habitSub"]}>{t((m) => m["IMS--Cards"].diningCard.habits.visits, {count: String(visits)})}</p>
+                <p className={styles["habitSub"]}>{t((m) => m.cards.invoices.diningCard.habits.visits, {count: String(visits)})}</p>
               </div>
             </div>
           </div>
@@ -140,7 +140,7 @@ export function DiningCard(): React.JSX.Element {
           <div>
             <div className={styles["swapsHeader"]}>
               <TbBulb className={styles["iconAmber"]} />
-              <h4 className={styles["swapsTitle"]}>{t((m) => m["IMS--Cards"].diningCard.swaps.title)}</h4>
+              <h4 className={styles["swapsTitle"]}>{t((m) => m.cards.invoices.diningCard.swaps.title)}</h4>
             </div>
             <ul className={styles["swapsList"]}>
               {swaps.map((s) => (
@@ -149,10 +149,10 @@ export function DiningCard(): React.JSX.Element {
                   className={styles["swapItem"]}>
                   <span className={styles["swapBullet"]}>•</span>
                   <span>
-                    {s.swap}: <span className={styles["swapSaving"]}>{t((m) => m["IMS--Cards"].diningCard.swaps.caloriesSaved, {count: String(s.calSaved)})}</span>
+                    {s.swap}: <span className={styles["swapSaving"]}>{t((m) => m.cards.invoices.diningCard.swaps.caloriesSaved, {count: String(s.calSaved)})}</span>
                     {s.moneySaved ? (
                       <span className={styles["swapSaving"]}>
-                        {t((m) => m["IMS--Cards"].diningCard.swaps.moneySaved, {amount: formatCurrency(s.moneySaved, {currencyCode: currency.code, locale})})}
+                        {t((m) => m.cards.invoices.diningCard.swaps.moneySaved, {amount: formatCurrency(s.moneySaved, {currencyCode: currency.code, locale})})}
                       </span>
                     ) : null}
                   </span>
@@ -165,13 +165,13 @@ export function DiningCard(): React.JSX.Element {
           <div className={styles["challengeBox"]}>
             <TbTarget className={styles["challengeIcon"]} />
             <div>
-              <p className={styles["challengeTitle"]}>{t((m) => m["IMS--Cards"].diningCard.challenge.title)}</p>
+              <p className={styles["challengeTitle"]}>{t((m) => m.cards.invoices.diningCard.challenge.title)}</p>
               <p className={styles["challengeDescription"]}>
-                {t((m) => m["IMS--Cards"].diningCard.challenge.descriptionPrefix)}{" "}
+                {t((m) => m.cards.invoices.diningCard.challenge.descriptionPrefix)}{" "}
                 <span className={styles["challengeHighlight"]}>
                   {formatCurrency(challengeSavings, {currencyCode: currency.code, locale})}
                 </span>
-                {t((m) => m["IMS--Cards"].diningCard.challenge.descriptionSuffix)}
+                {t((m) => m.cards.invoices.diningCard.challenge.descriptionSuffix)}
               </p>
             </div>
           </div>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/insights/GeneralExpenseCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/insights/GeneralExpenseCard.tsx
@@ -17,14 +17,14 @@ export function GeneralExpenseCard(): React.JSX.Element {
   const {currency, totalCostAmount: totalAmount} = paymentInformation;
 
   // Auto-detected category (mock)
-  const detectedCategory = t((m) => m["IMS--Cards"].generalExpenseCard.detectedCategory);
+  const detectedCategory = t((m) => m.cards.invoices.generalExpenseCard.detectedCategory);
   const confidence = 87;
 
   // Budget categories (mock)
   const budgets = [
-    {name: t((m) => m["IMS--Cards"].generalExpenseCard.budgetCategories.electronics), spent: 450, limit: 500, color: "bg-blue-500"},
-    {name: t((m) => m["IMS--Cards"].generalExpenseCard.budgetCategories.entertainment), spent: 120, limit: 300, color: "bg-purple-500"},
-    {name: t((m) => m["IMS--Cards"].generalExpenseCard.budgetCategories.shopping), spent: 280, limit: 400, color: "bg-pink-500"},
+    {name: t((m) => m.cards.invoices.generalExpenseCard.budgetCategories.electronics), spent: 450, limit: 500, color: "bg-blue-500"},
+    {name: t((m) => m.cards.invoices.generalExpenseCard.budgetCategories.entertainment), spent: 120, limit: 300, color: "bg-purple-500"},
+    {name: t((m) => m.cards.invoices.generalExpenseCard.budgetCategories.shopping), spent: 280, limit: 400, color: "bg-pink-500"},
   ];
 
   // Tax options
@@ -60,7 +60,7 @@ export function GeneralExpenseCard(): React.JSX.Element {
         <CardTitle>
           <span className={styles["titleRow"]}>
             <TbChartBar className={styles["titleIcon"]} />
-            {t((m) => m["IMS--Cards"].generalExpenseCard.title)}
+            {t((m) => m.cards.invoices.generalExpenseCard.title)}
           </span>
         </CardTitle>
       </CardHeader>
@@ -68,29 +68,29 @@ export function GeneralExpenseCard(): React.JSX.Element {
         <div className={styles["contentSpaced"]}>
           {/* Auto-detected Category */}
           <div>
-            <h4 className={styles["sectionTitle"]}>{t((m) => m["IMS--Cards"].generalExpenseCard.sections.autoDetectedCategory)}</h4>
+            <h4 className={styles["sectionTitle"]}>{t((m) => m.cards.invoices.generalExpenseCard.sections.autoDetectedCategory)}</h4>
             <div className={styles["detectedBox"]}>
               <div className={styles["detectedRow"]}>
                 <div className={styles["detectedLabel"]}>
                   <TbTag className={styles["iconIndigo"]} />
                   <span className={styles["detectedName"]}>{detectedCategory}</span>
                 </div>
-                <Badge variant='secondary'>{t((m) => m["IMS--Cards"].generalExpenseCard.confidence, {value: String(confidence)})}</Badge>
+                <Badge variant='secondary'>{t((m) => m.cards.invoices.generalExpenseCard.confidence, {value: String(confidence)})}</Badge>
               </div>
               <div className={styles["detectedActions"]}>
                 <Button
                   variant='outline'
                   size='sm'
-                  aria-label={t((m) => m["IMS--Cards"].generalExpenseCard.aria.confirmCategory)}>
+                  aria-label={t((m) => m.cards.invoices.generalExpenseCard.aria.confirmCategory)}>
                   <TbCheck className={styles["iconSmColored"]} />
-                  {t((m) => m["IMS--Cards"].generalExpenseCard.buttons.correct)}
+                  {t((m) => m.cards.invoices.generalExpenseCard.buttons.correct)}
                 </Button>
                 <Button
                   variant='ghost'
                   size='sm'
-                  aria-label={t((m) => m["IMS--Cards"].generalExpenseCard.aria.changeCategory)}>
+                  aria-label={t((m) => m.cards.invoices.generalExpenseCard.aria.changeCategory)}>
                   <TbRefresh className={styles["iconSmColored"]} />
-                  {t((m) => m["IMS--Cards"].generalExpenseCard.buttons.change)}
+                  {t((m) => m.cards.invoices.generalExpenseCard.buttons.change)}
                 </Button>
               </div>
             </div>
@@ -98,7 +98,7 @@ export function GeneralExpenseCard(): React.JSX.Element {
 
           {/* Budget Impact */}
           <div className={styles["budgetSection"]}>
-            <h4 className={styles["sectionTitle"]}>{t((m) => m["IMS--Cards"].generalExpenseCard.sections.budgetImpact)}</h4>
+            <h4 className={styles["sectionTitle"]}>{t((m) => m.cards.invoices.generalExpenseCard.sections.budgetImpact)}</h4>
             <div className={styles["budgetSection"]}>
               {budgets.map((budget) => {
                 const pct = (budget.spent / budget.limit) * 100;
@@ -125,7 +125,7 @@ export function GeneralExpenseCard(): React.JSX.Element {
                 role='alert'
                 aria-live='polite'>
                 <span aria-hidden='true'>!</span>
-                {t((m) => m["IMS--Cards"].generalExpenseCard.nearLimitAlert, {
+                {t((m) => m.cards.invoices.generalExpenseCard.nearLimitAlert, {
                   name: nearLimitBudget.name,
                   percent: String(Math.round((nearLimitBudget.spent / nearLimitBudget.limit) * 100)),
                 })}
@@ -137,7 +137,7 @@ export function GeneralExpenseCard(): React.JSX.Element {
           <div>
             <h4 className={styles["sectionTitleWithIcon"]}>
               <TbFileText className={styles["iconSm"]} />
-              {t((m) => m["IMS--Cards"].generalExpenseCard.sections.taxBusiness)}
+              {t((m) => m.cards.invoices.generalExpenseCard.sections.taxBusiness)}
             </h4>
             <div className={styles["checkboxSection"]}>
               <div className={styles["checkboxRow"]}>
@@ -146,7 +146,7 @@ export function GeneralExpenseCard(): React.JSX.Element {
                   checked={businessExpense}
                   onCheckedChange={handleBusinessExpenseChange}
                 />
-                <Label htmlFor='business'>{t((m) => m["IMS--Cards"].generalExpenseCard.options.businessExpense)}</Label>
+                <Label htmlFor='business'>{t((m) => m.cards.invoices.generalExpenseCard.options.businessExpense)}</Label>
               </div>
               <div className={styles["checkboxRow"]}>
                 <Checkbox
@@ -154,7 +154,7 @@ export function GeneralExpenseCard(): React.JSX.Element {
                   checked={trackWarranty}
                   onCheckedChange={handleTrackWarrantyChange}
                 />
-                <Label htmlFor='warranty'>{t((m) => m["IMS--Cards"].generalExpenseCard.options.trackWarranty)}</Label>
+                <Label htmlFor='warranty'>{t((m) => m.cards.invoices.generalExpenseCard.options.trackWarranty)}</Label>
               </div>
               <div className={styles["checkboxRow"]}>
                 <Checkbox
@@ -162,13 +162,13 @@ export function GeneralExpenseCard(): React.JSX.Element {
                   checked={insuranceInventory}
                   onCheckedChange={handleInsuranceInventoryChange}
                 />
-                <Label htmlFor='insurance'>{t((m) => m["IMS--Cards"].generalExpenseCard.options.insuranceInventory)}</Label>
+                <Label htmlFor='insurance'>{t((m) => m.cards.invoices.generalExpenseCard.options.insuranceInventory)}</Label>
               </div>
             </div>
             {businessExpense ? (
               <p className={styles["vatText"]}>
                 <TbBriefcase className={styles["briefcaseIcon"]} />
-                {t((m) => m["IMS--Cards"].generalExpenseCard.vatReclaimable)}: {formatCurrency(vatReclaimable, {currencyCode: currency.code, locale})}
+                {t((m) => m.cards.invoices.generalExpenseCard.vatReclaimable)}: {formatCurrency(vatReclaimable, {currencyCode: currency.code, locale})}
               </p>
             ) : null}
           </div>
@@ -177,7 +177,7 @@ export function GeneralExpenseCard(): React.JSX.Element {
           <div>
             <div className={styles["pastHeader"]}>
               <TbHistory className={styles["iconGray"]} />
-              <h4 className={styles["pastTitle"]}>{t((m) => m["IMS--Cards"].generalExpenseCard.sections.similarPurchases)}</h4>
+              <h4 className={styles["pastTitle"]}>{t((m) => m.cards.invoices.generalExpenseCard.sections.similarPurchases)}</h4>
             </div>
             <ul className={styles["pastList"]}>
               {pastPurchases.map((p) => (
@@ -196,16 +196,16 @@ export function GeneralExpenseCard(): React.JSX.Element {
             <Button
               variant='outline'
               size='sm'
-              aria-label={t((m) => m["IMS--Cards"].generalExpenseCard.aria.organize)}>
+              aria-label={t((m) => m.cards.invoices.generalExpenseCard.aria.organize)}>
               <TbFolderOpen className={styles["iconSmColored"]} />
-              {t((m) => m["IMS--Cards"].generalExpenseCard.buttons.organize)}
+              {t((m) => m.cards.invoices.generalExpenseCard.buttons.organize)}
             </Button>
             <Button
               variant='outline'
               size='sm'
-              aria-label={t((m) => m["IMS--Cards"].generalExpenseCard.aria.export)}>
+              aria-label={t((m) => m.cards.invoices.generalExpenseCard.aria.export)}>
               <TbDownload className={styles["iconSmColored"]} />
-              {t((m) => m["IMS--Cards"].generalExpenseCard.buttons.export)}
+              {t((m) => m.cards.invoices.generalExpenseCard.buttons.export)}
             </Button>
           </div>
         </div>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/insights/HomeInventoryCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/insights/HomeInventoryCard.tsx
@@ -56,7 +56,7 @@ export function HomeInventoryCard(): React.JSX.Element {
           className={styles["iconBlue"]}
         />
       );
-      supplies.push({id: `laundry-${item.productCode}`, name: t((m) => m["IMS--Cards"].homeInventoryCard.supplyNames.laundryDetergent), icon, daysRemaining, maxDays: 60});
+      supplies.push({id: `laundry-${item.productCode}`, name: t((m) => m.cards.invoices.homeInventoryCard.supplyNames.laundryDetergent), icon, daysRemaining, maxDays: 60});
     } else if (name.includes("dish") || name.includes("soap")) {
       daysRemaining = 18;
       icon = (
@@ -65,7 +65,7 @@ export function HomeInventoryCard(): React.JSX.Element {
           className={styles["iconCyan"]}
         />
       );
-      supplies.push({id: `dish-${item.productCode}`, name: t((m) => m["IMS--Cards"].homeInventoryCard.supplyNames.dishSoap), icon, daysRemaining, maxDays: 30});
+      supplies.push({id: `dish-${item.productCode}`, name: t((m) => m.cards.invoices.homeInventoryCard.supplyNames.dishSoap), icon, daysRemaining, maxDays: 30});
     } else if (name.includes("paper") || name.includes("towel") || name.includes("tissue")) {
       // daysRemaining stays at default 30
       icon = (
@@ -74,7 +74,7 @@ export function HomeInventoryCard(): React.JSX.Element {
           className={styles["iconGray"]}
         />
       );
-      supplies.push({id: `paper-${item.productCode}`, name: t((m) => m["IMS--Cards"].homeInventoryCard.supplyNames.paperProducts), icon, daysRemaining, maxDays: 45});
+      supplies.push({id: `paper-${item.productCode}`, name: t((m) => m.cards.invoices.homeInventoryCard.supplyNames.paperProducts), icon, daysRemaining, maxDays: 45});
     } else if (name.includes("floor") || name.includes("cleaner")) {
       daysRemaining = 60;
       icon = (
@@ -83,7 +83,7 @@ export function HomeInventoryCard(): React.JSX.Element {
           className={styles["iconGreen"]}
         />
       );
-      supplies.push({id: `floor-${item.productCode}`, name: t((m) => m["IMS--Cards"].homeInventoryCard.supplyNames.floorCleaner), icon, daysRemaining, maxDays: 90});
+      supplies.push({id: `floor-${item.productCode}`, name: t((m) => m.cards.invoices.homeInventoryCard.supplyNames.floorCleaner), icon, daysRemaining, maxDays: 90});
     } else {
       supplies.push({id: `generic-${item.productCode}`, name: item.name, icon, daysRemaining, maxDays: 45});
     }
@@ -94,7 +94,7 @@ export function HomeInventoryCard(): React.JSX.Element {
     supplies.push(
       {
         id: "default-laundry",
-        name: t((m) => m["IMS--Cards"].homeInventoryCard.supplyNames.laundryDetergent),
+        name: t((m) => m.cards.invoices.homeInventoryCard.supplyNames.laundryDetergent),
         icon: (
           <TbDroplets
             key='default-droplets'
@@ -106,7 +106,7 @@ export function HomeInventoryCard(): React.JSX.Element {
       },
       {
         id: "default-dish",
-        name: t((m) => m["IMS--Cards"].homeInventoryCard.supplyNames.dishSoap),
+        name: t((m) => m.cards.invoices.homeInventoryCard.supplyNames.dishSoap),
         icon: (
           <TbSparkles
             key='default-sparkles'
@@ -133,7 +133,7 @@ export function HomeInventoryCard(): React.JSX.Element {
         <CardTitle>
           <span className={styles["titleRow"]}>
             <TbHome className={styles["titleIcon"]} />
-            {t((m) => m["IMS--Cards"].homeInventoryCard.title)}
+            {t((m) => m.cards.invoices.homeInventoryCard.title)}
           </span>
         </CardTitle>
       </CardHeader>
@@ -141,7 +141,7 @@ export function HomeInventoryCard(): React.JSX.Element {
         <div className={styles["contentSpaced"]}>
           {/* Supply Stock Levels */}
           <div>
-            <h4 className={styles["sectionTitle"]}>{t((m) => m["IMS--Cards"].homeInventoryCard.stockLevels.title)}</h4>
+            <h4 className={styles["sectionTitle"]}>{t((m) => m.cards.invoices.homeInventoryCard.stockLevels.title)}</h4>
             <div className={styles["suppliesList"]}>
               {supplies.map((supply) => {
                 const pct = (supply.daysRemaining / supply.maxDays) * 100;
@@ -155,7 +155,7 @@ export function HomeInventoryCard(): React.JSX.Element {
                         {supply.icon}
                         <span>{supply.name}</span>
                       </div>
-                      <span className={styles["supplyDays"]}>{t((m) => m["IMS--Cards"].homeInventoryCard.stockLevels.daysRemaining, {count: String(supply.daysRemaining)})}</span>
+                      <span className={styles["supplyDays"]}>{t((m) => m.cards.invoices.homeInventoryCard.stockLevels.daysRemaining, {count: String(supply.daysRemaining)})}</span>
                     </div>
                     <div className={styles["progressTrack"]}>
                       <div
@@ -174,7 +174,7 @@ export function HomeInventoryCard(): React.JSX.Element {
             <div className={styles["ecoHeader"]}>
               <div className={styles["ecoLabel"]}>
                 <TbLeaf className={styles["leafIcon"]} />
-                <span className={styles["ecoLabelText"]}>{t((m) => m["IMS--Cards"].homeInventoryCard.eco.title)}</span>
+                <span className={styles["ecoLabelText"]}>{t((m) => m.cards.invoices.homeInventoryCard.eco.title)}</span>
               </div>
               <div className={styles["ecoStars"]}>
                 {[1, 2, 3, 4, 5].map((star) => (
@@ -188,15 +188,15 @@ export function HomeInventoryCard(): React.JSX.Element {
             <ul className={styles["ecoList"]}>
               <li className={styles["ecoItem"]}>
                 <span className={styles["ecoBullet"]}>•</span>
-                {t((m) => m["IMS--Cards"].homeInventoryCard.eco.productsWithEcoLabels, {count: String(ecoProducts)})}
+                {t((m) => m.cards.invoices.homeInventoryCard.eco.productsWithEcoLabels, {count: String(ecoProducts)})}
               </li>
               <li className={styles["ecoItem"]}>
                 <span className={styles["ecoBullet"]}>•</span>
-                {t((m) => m["IMS--Cards"].homeInventoryCard.eco.recyclablePackaging, {count: String(recyclablePackaging)})}
+                {t((m) => m.cards.invoices.homeInventoryCard.eco.recyclablePackaging, {count: String(recyclablePackaging)})}
               </li>
               <li className={styles["ecoItem"]}>
                 <span className={styles["ecoTipBullet"]}>•</span>
-                <span className={styles["ecoTipText"]}>{t((m) => m["IMS--Cards"].homeInventoryCard.eco.tip)}</span>
+                <span className={styles["ecoTipText"]}>{t((m) => m.cards.invoices.homeInventoryCard.eco.tip)}</span>
               </li>
             </ul>
           </div>
@@ -205,9 +205,9 @@ export function HomeInventoryCard(): React.JSX.Element {
           <div className={styles["bulkBox"]}>
             <TbPackage className={styles["packageIcon"]} />
             <div>
-              <p className={styles["bulkTitle"]}>{t((m) => m["IMS--Cards"].homeInventoryCard.bulk.title)}</p>
+              <p className={styles["bulkTitle"]}>{t((m) => m.cards.invoices.homeInventoryCard.bulk.title)}</p>
               <p className={styles["bulkDescription"]}>
-                {t((m) => m["IMS--Cards"].homeInventoryCard.bulk.description, {
+                {t((m) => m.cards.invoices.homeInventoryCard.bulk.description, {
                   amount: formatCurrency(potentialSavings, {currencyCode: currency.code, locale}),
                 })}
               </p>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/insights/NutritionCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/insights/NutritionCard.tsx
@@ -30,10 +30,10 @@ type FoodGroup = {
 
 /** Get the label for a balance score */
 function getScoreLabel(score: number, t: ReturnType<typeof useTranslations>): string {
-  if (score >= 80) return t(selectorFromPath("IMS--Cards.nutritionCard.score.excellent"));
-  if (score >= 60) return t(selectorFromPath("IMS--Cards.nutritionCard.score.good"));
-  if (score >= 40) return t(selectorFromPath("IMS--Cards.nutritionCard.score.fair"));
-  return t(selectorFromPath("IMS--Cards.nutritionCard.score.needsWork"));
+  if (score >= 80) return t(selectorFromPath("cards.invoices.nutritionCard.score.excellent"));
+  if (score >= 60) return t(selectorFromPath("cards.invoices.nutritionCard.score.good"));
+  if (score >= 40) return t(selectorFromPath("cards.invoices.nutritionCard.score.fair"));
+  return t(selectorFromPath("cards.invoices.nutritionCard.score.needsWork"));
 }
 
 /** Get the color class for a balance score */
@@ -57,18 +57,18 @@ function calculateBalanceScore(hasVeggies: boolean, hasFruits: boolean, hasProte
 /** Generate a nutrition suggestion based on basket composition */
 function generateSuggestion(hasVeggies: boolean, hasFruits: boolean, processedPct: number, t: ReturnType<typeof useTranslations>): string {
   if (!hasVeggies && !hasFruits) {
-    return t(selectorFromPath("IMS--Cards.nutritionCard.suggestions.addFruitsAndVegetables"));
+    return t(selectorFromPath("cards.invoices.nutritionCard.suggestions.addFruitsAndVegetables"));
   }
   if (!hasVeggies) {
-    return t(selectorFromPath("IMS--Cards.nutritionCard.suggestions.addVegetables"));
+    return t(selectorFromPath("cards.invoices.nutritionCard.suggestions.addVegetables"));
   }
   if (!hasFruits) {
-    return t(selectorFromPath("IMS--Cards.nutritionCard.suggestions.addFruits"));
+    return t(selectorFromPath("cards.invoices.nutritionCard.suggestions.addFruits"));
   }
   if (processedPct > 40) {
-    return t(selectorFromPath("IMS--Cards.nutritionCard.suggestions.swapProcessed"));
+    return t(selectorFromPath("cards.invoices.nutritionCard.suggestions.swapProcessed"));
   }
-  return t(selectorFromPath("IMS--Cards.nutritionCard.suggestions.greatBalance"));
+  return t(selectorFromPath("cards.invoices.nutritionCard.suggestions.greatBalance"));
 }
 
 export function NutritionCard(): React.JSX.Element {
@@ -81,28 +81,28 @@ export function NutritionCard(): React.JSX.Element {
   // Define food groups
   const foodGroups: FoodGroup[] = [
     {
-      name: t((m) => m["IMS--Cards"].nutritionCard.foodGroups.fruits),
+      name: t((m) => m.cards.invoices.nutritionCard.foodGroups.fruits),
       icon: <TbApple className={styles["iconRed"]} />,
       items: 0,
       amount: 0,
       categories: [ProductCategory.FRUITS],
     },
     {
-      name: t((m) => m["IMS--Cards"].nutritionCard.foodGroups.vegetables),
+      name: t((m) => m.cards.invoices.nutritionCard.foodGroups.vegetables),
       icon: <TbLeaf className={styles["iconGreen"]} />,
       items: 0,
       amount: 0,
       categories: [ProductCategory.VEGETABLES],
     },
     {
-      name: t((m) => m["IMS--Cards"].nutritionCard.foodGroups.protein),
+      name: t((m) => m.cards.invoices.nutritionCard.foodGroups.protein),
       icon: <TbMeat className={styles["iconAmber"]} />,
       items: 0,
       amount: 0,
       categories: [ProductCategory.MEAT, ProductCategory.FISH, ProductCategory.DAIRY],
     },
     {
-      name: t((m) => m["IMS--Cards"].nutritionCard.foodGroups.grains),
+      name: t((m) => m.cards.invoices.nutritionCard.foodGroups.grains),
       icon: <TbWheat className={styles["iconWheat"]} />,
       items: 0,
       amount: 0,
@@ -139,9 +139,9 @@ export function NutritionCard(): React.JSX.Element {
   const dairySnackPct = totalFoodItems > 0 ? 100 - wholeFoodPct - processedPct : 0;
 
   // Food balance score (simple heuristic)
-  const hasVeggies = foodGroups.find((g) => g.name === t((m) => m["IMS--Cards"].nutritionCard.foodGroups.vegetables))!.items > 0;
-  const hasFruits = foodGroups.find((g) => g.name === t((m) => m["IMS--Cards"].nutritionCard.foodGroups.fruits))!.items > 0;
-  const hasProtein = foodGroups.find((g) => g.name === t((m) => m["IMS--Cards"].nutritionCard.foodGroups.protein))!.items > 0;
+  const hasVeggies = foodGroups.find((g) => g.name === t((m) => m.cards.invoices.nutritionCard.foodGroups.vegetables))!.items > 0;
+  const hasFruits = foodGroups.find((g) => g.name === t((m) => m.cards.invoices.nutritionCard.foodGroups.fruits))!.items > 0;
+  const hasProtein = foodGroups.find((g) => g.name === t((m) => m.cards.invoices.nutritionCard.foodGroups.protein))!.items > 0;
   const balanceScore = calculateBalanceScore(hasVeggies, hasFruits, hasProtein, wholeFoodPct);
   const scoreLabel = getScoreLabel(balanceScore, t);
   const scoreColor = getScoreColorClass(balanceScore, styles);
@@ -163,14 +163,14 @@ export function NutritionCard(): React.JSX.Element {
       <CardHeader className={styles["cardHeader"]}>
         <CardTitle className={styles["titleRow"]}>
           <TbLeaf className={styles["titleIcon"]} />
-          {t((m) => m["IMS--Cards"].nutritionCard.title)}
+          {t((m) => m.cards.invoices.nutritionCard.title)}
         </CardTitle>
       </CardHeader>
       <CardContent className={styles["contentSpaced"]}>
         {/* Food Balance Score */}
         <div className={styles["scoreSection"]}>
           <div className={styles["scoreRow"]}>
-            <span className={styles["scoreLabel"]}>{t((m) => m["IMS--Cards"].nutritionCard.score.title)}</span>
+            <span className={styles["scoreLabel"]}>{t((m) => m.cards.invoices.nutritionCard.score.title)}</span>
             <span className={`${styles["scoreLabel"]} ${scoreColor}`}>
               {balanceScore}/100 - {scoreLabel}
             </span>
@@ -183,11 +183,11 @@ export function NutritionCard(): React.JSX.Element {
 
         {/* Basket Composition */}
         <div className={styles["compositionSection"]}>
-          <h4 className={styles["compositionTitle"]}>{t((m) => m["IMS--Cards"].nutritionCard.composition.title)}</h4>
+          <h4 className={styles["compositionTitle"]}>{t((m) => m.cards.invoices.nutritionCard.composition.title)}</h4>
           <div className={styles["compositionList"]}>
             <div className={styles["compositionRow"]}>
               <TbLeaf className={styles["iconCompositionGreen"]} />
-              <span className={styles["compositionLabel"]}>{t((m) => m["IMS--Cards"].nutritionCard.composition.wholeFoods)}</span>
+              <span className={styles["compositionLabel"]}>{t((m) => m.cards.invoices.nutritionCard.composition.wholeFoods)}</span>
               <div className={styles["progressTrack"]}>
                 <div
                   className={`${styles["progressBar"]} ${styles["progressGreen"]}`}
@@ -198,7 +198,7 @@ export function NutritionCard(): React.JSX.Element {
             </div>
             <div className={styles["compositionRow"]}>
               <TbWheat className={styles["iconCompositionAmber"]} />
-              <span className={styles["compositionLabel"]}>{t((m) => m["IMS--Cards"].nutritionCard.composition.processed)}</span>
+              <span className={styles["compositionLabel"]}>{t((m) => m.cards.invoices.nutritionCard.composition.processed)}</span>
               <div className={styles["progressTrack"]}>
                 <div
                   className={`${styles["progressBar"]} ${styles["progressAmber"]}`}
@@ -209,7 +209,7 @@ export function NutritionCard(): React.JSX.Element {
             </div>
             <div className={styles["compositionRow"]}>
               <TbMilk className={styles["iconCompositionBlue"]} />
-              <span className={styles["compositionLabel"]}>{t((m) => m["IMS--Cards"].nutritionCard.composition.dairyOther)}</span>
+              <span className={styles["compositionLabel"]}>{t((m) => m.cards.invoices.nutritionCard.composition.dairyOther)}</span>
               <div className={styles["progressTrack"]}>
                 <div
                   className={`${styles["progressBar"]} ${styles["progressBlue"]}`}
@@ -229,7 +229,7 @@ export function NutritionCard(): React.JSX.Element {
               className={styles["foodGroupCard"]}>
               <div className={styles["foodGroupIconRow"]}>{group.icon}</div>
               <p className={styles["foodGroupName"]}>{group.name}</p>
-              <p className={styles["foodGroupCount"]}>{t((m) => m["IMS--Cards"].nutritionCard.foodGroups.itemsCount, {count: String(group.items)})}</p>
+              <p className={styles["foodGroupCount"]}>{t((m) => m.cards.invoices.nutritionCard.foodGroups.itemsCount, {count: String(group.items)})}</p>
               <p className={styles["foodGroupAmount"]}>{formatCurrency(group.amount, {currencyCode: currency.code, locale})}</p>
             </div>
           ))}
@@ -240,7 +240,7 @@ export function NutritionCard(): React.JSX.Element {
           <div className={styles["allergensSection"]}>
             <div className={styles["allergensHeader"]}>
               <TbAlertTriangle className={styles["iconAllergenAmber"]} />
-              <h4 className={styles["allergensTitle"]}>{t((m) => m["IMS--Cards"].nutritionCard.allergens.title)}</h4>
+              <h4 className={styles["allergensTitle"]}>{t((m) => m.cards.invoices.nutritionCard.allergens.title)}</h4>
             </div>
             <div className={styles["allergensList"]}>
               <TooltipProvider>
@@ -258,7 +258,7 @@ export function NutritionCard(): React.JSX.Element {
                       }
                     />
                     <TooltipContent>
-                      <p>{t((m) => m["IMS--Cards"].nutritionCard.allergens.foundInItems, {count: String(count)})}</p>
+                      <p>{t((m) => m.cards.invoices.nutritionCard.allergens.foundInItems, {count: String(count)})}</p>
                     </TooltipContent>
                   </Tooltip>
                 ))}

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/insights/VehicleCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/cards/insights/VehicleCard.tsx
@@ -45,10 +45,10 @@ export function VehicleCard(): React.JSX.Element {
 
   // Monthly fuel data
   const fuelData = [
-    {month: t((m) => m["IMS--Cards"].vehicleCard.months.sep), amount: 420},
-    {month: t((m) => m["IMS--Cards"].vehicleCard.months.oct), amount: 480},
-    {month: t((m) => m["IMS--Cards"].vehicleCard.months.nov), amount: 510},
-    {month: t((m) => m["IMS--Cards"].vehicleCard.months.dec), amount: 560},
+    {month: t((m) => m.cards.invoices.vehicleCard.months.sep), amount: 420},
+    {month: t((m) => m.cards.invoices.vehicleCard.months.oct), amount: 480},
+    {month: t((m) => m.cards.invoices.vehicleCard.months.nov), amount: 510},
+    {month: t((m) => m.cards.invoices.vehicleCard.months.dec), amount: 560},
   ];
 
   const monthlyTotal = 560;
@@ -58,8 +58,8 @@ export function VehicleCard(): React.JSX.Element {
 
   // Maintenance reminders
   const reminders = [
-    {id: "oil-change", task: t((m) => m["IMS--Cards"].vehicleCard.reminders.oilChange), urgent: false},
-    {id: "tire-rotation", task: t((m) => m["IMS--Cards"].vehicleCard.reminders.tireRotation), urgent: false},
+    {id: "oil-change", task: t((m) => m.cards.invoices.vehicleCard.reminders.oilChange), urgent: false},
+    {id: "tire-rotation", task: t((m) => m.cards.invoices.vehicleCard.reminders.tireRotation), urgent: false},
   ];
 
   // Cheapest nearby
@@ -72,7 +72,7 @@ export function VehicleCard(): React.JSX.Element {
         <CardTitle>
           <span className={styles["titleRow"]}>
             <TbCar className={styles["titleIcon"]} />
-            {t((m) => m["IMS--Cards"].vehicleCard.title)}
+            {t((m) => m.cards.invoices.vehicleCard.title)}
           </span>
         </CardTitle>
       </CardHeader>
@@ -81,7 +81,7 @@ export function VehicleCard(): React.JSX.Element {
           {/* Expense Type Badge */}
           <div className={styles["expenseType"]}>
             <TbGasStation className={styles["iconAmber"]} />
-            <span className={styles["expenseTypeLabel"]}>{t((m) => m["IMS--Cards"].vehicleCard.expenseType)}</span>
+            <span className={styles["expenseTypeLabel"]}>{t((m) => m.cards.invoices.vehicleCard.expenseType)}</span>
           </div>
 
           {/* Fuel Details Grid */}
@@ -89,39 +89,39 @@ export function VehicleCard(): React.JSX.Element {
             <div className={styles["detailItem"]}>
               <TbGasStation className={styles["iconAmber"]} />
               <div>
-                <p className={styles["detailLabel"]}>{t((m) => m["IMS--Cards"].vehicleCard.details.liters)}</p>
+                <p className={styles["detailLabel"]}>{t((m) => m.cards.invoices.vehicleCard.details.liters)}</p>
                 <p className={styles["detailValue"]}>~{liters}L</p>
               </div>
             </div>
             <div className={styles["detailItem"]}>
               <TbCurrencyDollar className={styles["iconGreen"]} />
               <div>
-                <p className={styles["detailLabel"]}>{t((m) => m["IMS--Cards"].vehicleCard.details.pricePerLiter)}</p>
+                <p className={styles["detailLabel"]}>{t((m) => m.cards.invoices.vehicleCard.details.pricePerLiter)}</p>
                 <p className={styles["detailValue"]}>{formatCurrency(pricePerLiter, {currencyCode: currency.code, locale})}</p>
               </div>
             </div>
             <div className={styles["detailItem"]}>
               <TbMapPin className={styles["iconRed"]} />
               <div>
-                <p className={styles["detailLabel"]}>{t((m) => m["IMS--Cards"].vehicleCard.details.station)}</p>
+                <p className={styles["detailLabel"]}>{t((m) => m.cards.invoices.vehicleCard.details.station)}</p>
                 <p className={styles["detailValue"]}>{station}</p>
               </div>
             </div>
             <div className={styles["detailItem"]}>
               <TbCar className={styles["iconBlue"]} />
               <div>
-                <p className={styles["detailLabel"]}>{t((m) => m["IMS--Cards"].vehicleCard.details.vehicle)}</p>
-                <p className={styles["detailValueMuted"]}>{t((m) => m["IMS--Cards"].vehicleCard.details.notSet)}</p>
+                <p className={styles["detailLabel"]}>{t((m) => m.cards.invoices.vehicleCard.details.vehicle)}</p>
+                <p className={styles["detailValueMuted"]}>{t((m) => m.cards.invoices.vehicleCard.details.notSet)}</p>
               </div>
             </div>
           </div>
 
           {/* Monthly Fuel Spending Chart */}
           <div className={styles["chartSection"]}>
-            <h4 className={styles["chartTitle"]}>{t((m) => m["IMS--Cards"].vehicleCard.chart.title)}</h4>
+            <h4 className={styles["chartTitle"]}>{t((m) => m.cards.invoices.vehicleCard.chart.title)}</h4>
             <ChartContainer
               config={{
-                amount: {label: t((m) => m["IMS--Cards"].vehicleCard.chart.amount), color: "var(--ac-chart-1)"},
+                amount: {label: t((m) => m.cards.invoices.vehicleCard.chart.amount), color: "var(--ac-chart-1)"},
               }}
               className={styles["chartWrapper"]}>
               <ResponsiveContainer
@@ -177,21 +177,21 @@ export function VehicleCard(): React.JSX.Element {
           <div className={styles["statsGrid"]}>
             <div className={styles["statCard"]}>
               <TbCalendar className={`${styles["habitIconWrapper"]} ${styles["iconBlue"]}`} />
-              <p className={styles["statLabel"]}>{t((m) => m["IMS--Cards"].vehicleCard.stats.thisMonth)}</p>
+              <p className={styles["statLabel"]}>{t((m) => m.cards.invoices.vehicleCard.stats.thisMonth)}</p>
               <p className={styles["statValue"]}>{formatCurrency(monthlyTotal, {currencyCode: currency.code, locale})}</p>
-              <p className={styles["statSub"]}>{t((m) => m["IMS--Cards"].vehicleCard.stats.fillUps, {count: String(fillUps)})}</p>
+              <p className={styles["statSub"]}>{t((m) => m.cards.invoices.vehicleCard.stats.fillUps, {count: String(fillUps)})}</p>
             </div>
             <div className={styles["statCard"]}>
               <TbGauge className={`${styles["habitIconWrapper"]} ${styles["iconGreen"]}`} />
-              <p className={styles["statLabel"]}>{t((m) => m["IMS--Cards"].vehicleCard.stats.costPerKm)}</p>
+              <p className={styles["statLabel"]}>{t((m) => m.cards.invoices.vehicleCard.stats.costPerKm)}</p>
               <p className={styles["statValue"]}>{formatCurrency(costPerKm, {currencyCode: currency.code, locale})}</p>
-              <p className={styles["statSub"]}>{t((m) => m["IMS--Cards"].vehicleCard.stats.estimated)}</p>
+              <p className={styles["statSub"]}>{t((m) => m.cards.invoices.vehicleCard.stats.estimated)}</p>
             </div>
             <div className={styles["statCard"]}>
               <TbTrendingUp className={`${styles["habitIconWrapper"]} ${styles["iconRed"]}`} />
-              <p className={styles["statLabel"]}>{t((m) => m["IMS--Cards"].vehicleCard.stats.fuelPrice)}</p>
+              <p className={styles["statLabel"]}>{t((m) => m.cards.invoices.vehicleCard.stats.fuelPrice)}</p>
               <p className={`${styles["statValue"]} ${styles["statValueRed"]}`}>+{priceChange}%</p>
-              <p className={styles["statSub"]}>{t((m) => m["IMS--Cards"].vehicleCard.stats.thisMonthSuffix)}</p>
+              <p className={styles["statSub"]}>{t((m) => m.cards.invoices.vehicleCard.stats.thisMonthSuffix)}</p>
             </div>
           </div>
 
@@ -199,7 +199,7 @@ export function VehicleCard(): React.JSX.Element {
           <div>
             <div className={styles["remindersHeader"]}>
               <TbBarrel className={styles["iconGray"]} />
-              <h4 className={styles["remindersTitle"]}>{t((m) => m["IMS--Cards"].vehicleCard.maintenance.title)}</h4>
+              <h4 className={styles["remindersTitle"]}>{t((m) => m.cards.invoices.vehicleCard.maintenance.title)}</h4>
             </div>
             <ul className={styles["remindersList"]}>
               {reminders.map((r) => (
@@ -217,9 +217,9 @@ export function VehicleCard(): React.JSX.Element {
           <div className={styles["tipBox"]}>
             <TbBulb className={styles["tipIcon"]} />
             <div>
-              <p className={styles["tipTitle"]}>{t((m) => m["IMS--Cards"].vehicleCard.tip.title)}</p>
+              <p className={styles["tipTitle"]}>{t((m) => m.cards.invoices.vehicleCard.tip.title)}</p>
               <p className={styles["tipDescription"]}>
-                {cheapestStation} - {formatCurrency(cheapestPrice, {currencyCode: currency.code, locale})}/{t((m) => m["IMS--Cards"].vehicleCard.tip.perLiter)}
+                {cheapestStation} - {formatCurrency(cheapestPrice, {currencyCode: currency.code, locale})}/{t((m) => m.cards.invoices.vehicleCard.tip.perLiter)}
               </p>
             </div>
           </div>
@@ -229,12 +229,12 @@ export function VehicleCard(): React.JSX.Element {
             <Button
               variant='outline'
               size='sm'>
-              {t((m) => m["IMS--Cards"].vehicleCard.buttons.addVehicle)}
+              {t((m) => m.cards.invoices.vehicleCard.buttons.addVehicle)}
             </Button>
             <Button
               variant='outline'
               size='sm'>
-              {t((m) => m["IMS--Cards"].vehicleCard.buttons.fullReport)}
+              {t((m) => m.cards.invoices.vehicleCard.buttons.fullReport)}
             </Button>
           </div>
         </div>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/charts/CategoryComparisonChart.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/charts/CategoryComparisonChart.tsx
@@ -65,11 +65,11 @@ export function CategoryComparisonChart({data, currency}: Props): React.JSX.Elem
   const t = useTranslations();
   const chartConfig = {
     current: {
-      label: t((m) => m["IMS--View"].categoryComparisonChart.labels.current),
+      label: t((m) => m.pages.invoices.viewInvoice.categoryComparisonChart.labels.current),
       color: "var(--ac-chart-1)",
     },
     average: {
-      label: t((m) => m["IMS--View"].categoryComparisonChart.labels.average),
+      label: t((m) => m.pages.invoices.viewInvoice.categoryComparisonChart.labels.average),
       color: "var(--ac-chart-3)",
     },
   };
@@ -77,8 +77,8 @@ export function CategoryComparisonChart({data, currency}: Props): React.JSX.Elem
   return (
     <Card className={styles["card"]}>
       <CardHeader className={styles["cardHeader"]}>
-        <CardTitle className={styles["cardTitle"]}>{t((m) => m["IMS--View"].categoryComparisonChart.title)}</CardTitle>
-        <CardDescription className={styles["cardDescription"]}>{t((m) => m["IMS--View"].categoryComparisonChart.description)}</CardDescription>
+        <CardTitle className={styles["cardTitle"]}>{t((m) => m.pages.invoices.viewInvoice.categoryComparisonChart.title)}</CardTitle>
+        <CardDescription className={styles["cardDescription"]}>{t((m) => m.pages.invoices.viewInvoice.categoryComparisonChart.description)}</CardDescription>
       </CardHeader>
       <CardContent className={styles["cardContent"]}>
         <ChartContainer
@@ -111,8 +111,8 @@ export function CategoryComparisonChart({data, currency}: Props): React.JSX.Elem
                     active={false}
                     payload={[]}
                     currency={currency}
-                    currentLabel={t((m) => m["IMS--View"].categoryComparisonChart.labels.current)}
-                    averageLabel={t((m) => m["IMS--View"].categoryComparisonChart.labels.average)}
+                    currentLabel={t((m) => m.pages.invoices.viewInvoice.categoryComparisonChart.labels.current)}
+                    averageLabel={t((m) => m.pages.invoices.viewInvoice.categoryComparisonChart.labels.average)}
                   />
                 }
               />
@@ -125,14 +125,14 @@ export function CategoryComparisonChart({data, currency}: Props): React.JSX.Elem
                 fill='var(--ac-chart-1)'
                 radius={[0, 4, 4, 0]}
                 maxBarSize={16}
-                name={t((m) => m["IMS--View"].categoryComparisonChart.labels.current)}
+                name={t((m) => m.pages.invoices.viewInvoice.categoryComparisonChart.labels.current)}
               />
               <Bar
                 dataKey='average'
                 fill='var(--ac-chart-3)'
                 radius={[0, 4, 4, 0]}
                 maxBarSize={16}
-                name={t((m) => m["IMS--View"].categoryComparisonChart.labels.average)}
+                name={t((m) => m.pages.invoices.viewInvoice.categoryComparisonChart.labels.average)}
               />
             </BarChart>
           </ResponsiveContainer>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/charts/ItemsBreakdownChart.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/charts/ItemsBreakdownChart.tsx
@@ -56,7 +56,7 @@ export function ItemsBreakdownChart({data, currency}: Props): React.JSX.Element 
   const t = useTranslations();
   const chartConfig = {
     price: {
-      label: t((m) => m["IMS--View"].itemsBreakdownChart.labels.price),
+      label: t((m) => m.pages.invoices.viewInvoice.itemsBreakdownChart.labels.price),
       color: "var(--ac-chart-2)",
     },
   };
@@ -71,8 +71,8 @@ export function ItemsBreakdownChart({data, currency}: Props): React.JSX.Element 
   return (
     <Card className={styles["card"]}>
       <CardHeader className={styles["cardHeader"]}>
-        <CardTitle className={styles["cardTitle"]}>{t((m) => m["IMS--View"].itemsBreakdownChart.title)}</CardTitle>
-        <CardDescription className={styles["cardDescription"]}>{t((m) => m["IMS--View"].itemsBreakdownChart.description)}</CardDescription>
+        <CardTitle className={styles["cardTitle"]}>{t((m) => m.pages.invoices.viewInvoice.itemsBreakdownChart.title)}</CardTitle>
+        <CardDescription className={styles["cardDescription"]}>{t((m) => m.pages.invoices.viewInvoice.itemsBreakdownChart.description)}</CardDescription>
       </CardHeader>
       <CardContent className={styles["cardContent"]}>
         <ChartContainer
@@ -106,7 +106,7 @@ export function ItemsBreakdownChart({data, currency}: Props): React.JSX.Element 
                     active={false}
                     payload={[]}
                     currency={currency}
-                    quantityLabel={t((m) => m["IMS--View"].itemsBreakdownChart.labels.quantity)}
+                    quantityLabel={t((m) => m.pages.invoices.viewInvoice.itemsBreakdownChart.labels.quantity)}
                   />
                 }
               />

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/charts/MerchantBreakdownChart.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/charts/MerchantBreakdownChart.tsx
@@ -81,12 +81,12 @@ export function MerchantBreakdownChart({data, currency, currentMerchant}: Props)
   // Resolve merchant names from Zustand store
   const getMerchantName = (merchantId: string): string => {
     const merchant = merchants.find((m) => m.id === merchantId);
-    return merchant?.name ?? t((m) => m["IMS--View"].merchantBreakdownChart.unknownMerchant);
+    return merchant?.name ?? t((m) => m.pages.invoices.viewInvoice.merchantBreakdownChart.unknownMerchant);
   };
 
   const chartConfig = {
     total: {
-      label: t((m) => m["IMS--View"].merchantBreakdownChart.labels.totalSpent),
+      label: t((m) => m.pages.invoices.viewInvoice.merchantBreakdownChart.labels.totalSpent),
       color: "var(--ac-chart-2)",
     },
   };
@@ -102,8 +102,8 @@ export function MerchantBreakdownChart({data, currency, currentMerchant}: Props)
   return (
     <Card className={styles["card"]}>
       <CardHeader className={styles["cardHeader"]}>
-        <CardTitle className={styles["cardTitle"]}>{t((m) => m["IMS--View"].merchantBreakdownChart.title)}</CardTitle>
-        <CardDescription className={styles["cardDescription"]}>{t((m) => m["IMS--View"].merchantBreakdownChart.description)}</CardDescription>
+        <CardTitle className={styles["cardTitle"]}>{t((m) => m.pages.invoices.viewInvoice.merchantBreakdownChart.title)}</CardTitle>
+        <CardDescription className={styles["cardDescription"]}>{t((m) => m.pages.invoices.viewInvoice.merchantBreakdownChart.description)}</CardDescription>
       </CardHeader>
       <CardContent className={styles["cardContent"]}>
         <ChartContainer
@@ -137,9 +137,9 @@ export function MerchantBreakdownChart({data, currency, currentMerchant}: Props)
                     active={false}
                     payload={[]}
                     currency={currency}
-                    totalLabel={t((m) => m["IMS--View"].merchantBreakdownChart.labels.total)}
-                    visitsLabel={t((m) => m["IMS--View"].merchantBreakdownChart.labels.visits)}
-                    averagePerVisitLabel={t((m) => m["IMS--View"].merchantBreakdownChart.labels.averagePerVisit)}
+                    totalLabel={t((m) => m.pages.invoices.viewInvoice.merchantBreakdownChart.labels.total)}
+                    visitsLabel={t((m) => m.pages.invoices.viewInvoice.merchantBreakdownChart.labels.visits)}
+                    averagePerVisitLabel={t((m) => m.pages.invoices.viewInvoice.merchantBreakdownChart.labels.averagePerVisit)}
                   />
                 }
               />

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/charts/PriceDistributionChart.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/charts/PriceDistributionChart.tsx
@@ -42,7 +42,7 @@ function CustomTooltip({active, payload}: CustomTooltipProps): React.JSX.Element
       <p className={styles["tooltipRange"]}>
         {data.range} {data.currency}
       </p>
-      <p className={styles["tooltipCount"]}>{t((m) => m["IMS--View"].priceDistributionChart.tooltip.itemCount, {count: data.count})}</p>
+      <p className={styles["tooltipCount"]}>{t((m) => m.pages.invoices.viewInvoice.priceDistributionChart.tooltip.itemCount, {count: data.count})}</p>
     </div>
   );
 }
@@ -51,7 +51,7 @@ export function PriceDistributionChart({data, currency}: Readonly<Props>): React
   const t = useTranslations();
   const chartConfig = {
     count: {
-      label: t((m) => m["IMS--View"].priceDistributionChart.labels.items),
+      label: t((m) => m.pages.invoices.viewInvoice.priceDistributionChart.labels.items),
       color: "var(--ac-chart-1)",
     },
   };
@@ -61,8 +61,8 @@ export function PriceDistributionChart({data, currency}: Readonly<Props>): React
   return (
     <Card className={styles["card"]}>
       <CardHeader className={styles["cardHeader"]}>
-        <CardTitle className={styles["cardTitle"]}>{t((m) => m["IMS--View"].priceDistributionChart.title)}</CardTitle>
-        <CardDescription className={styles["cardDescription"]}>{t((m) => m["IMS--View"].priceDistributionChart.description, {currency})}</CardDescription>
+        <CardTitle className={styles["cardTitle"]}>{t((m) => m.pages.invoices.viewInvoice.priceDistributionChart.title)}</CardTitle>
+        <CardDescription className={styles["cardDescription"]}>{t((m) => m.pages.invoices.viewInvoice.priceDistributionChart.description, {currency})}</CardDescription>
       </CardHeader>
       <CardContent className={styles["cardContent"]}>
         <ChartContainer

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/charts/SpendingByCategoryChart.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/charts/SpendingByCategoryChart.tsx
@@ -52,7 +52,7 @@ function CustomTooltip({active, payload, currency}: CustomTooltipProps): React.J
       <p className={styles["tooltipAmount"]}>
         {data.amount.toFixed(2)} {currency}
       </p>
-      <p className={styles["tooltipCount"]}>{t((m) => m["IMS--View"].spendingByCategoryChart.tooltip.itemCount, {count: data.count})}</p>
+      <p className={styles["tooltipCount"]}>{t((m) => m.pages.invoices.viewInvoice.spendingByCategoryChart.tooltip.itemCount, {count: data.count})}</p>
     </div>
   );
 }
@@ -98,8 +98,8 @@ export function SpendingByCategoryChart({data, currency}: Props): React.JSX.Elem
   return (
     <Card className={styles["card"]}>
       <CardHeader className={styles["cardHeader"]}>
-        <CardTitle className={styles["cardTitle"]}>{t((m) => m["IMS--View"].spendingByCategoryChart.title)}</CardTitle>
-        <CardDescription className={styles["cardDescription"]}>{t((m) => m["IMS--View"].spendingByCategoryChart.description)}</CardDescription>
+        <CardTitle className={styles["cardTitle"]}>{t((m) => m.pages.invoices.viewInvoice.spendingByCategoryChart.title)}</CardTitle>
+        <CardDescription className={styles["cardDescription"]}>{t((m) => m.pages.invoices.viewInvoice.spendingByCategoryChart.description)}</CardDescription>
       </CardHeader>
       <CardContent className={styles["cardContent"]}>
         <ChartContainer
@@ -137,7 +137,7 @@ export function SpendingByCategoryChart({data, currency}: Props): React.JSX.Elem
           <p className={styles["totalAmount"]}>
             {total.toFixed(2)} {currency}
           </p>
-          <p className={styles["totalLabel"]}>{t((m) => m["IMS--View"].spendingByCategoryChart.totalLabel)}</p>
+          <p className={styles["totalLabel"]}>{t((m) => m.pages.invoices.viewInvoice.spendingByCategoryChart.totalLabel)}</p>
         </div>
       </CardContent>
     </Card>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/charts/SpendingTrendChart.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/charts/SpendingTrendChart.tsx
@@ -60,7 +60,7 @@ function CustomTooltip({active, payload, currency}: CustomTooltipProps): React.J
         <Badge
           variant='secondary'
           className={styles["tooltipCurrentBadge"]}>
-          {t((m) => m["IMS--View"].spendingTrendChart.tooltip.currentInvoice)}
+          {t((m) => m.pages.invoices.viewInvoice.spendingTrendChart.tooltip.currentInvoice)}
         </Badge>
       ) : null}
       {data.invoices && data.invoices.length > 0 ? (
@@ -78,7 +78,7 @@ function CustomTooltip({active, payload, currency}: CustomTooltipProps): React.J
             </li>
           ))}
           {data.invoices.length > 10 ? (
-            <li className={styles["tooltipMore"]}>{t((m) => m["IMS--View"].spendingTrendChart.tooltip.andMore, {count: String(data.invoices.length - 10)})}</li>
+            <li className={styles["tooltipMore"]}>{t((m) => m.pages.invoices.viewInvoice.spendingTrendChart.tooltip.andMore, {count: String(data.invoices.length - 10)})}</li>
           ) : null}
         </ul>
       ) : null}
@@ -90,7 +90,7 @@ export function SpendingTrendChart({data, currency}: Props): React.JSX.Element {
   const t = useTranslations();
   const chartConfig = {
     amount: {
-      label: t((m) => m["IMS--View"].spendingTrendChart.labels.amount),
+      label: t((m) => m.pages.invoices.viewInvoice.spendingTrendChart.labels.amount),
       color: "var(--ac-chart-1)",
     },
   };
@@ -101,8 +101,8 @@ export function SpendingTrendChart({data, currency}: Props): React.JSX.Element {
   return (
     <Card className={styles["card"]}>
       <CardHeader className={styles["cardHeader"]}>
-        <CardTitle className={styles["cardTitle"]}>{t((m) => m["IMS--View"].spendingTrendChart.title)}</CardTitle>
-        <CardDescription className={styles["cardDescription"]}>{t((m) => m["IMS--View"].spendingTrendChart.description)}</CardDescription>
+        <CardTitle className={styles["cardTitle"]}>{t((m) => m.pages.invoices.viewInvoice.spendingTrendChart.title)}</CardTitle>
+        <CardDescription className={styles["cardDescription"]}>{t((m) => m.pages.invoices.viewInvoice.spendingTrendChart.description)}</CardDescription>
       </CardHeader>
       <CardContent className={styles["cardContent"]}>
         <ChartContainer

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/dialogs/ExportDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/dialogs/ExportDialog.tsx
@@ -136,11 +136,11 @@ export function ExportDialog(): React.JSX.Element {
       link.remove();
       URL.revokeObjectURL(url);
 
-      toast.success(t((m) => m["IMS--View"].export.csvSuccess));
+      toast.success(t((m) => m.pages.invoices.viewInvoice.export.csvSuccess));
       close();
     } catch (error) {
       console.error("Failed to export CSV:", error);
-      toast.error(t((m) => m["IMS--View"].export.csvError));
+      toast.error(t((m) => m.pages.invoices.viewInvoice.export.csvError));
     }
   }, [invoice, close, t]);
 
@@ -171,11 +171,11 @@ export function ExportDialog(): React.JSX.Element {
       link.remove();
       URL.revokeObjectURL(url);
 
-      toast.success(t((m) => m["IMS--View"].export.jsonSuccess));
+      toast.success(t((m) => m.pages.invoices.viewInvoice.export.jsonSuccess));
       close();
     } catch (error) {
       console.error("Failed to export JSON:", error);
-      toast.error(t((m) => m["IMS--View"].export.jsonError));
+      toast.error(t((m) => m.pages.invoices.viewInvoice.export.jsonError));
     }
   }, [invoice, close, t]);
 
@@ -207,11 +207,11 @@ Items: ${invoice.items.length}
       `.trim();
 
       await navigator.clipboard.writeText(summary);
-      toast.success(t((m) => m["IMS--View"].export.copySuccess));
+      toast.success(t((m) => m.pages.invoices.viewInvoice.export.copySuccess));
       close();
     } catch (error) {
       console.error("Failed to copy summary:", error);
-      toast.error(t((m) => m["IMS--View"].export.copyError));
+      toast.error(t((m) => m.pages.invoices.viewInvoice.export.copyError));
     }
   }, [invoice, merchant, close, t]);
 
@@ -239,7 +239,7 @@ Items: ${invoice.items.length}
    */
   const handleExportPDF = useCallback(async (): Promise<void> => {
     setIsGeneratingPDF(true);
-    const loadingToastId = toast.loading(t((m) => m["IMS--View"].export.pdfGenerating));
+    const loadingToastId = toast.loading(t((m) => m.pages.invoices.viewInvoice.export.pdfGenerating));
 
     try {
       // Generate PDF blob
@@ -266,12 +266,12 @@ Items: ${invoice.items.length}
       URL.revokeObjectURL(url);
 
       toast.dismiss(loadingToastId);
-      toast.success(t((m) => m["IMS--View"].export.pdfSuccess));
+      toast.success(t((m) => m.pages.invoices.viewInvoice.export.pdfSuccess));
       close();
     } catch (error) {
       console.error("Failed to generate PDF:", error);
       toast.dismiss(loadingToastId);
-      toast.error(t((m) => m["IMS--View"].export.pdfError));
+      toast.error(t((m) => m.pages.invoices.viewInvoice.export.pdfError));
     } finally {
       setIsGeneratingPDF(false);
     }
@@ -283,8 +283,8 @@ Items: ${invoice.items.length}
       onOpenChange={close}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
-          <DialogTitle>{t((m) => m["IMS--View"].export.title)}</DialogTitle>
-          <DialogDescription>{t((m) => m["IMS--View"].export.description)}</DialogDescription>
+          <DialogTitle>{t((m) => m.pages.invoices.viewInvoice.export.title)}</DialogTitle>
+          <DialogDescription>{t((m) => m.pages.invoices.viewInvoice.export.description)}</DialogDescription>
         </DialogHeader>
 
         <div className={styles["exportOptions"]}>
@@ -298,8 +298,8 @@ Items: ${invoice.items.length}
               <TbFileTypePdf />
             </div>
             <div className={styles["exportCardContent"]}>
-              <h3>{t((m) => m["IMS--View"].export.pdf.title)}</h3>
-              <p>{t((m) => m["IMS--View"].export.pdf.description)}</p>
+              <h3>{t((m) => m.pages.invoices.viewInvoice.export.pdf.title)}</h3>
+              <p>{t((m) => m.pages.invoices.viewInvoice.export.pdf.description)}</p>
             </div>
             <TbChevronRight className={styles["exportCardArrow"]} />
           </button>
@@ -313,8 +313,8 @@ Items: ${invoice.items.length}
               <TbFileSpreadsheet />
             </div>
             <div className={styles["exportCardContent"]}>
-              <h3>{t((m) => m["IMS--View"].export.csv.title)}</h3>
-              <p>{t((m) => m["IMS--View"].export.csv.description)}</p>
+              <h3>{t((m) => m.pages.invoices.viewInvoice.export.csv.title)}</h3>
+              <p>{t((m) => m.pages.invoices.viewInvoice.export.csv.description)}</p>
             </div>
             <TbChevronRight className={styles["exportCardArrow"]} />
           </button>
@@ -328,8 +328,8 @@ Items: ${invoice.items.length}
               <TbCode />
             </div>
             <div className={styles["exportCardContent"]}>
-              <h3>{t((m) => m["IMS--View"].export.json.title)}</h3>
-              <p>{t((m) => m["IMS--View"].export.json.description)}</p>
+              <h3>{t((m) => m.pages.invoices.viewInvoice.export.json.title)}</h3>
+              <p>{t((m) => m.pages.invoices.viewInvoice.export.json.description)}</p>
             </div>
             <TbChevronRight className={styles["exportCardArrow"]} />
           </button>
@@ -343,8 +343,8 @@ Items: ${invoice.items.length}
               <TbClipboard />
             </div>
             <div className={styles["exportCardContent"]}>
-              <h3>{t((m) => m["IMS--View"].export.copySummary.title)}</h3>
-              <p>{t((m) => m["IMS--View"].export.copySummary.description)}</p>
+              <h3>{t((m) => m.pages.invoices.viewInvoice.export.copySummary.title)}</h3>
+              <p>{t((m) => m.pages.invoices.viewInvoice.export.copySummary.description)}</p>
             </div>
             <TbChevronRight className={styles["exportCardArrow"]} />
           </button>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/dialogs/ShareAnalyticsDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/dialogs/ShareAnalyticsDialog.tsx
@@ -90,16 +90,16 @@ export default function ShareAnalyticsDialog(): React.JSX.Element {
     const item = new ClipboardItem({[blob.type]: blob});
     await navigator.clipboard.write([item]);
 
-    toast(t((m) => m["IMS--Dialogs"].shareAnalyticsDialog.toasts.imageCopied.title), {
-      description: t((m) => m["IMS--Dialogs"].shareAnalyticsDialog.toasts.imageCopied.description),
+    toast(t((m) => m.dialogs.invoices.shareAnalyticsDialog.toasts.imageCopied.title), {
+      description: t((m) => m.dialogs.invoices.shareAnalyticsDialog.toasts.imageCopied.description),
     });
   }, [invoice, merchant, t]);
 
   const handleSendEmail = useCallback(
     (e: React.MouseEvent) => {
       e.preventDefault();
-      toast(t((m) => m["IMS--Dialogs"].shareAnalyticsDialog.toasts.emailSent.title), {
-        description: t((m) => m["IMS--Dialogs"].shareAnalyticsDialog.toasts.emailSent.description, {email}),
+      toast(t((m) => m.dialogs.invoices.shareAnalyticsDialog.toasts.emailSent.title), {
+        description: t((m) => m.dialogs.invoices.shareAnalyticsDialog.toasts.emailSent.description, {email}),
       });
       setEmail("");
     },
@@ -108,8 +108,8 @@ export default function ShareAnalyticsDialog(): React.JSX.Element {
 
   const handleDownloadImage = useCallback(() => {
     // In a real app, this would generate and download an image
-    toast(t((m) => m["IMS--Dialogs"].shareAnalyticsDialog.toasts.imageSaved.title), {
-      description: t((m) => m["IMS--Dialogs"].shareAnalyticsDialog.toasts.imageSaved.description, {merchant: merchant.name}),
+    toast(t((m) => m.dialogs.invoices.shareAnalyticsDialog.toasts.imageSaved.title), {
+      description: t((m) => m.dialogs.invoices.shareAnalyticsDialog.toasts.imageSaved.description, {merchant: merchant.name}),
     });
   }, [merchant, t]);
 
@@ -122,26 +122,26 @@ export default function ShareAnalyticsDialog(): React.JSX.Element {
       }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
-          <DialogTitle>{t((m) => m["IMS--Dialogs"].shareAnalyticsDialog.title)}</DialogTitle>
-          <DialogDescription>{t((m) => m["IMS--Dialogs"].shareAnalyticsDialog.description, {merchant: merchant?.name ?? ""})}</DialogDescription>
+          <DialogTitle>{t((m) => m.dialogs.invoices.shareAnalyticsDialog.title)}</DialogTitle>
+          <DialogDescription>{t((m) => m.dialogs.invoices.shareAnalyticsDialog.description, {merchant: merchant?.name ?? ""})}</DialogDescription>
         </DialogHeader>
 
         <Tabs
           defaultValue='image'
           className={styles["tabs"]}>
           <TabsList className={styles["tabsList"]}>
-            <TabsTrigger value='image'>{t((m) => m["IMS--Dialogs"].shareAnalyticsDialog.tabs.image)}</TabsTrigger>
-            <TabsTrigger value='email'>{t((m) => m["IMS--Dialogs"].shareAnalyticsDialog.tabs.email)}</TabsTrigger>
+            <TabsTrigger value='image'>{t((m) => m.dialogs.invoices.shareAnalyticsDialog.tabs.image)}</TabsTrigger>
+            <TabsTrigger value='email'>{t((m) => m.dialogs.invoices.shareAnalyticsDialog.tabs.email)}</TabsTrigger>
           </TabsList>
 
           <TabsContent
             value='image'
             className={styles["tabsContent"]}>
             <div className={styles["contentSection"]}>
-              <p className={styles["description"]}>{t((m) => m["IMS--Dialogs"].shareAnalyticsDialog.image.description)}</p>
+              <p className={styles["description"]}>{t((m) => m.dialogs.invoices.shareAnalyticsDialog.image.description)}</p>
               <div className={styles["previewContainer"]}>
                 <div className={styles["previewBox"]}>
-                  <div className={styles["previewPlaceholder"]}>{t((m) => m["IMS--Dialogs"].shareAnalyticsDialog.image.previewPlaceholder)}</div>
+                  <div className={styles["previewPlaceholder"]}>{t((m) => m.dialogs.invoices.shareAnalyticsDialog.image.previewPlaceholder)}</div>
                 </div>
               </div>
             </div>
@@ -151,14 +151,14 @@ export default function ShareAnalyticsDialog(): React.JSX.Element {
                   onClick={handleDownloadImage}
                   className={styles["fullWidthButton"]}>
                   <TbDownload className={styles["buttonIcon"]} />
-                  {t((m) => m["IMS--Dialogs"].shareAnalyticsDialog.image.download)}
+                  {t((m) => m.dialogs.invoices.shareAnalyticsDialog.image.download)}
                 </Button>
                 <Button
                   variant='outline'
                   onClick={handleCopyImage}
                   className={styles["fullWidthButton"]}>
                   <TbCopy className={styles["buttonIcon"]} />
-                  {t((m) => m["IMS--Dialogs"].shareAnalyticsDialog.image.copyToClipboard)}
+                  {t((m) => m.dialogs.invoices.shareAnalyticsDialog.image.copyToClipboard)}
                 </Button>
               </div>
             </DialogFooter>
@@ -168,13 +168,13 @@ export default function ShareAnalyticsDialog(): React.JSX.Element {
             value='email'
             className={styles["tabsContent"]}>
             <div className={styles["contentSection"]}>
-              <p className={styles["description"]}>{t((m) => m["IMS--Dialogs"].shareAnalyticsDialog.email.description)}</p>
+              <p className={styles["description"]}>{t((m) => m.dialogs.invoices.shareAnalyticsDialog.email.description)}</p>
               <div className={styles["emailSection"]}>
-                <Label htmlFor='email'>{t((m) => m["IMS--Dialogs"].shareAnalyticsDialog.email.label)}</Label>
+                <Label htmlFor='email'>{t((m) => m.dialogs.invoices.shareAnalyticsDialog.email.label)}</Label>
                 <Input
                   id='email'
                   type='email'
-                  placeholder={t((m) => m["IMS--Dialogs"].shareAnalyticsDialog.email.placeholder)}
+                  placeholder={t((m) => m.dialogs.invoices.shareAnalyticsDialog.email.placeholder)}
                   value={email}
                   // eslint-disable-next-line react/jsx-no-bind -- inline event handler
                   onChange={(e) => setEmail(e.target.value)}
@@ -186,7 +186,7 @@ export default function ShareAnalyticsDialog(): React.JSX.Element {
                 onClick={handleSendEmail}
                 className={styles["fullWidthButton"]}>
                 <TbMail className={styles["buttonIcon"]} />
-                {t((m) => m["IMS--Dialogs"].shareAnalyticsDialog.email.send)}
+                {t((m) => m.dialogs.invoices.shareAnalyticsDialog.email.send)}
               </Button>
             </DialogFooter>
           </TabsContent>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/dialogs/ShareAnalyticsDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/dialogs/ShareAnalyticsDialog.tsx
@@ -24,7 +24,7 @@ import {TbCopy, TbDownload, TbMail} from "react-icons/tb";
 import styles from "./ShareAnalyticsDialog.module.scss";
 
 /**
- * Dialog for sharing spending analytics via image download, clipboard, or email.
+ * Dialog for sharing spending analytics via image download, clipboard, or emails.
  *
  * @remarks
  * **Rendering Context**: Client Component (`"use client"` directive).

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/tabs/InvoiceTabs.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/tabs/InvoiceTabs.tsx
@@ -78,13 +78,13 @@ export function InvoiceTabs(): React.JSX.Element {
               value='recipes'
               className={styles["tabsTrigger"]}>
               <TbChefHat className={styles["tabIcon"]} />
-              {t((m) => m["IMS--View"].invoiceTabs.tabs.possibleRecipes)}
+              {t((m) => m.pages.invoices.viewInvoice.invoiceTabs.tabs.possibleRecipes)}
             </TabsTrigger>
             <TabsTrigger
               value='info'
               className={styles["tabsTrigger"]}>
               <TbInfoCircle className={styles["tabIcon"]} />
-              {t((m) => m["IMS--View"].invoiceTabs.tabs.additionalInfo)}
+              {t((m) => m.pages.invoices.viewInvoice.invoiceTabs.tabs.additionalInfo)}
             </TabsTrigger>
           </TabsList>
         </CardHeader>
@@ -119,11 +119,11 @@ export function InvoiceTabs(): React.JSX.Element {
                         <div className={styles["recipeDetails"]}>
                           <div className={styles["recipeDetailItem"]}>
                             <TbClock className={styles["tabIcon"]} />
-                            <span>{t((m) => m["IMS--View"].invoiceTabs.recipe.duration, {minutes: String(recipe.approximateTotalDuration)})}</span>
+                            <span>{t((m) => m.pages.invoices.viewInvoice.invoiceTabs.recipe.duration, {minutes: String(recipe.approximateTotalDuration)})}</span>
                           </div>
                           {recipe.preparationTime > 0 && recipe.cookingTime > 0 && (
                             <div className={styles["recipeDetailMuted"]}>
-                              {t((m) => m["IMS--View"].invoiceTabs.recipe.prepCook, {prep: String(recipe.preparationTime), cook: String(recipe.cookingTime)})}
+                              {t((m) => m.pages.invoices.viewInvoice.invoiceTabs.recipe.prepCook, {prep: String(recipe.preparationTime), cook: String(recipe.cookingTime)})}
                             </div>
                           )}
                         </div>
@@ -133,7 +133,7 @@ export function InvoiceTabs(): React.JSX.Element {
                           <div className={styles["ingredientsSection"]}>
                             <div className={styles["ingredientsHeader"]}>
                               <TbToolsKitchen2 className={styles["sectionIcon"]} />
-                              <h4 className={styles["sectionTitle"]}>{t((m) => m["IMS--View"].invoiceTabs.recipe.ingredients)}</h4>
+                              <h4 className={styles["sectionTitle"]}>{t((m) => m.pages.invoices.viewInvoice.invoiceTabs.recipe.ingredients)}</h4>
                             </div>
                             <ul className={styles["ingredientsList"]}>
                               {recipe.ingredients.map((ingredient) => (
@@ -150,7 +150,7 @@ export function InvoiceTabs(): React.JSX.Element {
                         {/* Instructions */}
                         {recipe.instructions ? (
                           <div className={styles["instructionsSection"]}>
-                            <h4 className={styles["sectionTitle"]}>{t((m) => m["IMS--View"].invoiceTabs.recipe.instructions)}</h4>
+                            <h4 className={styles["sectionTitle"]}>{t((m) => m.pages.invoices.viewInvoice.invoiceTabs.recipe.instructions)}</h4>
                             <p className={styles["instructionsText"]}>{recipe.instructions}</p>
                           </div>
                         ) : null}
@@ -165,7 +165,7 @@ export function InvoiceTabs(): React.JSX.Element {
                               href={recipe.referenceForMoreDetails}
                               target='_blank'
                               rel='noopener noreferrer'>
-                              {t((m) => m["IMS--View"].invoiceTabs.recipe.viewRecipe)}
+                              {t((m) => m.pages.invoices.viewInvoice.invoiceTabs.recipe.viewRecipe)}
                               <TbExternalLink className={styles["externalLinkIcon"]} />
                             </a>
                           </Button>
@@ -178,7 +178,7 @@ export function InvoiceTabs(): React.JSX.Element {
             ) : (
               <div className={styles["emptyState"]}>
                 <TbChefHat className={styles["emptyIcon"]} />
-                <p className={styles["emptyStateText"]}>{t((m) => m["IMS--View"].invoiceTabs.empty.recipes)}</p>
+                <p className={styles["emptyStateText"]}>{t((m) => m.pages.invoices.viewInvoice.invoiceTabs.empty.recipes)}</p>
               </div>
             )}
           </TabsContent>
@@ -199,7 +199,7 @@ export function InvoiceTabs(): React.JSX.Element {
             ) : (
               <div className={styles["emptyState"]}>
                 <TbInfoCircle className={styles["emptyIcon"]} />
-                <p className={styles["emptyStateText"]}>{t((m) => m["IMS--View"].invoiceTabs.empty.additionalInfo)}</p>
+                <p className={styles["emptyStateText"]}>{t((m) => m.pages.invoices.viewInvoice.invoiceTabs.empty.additionalInfo)}</p>
               </div>
             )}
           </TabsContent>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/timeline/InvoiceTimeline.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/timeline/InvoiceTimeline.tsx
@@ -42,15 +42,15 @@ export function InvoiceTimeline(): React.JSX.Element {
         <div className={styles["headerRow"]}>
           <CardTitle className={styles["cardTitle"]}>
             <TbCalendar className={styles["calendarIcon"]} />
-            {t((m) => m["IMS--View"].invoiceTimeline.title)}
+            {t((m) => m.pages.invoices.viewInvoice.invoiceTimeline.title)}
           </CardTitle>
           <Badge
             variant='secondary'
             className={styles["badge"]}>
-            {t((m) => m["IMS--View"].invoiceTimeline.eventCount, {count: totalEvents})}
+            {t((m) => m.pages.invoices.viewInvoice.invoiceTimeline.eventCount, {count: totalEvents})}
           </Badge>
         </div>
-        <p className={styles["subtitle"]}>{t((m) => m["IMS--View"].invoiceTimeline.subtitle)}</p>
+        <p className={styles["subtitle"]}>{t((m) => m.pages.invoices.viewInvoice.invoiceTimeline.subtitle)}</p>
       </CardHeader>
 
       <CardContent className={styles["cardContent"]}>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/timeline/TimelineItem.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/timeline/TimelineItem.tsx
@@ -22,7 +22,7 @@ type TranslateFn = {
 
 function createTimelineTranslator(t: ReturnType<typeof useTranslations>): TranslateFn {
   return ((key: string, values?: TranslationValues) =>
-    t(selectorFromPath(`IMS--View.timelineItem.${key}`), values)) as TranslateFn;
+    t(selectorFromPath(`sections.invoices.timeline.item.${key}`), values)) as TranslateFn;
 }
 
 function getEventTitle(event: TimelineEvent, translate: TranslateFn): string {
@@ -179,7 +179,7 @@ export function TimelineItem({event, icon, isLast = false}: Readonly<Props>): Re
                         variant='ghost'
                         size='icon'
                         className={styles["infoButton"]}
-                        aria-label={t((m) => m["IMS--View"].timelineItem.aria.moreInfo, {title: eventTitle})}>
+                        aria-label={t((m) => m.sections.invoices.timeline.item.aria.moreInfo, {title: eventTitle})}>
                         <TbInfoCircle className={styles["infoIcon"]} />
                       </Button>
                     }
@@ -190,7 +190,7 @@ export function TimelineItem({event, icon, isLast = false}: Readonly<Props>): Re
                     sideOffset={8}>
                     <p>{tooltipContent}</p>
                     {Boolean(event.metadata?.confidence) && (
-                      <p className={styles["confidenceText"]}>{t((m) => m["IMS--View"].timelineItem.confidence, {value: String(event.metadata!.confidence)})}</p>
+                      <p className={styles["confidenceText"]}>{t((m) => m.sections.invoices.timeline.item.confidence, {value: String(event.metadata!.confidence)})}</p>
                     )}
                   </TooltipContent>
                 </Tooltip>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/timeline/TimelineSharedWithList.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/_components/timeline/TimelineSharedWithList.tsx
@@ -69,12 +69,12 @@ export function TimelineSharedWithList(): React.JSX.Element | null {
     <div className={styles["container"]}>
       <div className={styles["header"]}>
         <TbUsers className={styles["iconMuted"]} />
-        <p className={styles["headerLabel"]}>{t((m) => m["IMS--View"].timelineSharedWithList.header.title)}</p>
+        <p className={styles["headerLabel"]}>{t((m) => m.pages.invoices.viewInvoice.timelineSharedWithList.header.title)}</p>
         {Boolean(sharedUsers.length > 0 || isPublic) && (
           <Badge
             variant='secondary'
             className={styles["badgeSmall"]}>
-            {isPublic ? t((m) => m["IMS--View"].timelineSharedWithList.header.publicBadge) : sharedUsers.length}
+            {isPublic ? t((m) => m.pages.invoices.viewInvoice.timelineSharedWithList.header.publicBadge) : sharedUsers.length}
           </Badge>
         )}
       </div>
@@ -85,8 +85,8 @@ export function TimelineSharedWithList(): React.JSX.Element | null {
           variant='default'
           className={styles["alertWarning"]}>
           <TbGlobe className={styles["iconWarning"]} />
-          <AlertTitle className={styles["alertTitleWarning"]}>{t((m) => m["IMS--View"].timelineSharedWithList.publicAccess.title)}</AlertTitle>
-          <AlertDescription className={styles["alertDescMuted"]}>{t((m) => m["IMS--View"].timelineSharedWithList.publicAccess.description)}</AlertDescription>
+          <AlertTitle className={styles["alertTitleWarning"]}>{t((m) => m.pages.invoices.viewInvoice.timelineSharedWithList.publicAccess.title)}</AlertTitle>
+          <AlertDescription className={styles["alertDescMuted"]}>{t((m) => m.pages.invoices.viewInvoice.timelineSharedWithList.publicAccess.description)}</AlertDescription>
         </Alert>
       )}
 
@@ -114,7 +114,7 @@ export function TimelineSharedWithList(): React.JSX.Element | null {
                         variant='ghost'
                         size='icon'
                         className={styles["iconButton"]}
-                        aria-label={t((m) => m["IMS--View"].timelineSharedWithList.aria.sendEmail, {user})}>
+                        aria-label={t((m) => m.pages.invoices.viewInvoice.timelineSharedWithList.aria.sendEmail, {user})}>
                         <TbMail className={styles["iconXs"]} />
                       </Button>
                     }
@@ -122,7 +122,7 @@ export function TimelineSharedWithList(): React.JSX.Element | null {
                   <TooltipContent
                     side='left'
                     className={styles["tooltipXs"]}>
-                    {t((m) => m["IMS--View"].timelineSharedWithList.actions.sendEmail)}
+                    {t((m) => m.pages.invoices.viewInvoice.timelineSharedWithList.actions.sendEmail)}
                   </TooltipContent>
                 </Tooltip>
               </TooltipProvider>
@@ -137,7 +137,7 @@ export function TimelineSharedWithList(): React.JSX.Element | null {
         onClick={openShareDialog}
         className={styles["manageButton"]}>
         <TbExternalLink className={styles["iconXs"]} />
-        {t((m) => m["IMS--View"].timelineSharedWithList.actions.manageSharing)}
+        {t((m) => m.pages.invoices.viewInvoice.timelineSharedWithList.actions.manageSharing)}
       </Button>
     </div>
   );

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/island.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/island.tsx
@@ -107,7 +107,7 @@ export default function RenderViewInvoiceScreen(props: Readonly<Props>): React.J
                     variant='ghost'
                     size='sm'
                     onClick={handleShowHealthDialog}>
-                    {t((m) => m["IMS--View"].healthScore.seeReport)}
+                    {t((m) => m.pages.invoices.viewInvoice.healthScore.seeReport)}
                   </Button>
                 </div>
               </div>
@@ -172,7 +172,7 @@ export default function RenderViewInvoiceScreen(props: Readonly<Props>): React.J
           onOpenChange={setShowHealthDialog}>
           <DialogContent className='max-h-[85vh] max-w-2xl overflow-y-auto'>
             <DialogHeader>
-              <DialogTitle>{t((m) => m["IMS--View"].healthScore.dialogTitle)}</DialogTitle>
+              <DialogTitle>{t((m) => m.pages.invoices.viewInvoice.healthScore.dialogTitle)}</DialogTitle>
             </DialogHeader>
             <InvoiceHealthScore />
           </DialogContent>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/not-found.test.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/not-found.test.tsx
@@ -5,13 +5,13 @@ import InvoiceNotFound from "./not-found";
 describe("view-invoice/[id]/not-found.tsx", () => {
   it("renders the invoice-scoped not-found message", () => {
     render(<InvoiceNotFound />);
-    expect(screen.getByText("Errors.notFound.title")).toBeInTheDocument();
-    expect(screen.getByText("Errors.notFound.subtitle")).toBeInTheDocument();
+    expect(screen.getByText("app.errors.notFound.title")).toBeInTheDocument();
+    expect(screen.getByText("app.errors.notFound.subtitle")).toBeInTheDocument();
   });
 
   it("links back to the invoices listing", () => {
     render(<InvoiceNotFound />);
-    const link = screen.getByRole("link", {name: "Errors.notFound.buttons.returnButton"});
+    const link = screen.getByRole("link", {name: "app.errors.notFound.buttons.returnButton"});
     expect(link).toHaveAttribute("href", "/domains/invoices/view-invoices");
   });
 });

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/not-found.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/not-found.tsx
@@ -7,9 +7,9 @@ export default function InvoiceNotFound(): React.JSX.Element {
   const t = useTranslations();
   return (
     <section data-scope='view-invoice'>
-      <h1>{t((m) => m.Errors.notFound.title)}</h1>
-      <p>{t((m) => m.Errors.notFound.subtitle)}</p>
-      <Link href='/domains/invoices/view-invoices'>{t((m) => m.Errors.notFound.buttons.returnButton)}</Link>
+      <h1>{t((m) => m.app.errors.notFound.title)}</h1>
+      <p>{t((m) => m.app.errors.notFound.subtitle)}</p>
+      <Link href='/domains/invoices/view-invoices'>{t((m) => m.app.errors.notFound.buttons.returnButton)}</Link>
     </section>
   );
 }

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/page.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoice/[id]/page.tsx
@@ -61,8 +61,8 @@ export async function generateMetadata(): Promise<Metadata> {
   const locale = await getLocale();
   return createMetadata({
     locale,
-    title: t((m) => m["IMS--View"].metadata.title),
-    description: t((m) => m["IMS--View"].metadata.description),
+    title: t((m) => m.pages.invoices.viewInvoice.metadata.title),
+    description: t((m) => m.pages.invoices.viewInvoice.metadata.description),
   });
 }
 

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/BulkActionsToolbar.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/BulkActionsToolbar.tsx
@@ -183,17 +183,17 @@ export default function BulkActionsToolbar(): React.JSX.Element | null {
 
         // Show appropriate toast based on results
         if (failureCount === 0) {
-          toast.success(t((m) => m["IMS--List"].bulkActions.categoryChanged, {count: successCount}));
+          toast.success(t((m) => m.pages.invoices.viewInvoices.bulkActions.categoryChanged, {count: successCount}));
         } else if (successCount === 0) {
-          toast.error(t((m) => m["IMS--List"].bulkActions.categoryChangeError));
+          toast.error(t((m) => m.pages.invoices.viewInvoices.bulkActions.categoryChangeError));
         } else {
-          toast.success(t((m) => m["IMS--List"].bulkActions.categoryPartialSuccess, {success: String(successCount), failed: String(failureCount)}));
+          toast.success(t((m) => m.pages.invoices.viewInvoices.bulkActions.categoryPartialSuccess, {success: String(successCount), failed: String(failureCount)}));
         }
 
         clearSelectedInvoices();
       } catch (error) {
         console.error("Bulk category change error:", error);
-        toast.error(t((m) => m["IMS--List"].bulkActions.categoryChangeError));
+        toast.error(t((m) => m.pages.invoices.viewInvoices.bulkActions.categoryChangeError));
       } finally {
         setIsCategoryChanging(false);
       }
@@ -217,15 +217,15 @@ export default function BulkActionsToolbar(): React.JSX.Element | null {
         <div className={styles["toolbarContent"]}>
           {/* Left side: Selection count and clear button */}
           <div className={styles["toolbarLeft"]}>
-            <span className={styles["selectedCount"]}>{t((m) => m["IMS--List"].bulkActions.selected, {count: selectedInvoices.length})}</span>
+            <span className={styles["selectedCount"]}>{t((m) => m.pages.invoices.viewInvoices.bulkActions.selected, {count: selectedInvoices.length})}</span>
             <Button
               variant='ghost'
               size='sm'
               onClick={clearSelectedInvoices}
               className={styles["clearButton"]}
-              aria-label={t((m) => m["IMS--List"].bulkActions.clearSelection)}>
+              aria-label={t((m) => m.pages.invoices.viewInvoices.bulkActions.clearSelection)}>
               <TbX className={styles["icon"]} />
-              <span className={styles["hiddenMobile"]}>{t((m) => m["IMS--List"].bulkActions.clearSelection)}</span>
+              <span className={styles["hiddenMobile"]}>{t((m) => m.pages.invoices.viewInvoices.bulkActions.clearSelection)}</span>
             </Button>
           </div>
 
@@ -237,9 +237,9 @@ export default function BulkActionsToolbar(): React.JSX.Element | null {
               size='sm'
               onClick={handleExport}
               className={styles["actionButton"]}
-              aria-label={t((m) => m["IMS--List"].bulkActions.export)}>
+              aria-label={t((m) => m.pages.invoices.viewInvoices.bulkActions.export)}>
               <TbDownload className={styles["icon"]} />
-              <span className={styles["hiddenMobile"]}>{t((m) => m["IMS--List"].bulkActions.export)}</span>
+              <span className={styles["hiddenMobile"]}>{t((m) => m.pages.invoices.viewInvoices.bulkActions.export)}</span>
             </Button>
 
             {/* Delete button with confirmation dialog */}
@@ -251,20 +251,20 @@ export default function BulkActionsToolbar(): React.JSX.Element | null {
                     size='sm'
                     className={styles["actionButton"]}
                     disabled={isDeleting}
-                    aria-label={t((m) => m["IMS--List"].bulkActions.delete)}>
+                    aria-label={t((m) => m.pages.invoices.viewInvoices.bulkActions.delete)}>
                     <TbTrash className={styles["icon"]} />
-                    <span className={styles["hiddenMobile"]}>{t((m) => m["IMS--List"].bulkActions.delete)}</span>
+                    <span className={styles["hiddenMobile"]}>{t((m) => m.pages.invoices.viewInvoices.bulkActions.delete)}</span>
                   </Button>
                 }
               />
               <AlertDialogContent>
                 <AlertDialogHeader>
-                  <AlertDialogTitle>{t((m) => m["IMS--List"].bulkActions.deleteConfirm.title)}</AlertDialogTitle>
-                  <AlertDialogDescription>{t((m) => m["IMS--List"].bulkActions.deleteConfirm.description, {count: selectedInvoices.length})}</AlertDialogDescription>
+                  <AlertDialogTitle>{t((m) => m.pages.invoices.viewInvoices.bulkActions.deleteConfirm.title)}</AlertDialogTitle>
+                  <AlertDialogDescription>{t((m) => m.pages.invoices.viewInvoices.bulkActions.deleteConfirm.description, {count: selectedInvoices.length})}</AlertDialogDescription>
                 </AlertDialogHeader>
                 <AlertDialogFooter>
-                  <AlertDialogCancel>{t((m) => m["IMS--List"].bulkActions.deleteConfirm.cancel)}</AlertDialogCancel>
-                  <AlertDialogAction onClick={handleDelete}>{t((m) => m["IMS--List"].bulkActions.deleteConfirm.confirm)}</AlertDialogAction>
+                  <AlertDialogCancel>{t((m) => m.pages.invoices.viewInvoices.bulkActions.deleteConfirm.cancel)}</AlertDialogCancel>
+                  <AlertDialogAction onClick={handleDelete}>{t((m) => m.pages.invoices.viewInvoices.bulkActions.deleteConfirm.confirm)}</AlertDialogAction>
                 </AlertDialogFooter>
               </AlertDialogContent>
             </AlertDialog>
@@ -277,16 +277,16 @@ export default function BulkActionsToolbar(): React.JSX.Element | null {
                 disabled={isCategoryChanging}>
                 <SelectTrigger
                   className={styles["selectTrigger"]}
-                  aria-label={t((m) => m["IMS--List"].bulkActions.changeCategory)}>
-                  <SelectValue placeholder={t((m) => m["IMS--List"].bulkActions.changeCategory)} />
+                  aria-label={t((m) => m.pages.invoices.viewInvoices.bulkActions.changeCategory)}>
+                  <SelectValue placeholder={t((m) => m.pages.invoices.viewInvoices.bulkActions.changeCategory)} />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value={InvoiceCategory.NOT_DEFINED.toString()}>{t((m) => m["IMS--List"].bulkActions.categories.notDefined)}</SelectItem>
-                  <SelectItem value={InvoiceCategory.GROCERY.toString()}>{t((m) => m["IMS--List"].bulkActions.categories.grocery)}</SelectItem>
-                  <SelectItem value={InvoiceCategory.FAST_FOOD.toString()}>{t((m) => m["IMS--List"].bulkActions.categories.fastFood)}</SelectItem>
-                  <SelectItem value={InvoiceCategory.HOME_CLEANING.toString()}>{t((m) => m["IMS--List"].bulkActions.categories.homeCleaning)}</SelectItem>
-                  <SelectItem value={InvoiceCategory.CAR_AUTO.toString()}>{t((m) => m["IMS--List"].bulkActions.categories.carAuto)}</SelectItem>
-                  <SelectItem value={InvoiceCategory.OTHER.toString()}>{t((m) => m["IMS--List"].bulkActions.categories.other)}</SelectItem>
+                  <SelectItem value={InvoiceCategory.NOT_DEFINED.toString()}>{t((m) => m.pages.invoices.viewInvoices.bulkActions.categories.notDefined)}</SelectItem>
+                  <SelectItem value={InvoiceCategory.GROCERY.toString()}>{t((m) => m.pages.invoices.viewInvoices.bulkActions.categories.grocery)}</SelectItem>
+                  <SelectItem value={InvoiceCategory.FAST_FOOD.toString()}>{t((m) => m.pages.invoices.viewInvoices.bulkActions.categories.fastFood)}</SelectItem>
+                  <SelectItem value={InvoiceCategory.HOME_CLEANING.toString()}>{t((m) => m.pages.invoices.viewInvoices.bulkActions.categories.homeCleaning)}</SelectItem>
+                  <SelectItem value={InvoiceCategory.CAR_AUTO.toString()}>{t((m) => m.pages.invoices.viewInvoices.bulkActions.categories.carAuto)}</SelectItem>
+                  <SelectItem value={InvoiceCategory.OTHER.toString()}>{t((m) => m.pages.invoices.viewInvoices.bulkActions.categories.other)}</SelectItem>
                 </SelectContent>
               </Select>
             </div>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/BulkActionsToolbar.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/BulkActionsToolbar.tsx
@@ -131,17 +131,17 @@ export default function BulkActionsToolbar(): React.JSX.Element | null {
 
       // Show appropriate toast based on results
       if (failureCount === 0) {
-        toast.success(t((m) => m["IMS--List"].bulkActions.deleteSuccess, {count: successCount}));
+        toast.success(t((m) => m.pages.invoices.viewInvoices.bulkActions.deleteSuccess, {count: successCount}));
       } else if (successCount === 0) {
-        toast.error(t((m) => m["IMS--List"].bulkActions.deleteError));
+        toast.error(t((m) => m.pages.invoices.viewInvoices.bulkActions.deleteError));
       } else {
-        toast.success(t((m) => m["IMS--List"].bulkActions.deletePartialSuccess, {success: String(successCount), failed: String(failureCount)}));
+        toast.success(t((m) => m.pages.invoices.viewInvoices.bulkActions.deletePartialSuccess, {success: String(successCount), failed: String(failureCount)}));
       }
 
       clearSelectedInvoices();
     } catch (error) {
       console.error("Bulk delete error:", error);
-      toast.error(t((m) => m["IMS--List"].bulkActions.deleteError));
+      toast.error(t((m) => m.pages.invoices.viewInvoices.bulkActions.deleteError));
     } finally {
       setIsDeleting(false);
     }

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/InvoicesHeader.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/InvoicesHeader.tsx
@@ -30,8 +30,8 @@ export default function InvoicesHeader(): React.JSX.Element {
       transition={{duration: 0.3}}
       className={styles["header"]}>
       <div>
-        <h1 className={styles["title"]}>{t((m) => m["IMS--List"].invoicesHeader.title)}</h1>
-        <p className={styles["description"]}>{t((m) => m["IMS--List"].invoicesHeader.description)}</p>
+        <h1 className={styles["title"]}>{t((m) => m.pages.invoices.viewInvoices.invoicesHeader.title)}</h1>
+        <p className={styles["description"]}>{t((m) => m.pages.invoices.viewInvoices.invoicesHeader.description)}</p>
       </div>
       <div className={styles["actions"]}>
         <TooltipProvider>
@@ -44,11 +44,11 @@ export default function InvoicesHeader(): React.JSX.Element {
                   className={styles["actionButton"]}
                   onClick={openImportDialog}>
                   <TbUpload className={styles["actionIcon"]} />
-                  <span className={styles["buttonLabel"]}>{t((m) => m["IMS--List"].invoicesHeader.actions.import)}</span>
+                  <span className={styles["buttonLabel"]}>{t((m) => m.pages.invoices.viewInvoices.invoicesHeader.actions.import)}</span>
                 </Button>
               }
             />
-            <TooltipContent>{t((m) => m["IMS--List"].invoicesHeader.tooltips.import)}</TooltipContent>
+            <TooltipContent>{t((m) => m.pages.invoices.viewInvoices.invoicesHeader.tooltips.import)}</TooltipContent>
           </Tooltip>
         </TooltipProvider>
 
@@ -62,11 +62,11 @@ export default function InvoicesHeader(): React.JSX.Element {
                   className={styles["actionButton"]}
                   onClick={openExportDialog}>
                   <TbDownload className={styles["actionIcon"]} />
-                  <span className={styles["buttonLabel"]}>{t((m) => m["IMS--List"].invoicesHeader.actions.export)}</span>
+                  <span className={styles["buttonLabel"]}>{t((m) => m.pages.invoices.viewInvoices.invoicesHeader.actions.export)}</span>
                 </Button>
               }
             />
-            <TooltipContent>{t((m) => m["IMS--List"].invoicesHeader.tooltips.export)}</TooltipContent>
+            <TooltipContent>{t((m) => m.pages.invoices.viewInvoices.invoicesHeader.tooltips.export)}</TooltipContent>
           </Tooltip>
         </TooltipProvider>
 
@@ -80,11 +80,11 @@ export default function InvoicesHeader(): React.JSX.Element {
                   className={styles["actionButton"]}
                   onClick={handlePrintAction}>
                   <TbPrinter className={styles["actionIcon"]} />
-                  <span className={styles["buttonLabel"]}>{t((m) => m["IMS--List"].invoicesHeader.actions.print)}</span>
+                  <span className={styles["buttonLabel"]}>{t((m) => m.pages.invoices.viewInvoices.invoicesHeader.actions.print)}</span>
                 </Button>
               }
             />
-            <TooltipContent>{t((m) => m["IMS--List"].invoicesHeader.tooltips.print)}</TooltipContent>
+            <TooltipContent>{t((m) => m.pages.invoices.viewInvoices.invoicesHeader.tooltips.print)}</TooltipContent>
           </Tooltip>
         </TooltipProvider>
 
@@ -97,12 +97,12 @@ export default function InvoicesHeader(): React.JSX.Element {
                     size='sm'
                     className={styles["actionButton"]}>
                     <TbPlus className={styles["actionIcon"]} />
-                    <span>{t((m) => m["IMS--List"].invoicesHeader.actions.newInvoice)}</span>
+                    <span>{t((m) => m.pages.invoices.viewInvoices.invoicesHeader.actions.newInvoice)}</span>
                   </Button>
                 </Link>
               }
             />
-            <TooltipContent>{t((m) => m["IMS--List"].invoicesHeader.tooltips.newInvoice)}</TooltipContent>
+            <TooltipContent>{t((m) => m.pages.invoices.viewInvoices.invoicesHeader.tooltips.newInvoice)}</TooltipContent>
           </Tooltip>
         </TooltipProvider>
       </div>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/MessageList.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/MessageList.tsx
@@ -54,7 +54,7 @@ export function MessageList({messages}: Readonly<Props>): React.JSX.Element {
           </Avatar>
           <div className={styles["messageBody"]}>
             <div className={styles["messageHeader"]}>
-              <p className={styles["messageSender"]}>{message.role === "assistant" ? t((m) => m["IMS--List"].messageList.aiAssistant) : t((m) => m["IMS--List"].messageList.you)}</p>
+              <p className={styles["messageSender"]}>{message.role === "assistant" ? t((m) => m.pages.invoices.viewInvoices.messageList.aiAssistant) : t((m) => m.pages.invoices.viewInvoices.messageList.you)}</p>
               <span className={styles["messageTimestamp"]}>{formatDateTime(message.timestamp, locale, {timeStyle: "short"})}</span>
             </div>
             <div className={styles["messageContent"]}>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/dialogs/ExportDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/dialogs/ExportDialog.tsx
@@ -132,14 +132,14 @@ export default function ExportDialog(): React.JSX.Element {
       }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
-          <DialogTitle>{t((m) => m["IMS--Dialogs"].exportDialog.title)}</DialogTitle>
-          <DialogDescription>{t((m) => m["IMS--Dialogs"].exportDialog.description, {count: String(invoicesToExport.length)})}</DialogDescription>
+          <DialogTitle>{t((m) => m.dialogs.invoices.exportDialog.title)}</DialogTitle>
+          <DialogDescription>{t((m) => m.dialogs.invoices.exportDialog.description, {count: String(invoicesToExport.length)})}</DialogDescription>
         </DialogHeader>
 
         <div className={styles["body"]}>
           {/* Custom Filename Input */}
           <div className={styles["section"]}>
-            <Label htmlFor='filename'>{t((m) => m["IMS--Dialogs"].exportDialog.filename.label)}</Label>
+            <Label htmlFor='filename'>{t((m) => m.dialogs.invoices.exportDialog.filename.label)}</Label>
             <Input
               id='filename'
               placeholder={defaultFilename}
@@ -148,13 +148,13 @@ export default function ExportDialog(): React.JSX.Element {
               onChange={(e) => setFilename(e.target.value)}
               className={styles["filenameInput"]}
             />
-            <p className={styles["hint"]}>{t((m) => m["IMS--Dialogs"].exportDialog.filename.hint)}</p>
+            <p className={styles["hint"]}>{t((m) => m.dialogs.invoices.exportDialog.filename.hint)}</p>
           </div>
 
           {/* Format Selection Card */}
           <Card className={styles["formatCard"]}>
             <CardContent className={styles["cardContent"]}>
-              <h3 className={styles["sectionTitle"]}>{t((m) => m["IMS--Dialogs"].exportDialog.format.title)}</h3>
+              <h3 className={styles["sectionTitle"]}>{t((m) => m.dialogs.invoices.exportDialog.format.title)}</h3>
               <RadioGroup
                 value={exportOptions.format}
                 // eslint-disable-next-line react/jsx-no-bind -- inline event handler
@@ -170,8 +170,8 @@ export default function ExportDialog(): React.JSX.Element {
                     className={styles["formatLabel"]}>
                     <TbFileSpreadsheet className={styles["formatIcon"]} />
                     <div>
-                      <p className={styles["formatName"]}>{t((m) => m["IMS--Dialogs"].exportDialog.format.labels.csv)}</p>
-                      <p className={styles["formatDesc"]}>{t((m) => m["IMS--Dialogs"].exportDialog.format.descriptions.csv)}</p>
+                      <p className={styles["formatName"]}>{t((m) => m.dialogs.invoices.exportDialog.format.labels.csv)}</p>
+                      <p className={styles["formatDesc"]}>{t((m) => m.dialogs.invoices.exportDialog.format.descriptions.csv)}</p>
                     </div>
                   </Label>
                 </div>
@@ -186,8 +186,8 @@ export default function ExportDialog(): React.JSX.Element {
                     className={styles["formatLabel"]}>
                     <TbJson className={styles["formatIcon"]} />
                     <div>
-                      <p className={styles["formatName"]}>{t((m) => m["IMS--Dialogs"].exportDialog.format.labels.json)}</p>
-                      <p className={styles["formatDesc"]}>{t((m) => m["IMS--Dialogs"].exportDialog.format.descriptions.json)}</p>
+                      <p className={styles["formatName"]}>{t((m) => m.dialogs.invoices.exportDialog.format.labels.json)}</p>
+                      <p className={styles["formatDesc"]}>{t((m) => m.dialogs.invoices.exportDialog.format.descriptions.json)}</p>
                     </div>
                   </Label>
                 </div>
@@ -202,8 +202,8 @@ export default function ExportDialog(): React.JSX.Element {
                     className={styles["formatLabel"]}>
                     <TbFileText className={styles["formatIcon"]} />
                     <div>
-                      <p className={styles["formatName"]}>{t((m) => m["IMS--Dialogs"].exportDialog.format.labels.pdf)}</p>
-                      <p className={styles["formatDesc"]}>{t((m) => m["IMS--Dialogs"].exportDialog.format.descriptions.pdf)}</p>
+                      <p className={styles["formatName"]}>{t((m) => m.dialogs.invoices.exportDialog.format.labels.pdf)}</p>
+                      <p className={styles["formatDesc"]}>{t((m) => m.dialogs.invoices.exportDialog.format.descriptions.pdf)}</p>
                     </div>
                   </Label>
                 </div>
@@ -214,7 +214,7 @@ export default function ExportDialog(): React.JSX.Element {
           {/* Options Card */}
           <Card className={styles["optionsCard"]}>
             <CardContent className={styles["cardContent"]}>
-              <h3 className={styles["sectionTitle"]}>{t((m) => m["IMS--Dialogs"].exportDialog.options.title)}</h3>
+              <h3 className={styles["sectionTitle"]}>{t((m) => m.dialogs.invoices.exportDialog.options.title)}</h3>
               <div className={styles["checkboxGroup"]}>
                 <div className={styles["radioRow"]}>
                   <Checkbox
@@ -224,7 +224,7 @@ export default function ExportDialog(): React.JSX.Element {
                     // eslint-disable-next-line react/jsx-no-bind -- inline event handler
                     onCheckedChange={(checked) => handleOptionsChange("includeMetadata", checked === true)}
                   />
-                  <Label htmlFor='include-metadata'>{t((m) => m["IMS--Dialogs"].exportDialog.options.includeMetadata)}</Label>
+                  <Label htmlFor='include-metadata'>{t((m) => m.dialogs.invoices.exportDialog.options.includeMetadata)}</Label>
                 </div>
                 <div className={styles["radioRow"]}>
                   <Checkbox
@@ -234,7 +234,7 @@ export default function ExportDialog(): React.JSX.Element {
                     // eslint-disable-next-line react/jsx-no-bind -- inline event handler
                     onCheckedChange={(checked) => handleOptionsChange("includeProducts", checked === true)}
                   />
-                  <Label htmlFor='include-items'>{t((m) => m["IMS--Dialogs"].exportDialog.options.includeProducts)}</Label>
+                  <Label htmlFor='include-items'>{t((m) => m.dialogs.invoices.exportDialog.options.includeProducts)}</Label>
                 </div>
                 <div className={styles["radioRow"]}>
                   <Checkbox
@@ -244,7 +244,7 @@ export default function ExportDialog(): React.JSX.Element {
                     // eslint-disable-next-line react/jsx-no-bind -- inline event handler
                     onCheckedChange={(checked) => handleOptionsChange("includeMerchant", checked === true)}
                   />
-                  <Label htmlFor='include-merchant'>{t((m) => m["IMS--Dialogs"].exportDialog.options.includeMerchant)}</Label>
+                  <Label htmlFor='include-merchant'>{t((m) => m.dialogs.invoices.exportDialog.options.includeMerchant)}</Label>
                 </div>
               </div>
 
@@ -264,14 +264,14 @@ export default function ExportDialog(): React.JSX.Element {
                         })
                       }
                     />
-                    <Label htmlFor='csv-include-headers'>{t((m) => m["IMS--Dialogs"].exportDialog.options.csv.includeHeaders)}</Label>
+                    <Label htmlFor='csv-include-headers'>{t((m) => m.dialogs.invoices.exportDialog.options.csv.includeHeaders)}</Label>
                   </div>
                   <div className={styles["delimiterGroup"]}>
-                    <Label htmlFor='csv-delimiter'>{t((m) => m["IMS--Dialogs"].exportDialog.options.csv.delimiterLabel)}</Label>
+                    <Label htmlFor='csv-delimiter'>{t((m) => m.dialogs.invoices.exportDialog.options.csv.delimiterLabel)}</Label>
                     <Input
                       className={styles["delimiterInput"]}
                       id='csv-delimiter'
-                      placeholder={t((m) => m["IMS--Dialogs"].exportDialog.options.csv.delimiterPlaceholder)}
+                      placeholder={t((m) => m.dialogs.invoices.exportDialog.options.csv.delimiterPlaceholder)}
                       value={exportOptions.csvOptions?.delimiter ?? ","}
                       // eslint-disable-next-line react/jsx-no-bind -- inline event handler
                       onChange={(e) =>
@@ -294,7 +294,7 @@ export default function ExportDialog(): React.JSX.Element {
                       // eslint-disable-next-line react/jsx-no-bind -- inline event handler
                       onCheckedChange={(checked) => handleOptionsChange("jsonOptions", {prettyPrint: checked === true})}
                     />
-                    <Label htmlFor='json-pretty-print'>{t((m) => m["IMS--Dialogs"].exportDialog.options.json.prettyPrint)}</Label>
+                    <Label htmlFor='json-pretty-print'>{t((m) => m.dialogs.invoices.exportDialog.options.json.prettyPrint)}</Label>
                   </div>
                 </div>
               )}
@@ -304,7 +304,7 @@ export default function ExportDialog(): React.JSX.Element {
           {/* File Size Estimate */}
           <div className={styles["estimate"]}>
             <p className={styles["estimateText"]}>
-              {t((m) => m["IMS--Dialogs"].exportDialog.estimate.label)} <strong>~{estimatedSizeKB} KB</strong>
+              {t((m) => m.dialogs.invoices.exportDialog.estimate.label)} <strong>~{estimatedSizeKB} KB</strong>
             </p>
           </div>
         </div>
@@ -313,7 +313,7 @@ export default function ExportDialog(): React.JSX.Element {
           <Button
             variant='outline'
             onClick={close}>
-            {t((m) => m["IMS--Dialogs"].exportDialog.buttons.cancel)}
+            {t((m) => m.dialogs.invoices.exportDialog.buttons.cancel)}
           </Button>
           {exportOptions.format === "json" && (
             <Button
@@ -323,12 +323,12 @@ export default function ExportDialog(): React.JSX.Element {
               {copied ? (
                 <>
                   <TbCheck className={styles["formatIcon"]} />
-                  {t((m) => m["IMS--Dialogs"].exportDialog.buttons.copied)}
+                  {t((m) => m.dialogs.invoices.exportDialog.buttons.copied)}
                 </>
               ) : (
                 <>
                   <TbCopy className={styles["formatIcon"]} />
-                  {t((m) => m["IMS--Dialogs"].exportDialog.buttons.copy)}
+                  {t((m) => m.dialogs.invoices.exportDialog.buttons.copy)}
                 </>
               )}
             </Button>
@@ -337,7 +337,7 @@ export default function ExportDialog(): React.JSX.Element {
             onClick={handleExport}
             className={styles["exportButton"]}>
             <TbDownload className={styles["formatIcon"]} />
-            {t((m) => m["IMS--Dialogs"].exportDialog.buttons.export)}
+            {t((m) => m.dialogs.invoices.exportDialog.buttons.export)}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/dialogs/ImportDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/dialogs/ImportDialog.tsx
@@ -121,8 +121,8 @@ export default function ImportDialog(): React.JSX.Element {
       }}>
       <DialogContent className={styles["dialogContent"]}>
         <DialogHeader>
-          <DialogTitle>{t((m) => m["IMS--Dialogs"].importDialog.title)}</DialogTitle>
-          <DialogDescription>{t((m) => m["IMS--Dialogs"].importDialog.description)}</DialogDescription>
+          <DialogTitle>{t((m) => m.dialogs.invoices.importDialog.title)}</DialogTitle>
+          <DialogDescription>{t((m) => m.dialogs.invoices.importDialog.description)}</DialogDescription>
         </DialogHeader>
 
         <Tabs
@@ -130,9 +130,9 @@ export default function ImportDialog(): React.JSX.Element {
           onValueChange={handleTabChange}
           className={styles["tabs"]}>
           <TabsList className={styles["tabsList"]}>
-            <TabsTrigger value='csv'>{t((m) => m["IMS--Dialogs"].importDialog.tabs.csv)}</TabsTrigger>
-            <TabsTrigger value='pdf'>{t((m) => m["IMS--Dialogs"].importDialog.tabs.pdf)}</TabsTrigger>
-            <TabsTrigger value='xlsx'>{t((m) => m["IMS--Dialogs"].importDialog.tabs.xlsx)}</TabsTrigger>
+            <TabsTrigger value='csv'>{t((m) => m.dialogs.invoices.importDialog.tabs.csv)}</TabsTrigger>
+            <TabsTrigger value='pdf'>{t((m) => m.dialogs.invoices.importDialog.tabs.pdf)}</TabsTrigger>
+            <TabsTrigger value='xlsx'>{t((m) => m.dialogs.invoices.importDialog.tabs.xlsx)}</TabsTrigger>
           </TabsList>
 
           <div
@@ -150,19 +150,19 @@ export default function ImportDialog(): React.JSX.Element {
                 transition={{duration: 0.2}}>
                 <TbUpload className={styles["uploadIcon"]} />
               </motion.div>
-              <h3 className={styles["dropzoneTitle"]}>{isDragActive ? t((m) => m["IMS--Dialogs"].importDialog.dropzone.dropHere) : t((m) => m["IMS--Dialogs"].importDialog.dropzone.dragAndDrop)}</h3>
-              <p className={styles["dropzoneSubtitle"]}>{t((m) => m["IMS--Dialogs"].importDialog.dropzone.orClickBrowse)}</p>
+              <h3 className={styles["dropzoneTitle"]}>{isDragActive ? t((m) => m.dialogs.invoices.importDialog.dropzone.dropHere) : t((m) => m.dialogs.invoices.importDialog.dropzone.dragAndDrop)}</h3>
+              <p className={styles["dropzoneSubtitle"]}>{t((m) => m.dialogs.invoices.importDialog.dropzone.orClickBrowse)}</p>
               <p className={styles["dropzoneHint"]}>
-                {activeTab === "csv" && t((m) => m["IMS--Dialogs"].importDialog.dropzone.acceptsCsv)}
-                {activeTab === "pdf" && t((m) => m["IMS--Dialogs"].importDialog.dropzone.acceptsPdf)}
-                {activeTab === "xlsx" && t((m) => m["IMS--Dialogs"].importDialog.dropzone.acceptsXlsx)}
+                {activeTab === "csv" && t((m) => m.dialogs.invoices.importDialog.dropzone.acceptsCsv)}
+                {activeTab === "pdf" && t((m) => m.dialogs.invoices.importDialog.dropzone.acceptsPdf)}
+                {activeTab === "xlsx" && t((m) => m.dialogs.invoices.importDialog.dropzone.acceptsXlsx)}
               </p>
             </div>
           </div>
 
           {files.length > 0 && (
             <div className={styles["fileListWrapper"]}>
-              <h4 className={styles["fileListTitle"]}>{t((m) => m["IMS--Dialogs"].importDialog.selectedFiles)}</h4>
+              <h4 className={styles["fileListTitle"]}>{t((m) => m.dialogs.invoices.importDialog.selectedFiles)}</h4>
               <div className={styles["fileList"]}>
                 {files.map((file, index) => (
                   <div
@@ -177,7 +177,7 @@ export default function ImportDialog(): React.JSX.Element {
                       size='sm'
                       data-index={index}
                       onClick={handleRemoveClick}>
-                      {t((m) => m["IMS--Dialogs"].importDialog.remove)}
+                      {t((m) => m.dialogs.invoices.importDialog.remove)}
                     </Button>
                   </div>
                 ))}
@@ -194,7 +194,7 @@ export default function ImportDialog(): React.JSX.Element {
               exit={{opacity: 0}}
               className={styles["statusSuccess"]}>
               <TbCheck className={styles["statusIcon"]} />
-              <span>{t((m) => m["IMS--Dialogs"].importDialog.status.success)}</span>
+              <span>{t((m) => m.dialogs.invoices.importDialog.status.success)}</span>
             </motion.div>
           )}
 
@@ -205,7 +205,7 @@ export default function ImportDialog(): React.JSX.Element {
               exit={{opacity: 0}}
               className={styles["statusError"]}>
               <TbAlertCircle className={styles["statusIcon"]} />
-              <span>{t((m) => m["IMS--Dialogs"].importDialog.status.error)}</span>
+              <span>{t((m) => m.dialogs.invoices.importDialog.status.error)}</span>
             </motion.div>
           )}
         </AnimatePresence>
@@ -214,12 +214,12 @@ export default function ImportDialog(): React.JSX.Element {
           <Button
             variant='outline'
             onClick={close}>
-            {t((m) => m["IMS--Dialogs"].importDialog.buttons.cancel)}
+            {t((m) => m.dialogs.invoices.importDialog.buttons.cancel)}
           </Button>
           <Button
             onClick={handleImport}
             disabled={files.length === 0 || uploadStatus !== "idle"}>
-            {files.length > 0 ? t((m) => m["IMS--Dialogs"].importDialog.buttons.importWithCount, {count: String(files.length)}) : t((m) => m["IMS--Dialogs"].importDialog.buttons.import)}
+            {files.length > 0 ? t((m) => m.dialogs.invoices.importDialog.buttons.importWithCount, {count: String(files.length)}) : t((m) => m.dialogs.invoices.importDialog.buttons.import)}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/FilterBar.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/FilterBar.tsx
@@ -356,12 +356,12 @@ export default function FilterBar({
 
   const getSortLabel = useCallback(
     (sortBy: FilterState["sortBy"], sortOrder: FilterState["sortOrder"]): string => {
-      if (sortBy === "date" && sortOrder === "desc") return t((m) => m["IMS--List"].invoicesView.filters.sortOptions.dateNewest);
-      if (sortBy === "date" && sortOrder === "asc") return t((m) => m["IMS--List"].invoicesView.filters.sortOptions.dateOldest);
-      if (sortBy === "amount" && sortOrder === "desc") return t((m) => m["IMS--List"].invoicesView.filters.sortOptions.amountHighToLow);
-      if (sortBy === "amount" && sortOrder === "asc") return t((m) => m["IMS--List"].invoicesView.filters.sortOptions.amountLowToHigh);
-      if (sortBy === "name" && sortOrder === "asc") return t((m) => m["IMS--List"].invoicesView.filters.sortOptions.nameAZ);
-      if (sortBy === "name" && sortOrder === "desc") return t((m) => m["IMS--List"].invoicesView.filters.sortOptions.nameZA);
+      if (sortBy === "date" && sortOrder === "desc") return t((m) => m.forms.invoices.filters.sortOptions.dateNewest);
+      if (sortBy === "date" && sortOrder === "asc") return t((m) => m.forms.invoices.filters.sortOptions.dateOldest);
+      if (sortBy === "amount" && sortOrder === "desc") return t((m) => m.forms.invoices.filters.sortOptions.amountHighToLow);
+      if (sortBy === "amount" && sortOrder === "asc") return t((m) => m.forms.invoices.filters.sortOptions.amountLowToHigh);
+      if (sortBy === "name" && sortOrder === "asc") return t((m) => m.forms.invoices.filters.sortOptions.nameAZ);
+      if (sortBy === "name" && sortOrder === "desc") return t((m) => m.forms.invoices.filters.sortOptions.nameZA);
       return "";
     },
     [t],
@@ -369,9 +369,9 @@ export default function FilterBar({
 
   const dateActivePillText = useMemo(() => {
     if (!isDateActive) return null;
-    if (activeDatePreset === "30d") return t((m) => m["IMS--List"].invoicesView.filters.datePresets["30d"]);
-    if (activeDatePreset === "90d") return t((m) => m["IMS--List"].invoicesView.filters.datePresets["90d"]);
-    if (activeDatePreset === "ytd") return t((m) => m["IMS--List"].invoicesView.filters.datePresets.ytd);
+    if (activeDatePreset === "30d") return t((m) => m.forms.invoices.filters.datePresets.value30d);
+    if (activeDatePreset === "90d") return t((m) => m.forms.invoices.filters.datePresets.value90d);
+    if (activeDatePreset === "ytd") return t((m) => m.forms.invoices.filters.datePresets.ytd);
     if (filters.dateFrom && filters.dateTo) return `${formatDate(filters.dateFrom, {locale})} – ${formatDate(filters.dateTo, {locale})}`;
     if (filters.dateFrom) return `≥ ${formatDate(filters.dateFrom, {locale})}`;
     if (filters.dateTo) return `≤ ${formatDate(filters.dateTo, {locale})}`;
@@ -395,12 +395,12 @@ export default function FilterBar({
         render={
           <span
             className={styles["dynamicHintIcon"]}
-            aria-label={t((m) => m["IMS--List"].invoicesView.filters.dynamicHint)}>
+            aria-label={t((m) => m.forms.invoices.filters.dynamicHint)}>
             <TbInfoCircle aria-hidden='true' />
           </span>
         }
       />
-      <TooltipContent>{t((m) => m["IMS--List"].invoicesView.filters.dynamicHint)}</TooltipContent>
+      <TooltipContent>{t((m) => m.forms.invoices.filters.dynamicHint)}</TooltipContent>
     </Tooltip>
   );
 
@@ -415,12 +415,12 @@ export default function FilterBar({
         <div className={`${styles["cardSection"]} ${isDateActive ? styles["cardSectionActive"] : ""}`}>
           <div className={styles["cardSectionHeader"]}>
             <span className={styles["cardSectionTitle"]}>
-              <TbCalendar /> {t((m) => m["IMS--List"].invoicesView.filters.dateRange)}
+              <TbCalendar /> {t((m) => m.forms.invoices.filters.dateRange)}
             </span>
             {dateActivePillText ? (
               <span className={styles["activeValuePill"]}>{dateActivePillText}</span>
             ) : (
-              <span className={styles["inactiveLabel"]}>{t((m) => m["IMS--List"].invoicesView.filters.anyValue)}</span>
+              <span className={styles["inactiveLabel"]}>{t((m) => m.forms.invoices.filters.anyValue)}</span>
             )}
           </div>
           <div className={styles["presetRow"]}>
@@ -444,7 +444,7 @@ export default function FilterBar({
                     variant='outline'
                     className={styles["dateButton"]}>
                     <TbCalendar className={styles["dateIcon"]} />
-                    {filters.dateFrom ? formatDate(filters.dateFrom, {locale}) : t((m) => m["IMS--List"].invoicesView.filters.dateFrom)}
+                    {filters.dateFrom ? formatDate(filters.dateFrom, {locale}) : t((m) => m.forms.invoices.filters.dateFrom)}
                   </Button>
                 }
               />
@@ -463,7 +463,7 @@ export default function FilterBar({
                     variant='outline'
                     className={styles["dateButton"]}>
                     <TbCalendar className={styles["dateIcon"]} />
-                    {filters.dateTo ? formatDate(filters.dateTo, {locale}) : t((m) => m["IMS--List"].invoicesView.filters.dateTo)}
+                    {filters.dateTo ? formatDate(filters.dateTo, {locale}) : t((m) => m.forms.invoices.filters.dateTo)}
                   </Button>
                 }
               />
@@ -482,12 +482,12 @@ export default function FilterBar({
         <div className={`${styles["cardSection"]} ${isAmountActive ? styles["cardSectionActive"] : ""}`}>
           <div className={styles["cardSectionHeader"]}>
             <span className={styles["cardSectionTitle"]}>
-              <TbCurrencyDollar /> {t((m) => m["IMS--List"].invoicesView.filters.amountRange)}
+              <TbCurrencyDollar /> {t((m) => m.forms.invoices.filters.amountRange)}
             </span>
             {amountActivePillText ? (
               <span className={styles["activeValuePill"]}>{amountActivePillText}</span>
             ) : (
-              <span className={styles["inactiveLabel"]}>{t((m) => m["IMS--List"].invoicesView.filters.anyValue)}</span>
+              <span className={styles["inactiveLabel"]}>{t((m) => m.forms.invoices.filters.anyValue)}</span>
             )}
           </div>
           <div className={styles["amountRangeInputs"]}>
@@ -495,7 +495,7 @@ export default function FilterBar({
               <TbCurrencyDollar className={styles["currencyIcon"]} />
               <Input
                 type='number'
-                placeholder={t((m) => m["IMS--List"].invoicesView.filters.amountMin)}
+                placeholder={t((m) => m.forms.invoices.filters.amountMin)}
                 value={filters.amountMin ?? ""}
                 onChange={handleAmountMinChange}
                 className={styles["amountInput"]}
@@ -505,7 +505,7 @@ export default function FilterBar({
               <TbCurrencyDollar className={styles["currencyIcon"]} />
               <Input
                 type='number'
-                placeholder={t((m) => m["IMS--List"].invoicesView.filters.amountMax)}
+                placeholder={t((m) => m.forms.invoices.filters.amountMax)}
                 value={filters.amountMax ?? ""}
                 onChange={handleAmountMaxChange}
                 className={styles["amountInput"]}
@@ -532,13 +532,13 @@ export default function FilterBar({
           <div className={`${styles["cardSection"]} ${isCurrencyActive ? styles["cardSectionActive"] : ""}`}>
             <div className={styles["cardSectionHeader"]}>
               <span className={styles["cardSectionTitle"]}>
-                💵 {t((m) => m["IMS--List"].invoicesView.filters.currency)}
+                💵 {t((m) => m.forms.invoices.filters.currency)}
                 {dynamicHint}
               </span>
               {isCurrencyActive ? (
                 <span className={styles["activeValuePill"]}>{formatCurrencyList(filters.currencies)}</span>
               ) : (
-                <span className={styles["inactiveLabel"]}>{t((m) => m["IMS--List"].invoicesView.filters.currencyAny)}</span>
+                <span className={styles["inactiveLabel"]}>{t((m) => m.forms.invoices.filters.currencyAny)}</span>
               )}
             </div>
             <div className={styles["categoryChips"]}>
@@ -566,7 +566,7 @@ export default function FilterBar({
           <div className={`${styles["cardSection"]} ${isCategoryActive ? styles["cardSectionActive"] : ""}`}>
             <div className={styles["cardSectionHeader"]}>
               <span className={styles["cardSectionTitle"]}>
-                📂 {t((m) => m["IMS--List"].invoicesView.filters.categories)}
+                📂 {t((m) => m.forms.invoices.filters.categories)}
                 {dynamicHint}
               </span>
               {isCategoryActive ? (
@@ -574,7 +574,7 @@ export default function FilterBar({
                   {filters.categories.map((c) => getCategoryLabel(c as InvoiceCategory)).join(", ")}
                 </span>
               ) : (
-                <span className={styles["inactiveLabel"]}>{t((m) => m["IMS--List"].invoicesView.filters.anyValue)}</span>
+                <span className={styles["inactiveLabel"]}>{t((m) => m.forms.invoices.filters.anyValue)}</span>
               )}
             </div>
             <div className={styles["categoryChips"]}>
@@ -602,7 +602,7 @@ export default function FilterBar({
           <div className={`${styles["cardSection"]} ${isPaymentActive ? styles["cardSectionActive"] : ""}`}>
             <div className={styles["cardSectionHeader"]}>
               <span className={styles["cardSectionTitle"]}>
-                💳 {t((m) => m["IMS--List"].invoicesView.filters.paymentTypes)}
+                💳 {t((m) => m.forms.invoices.filters.paymentTypes)}
                 {dynamicHint}
               </span>
               {isPaymentActive ? (
@@ -610,7 +610,7 @@ export default function FilterBar({
                   {filters.paymentTypes.map((p) => getPaymentTypeLabel(p as PaymentType)).join(", ")}
                 </span>
               ) : (
-                <span className={styles["inactiveLabel"]}>{t((m) => m["IMS--List"].invoicesView.filters.anyValue)}</span>
+                <span className={styles["inactiveLabel"]}>{t((m) => m.forms.invoices.filters.anyValue)}</span>
               )}
             </div>
             <div className={styles["categoryChips"]}>
@@ -636,11 +636,11 @@ export default function FilterBar({
         {/* ─────── Sort By ─────── */}
         <div className={`${styles["cardSection"]} ${isSortActive ? styles["cardSectionActive"] : ""}`}>
           <div className={styles["cardSectionHeader"]}>
-            <span className={styles["cardSectionTitle"]}>↕ {t((m) => m["IMS--List"].invoicesView.filters.sortBy)}</span>
+            <span className={styles["cardSectionTitle"]}>↕ {t((m) => m.forms.invoices.filters.sortBy)}</span>
             {isSortActive ? (
               <span className={styles["activeValuePill"]}>{getSortLabel(filters.sortBy, filters.sortOrder)}</span>
             ) : (
-              <span className={styles["inactiveLabel"]}>{t((m) => m["IMS--List"].invoicesView.filters.defaultValue)}</span>
+              <span className={styles["inactiveLabel"]}>{t((m) => m.forms.invoices.filters.defaultValue)}</span>
             )}
           </div>
           <Select
@@ -650,12 +650,12 @@ export default function FilterBar({
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value='date-desc'>{t((m) => m["IMS--List"].invoicesView.filters.sortOptions.dateNewest)}</SelectItem>
-              <SelectItem value='date-asc'>{t((m) => m["IMS--List"].invoicesView.filters.sortOptions.dateOldest)}</SelectItem>
-              <SelectItem value='amount-desc'>{t((m) => m["IMS--List"].invoicesView.filters.sortOptions.amountHighToLow)}</SelectItem>
-              <SelectItem value='amount-asc'>{t((m) => m["IMS--List"].invoicesView.filters.sortOptions.amountLowToHigh)}</SelectItem>
-              <SelectItem value='name-asc'>{t((m) => m["IMS--List"].invoicesView.filters.sortOptions.nameAZ)}</SelectItem>
-              <SelectItem value='name-desc'>{t((m) => m["IMS--List"].invoicesView.filters.sortOptions.nameZA)}</SelectItem>
+              <SelectItem value='date-desc'>{t((m) => m.forms.invoices.filters.sortOptions.dateNewest)}</SelectItem>
+              <SelectItem value='date-asc'>{t((m) => m.forms.invoices.filters.sortOptions.dateOldest)}</SelectItem>
+              <SelectItem value='amount-desc'>{t((m) => m.forms.invoices.filters.sortOptions.amountHighToLow)}</SelectItem>
+              <SelectItem value='amount-asc'>{t((m) => m.forms.invoices.filters.sortOptions.amountLowToHigh)}</SelectItem>
+              <SelectItem value='name-asc'>{t((m) => m.forms.invoices.filters.sortOptions.nameAZ)}</SelectItem>
+              <SelectItem value='name-desc'>{t((m) => m.forms.invoices.filters.sortOptions.nameZA)}</SelectItem>
             </SelectContent>
           </Select>
         </div>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/FilterBar.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/FilterBar.tsx
@@ -320,15 +320,15 @@ export default function FilterBar({
     (cat: InvoiceCategory): string => {
       switch (cat) {
         case InvoiceCategory.GROCERY:
-          return t((m) => m["IMS--List"].invoicesView.categories.groceries);
+          return t((m) => m.pages.invoices.viewInvoices.invoicesView.categories.groceries);
         case InvoiceCategory.FAST_FOOD:
-          return t((m) => m["IMS--List"].invoicesView.categories.dining);
+          return t((m) => m.pages.invoices.viewInvoices.invoicesView.categories.dining);
         case InvoiceCategory.HOME_CLEANING:
-          return t((m) => m["IMS--List"].invoicesView.categories.utilities);
+          return t((m) => m.pages.invoices.viewInvoices.invoicesView.categories.utilities);
         case InvoiceCategory.CAR_AUTO:
-          return t((m) => m["IMS--List"].invoicesView.categories.travel);
+          return t((m) => m.pages.invoices.viewInvoices.invoicesView.categories.travel);
         default:
-          return t((m) => m["IMS--List"].invoicesView.categories.other);
+          return t((m) => m.pages.invoices.viewInvoices.invoicesView.categories.other);
       }
     },
     [t],
@@ -338,17 +338,17 @@ export default function FilterBar({
     (pt: PaymentType): string => {
       switch (pt) {
         case PaymentType.Cash:
-          return t((m) => m["IMS--List"].invoicesView.filters.paymentTypeLabels.cash);
+          return t((m) => m.forms.invoices.filters.paymentTypeLabels.cash);
         case PaymentType.Card:
-          return t((m) => m["IMS--List"].invoicesView.filters.paymentTypeLabels.card);
+          return t((m) => m.forms.invoices.filters.paymentTypeLabels.card);
         case PaymentType.Transfer:
-          return t((m) => m["IMS--List"].invoicesView.filters.paymentTypeLabels.transfer);
+          return t((m) => m.forms.invoices.filters.paymentTypeLabels.transfer);
         case PaymentType.MobilePayment:
-          return t((m) => m["IMS--List"].invoicesView.filters.paymentTypeLabels.mobile);
+          return t((m) => m.forms.invoices.filters.paymentTypeLabels.mobile);
         case PaymentType.Voucher:
-          return t((m) => m["IMS--List"].invoicesView.filters.paymentTypeLabels.voucher);
+          return t((m) => m.forms.invoices.filters.paymentTypeLabels.voucher);
         default:
-          return t((m) => m["IMS--List"].invoicesView.filters.paymentTypeLabels.other);
+          return t((m) => m.forms.invoices.filters.paymentTypeLabels.other);
       }
     },
     [t],
@@ -671,7 +671,7 @@ export default function FilterBar({
         <div className={styles["searchWrapper"]}>
           <TbSearch className={styles["searchIcon"]} />
           <Input
-            placeholder={t((m) => m["IMS--List"].invoicesView.searchPlaceholder)}
+            placeholder={t((m) => m.pages.invoices.viewInvoices.invoicesView.searchPlaceholder)}
             className={styles["searchInput"]}
             value={searchInput}
             onChange={handleSearchChange}
@@ -703,9 +703,9 @@ export default function FilterBar({
             <SheetContent className={styles["filterSheet"]}>
               <div className={styles["sheetHeader"]}>
                 <h3 className={styles["sheetTitle"]}>
-                  {t((m) => m["IMS--List"].invoicesView.filters.title)}
+                  {t((m) => m.forms.invoices.filters.title)}
                   {activeFilterCount > 0 && (
-                    <span className={styles["panelHeaderActiveBadge"]}>{t((m) => m["IMS--List"].invoicesView.filters.activeCount, {count: String(activeFilterCount)})}</span>
+                    <span className={styles["panelHeaderActiveBadge"]}>{t((m) => m.forms.invoices.filters.activeCount, {count: String(activeFilterCount)})}</span>
                   )}
                 </h3>
                 {activeFilterCount > 0 && (
@@ -715,7 +715,7 @@ export default function FilterBar({
                     onClick={handleClearFilters}
                     className={styles["clearButton"]}>
                     <TbX className={styles["clearIcon"]} />
-                    {t((m) => m["IMS--List"].invoicesView.filters.clear)}
+                    {t((m) => m.forms.invoices.filters.clear)}
                   </Button>
                 )}
               </div>
@@ -725,7 +725,7 @@ export default function FilterBar({
                   className={styles["mobileShowResultsButton"]}
                   // eslint-disable-next-line react/jsx-no-bind -- inline close handler
                   onClick={() => setIsFilterOpen(false)}>
-                  {t((m) => m["IMS--List"].invoicesView.filters.showResults, {count: filteredCount})}
+                  {t((m) => m.forms.invoices.filters.showResults, {count: filteredCount})}
                 </Button>
               </div>
             </SheetContent>
@@ -740,7 +740,7 @@ export default function FilterBar({
             aria-expanded={isFilterOpen}
             aria-controls='inline-filter-panel'>
             <TbFilter className={styles["filterIcon"]} />
-            {t((m) => m["IMS--List"].invoicesView.filters.button)}
+            {t((m) => m.forms.invoices.filters.button)}
             {activeFilterCount > 0 && (
               <Badge
                 variant='default'
@@ -759,7 +759,7 @@ export default function FilterBar({
             onClick={handleClearFilters}
             className={styles["clearFiltersButton"]}>
             <TbX className={styles["clearIcon"]} />
-            {t((m) => m["IMS--List"].invoicesView.filters.clear)}
+            {t((m) => m.forms.invoices.filters.clear)}
           </Button>
         )}
 
@@ -780,7 +780,7 @@ export default function FilterBar({
                   </Button>
                 }
               />
-              <TooltipContent>{t((m) => m["IMS--List"].invoicesView.viewModes.table)}</TooltipContent>
+              <TooltipContent>{t((m) => m.pages.invoices.viewInvoices.invoicesView.viewModes.table)}</TooltipContent>
             </Tooltip>
             <Tooltip>
               <TooltipTrigger
@@ -796,7 +796,7 @@ export default function FilterBar({
                   </Button>
                 }
               />
-              <TooltipContent>{t((m) => m["IMS--List"].invoicesView.viewModes.grid)}</TooltipContent>
+              <TooltipContent>{t((m) => m.pages.invoices.viewInvoices.invoicesView.viewModes.grid)}</TooltipContent>
             </Tooltip>
           </TooltipProvider>
         </div>
@@ -809,9 +809,9 @@ export default function FilterBar({
           className={styles["inlineFilterPanel"]}>
           <div className={styles["inlineFilterHeader"]}>
             <h4 className={styles["inlineFilterTitle"]}>
-              {t((m) => m["IMS--List"].invoicesView.filters.title)}
+              {t((m) => m.forms.invoices.filters.title)}
               {activeFilterCount > 0 && (
-                <span className={styles["panelHeaderActiveBadge"]}>{t((m) => m["IMS--List"].invoicesView.filters.activeCount, {count: String(activeFilterCount)})}</span>
+                <span className={styles["panelHeaderActiveBadge"]}>{t((m) => m.forms.invoices.filters.activeCount, {count: String(activeFilterCount)})}</span>
               )}
             </h4>
             <div className={styles["inlineFilterActions"]}>
@@ -822,7 +822,7 @@ export default function FilterBar({
                   onClick={handleClearFilters}
                   className={styles["clearButton"]}>
                   <TbX className={styles["clearIcon"]} />
-                  {t((m) => m["IMS--List"].invoicesView.filters.clear)}
+                  {t((m) => m.forms.invoices.filters.clear)}
                 </Button>
               )}
               <Button
@@ -830,7 +830,7 @@ export default function FilterBar({
                 size='sm'
                 // eslint-disable-next-line react/jsx-no-bind -- inline close handler
                 onClick={() => setIsFilterOpen(false)}
-                aria-label={t((m) => m["IMS--List"].invoicesView.filters.title)}
+                aria-label={t((m) => m.forms.invoices.filters.title)}
                 className={styles["clearButton"]}>
                 <TbX className={styles["clearIcon"]} />
               </Button>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/tables/GridView.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/tables/GridView.tsx
@@ -77,10 +77,10 @@ export const GridView = (props: Readonly<Props>): React.JSX.Element => {
     return (
       <EmptyState
         icon={<TbReceipt className={styles["emptyIcon"]} />}
-        title={tTableView((m) => m["IMS--List"].tableView.empty.title)}
-        description={tTableView((m) => m["IMS--List"].tableView.empty.description)}
+        title={tTableView((m) => m.pages.invoices.viewInvoices.tableView.empty.title)}
+        description={tTableView((m) => m.pages.invoices.viewInvoices.tableView.empty.description)}
         primaryAction={{
-          label: tTableView((m) => m["IMS--List"].tableView.empty.uploadCta),
+          label: tTableView((m) => m.pages.invoices.viewInvoices.tableView.empty.uploadCta),
           href: "/domains/invoices/upload-scans",
         }}
       />
@@ -105,7 +105,7 @@ export const GridView = (props: Readonly<Props>): React.JSX.Element => {
                 checked={selectedInvoices.includes(invoice)}
                 // eslint-disable-next-line react/jsx-no-bind -- inline fn for ease.
                 onCheckedChange={() => handleSelectInvoice(invoice.id)}
-                aria-label={tTableView((m) => m["IMS--List"].tableView.aria.selectInvoice, {name: invoice.name})}
+                aria-label={tTableView((m) => m.pages.invoices.viewInvoices.tableView.aria.selectInvoice, {name: invoice.name})}
                 className={styles["frostedCheckbox"]}
               />
             </div>
@@ -136,14 +136,14 @@ export const GridView = (props: Readonly<Props>): React.JSX.Element => {
                             render={
                               <Link
                                 href={`/domains/invoices/view-invoice/${invoice.id}`}
-                                aria-label={t((m) => m["IMS--List"].gridView.tooltips.viewDetails)}>
+                                aria-label={t((m) => m.pages.invoices.viewInvoices.gridView.tooltips.viewDetails)}>
                                 <TbEye className={styles["viewIcon"]} />
                               </Link>
                             }
                           />
                         }
                       />
-                      <TooltipContent>{t((m) => m["IMS--List"].gridView.tooltips.viewDetails)}</TooltipContent>
+                      <TooltipContent>{t((m) => m.pages.invoices.viewInvoices.gridView.tooltips.viewDetails)}</TooltipContent>
                     </Tooltip>
                   </TooltipProvider>
                   <TableViewActions invoice={invoice} />
@@ -173,7 +173,7 @@ export const GridView = (props: Readonly<Props>): React.JSX.Element => {
                 </div>
               </CardContent>
               <CardFooter className={styles["cardFooter"]}>
-                <div className={styles["itemCount"]}>{t((m) => m["IMS--List"].gridView.itemCount, {count: invoice.items?.length ?? 0})}</div>
+                <div className={styles["itemCount"]}>{t((m) => m.pages.invoices.viewInvoices.gridView.itemCount, {count: invoice.items?.length ?? 0})}</div>
               </CardFooter>
             </Card>
           </div>
@@ -183,14 +183,14 @@ export const GridView = (props: Readonly<Props>): React.JSX.Element => {
       {totalPages > 1 && (
         <div className={styles["paginationControls"]}>
           <div className={styles["pageSizeSelector"]}>
-            <span className={styles["pageSizeLabel"]}>{tTableView((m) => m["IMS--List"].tableView.rowsPerPage)}</span>
+            <span className={styles["pageSizeLabel"]}>{tTableView((m) => m.pages.invoices.viewInvoices.tableView.rowsPerPage)}</span>
             <Select
               value={String(pageSize)}
               // eslint-disable-next-line react/jsx-no-bind -- inline fn for ease.
               onValueChange={(value) => handlePageSizeChange(Number(value))}>
               <SelectTrigger
                 className={styles["pageSizeTrigger"]}
-                aria-label={tTableView((m) => m["IMS--List"].tableView.aria.rowsPerPage)}>
+                aria-label={tTableView((m) => m.pages.invoices.viewInvoices.tableView.aria.rowsPerPage)}>
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -205,7 +205,7 @@ export const GridView = (props: Readonly<Props>): React.JSX.Element => {
             </Select>
           </div>
           <div className={styles["pageIndicator"]}>
-            <span className={styles["pageLabel"]}>{tTableView((m) => m["IMS--List"].tableView.pageOf, {current: String(currentPage), total: String(totalPages)})}</span>
+            <span className={styles["pageLabel"]}>{tTableView((m) => m.pages.invoices.viewInvoices.tableView.pageOf, {current: String(currentPage), total: String(totalPages)})}</span>
           </div>
           <div className={styles["pageNavigation"]}>
             <Button
@@ -214,8 +214,8 @@ export const GridView = (props: Readonly<Props>): React.JSX.Element => {
               size='sm'
               onClick={handlePrevPage}
               disabled={currentPage === 1}
-              aria-label={tTableView((m) => m["IMS--List"].tableView.previousPage)}>
-              {tTableView((m) => m["IMS--List"].tableView.previousPage)}
+              aria-label={tTableView((m) => m.pages.invoices.viewInvoices.tableView.previousPage)}>
+              {tTableView((m) => m.pages.invoices.viewInvoices.tableView.previousPage)}
             </Button>
             <Button
               variant='outline'
@@ -223,8 +223,8 @@ export const GridView = (props: Readonly<Props>): React.JSX.Element => {
               size='sm'
               onClick={handleNextPage}
               disabled={currentPage === totalPages}
-              aria-label={tTableView((m) => m["IMS--List"].tableView.nextPage)}>
-              {tTableView((m) => m["IMS--List"].tableView.nextPage)}
+              aria-label={tTableView((m) => m.pages.invoices.viewInvoices.tableView.nextPage)}>
+              {tTableView((m) => m.pages.invoices.viewInvoices.tableView.nextPage)}
             </Button>
           </div>
         </div>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/tables/TableView.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/tables/TableView.tsx
@@ -121,10 +121,10 @@ export const TableView = (props: Readonly<Props>): React.JSX.Element => {
     return (
       <EmptyState
         icon={<TbReceipt className={styles["emptyIcon"]} />}
-        title={t((m) => m["IMS--List"].tableView.empty.title)}
-        description={t((m) => m["IMS--List"].tableView.empty.description)}
+        title={t((m) => m.pages.invoices.viewInvoices.tableView.empty.title)}
+        description={t((m) => m.pages.invoices.viewInvoices.tableView.empty.description)}
         primaryAction={{
-          label: t((m) => m["IMS--List"].tableView.empty.uploadCta),
+          label: t((m) => m.pages.invoices.viewInvoices.tableView.empty.uploadCta),
           href: "/domains/invoices/upload-scans",
         }}
       />
@@ -145,7 +145,7 @@ export const TableView = (props: Readonly<Props>): React.JSX.Element => {
               className={styles["frostedCheckbox"]}
               checked={isAllSelected || (isIndeterminate && "indeterminate")}
               onCheckedChange={handleSelectAllInvoices}
-              aria-label={t((m) => m["IMS--List"].tableView.aria.selectAllInvoices)}
+              aria-label={t((m) => m.pages.invoices.viewInvoices.tableView.aria.selectAllInvoices)}
             />
           </TableHead>
           <TableHead
@@ -156,14 +156,14 @@ export const TableView = (props: Readonly<Props>): React.JSX.Element => {
             tabIndex={0}
             // eslint-disable-next-line react/jsx-no-bind -- inline fn for ease.
             onKeyDown={(e) => handleSortKeyDown(e, "name")}>
-            {t((m) => m["IMS--List"].tableView.columns.invoice)}
+            {t((m) => m.pages.invoices.viewInvoices.tableView.columns.invoice)}
             <span
               className={`${styles["sortArrow"]} ${sortBy === "name" && sortDirection ? "" : styles["sortArrowInactive"]}`}
               aria-hidden='true'>
               {sortBy === "name" && sortDirection === "desc" ? "\u25BC" : "\u25B2"}
             </span>
           </TableHead>
-          <TableHead>{t((m) => m["IMS--List"].tableView.columns.category)}</TableHead>
+          <TableHead>{t((m) => m.pages.invoices.viewInvoices.tableView.columns.category)}</TableHead>
           <TableHead
             className={`${styles["tableHeaderCell"]} ${styles["sortableHeader"]}`}
             onClick={handleSortByDate}
@@ -172,7 +172,7 @@ export const TableView = (props: Readonly<Props>): React.JSX.Element => {
             tabIndex={0}
             // eslint-disable-next-line react/jsx-no-bind -- inline fn for ease.
             onKeyDown={(e) => handleSortKeyDown(e, "date")}>
-            {t((m) => m["IMS--List"].tableView.columns.date)}
+            {t((m) => m.pages.invoices.viewInvoices.tableView.columns.date)}
             <span
               className={`${styles["sortArrow"]} ${sortBy === "date" && sortDirection ? "" : styles["sortArrowInactive"]}`}
               aria-hidden='true'>
@@ -187,14 +187,14 @@ export const TableView = (props: Readonly<Props>): React.JSX.Element => {
             tabIndex={0}
             // eslint-disable-next-line react/jsx-no-bind -- inline fn for ease.
             onKeyDown={(e) => handleSortKeyDown(e, "amount")}>
-            {t((m) => m["IMS--List"].tableView.columns.amount)}
+            {t((m) => m.pages.invoices.viewInvoices.tableView.columns.amount)}
             <span
               className={`${styles["sortArrow"]} ${sortBy === "amount" && sortDirection ? "" : styles["sortArrowInactive"]}`}
               aria-hidden='true'>
               {sortBy === "amount" && sortDirection === "desc" ? "\u25BC" : "\u25B2"}
             </span>
           </TableHead>
-          <TableHead className={styles["actionsHeader"]}>{t((m) => m["IMS--List"].tableView.columns.actions)}</TableHead>
+          <TableHead className={styles["actionsHeader"]}>{t((m) => m.pages.invoices.viewInvoices.tableView.columns.actions)}</TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
@@ -206,7 +206,7 @@ export const TableView = (props: Readonly<Props>): React.JSX.Element => {
                 checked={selectedInvoices.some((s) => s.id === invoice.id)}
                 // eslint-disable-next-line react/jsx-no-bind -- inline fn for ease.
                 onCheckedChange={() => handleSelectInvoice(invoice.id)}
-                aria-label={t((m) => m["IMS--List"].tableView.aria.selectInvoice, {name: invoice.name || invoice.id})}
+                aria-label={t((m) => m.pages.invoices.viewInvoices.tableView.aria.selectInvoice, {name: invoice.name || invoice.id})}
               />
             </TableCell>
             <TableCell>
@@ -237,7 +237,7 @@ export const TableView = (props: Readonly<Props>): React.JSX.Element => {
                   <Tooltip>
                     <TooltipTrigger render={<Badge variant='outline'>N/A</Badge>} />
                     <TooltipContent>
-                      <p>{t((m) => m["IMS--List"].tableView.tooltips.notAnalyzed)}</p>
+                      <p>{t((m) => m.pages.invoices.viewInvoices.tableView.tooltips.notAnalyzed)}</p>
                     </TooltipContent>
                   </Tooltip>
                 </TooltipProvider>
@@ -263,7 +263,7 @@ export const TableView = (props: Readonly<Props>): React.JSX.Element => {
                         </Link>
                       }
                     />
-                    <TooltipContent>{t((m) => m["IMS--List"].tableView.viewInvoice)}</TooltipContent>
+                    <TooltipContent>{t((m) => m.pages.invoices.viewInvoices.tableView.viewInvoice)}</TooltipContent>
                   </Tooltip>
                 </TooltipProvider>
                 <TableViewActions invoice={invoice} />
@@ -277,14 +277,14 @@ export const TableView = (props: Readonly<Props>): React.JSX.Element => {
           <TableRow>
             <TableCell colSpan={4}>
               <div className={styles["footerContent"]}>
-                <span className={styles["footerLabel"]}>{t((m) => m["IMS--List"].tableView.rowsPerPage)}</span>
+                <span className={styles["footerLabel"]}>{t((m) => m.pages.invoices.viewInvoices.tableView.rowsPerPage)}</span>
                 <Select
                   value={String(pageSize)}
                   // eslint-disable-next-line react/jsx-no-bind -- inline fn for ease.
                   onValueChange={(value) => handlePageSizeChange(Number(value))}>
                   <SelectTrigger
                     className={styles["pageSizeTrigger"]}
-                    aria-label={t((m) => m["IMS--List"].tableView.aria.rowsPerPage)}>
+                    aria-label={t((m) => m.pages.invoices.viewInvoices.tableView.aria.rowsPerPage)}>
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
@@ -297,7 +297,7 @@ export const TableView = (props: Readonly<Props>): React.JSX.Element => {
                     ))}
                   </SelectContent>
                 </Select>
-                <span className={styles["footerLabel"]}>{t((m) => m["IMS--List"].tableView.pageOf, {current: String(currentPage), total: String(totalPages)})}</span>
+                <span className={styles["footerLabel"]}>{t((m) => m.pages.invoices.viewInvoices.tableView.pageOf, {current: String(currentPage), total: String(totalPages)})}</span>
               </div>
             </TableCell>
             <TableCell
@@ -309,7 +309,7 @@ export const TableView = (props: Readonly<Props>): React.JSX.Element => {
                 size='sm'
                 onClick={handlePrevPage}
                 disabled={invoices.length === 0}>
-                {t((m) => m["IMS--List"].tableView.previousPage)}
+                {t((m) => m.pages.invoices.viewInvoices.tableView.previousPage)}
               </Button>
             </TableCell>
             <TableCell>
@@ -319,7 +319,7 @@ export const TableView = (props: Readonly<Props>): React.JSX.Element => {
                 size='sm'
                 onClick={handleNextPage}
                 disabled={invoices.length === 0}>
-                {t((m) => m["IMS--List"].tableView.nextPage)}
+                {t((m) => m.pages.invoices.viewInvoices.tableView.nextPage)}
               </Button>
             </TableCell>
           </TableRow>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/tables/TableViewActions.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/tables/TableViewActions.tsx
@@ -50,7 +50,7 @@ export default function TableViewActions({invoice}: Readonly<Props>): React.JSX.
               />
             }
           />
-          <TooltipContent side='left'>{t((m) => m["IMS--List"].tableViewActions.tooltips.moreActions)}</TooltipContent>
+          <TooltipContent side='left'>{t((m) => m.pages.invoices.viewInvoices.tableViewActions.tooltips.moreActions)}</TooltipContent>
         </Tooltip>
         <DropdownMenuContent
           align='end'
@@ -65,13 +65,13 @@ export default function TableViewActions({invoice}: Readonly<Props>): React.JSX.
                       href={`/domains/invoices/edit-invoice/${invoice.id}`}
                       className={styles["editLink"]}>
                       <TbEdit className={styles["menuItemIcon"]} />
-                      {t((m) => m["IMS--List"].tableViewActions.actions.edit)}
+                      {t((m) => m.pages.invoices.viewInvoices.tableViewActions.actions.edit)}
                     </Link>
                   }
                 />
               }
             />
-            <TooltipContent side='left'>{t((m) => m["IMS--List"].tableViewActions.tooltips.edit)}</TooltipContent>
+            <TooltipContent side='left'>{t((m) => m.pages.invoices.viewInvoices.tableViewActions.tooltips.edit)}</TooltipContent>
           </Tooltip>
           <Tooltip>
             <TooltipTrigger
@@ -80,11 +80,11 @@ export default function TableViewActions({invoice}: Readonly<Props>): React.JSX.
                   onClick={openShareDialog}
                   className={styles["menuItem"]}>
                   <TbShare className={styles["menuItemIcon"]} />
-                  {t((m) => m["IMS--List"].tableViewActions.actions.share)}
+                  {t((m) => m.pages.invoices.viewInvoices.tableViewActions.actions.share)}
                 </DropdownMenuItem>
               }
             />
-            <TooltipContent side='left'>{t((m) => m["IMS--List"].tableViewActions.tooltips.share)}</TooltipContent>
+            <TooltipContent side='left'>{t((m) => m.pages.invoices.viewInvoices.tableViewActions.tooltips.share)}</TooltipContent>
           </Tooltip>
           <DropdownMenuSeparator />
           <Tooltip>
@@ -94,11 +94,11 @@ export default function TableViewActions({invoice}: Readonly<Props>): React.JSX.
                   className={styles["menuItemDestructive"]}
                   onClick={openDeleteDialog}>
                   <TbTrash className={styles["menuItemIcon"]} />
-                  {t((m) => m["IMS--List"].tableViewActions.actions.delete)}
+                  {t((m) => m.pages.invoices.viewInvoices.tableViewActions.actions.delete)}
                 </DropdownMenuItem>
               }
             />
-            <TooltipContent side='left'>{t((m) => m["IMS--List"].tableViewActions.tooltips.delete)}</TooltipContent>
+            <TooltipContent side='left'>{t((m) => m.pages.invoices.viewInvoices.tableViewActions.tooltips.delete)}</TooltipContent>
           </Tooltip>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/GenerativeView.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/GenerativeView.tsx
@@ -48,7 +48,7 @@ export default function RenderGenerativeView({invoices}: Readonly<Props>): React
   const [messages, setMessages] = useState<Message[]>(() => [
     {
       id: "welcome",
-      content: t((m) => m["IMS--List"].generativeView.welcomeMessage),
+      content: t((m) => m.pages.invoices.viewInvoices.generativeView.welcomeMessage),
       role: "assistant",
       timestamp: new Date().toISOString(),
     },
@@ -67,15 +67,15 @@ export default function RenderGenerativeView({invoices}: Readonly<Props>): React
       className={styles["container"]}>
       <div className={styles["header"]}>
         <div>
-          <h2 className={styles["title"]}>{t((m) => m["IMS--List"].generativeView.title)}</h2>
-          <p className={styles["subtitle"]}>{t((m) => m["IMS--List"].generativeView.subtitle)}</p>
+          <h2 className={styles["title"]}>{t((m) => m.pages.invoices.viewInvoices.generativeView.title)}</h2>
+          <p className={styles["subtitle"]}>{t((m) => m.pages.invoices.viewInvoices.generativeView.subtitle)}</p>
         </div>
         <Button
           variant='outline'
           size='sm'
           className={styles["helpButton"]}>
           <TbHelpCircle className={styles["actionIcon"]} />
-          <span>{t((m) => m["IMS--List"].generativeView.help)}</span>
+          <span>{t((m) => m.pages.invoices.viewInvoices.generativeView.help)}</span>
         </Button>
       </div>
 
@@ -87,13 +87,13 @@ export default function RenderGenerativeView({invoices}: Readonly<Props>): React
             value='chat'
             className={styles["tabTrigger"]}>
             <TbMessage className={styles["actionIcon"]} />
-            <span>{t((m) => m["IMS--List"].generativeView.tabs.chat)}</span>
+            <span>{t((m) => m.pages.invoices.viewInvoices.generativeView.tabs.chat)}</span>
           </TabsTrigger>
           <TabsTrigger
             value='settings'
             className={styles["tabTrigger"]}>
             <TbSettings className={styles["actionIcon"]} />
-            <span>{t((m) => m["IMS--List"].generativeView.tabs.settings)}</span>
+            <span>{t((m) => m.pages.invoices.viewInvoices.generativeView.tabs.settings)}</span>
           </TabsTrigger>
         </TabsList>
         <TabsContent
@@ -101,8 +101,8 @@ export default function RenderGenerativeView({invoices}: Readonly<Props>): React
           className={styles["tabContent"]}>
           <Card className={styles["fullWidth"]}>
             <CardHeader>
-              <CardTitle>{t((m) => m["IMS--List"].generativeView.title)}</CardTitle>
-              <CardDescription>{t((m) => m["IMS--List"].generativeView.chatDescription)}</CardDescription>
+              <CardTitle>{t((m) => m.pages.invoices.viewInvoices.generativeView.title)}</CardTitle>
+              <CardDescription>{t((m) => m.pages.invoices.viewInvoices.generativeView.chatDescription)}</CardDescription>
             </CardHeader>
             <CardContent>
               <div className={styles["chatContainer"]}>
@@ -120,28 +120,28 @@ export default function RenderGenerativeView({invoices}: Readonly<Props>): React
           className={styles["tabContent"]}>
           <Card className={styles["fullWidth"]}>
             <CardHeader>
-              <CardTitle>{t((m) => m["IMS--List"].generativeView.settings.title)}</CardTitle>
-              <CardDescription>{t((m) => m["IMS--List"].generativeView.settings.description)}</CardDescription>
+              <CardTitle>{t((m) => m.pages.invoices.viewInvoices.generativeView.settings.title)}</CardTitle>
+              <CardDescription>{t((m) => m.pages.invoices.viewInvoices.generativeView.settings.description)}</CardDescription>
             </CardHeader>
             <CardContent>
               <div className={styles["settingsContainer"]}>
                 <div className={styles["settingsField"]}>
-                  <Label htmlFor='history'>{t((m) => m["IMS--List"].generativeView.settings.historyLabel)}</Label>
+                  <Label htmlFor='history'>{t((m) => m.pages.invoices.viewInvoices.generativeView.settings.historyLabel)}</Label>
                   <Select defaultValue='30'>
                     <SelectTrigger id='history'>
-                      <SelectValue placeholder={t((m) => m["IMS--List"].generativeView.settings.retentionPlaceholder)} />
+                      <SelectValue placeholder={t((m) => m.pages.invoices.viewInvoices.generativeView.settings.retentionPlaceholder)} />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value='30'>{t((m) => m["IMS--List"].generativeView.settings.retention["30"])}</SelectItem>
-                      <SelectItem value='60'>{t((m) => m["IMS--List"].generativeView.settings.retention["60"])}</SelectItem>
-                      <SelectItem value='90'>{t((m) => m["IMS--List"].generativeView.settings.retention["90"])}</SelectItem>
-                      <SelectItem value='0'>{t((m) => m["IMS--List"].generativeView.settings.retention.none)}</SelectItem>
+                      <SelectItem value='30'>{t((m) => m.pages.invoices.viewInvoices.generativeView.settings.retention.item30)}</SelectItem>
+                      <SelectItem value='60'>{t((m) => m.pages.invoices.viewInvoices.generativeView.settings.retention.item60)}</SelectItem>
+                      <SelectItem value='90'>{t((m) => m.pages.invoices.viewInvoices.generativeView.settings.retention.item90)}</SelectItem>
+                      <SelectItem value='0'>{t((m) => m.pages.invoices.viewInvoices.generativeView.settings.retention.none)}</SelectItem>
                     </SelectContent>
                   </Select>
                 </div>
 
                 <div className={styles["settingsField"]}>
-                  <span className={styles["settingsLabel"]}>{t((m) => m["IMS--List"].generativeView.settings.dataAccessTitle)}</span>
+                  <span className={styles["settingsLabel"]}>{t((m) => m.pages.invoices.viewInvoices.generativeView.settings.dataAccessTitle)}</span>
                   <div className={styles["checkboxRow"]}>
                     <Checkbox
                       nativeButton
@@ -151,7 +151,7 @@ export default function RenderGenerativeView({invoices}: Readonly<Props>): React
                     <Label
                       htmlFor='access-invoices'
                       className={styles["checkboxLabel"]}>
-                      {t((m) => m["IMS--List"].generativeView.settings.allowInvoiceData)}
+                      {t((m) => m.pages.invoices.viewInvoices.generativeView.settings.allowInvoiceData)}
                     </Label>
                   </div>
                   <div className={styles["checkboxRow"]}>
@@ -163,13 +163,13 @@ export default function RenderGenerativeView({invoices}: Readonly<Props>): React
                     <Label
                       htmlFor='access-merchants'
                       className={styles["checkboxLabel"]}>
-                      {t((m) => m["IMS--List"].generativeView.settings.allowMerchantData)}
+                      {t((m) => m.pages.invoices.viewInvoices.generativeView.settings.allowMerchantData)}
                     </Label>
                   </div>
                 </div>
 
                 <div className={styles["settingsField"]}>
-                  <span className={styles["settingsLabel"]}>{t((m) => m["IMS--List"].generativeView.settings.notificationPreferences)}</span>
+                  <span className={styles["settingsLabel"]}>{t((m) => m.pages.invoices.viewInvoices.generativeView.settings.notificationPreferences)}</span>
                   <div className={styles["checkboxRow"]}>
                     <Checkbox
                       nativeButton
@@ -179,12 +179,12 @@ export default function RenderGenerativeView({invoices}: Readonly<Props>): React
                     <Label
                       htmlFor='notify-insights'
                       className={styles["checkboxLabel"]}>
-                      {t((m) => m["IMS--List"].generativeView.settings.notifyInsights)}
+                      {t((m) => m.pages.invoices.viewInvoices.generativeView.settings.notifyInsights)}
                     </Label>
                   </div>
                 </div>
 
-                <Button className={styles["saveButton"]}>{t((m) => m["IMS--List"].generativeView.settings.save)}</Button>
+                <Button className={styles["saveButton"]}>{t((m) => m.pages.invoices.viewInvoices.generativeView.settings.save)}</Button>
               </div>
             </CardContent>
           </Card>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/StatisticsView.stories.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/StatisticsView.stories.tsx
@@ -5,7 +5,7 @@ import RenderStatisticsView from "./StatisticsView";
 /**
  * StatisticsView renders a comprehensive analytics dashboard for invoices.
  * Features KPI cards, spending trends, category breakdowns, merchant leaderboards,
- * and time-based analytics. Uses the `IMS--Stats` i18n namespace.
+ * and time-based analytics. Uses the `cards.invoices.statistics` i18n namespace.
  *
  * **Components:**
  * - KPI Summary Row (total spending, invoice count, top merchant, average items)

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/StatisticsView.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/StatisticsView.tsx
@@ -78,8 +78,8 @@ function EmptyState(): React.JSX.Element {
       <div className={styles["emptyIcon"]}>
         <TbChartBar size={64} />
       </div>
-      <h2 className={styles["emptyTitle"]}>{t((m) => m["IMS--Stats"].empty.title)}</h2>
-      <p className={styles["emptySubtitle"]}>{t((m) => m["IMS--Stats"].empty.subtitle)}</p>
+      <h2 className={styles["emptyTitle"]}>{t((m) => m.cards.invoices.statistics.empty.title)}</h2>
+      <p className={styles["emptySubtitle"]}>{t((m) => m.cards.invoices.statistics.empty.subtitle)}</p>
     </motion.div>
   );
 }
@@ -139,8 +139,8 @@ export default function RenderStatisticsView({invoices}: Readonly<Props>): React
       <div className={styles["container"]}>
         <div className={styles["header"]}>
           <div className={styles["headerContent"]}>
-            <h1 className={styles["title"]}>{t((m) => m["IMS--Stats"].title)}</h1>
-            <p className={styles["subtitle"]}>{t((m) => m["IMS--Stats"].subtitle)}</p>
+            <h1 className={styles["title"]}>{t((m) => m.cards.invoices.statistics.title)}</h1>
+            <p className={styles["subtitle"]}>{t((m) => m.cards.invoices.statistics.subtitle)}</p>
           </div>
         </div>
         <EmptyState />
@@ -157,8 +157,8 @@ export default function RenderStatisticsView({invoices}: Readonly<Props>): React
         animate={{opacity: 1, y: 0}}
         transition={{duration: 0.5}}>
         <div className={styles["headerContent"]}>
-          <h1 className={styles["title"]}>{t((m) => m["IMS--Stats"].title)}</h1>
-          <p className={styles["subtitle"]}>{t((m) => m["IMS--Stats"].subtitle)}</p>
+          <h1 className={styles["title"]}>{t((m) => m.cards.invoices.statistics.title)}</h1>
+          <p className={styles["subtitle"]}>{t((m) => m.cards.invoices.statistics.subtitle)}</p>
         </div>
       </motion.div>
 
@@ -297,8 +297,8 @@ export default function RenderStatisticsView({invoices}: Readonly<Props>): React
           initial={{opacity: 0, y: 20}}
           animate={{opacity: 1, y: 0}}
           transition={{duration: 0.5, delay: 0.75}}>
-          <h2 className={styles["sectionTitle"]}>{t((m) => m["IMS--Stats"].productAnalytics.title)}</h2>
-          <p className={styles["sectionSubtitle"]}>{t((m) => m["IMS--Stats"].productAnalytics.subtitle)}</p>
+          <h2 className={styles["sectionTitle"]}>{t((m) => m.cards.invoices.statistics.productAnalytics.title)}</h2>
+          <p className={styles["sectionSubtitle"]}>{t((m) => m.cards.invoices.statistics.productAnalytics.subtitle)}</p>
         </motion.div>
       </section>
 

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/AllergenSummaryChart.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/AllergenSummaryChart.tsx
@@ -71,11 +71,11 @@ function AllergenCard({allergen}: {readonly allergen: AllergenFrequency}): React
       <div className={styles["allergenStats"]}>
         <div className={styles["statItem"]}>
           <span className={styles["statValue"]}>{allergen.productCount}</span>
-          <span className={styles["statLabel"]}>{t((m) => m["IMS--Stats"].allergenSummary.stats.products)}</span>
+          <span className={styles["statLabel"]}>{t((m) => m.cards.invoices.statistics.allergenSummary.stats.products)}</span>
         </div>
         <div className={styles["statItem"]}>
           <span className={styles["statValue"]}>{formatAmount(allergen.percentage, "en-US", 1)}%</span>
-          <span className={styles["statLabel"]}>{t((m) => m["IMS--Stats"].allergenSummary.stats.ofTotal)}</span>
+          <span className={styles["statLabel"]}>{t((m) => m.cards.invoices.statistics.allergenSummary.stats.ofTotal)}</span>
         </div>
       </div>
     </div>
@@ -112,13 +112,13 @@ export function AllergenSummaryChart({data}: Props): React.JSX.Element {
     return (
       <Card className={styles["card"]}>
         <CardHeader className={styles["cardHeader"]}>
-          <CardTitle className={styles["cardTitle"]}>{t((m) => m["IMS--Stats"].allergenSummary.title)}</CardTitle>
-          <CardDescription className={styles["cardDescription"]}>{t((m) => m["IMS--Stats"].allergenSummary.description)}</CardDescription>
+          <CardTitle className={styles["cardTitle"]}>{t((m) => m.cards.invoices.statistics.allergenSummary.title)}</CardTitle>
+          <CardDescription className={styles["cardDescription"]}>{t((m) => m.cards.invoices.statistics.allergenSummary.description)}</CardDescription>
         </CardHeader>
         <CardContent className={styles["cardContent"]}>
           <div className={styles["emptyState"]}>
             <div className={styles["emptyIcon"]}>✓</div>
-            <p className={styles["emptyText"]}>{t((m) => m["IMS--Stats"].allergenSummary.empty)}</p>
+            <p className={styles["emptyText"]}>{t((m) => m.cards.invoices.statistics.allergenSummary.empty)}</p>
           </div>
         </CardContent>
       </Card>
@@ -128,14 +128,14 @@ export function AllergenSummaryChart({data}: Props): React.JSX.Element {
   return (
     <Card className={styles["card"]}>
       <CardHeader className={styles["cardHeader"]}>
-        <CardTitle className={styles["cardTitle"]}>{t((m) => m["IMS--Stats"].allergenSummary.title)}</CardTitle>
-        <CardDescription className={styles["cardDescription"]}>{t((m) => m["IMS--Stats"].allergenSummary.description)}</CardDescription>
+        <CardTitle className={styles["cardTitle"]}>{t((m) => m.cards.invoices.statistics.allergenSummary.title)}</CardTitle>
+        <CardDescription className={styles["cardDescription"]}>{t((m) => m.cards.invoices.statistics.allergenSummary.description)}</CardDescription>
       </CardHeader>
       <CardContent className={styles["cardContent"]}>
         <div
           className={styles["allergenGrid"]}
           role='list'
-          aria-label={t((m) => m["IMS--Stats"].allergenSummary.ariaLabel)}>
+          aria-label={t((m) => m.cards.invoices.statistics.allergenSummary.ariaLabel)}>
           {data.map((allergen) => (
             <AllergenCard
               key={allergen.name}

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/CategoryBreakdownChart.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/CategoryBreakdownChart.tsx
@@ -63,7 +63,7 @@ function CustomTooltip({active, payload, currency}: CustomTooltipProps): React.J
         {formatAmount(data.amount)} {currency}
       </p>
       <p className={styles["tooltipPercentage"]}>{formatAmount(data.percentage, "en-US", 1)}%</p>
-      <p className={styles["tooltipCount"]}>{t((m) => m["IMS--Stats"].categoryBreakdown.tooltip.invoiceCount, {count: String(data.count)})}</p>
+      <p className={styles["tooltipCount"]}>{t((m) => m.cards.invoices.statistics.categoryBreakdown.tooltip.invoiceCount, {count: String(data.count)})}</p>
     </div>
   );
 }
@@ -117,8 +117,8 @@ export function CategoryBreakdownChart({data, currency}: Props): React.JSX.Eleme
   return (
     <Card className={styles["card"]}>
       <CardHeader className={styles["cardHeader"]}>
-        <CardTitle className={styles["cardTitle"]}>{t((m) => m["IMS--Stats"].categoryBreakdown.title)}</CardTitle>
-        <CardDescription className={styles["cardDescription"]}>{t((m) => m["IMS--Stats"].categoryBreakdown.description)}</CardDescription>
+        <CardTitle className={styles["cardTitle"]}>{t((m) => m.cards.invoices.statistics.categoryBreakdown.title)}</CardTitle>
+        <CardDescription className={styles["cardDescription"]}>{t((m) => m.cards.invoices.statistics.categoryBreakdown.description)}</CardDescription>
       </CardHeader>
       <CardContent className={styles["cardContent"]}>
         <ChartContainer
@@ -156,7 +156,7 @@ export function CategoryBreakdownChart({data, currency}: Props): React.JSX.Eleme
           <p className={styles["totalAmount"]}>
             {formatAmount(total)} {currency}
           </p>
-          <p className={styles["totalLabel"]}>{t((m) => m["IMS--Stats"].categoryBreakdown.totalLabel)}</p>
+          <p className={styles["totalLabel"]}>{t((m) => m.cards.invoices.statistics.categoryBreakdown.totalLabel)}</p>
         </div>
       </CardContent>
     </Card>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/ComparisonCards.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/ComparisonCards.tsx
@@ -91,7 +91,7 @@ export function ComparisonCards({data, currency}: Props): React.JSX.Element {
   const cards: Omit<ComparisonCardProps, "index">[] = [
     {
       icon: spendingIcon,
-      label: t((m) => m["IMS--Stats"].comparison.spendingDelta),
+      label: t((m) => m.cards.invoices.statistics.comparison.spendingDelta),
       value: `${formatAmount(Math.abs(data.spendingDelta))} ${currency}`,
       delta: `${data.spendingDeltaPercent >= 0 ? "+" : ""}${formatAmount(data.spendingDeltaPercent, "en-US", 1)}%`,
       isPositive: data.spendingDelta < 0, // Spending less is positive (saving)
@@ -99,7 +99,7 @@ export function ComparisonCards({data, currency}: Props): React.JSX.Element {
     },
     {
       icon: invoiceIcon,
-      label: t((m) => m["IMS--Stats"].comparison.invoiceCount),
+      label: t((m) => m.cards.invoices.statistics.comparison.invoiceCount),
       value: Math.abs(data.invoiceCountDelta).toString(),
       delta: `${data.invoiceCountDelta >= 0 ? "+" : ""}${data.invoiceCountDelta}`,
       isPositive: data.invoiceCountDelta >= 0,
@@ -107,9 +107,9 @@ export function ComparisonCards({data, currency}: Props): React.JSX.Element {
     },
     {
       icon: <TbBuildingStore size={20} />,
-      label: t((m) => m["IMS--Stats"].comparison.newMerchants),
+      label: t((m) => m.cards.invoices.statistics.comparison.newMerchants),
       value: data.newMerchantCount.toString(),
-      delta: data.newMerchantCount > 0 ? t((m) => m["IMS--Stats"].comparison.discovered) : t((m) => m["IMS--Stats"].comparison.none),
+      delta: data.newMerchantCount > 0 ? t((m) => m.cards.invoices.statistics.comparison.discovered) : t((m) => m.cards.invoices.statistics.comparison.none),
       isPositive: data.newMerchantCount > 0 ? true : null,
       progressValue: Math.min(data.newMerchantCount * 20, 100),
     },
@@ -117,7 +117,7 @@ export function ComparisonCards({data, currency}: Props): React.JSX.Element {
 
   return (
     <div className={styles["container"]}>
-      <h3 className={styles["sectionTitle"]}>{t((m) => m["IMS--Stats"].comparison.title)}</h3>
+      <h3 className={styles["sectionTitle"]}>{t((m) => m.cards.invoices.statistics.comparison.title)}</h3>
       <div className={styles["grid"]}>
         {cards.map((card, index) => (
           <ComparisonCard

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/CurrencyDistributionChart.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/CurrencyDistributionChart.tsx
@@ -78,20 +78,20 @@ function SingleCurrencyMessage({currency}: {readonly currency: CurrencyDistribut
         <TbCurrencyDollar size={48} />
       </div>
       <p className={styles["singleCurrencyText"]}>
-        {t((m) => m["IMS--Stats"].currencyDistribution.singleCurrency, {
+        {t((m) => m.cards.invoices.statistics.currencyDistribution.singleCurrency, {
           currency: currency.currencyCode,
           symbol: currency.currencySymbol,
         })}
       </p>
       <div className={styles["singleCurrencyStats"]}>
         <div className={styles["statItem"]}>
-          <span className={styles["statLabel"]}>{t((m) => m["IMS--Stats"].currencyDistribution.totalAmount)}</span>
+          <span className={styles["statLabel"]}>{t((m) => m.cards.invoices.statistics.currencyDistribution.totalAmount)}</span>
           <span className={styles["statValue"]}>
             {formatAmount(currency.totalOriginal)} {currency.currencySymbol}
           </span>
         </div>
         <div className={styles["statItem"]}>
-          <span className={styles["statLabel"]}>{t((m) => m["IMS--Stats"].currencyDistribution.invoiceCount)}</span>
+          <span className={styles["statLabel"]}>{t((m) => m.cards.invoices.statistics.currencyDistribution.invoiceCount)}</span>
           <span className={styles["statValue"]}>{currency.invoiceCount}</span>
         </div>
       </div>
@@ -138,8 +138,8 @@ export function CurrencyDistributionChart({data}: Props): React.JSX.Element {
     return (
       <Card className={styles["card"]}>
         <CardHeader className={styles["cardHeader"]}>
-          <CardTitle className={styles["cardTitle"]}>{t((m) => m["IMS--Stats"].currencyDistribution.title)}</CardTitle>
-          <CardDescription className={styles["cardDescription"]}>{t((m) => m["IMS--Stats"].currencyDistribution.description)}</CardDescription>
+          <CardTitle className={styles["cardTitle"]}>{t((m) => m.cards.invoices.statistics.currencyDistribution.title)}</CardTitle>
+          <CardDescription className={styles["cardDescription"]}>{t((m) => m.cards.invoices.statistics.currencyDistribution.description)}</CardDescription>
         </CardHeader>
         <CardContent className={styles["cardContent"]}>
           <SingleCurrencyMessage currency={currency} />
@@ -158,17 +158,17 @@ export function CurrencyDistributionChart({data}: Props): React.JSX.Element {
       <CardHeader className={styles["cardHeader"]}>
         <div className={styles["headerTop"]}>
           <div>
-            <CardTitle className={styles["cardTitle"]}>{t((m) => m["IMS--Stats"].currencyDistribution.title)}</CardTitle>
-            <CardDescription className={styles["cardDescription"]}>{t((m) => m["IMS--Stats"].currencyDistribution.description)}</CardDescription>
+            <CardTitle className={styles["cardTitle"]}>{t((m) => m.cards.invoices.statistics.currencyDistribution.title)}</CardTitle>
+            <CardDescription className={styles["cardDescription"]}>{t((m) => m.cards.invoices.statistics.currencyDistribution.description)}</CardDescription>
           </div>
           <button
             type='button'
             onClick={handleToggleRON}
             className={styles["toggleButton"]}
-            aria-label={t((m) => m["IMS--Stats"].currencyDistribution.toggleLabel)}
-            title={t((m) => m["IMS--Stats"].currencyDistribution.toggleLabel)}>
+            aria-label={t((m) => m.cards.invoices.statistics.currencyDistribution.toggleLabel)}
+            title={t((m) => m.cards.invoices.statistics.currencyDistribution.toggleLabel)}>
             <TbSwitchHorizontal size={20} />
-            <span className={styles["toggleText"]}>{showRON ? t((m) => m["IMS--Stats"].currencyDistribution.showOriginal) : t((m) => m["IMS--Stats"].currencyDistribution.showRON)}</span>
+            <span className={styles["toggleText"]}>{showRON ? t((m) => m.cards.invoices.statistics.currencyDistribution.showOriginal) : t((m) => m.cards.invoices.statistics.currencyDistribution.showRON)}</span>
           </button>
         </div>
       </CardHeader>
@@ -198,7 +198,7 @@ export function CurrencyDistributionChart({data}: Props): React.JSX.Element {
                     <Badge
                       variant='secondary'
                       className={styles["invoiceBadge"]}>
-                      {t((m) => m["IMS--Stats"].currencyDistribution.invoiceCount)}
+                      {t((m) => m.cards.invoices.statistics.currencyDistribution.invoiceCount)}
                     </Badge>
                   </div>
                   <div className={styles["currencyAmount"]}>
@@ -225,11 +225,11 @@ export function CurrencyDistributionChart({data}: Props): React.JSX.Element {
                   <div className={styles["secondaryAmount"]}>
                     {showRON ? (
                       <span>
-                        {t((m) => m["IMS--Stats"].currencyDistribution.originalAmount)}: {formatAmount(currency.totalOriginal)} {currency.currencySymbol}
+                        {t((m) => m.cards.invoices.statistics.currencyDistribution.originalAmount)}: {formatAmount(currency.totalOriginal)} {currency.currencySymbol}
                       </span>
                     ) : (
                       <span>
-                        {t((m) => m["IMS--Stats"].currencyDistribution.ronEquivalent)}: {formatAmount(currency.totalInRON)} lei
+                        {t((m) => m.cards.invoices.statistics.currencyDistribution.ronEquivalent)}: {formatAmount(currency.totalInRON)} lei
                       </span>
                     )}
                   </div>
@@ -242,11 +242,11 @@ export function CurrencyDistributionChart({data}: Props): React.JSX.Element {
         {/* Summary Section */}
         <div className={styles["summarySection"]}>
           <div className={styles["summaryItem"]}>
-            <span className={styles["summaryLabel"]}>{t((m) => m["IMS--Stats"].currencyDistribution.totalCurrencies)}</span>
+            <span className={styles["summaryLabel"]}>{t((m) => m.cards.invoices.statistics.currencyDistribution.totalCurrencies)}</span>
             <span className={styles["summaryValue"]}>{data.length}</span>
           </div>
           <div className={styles["summaryItem"]}>
-            <span className={styles["summaryLabel"]}>{t((m) => m["IMS--Stats"].currencyDistribution.totalSpending)}</span>
+            <span className={styles["summaryLabel"]}>{t((m) => m.cards.invoices.statistics.currencyDistribution.totalSpending)}</span>
             <span className={styles["summaryValue"]}>{formatAmount(data.reduce((sum, curr) => sum + curr.totalInRON, 0))} lei</span>
           </div>
         </div>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/KPISummaryRow.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/KPISummaryRow.tsx
@@ -77,32 +77,32 @@ export function KPISummaryRow({data, currency}: Props): React.JSX.Element {
   const kpiCards: Omit<KPICardProps, "index">[] = [
     {
       icon: <TbCurrencyDollar size={24} />,
-      label: t((m) => m["IMS--Stats"].kpi.totalSpending),
+      label: t((m) => m.cards.invoices.statistics.kpi.totalSpending),
       value: `${formatAmount(data.totalSpending)} ${currency}`,
       subtitle: `${data.invoiceCount} invoices`,
       trend: null,
     },
     {
       icon: <TbReceipt size={24} />,
-      label: t((m) => m["IMS--Stats"].kpi.invoiceCount),
+      label: t((m) => m.cards.invoices.statistics.kpi.invoiceCount),
       value: data.invoiceCount.toString(),
-      subtitle: t((m) => m["IMS--Stats"].kpi.avgPerInvoice, {
+      subtitle: t((m) => m.cards.invoices.statistics.kpi.avgPerInvoice, {
         amount: data.invoiceCount > 0 ? formatAmount(data.totalSpending / data.invoiceCount) : formatAmount(0),
       }),
       trend: null,
     },
     {
       icon: <TbBuildingStore size={24} />,
-      label: t((m) => m["IMS--Stats"].kpi.topMerchant),
-      value: data.mostFrequentMerchant ? data.mostFrequentMerchant.id.slice(0, 12) : t((m) => m["IMS--Stats"].kpi.noneYet),
-      subtitle: data.mostFrequentMerchant ? t((m) => m["IMS--Stats"].kpi.visits, {count: String(data.mostFrequentMerchant.count)}) : "",
+      label: t((m) => m.cards.invoices.statistics.kpi.topMerchant),
+      value: data.mostFrequentMerchant ? data.mostFrequentMerchant.id.slice(0, 12) : t((m) => m.cards.invoices.statistics.kpi.noneYet),
+      subtitle: data.mostFrequentMerchant ? t((m) => m.cards.invoices.statistics.kpi.visits, {count: String(data.mostFrequentMerchant.count)}) : "",
       trend: null,
     },
     {
       icon: <TbShoppingCart size={24} />,
-      label: t((m) => m["IMS--Stats"].kpi.averageItems),
+      label: t((m) => m.cards.invoices.statistics.kpi.averageItems),
       value: formatAmount(data.averageItemsPerInvoice, "en-US", 1),
-      subtitle: t((m) => m["IMS--Stats"].kpi.acrossInvoices, {count: String(data.invoiceCount)}),
+      subtitle: t((m) => m.cards.invoices.statistics.kpi.acrossInvoices, {count: String(data.invoiceCount)}),
       trend: null,
     },
   ];

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/MerchantLeaderboard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/MerchantLeaderboard.tsx
@@ -59,7 +59,7 @@ function CustomTooltip({active, payload, currency, getMerchantName}: Readonly<Cu
       <p className={styles["tooltipAmount"]}>
         {formatAmount(data.totalSpend)} {currency}
       </p>
-      <p className={styles["tooltipCount"]}>{t((m) => m["IMS--Stats"].merchantLeaderboard.tooltip.invoiceCount, {count: String(data.invoiceCount)})}</p>
+      <p className={styles["tooltipCount"]}>{t((m) => m.cards.invoices.statistics.merchantLeaderboard.tooltip.invoiceCount, {count: String(data.invoiceCount)})}</p>
     </div>
   );
 }
@@ -79,7 +79,7 @@ export function MerchantLeaderboard({data, currency}: Props): React.JSX.Element 
   const getMerchantName = useCallback(
     (id: string): string => {
       const merchant = getMerchantById(id);
-      return merchant?.name ?? t((m) => m["IMS--Stats"].merchantLeaderboard.unknownMerchant);
+      return merchant?.name ?? t((m) => m.cards.invoices.statistics.merchantLeaderboard.unknownMerchant);
     },
     [getMerchantById, t],
   );
@@ -103,7 +103,7 @@ export function MerchantLeaderboard({data, currency}: Props): React.JSX.Element 
 
   const chartConfig = {
     totalSpent: {
-      label: t((m) => m["IMS--Stats"].merchantLeaderboard.labels.totalSpent),
+      label: t((m) => m.cards.invoices.statistics.merchantLeaderboard.labels.totalSpent),
       color: "var(--ac-chart-2)",
     },
   };
@@ -113,12 +113,12 @@ export function MerchantLeaderboard({data, currency}: Props): React.JSX.Element 
     return (
       <Card className={styles["card"]}>
         <CardHeader className={styles["cardHeader"]}>
-          <CardTitle className={styles["cardTitle"]}>{t((m) => m["IMS--Stats"].merchantLeaderboard.title)}</CardTitle>
-          <CardDescription className={styles["cardDescription"]}>{t((m) => m["IMS--Stats"].merchantLeaderboard.description)}</CardDescription>
+          <CardTitle className={styles["cardTitle"]}>{t((m) => m.cards.invoices.statistics.merchantLeaderboard.title)}</CardTitle>
+          <CardDescription className={styles["cardDescription"]}>{t((m) => m.cards.invoices.statistics.merchantLeaderboard.description)}</CardDescription>
         </CardHeader>
         <CardContent className={styles["emptyContent"]}>
           <TbChartBar className={styles["emptyIcon"]} />
-          <p className={styles["emptyText"]}>{t((m) => m["IMS--Stats"].merchantLeaderboard.empty)}</p>
+          <p className={styles["emptyText"]}>{t((m) => m.cards.invoices.statistics.merchantLeaderboard.empty)}</p>
         </CardContent>
       </Card>
     );
@@ -136,8 +136,8 @@ export function MerchantLeaderboard({data, currency}: Props): React.JSX.Element 
   return (
     <Card className={styles["card"]}>
       <CardHeader className={styles["cardHeader"]}>
-        <CardTitle className={styles["cardTitle"]}>{t((m) => m["IMS--Stats"].merchantLeaderboard.title)}</CardTitle>
-        <CardDescription className={styles["cardDescription"]}>{t((m) => m["IMS--Stats"].merchantLeaderboard.description)}</CardDescription>
+        <CardTitle className={styles["cardTitle"]}>{t((m) => m.cards.invoices.statistics.merchantLeaderboard.title)}</CardTitle>
+        <CardDescription className={styles["cardDescription"]}>{t((m) => m.cards.invoices.statistics.merchantLeaderboard.description)}</CardDescription>
       </CardHeader>
       <CardContent className={styles["cardContent"]}>
         <ChartContainer

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/MerchantTrendsChart.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/MerchantTrendsChart.tsx
@@ -97,11 +97,11 @@ export function MerchantTrendsChart({data, currency}: Props): React.JSX.Element 
     return (
       <Card className={styles["card"]}>
         <CardHeader>
-          <CardTitle>{t((m) => m["IMS--Stats"].merchantTrends.title)}</CardTitle>
-          <CardDescription>{t((m) => m["IMS--Stats"].merchantTrends.description)}</CardDescription>
+          <CardTitle>{t((m) => m.cards.invoices.statistics.merchantTrends.title)}</CardTitle>
+          <CardDescription>{t((m) => m.cards.invoices.statistics.merchantTrends.description)}</CardDescription>
         </CardHeader>
         <CardContent>
-          <p className={styles["emptyState"]}>{t((m) => m["IMS--Stats"].merchantTrends.empty)}</p>
+          <p className={styles["emptyState"]}>{t((m) => m.cards.invoices.statistics.merchantTrends.empty)}</p>
         </CardContent>
       </Card>
     );
@@ -110,17 +110,17 @@ export function MerchantTrendsChart({data, currency}: Props): React.JSX.Element 
   return (
     <Card className={styles["card"]}>
       <CardHeader>
-        <CardTitle>{t((m) => m["IMS--Stats"].merchantTrends.title)}</CardTitle>
-        <CardDescription>{t((m) => m["IMS--Stats"].merchantTrends.description)}</CardDescription>
+        <CardTitle>{t((m) => m.cards.invoices.statistics.merchantTrends.title)}</CardTitle>
+        <CardDescription>{t((m) => m.cards.invoices.statistics.merchantTrends.description)}</CardDescription>
       </CardHeader>
       <CardContent className={styles["content"]}>
         <div className={styles["tableWrapper"]}>
           <table className={styles["table"]}>
             <thead>
               <tr>
-                <th className={styles["headerMerchant"]}>{t((m) => m["IMS--Stats"].merchantTrends.labels.merchant)}</th>
-                <th className={styles["headerTotal"]}>{t((m) => m["IMS--Stats"].merchantTrends.labels.totalSpend)}</th>
-                <th className={styles["headerTrend"]}>{t((m) => m["IMS--Stats"].merchantTrends.labels.trend)}</th>
+                <th className={styles["headerMerchant"]}>{t((m) => m.cards.invoices.statistics.merchantTrends.labels.merchant)}</th>
+                <th className={styles["headerTotal"]}>{t((m) => m.cards.invoices.statistics.merchantTrends.labels.totalSpend)}</th>
+                <th className={styles["headerTrend"]}>{t((m) => m.cards.invoices.statistics.merchantTrends.labels.trend)}</th>
               </tr>
             </thead>
             <tbody>
@@ -147,7 +147,7 @@ export function MerchantTrendsChart({data, currency}: Props): React.JSX.Element 
                     <td className={styles["cellTrend"]}>
                       <div
                         className={styles["sparkline"]}
-                        aria-label={t((m) => m["IMS--Stats"].merchantTrends.aria.sparkline, {merchant: merchantName})}>
+                        aria-label={t((m) => m.cards.invoices.statistics.merchantTrends.aria.sparkline, {merchant: merchantName})}>
                         {displayMonths.map((monthKey) => {
                           const amount = monthlyMap.get(monthKey) ?? 0;
                           const heightPercent = maxMonthlyAmount > 0 ? (amount / maxMonthlyAmount) * 100 : 0;

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/MerchantVisitChart.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/MerchantVisitChart.tsx
@@ -55,7 +55,7 @@ function MerchantVisitCard({
             <TbReceipt size={20} />
           </div>
           <div className={styles["metricContent"]}>
-            <span className={styles["metricLabel"]}>{t((m) => m["IMS--Stats"].merchantVisit.metrics.totalVisits)}</span>
+            <span className={styles["metricLabel"]}>{t((m) => m.cards.invoices.statistics.merchantVisit.metrics.totalVisits)}</span>
             <span className={styles["metricValue"]}>{pattern.totalVisits}</span>
           </div>
         </div>
@@ -65,7 +65,7 @@ function MerchantVisitCard({
             <TbTrendingUp size={20} />
           </div>
           <div className={styles["metricContent"]}>
-            <span className={styles["metricLabel"]}>{t((m) => m["IMS--Stats"].merchantVisit.metrics.visitsPerMonth)}</span>
+            <span className={styles["metricLabel"]}>{t((m) => m.cards.invoices.statistics.merchantVisit.metrics.visitsPerMonth)}</span>
             <span className={styles["metricValue"]}>{formatAmount(pattern.averageVisitsPerMonth, locale, 1)}</span>
           </div>
         </div>
@@ -75,7 +75,7 @@ function MerchantVisitCard({
             <TbShoppingCart size={20} />
           </div>
           <div className={styles["metricContent"]}>
-            <span className={styles["metricLabel"]}>{t((m) => m["IMS--Stats"].merchantVisit.metrics.basketSize)}</span>
+            <span className={styles["metricLabel"]}>{t((m) => m.cards.invoices.statistics.merchantVisit.metrics.basketSize)}</span>
             <span className={styles["metricValue"]}>{formatAmount(pattern.averageBasketSize, locale, 1)}</span>
           </div>
         </div>
@@ -85,14 +85,14 @@ function MerchantVisitCard({
             <TbCalendar size={20} />
           </div>
           <div className={styles["metricContent"]}>
-            <span className={styles["metricLabel"]}>{t((m) => m["IMS--Stats"].merchantVisit.metrics.preferredDay)}</span>
+            <span className={styles["metricLabel"]}>{t((m) => m.cards.invoices.statistics.merchantVisit.metrics.preferredDay)}</span>
             <span className={styles["metricValue"]}>{dayName}</span>
           </div>
         </div>
 
         <div className={styles["metricFull"]}>
           <div className={styles["metricContent"]}>
-            <span className={styles["metricLabel"]}>{t((m) => m["IMS--Stats"].merchantVisit.metrics.avgSpend)}</span>
+            <span className={styles["metricLabel"]}>{t((m) => m.cards.invoices.statistics.merchantVisit.metrics.avgSpend)}</span>
             <span className={styles["metricValue"]}>
               {formatAmount(pattern.averageSpendPerVisit, locale)} {currency}
             </span>
@@ -144,11 +144,11 @@ export function MerchantVisitChart({data, currency, topN = 6}: Readonly<Props>):
     return (
       <Card className={styles["card"]}>
         <CardHeader>
-          <CardTitle>{t((m) => m["IMS--Stats"].merchantVisit.title)}</CardTitle>
-          <CardDescription>{t((m) => m["IMS--Stats"].merchantVisit.description)}</CardDescription>
+          <CardTitle>{t((m) => m.cards.invoices.statistics.merchantVisit.title)}</CardTitle>
+          <CardDescription>{t((m) => m.cards.invoices.statistics.merchantVisit.description)}</CardDescription>
         </CardHeader>
         <CardContent>
-          <p className={styles["emptyState"]}>{t((m) => m["IMS--Stats"].merchantVisit.empty)}</p>
+          <p className={styles["emptyState"]}>{t((m) => m.cards.invoices.statistics.merchantVisit.empty)}</p>
         </CardContent>
       </Card>
     );
@@ -157,8 +157,8 @@ export function MerchantVisitChart({data, currency, topN = 6}: Readonly<Props>):
   return (
     <Card className={styles["card"]}>
       <CardHeader>
-        <CardTitle>{t((m) => m["IMS--Stats"].merchantVisit.title)}</CardTitle>
-        <CardDescription>{t((m) => m["IMS--Stats"].merchantVisit.description)}</CardDescription>
+        <CardTitle>{t((m) => m.cards.invoices.statistics.merchantVisit.title)}</CardTitle>
+        <CardDescription>{t((m) => m.cards.invoices.statistics.merchantVisit.description)}</CardDescription>
       </CardHeader>
       <CardContent className={styles["content"]}>
         <div className={styles["grid"]}>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/PriceDistributionChart.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/PriceDistributionChart.tsx
@@ -52,7 +52,7 @@ function CustomTooltip({active, payload, currency}: CustomTooltipProps): React.J
       <p className={styles["tooltipRange"]}>
         {data.range} {currency}
       </p>
-      <p className={styles["tooltipCount"]}>{t((m) => m["IMS--Stats"].priceDistribution.tooltip.itemCount, {count: String(data.count)})}</p>
+      <p className={styles["tooltipCount"]}>{t((m) => m.cards.invoices.statistics.priceDistribution.tooltip.itemCount, {count: String(data.count)})}</p>
     </div>
   );
 }
@@ -69,7 +69,7 @@ export function PriceDistributionChart({data, currency}: Props): React.JSX.Eleme
 
   const chartConfig = {
     count: {
-      label: t((m) => m["IMS--Stats"].priceDistribution.labels.itemCount),
+      label: t((m) => m.cards.invoices.statistics.priceDistribution.labels.itemCount),
       color: "var(--ac-chart-3)",
     },
   };
@@ -82,8 +82,8 @@ export function PriceDistributionChart({data, currency}: Props): React.JSX.Eleme
   return (
     <Card className={styles["card"]}>
       <CardHeader className={styles["cardHeader"]}>
-        <CardTitle className={styles["cardTitle"]}>{t((m) => m["IMS--Stats"].priceDistribution.title)}</CardTitle>
-        <CardDescription className={styles["cardDescription"]}>{t((m) => m["IMS--Stats"].priceDistribution.description)}</CardDescription>
+        <CardTitle className={styles["cardTitle"]}>{t((m) => m.cards.invoices.statistics.priceDistribution.title)}</CardTitle>
+        <CardDescription className={styles["cardDescription"]}>{t((m) => m.cards.invoices.statistics.priceDistribution.description)}</CardDescription>
       </CardHeader>
       <CardContent className={styles["cardContent"]}>
         <ChartContainer

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/ProductCategoryChart.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/ProductCategoryChart.tsx
@@ -82,7 +82,7 @@ function CustomTooltip({
         {formatAmount(data.totalSpent)} {currency}
       </p>
       <p className={styles["tooltipPercentage"]}>{formatAmount(data.percentage, "en-US", 1)}%</p>
-      <p className={styles["tooltipCount"]}>{t((m) => m["IMS--Stats"].productCategory.tooltip.productCount, {count: String(data.productCount)})}</p>
+      <p className={styles["tooltipCount"]}>{t((m) => m.cards.invoices.statistics.productCategory.tooltip.productCount, {count: String(data.productCount)})}</p>
     </div>
   );
 }
@@ -116,12 +116,12 @@ export function ProductCategoryChart({data, currency}: Props): React.JSX.Element
     return (
       <Card className={styles["card"]}>
         <CardHeader className={styles["cardHeader"]}>
-          <CardTitle className={styles["cardTitle"]}>{t((m) => m["IMS--Stats"].productCategory.title)}</CardTitle>
-          <CardDescription className={styles["cardDescription"]}>{t((m) => m["IMS--Stats"].productCategory.description)}</CardDescription>
+          <CardTitle className={styles["cardTitle"]}>{t((m) => m.cards.invoices.statistics.productCategory.title)}</CardTitle>
+          <CardDescription className={styles["cardDescription"]}>{t((m) => m.cards.invoices.statistics.productCategory.description)}</CardDescription>
         </CardHeader>
         <CardContent className={styles["cardContent"]}>
           <div className={styles["emptyState"]}>
-            <p className={styles["emptyText"]}>{t((m) => m["IMS--Stats"].productCategory.empty)}</p>
+            <p className={styles["emptyText"]}>{t((m) => m.cards.invoices.statistics.productCategory.empty)}</p>
           </div>
         </CardContent>
       </Card>
@@ -159,8 +159,8 @@ export function ProductCategoryChart({data, currency}: Props): React.JSX.Element
   return (
     <Card className={styles["card"]}>
       <CardHeader className={styles["cardHeader"]}>
-        <CardTitle className={styles["cardTitle"]}>{t((m) => m["IMS--Stats"].productCategory.title)}</CardTitle>
-        <CardDescription className={styles["cardDescription"]}>{t((m) => m["IMS--Stats"].productCategory.description)}</CardDescription>
+        <CardTitle className={styles["cardTitle"]}>{t((m) => m.cards.invoices.statistics.productCategory.title)}</CardTitle>
+        <CardDescription className={styles["cardDescription"]}>{t((m) => m.cards.invoices.statistics.productCategory.description)}</CardDescription>
       </CardHeader>
       <CardContent className={styles["cardContent"]}>
         <ChartContainer

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/SpendingCalendarHeatmap.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/SpendingCalendarHeatmap.tsx
@@ -220,12 +220,12 @@ function DayCell({day, currency, locale}: Readonly<{day: DayCell; currency: stri
           {day.amount > 0 ? (
             <>
               <div className={styles["tooltipAmount"]}>
-                {t((m) => m["IMS--Stats"].calendarHeatmap.tooltip.amount)}: {formatAmount(day.amount)} {currency}
+                {t((m) => m.cards.invoices.statistics.calendarHeatmap.tooltip.amount)}: {formatAmount(day.amount)} {currency}
               </div>
-              <div className={styles["tooltipInvoices"]}>{t((m) => m["IMS--Stats"].calendarHeatmap.tooltip.invoices, {count: String(day.invoiceCount)})}</div>
+              <div className={styles["tooltipInvoices"]}>{t((m) => m.cards.invoices.statistics.calendarHeatmap.tooltip.invoices, {count: String(day.invoiceCount)})}</div>
             </>
           ) : (
-            <div className={styles["tooltipNoSpending"]}>{t((m) => m["IMS--Stats"].calendarHeatmap.tooltip.noSpending)}</div>
+            <div className={styles["tooltipNoSpending"]}>{t((m) => m.cards.invoices.statistics.calendarHeatmap.tooltip.noSpending)}</div>
           )}
         </TooltipContent>
       </Tooltip>
@@ -262,7 +262,7 @@ export default function SpendingCalendarHeatmap({data, currency}: Props): React.
 
   const {weeks, monthLabel} = useMemo(() => generateCalendarGrid(data, monthOffset), [data, monthOffset]);
 
-  const dayLabels = [t((m) => m["IMS--Stats"].calendarHeatmap.days.sun), t((m) => m["IMS--Stats"].calendarHeatmap.days.mon), t((m) => m["IMS--Stats"].calendarHeatmap.days.tue), t((m) => m["IMS--Stats"].calendarHeatmap.days.wed), t((m) => m["IMS--Stats"].calendarHeatmap.days.thu), t((m) => m["IMS--Stats"].calendarHeatmap.days.fri), t((m) => m["IMS--Stats"].calendarHeatmap.days.sat)];
+  const dayLabels = [t((m) => m.cards.invoices.statistics.calendarHeatmap.days.sun), t((m) => m.cards.invoices.statistics.calendarHeatmap.days.mon), t((m) => m.cards.invoices.statistics.calendarHeatmap.days.tue), t((m) => m.cards.invoices.statistics.calendarHeatmap.days.wed), t((m) => m.cards.invoices.statistics.calendarHeatmap.days.thu), t((m) => m.cards.invoices.statistics.calendarHeatmap.days.fri), t((m) => m.cards.invoices.statistics.calendarHeatmap.days.sat)];
 
   /** Navigates to the previous month in the heatmap. */
   const handlePreviousMonth = useCallback((): void => {
@@ -279,14 +279,14 @@ export default function SpendingCalendarHeatmap({data, currency}: Props): React.
       <CardHeader className={styles["cardHeader"]}>
         <div className={styles["headerRow"]}>
           <div>
-            <CardTitle className={styles["cardTitle"]}>{t((m) => m["IMS--Stats"].calendarHeatmap.title)}</CardTitle>
-            <CardDescription className={styles["cardDescription"]}>{t((m) => m["IMS--Stats"].calendarHeatmap.description)}</CardDescription>
+            <CardTitle className={styles["cardTitle"]}>{t((m) => m.cards.invoices.statistics.calendarHeatmap.title)}</CardTitle>
+            <CardDescription className={styles["cardDescription"]}>{t((m) => m.cards.invoices.statistics.calendarHeatmap.description)}</CardDescription>
           </div>
           <div className={styles["navigationButtons"]}>
             <button
               onClick={handlePreviousMonth}
               className={styles["navButton"]}
-              aria-label={t((m) => m["IMS--Stats"].calendarHeatmap.navigation.previous)}
+              aria-label={t((m) => m.cards.invoices.statistics.calendarHeatmap.navigation.previous)}
               type='button'>
               <TbChevronLeft size={20} />
             </button>
@@ -295,7 +295,7 @@ export default function SpendingCalendarHeatmap({data, currency}: Props): React.
               onClick={handleNextMonth}
               className={styles["navButton"]}
               disabled={monthOffset === 0}
-              aria-label={t((m) => m["IMS--Stats"].calendarHeatmap.navigation.next)}
+              aria-label={t((m) => m.cards.invoices.statistics.calendarHeatmap.navigation.next)}
               type='button'>
               <TbChevronRight size={20} />
             </button>
@@ -306,7 +306,7 @@ export default function SpendingCalendarHeatmap({data, currency}: Props): React.
         <div
           className={styles["calendarContainer"]}
           role='grid'
-          aria-label={t((m) => m["IMS--Stats"].calendarHeatmap.aria.calendarGrid)}>
+          aria-label={t((m) => m.cards.invoices.statistics.calendarHeatmap.aria.calendarGrid)}>
           {/* Day of week labels */}
           <div className={styles["dayLabelsColumn"]}>
             <div className={styles["dayLabelEmpty"]} />
@@ -341,7 +341,7 @@ export default function SpendingCalendarHeatmap({data, currency}: Props): React.
 
         {/* Legend */}
         <div className={styles["legend"]}>
-          <span className={styles["legendLabel"]}>{t((m) => m["IMS--Stats"].calendarHeatmap.legend.less)}</span>
+          <span className={styles["legendLabel"]}>{t((m) => m.cards.invoices.statistics.calendarHeatmap.legend.less)}</span>
           <div className={styles["legendColors"]}>
             {[0, 1, 2, 3, 4].map((level) => (
               <div
@@ -351,7 +351,7 @@ export default function SpendingCalendarHeatmap({data, currency}: Props): React.
               />
             ))}
           </div>
-          <span className={styles["legendLabel"]}>{t((m) => m["IMS--Stats"].calendarHeatmap.legend.more)}</span>
+          <span className={styles["legendLabel"]}>{t((m) => m.cards.invoices.statistics.calendarHeatmap.legend.more)}</span>
         </div>
       </CardContent>
     </Card>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/SpendingOverTimeChart.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/SpendingOverTimeChart.tsx
@@ -56,7 +56,7 @@ function CustomTooltip({active = false, payload = [], currency}: Readonly<Custom
       <p className={styles["tooltipAmount"]}>
         {formatAmount(data.amount)} {currency}
       </p>
-      <p className={styles["tooltipCount"]}>{t((m) => m["IMS--Stats"].spendingOverTime.tooltip.invoiceCount, {count: String(data.invoiceCount)})}</p>
+      <p className={styles["tooltipCount"]}>{t((m) => m.cards.invoices.statistics.spendingOverTime.tooltip.invoiceCount, {count: String(data.invoiceCount)})}</p>
       {data.invoices && data.invoices.length > 0 ? (
         <ul className={styles["tooltipInvoices"]}>
           {data.invoices.slice(0, 10).map((inv) => (
@@ -71,7 +71,7 @@ function CustomTooltip({active = false, payload = [], currency}: Readonly<Custom
             </li>
           ))}
           {data.invoices.length > 10 && (
-            <li className={styles["tooltipMore"]}>{t((m) => m["IMS--Stats"].spendingOverTime.tooltip.andMore, {count: String(data.invoices.length - 10)})}</li>
+            <li className={styles["tooltipMore"]}>{t((m) => m.cards.invoices.statistics.spendingOverTime.tooltip.andMore, {count: String(data.invoices.length - 10)})}</li>
           )}
         </ul>
       ) : null}
@@ -98,7 +98,7 @@ export function SpendingOverTimeChart({data, currency}: Props): React.JSX.Elemen
 
   const chartConfig = {
     amount: {
-      label: t((m) => m["IMS--Stats"].spendingOverTime.labels.amount),
+      label: t((m) => m.cards.invoices.statistics.spendingOverTime.labels.amount),
       color: "var(--ac-chart-1)",
     },
   };
@@ -106,8 +106,8 @@ export function SpendingOverTimeChart({data, currency}: Props): React.JSX.Elemen
   return (
     <Card className={styles["card"]}>
       <CardHeader className={styles["cardHeader"]}>
-        <CardTitle className={styles["cardTitle"]}>{t((m) => m["IMS--Stats"].spendingOverTime.title)}</CardTitle>
-        <CardDescription className={styles["cardDescription"]}>{t((m) => m["IMS--Stats"].spendingOverTime.description)}</CardDescription>
+        <CardTitle className={styles["cardTitle"]}>{t((m) => m.cards.invoices.statistics.spendingOverTime.title)}</CardTitle>
+        <CardDescription className={styles["cardDescription"]}>{t((m) => m.cards.invoices.statistics.spendingOverTime.description)}</CardDescription>
       </CardHeader>
       <CardContent className={styles["cardContent"]}>
         <ChartContainer

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/TimeOfDayChart.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/TimeOfDayChart.tsx
@@ -49,7 +49,7 @@ function CustomTooltip({active, payload}: CustomTooltipProps): React.JSX.Element
   return (
     <div className={styles["tooltip"]}>
       <p className={styles["tooltipSegment"]}>{data.segment}</p>
-      <p className={styles["tooltipCount"]}>{t((m) => m["IMS--Stats"].timeOfDay.tooltip.invoiceCount, {count: String(data.invoiceCount)})}</p>
+      <p className={styles["tooltipCount"]}>{t((m) => m.cards.invoices.statistics.timeOfDay.tooltip.invoiceCount, {count: String(data.invoiceCount)})}</p>
     </div>
   );
 }
@@ -81,7 +81,7 @@ export function TimeOfDayChart({data}: Props): React.JSX.Element {
   // IMPORTANT: This key must match the field name in TimeOfDaySegment
   const chartConfig = {
     invoiceCount: {
-      label: t((m) => m["IMS--Stats"].timeOfDay.labels.invoiceCount),
+      label: t((m) => m.cards.invoices.statistics.timeOfDay.labels.invoiceCount),
       color: "var(--ac-chart-4)",
     },
   };
@@ -89,8 +89,8 @@ export function TimeOfDayChart({data}: Props): React.JSX.Element {
   return (
     <Card className={styles["card"]}>
       <CardHeader className={styles["cardHeader"]}>
-        <CardTitle className={styles["cardTitle"]}>{t((m) => m["IMS--Stats"].timeOfDay.title)}</CardTitle>
-        <CardDescription className={styles["cardDescription"]}>{t((m) => m["IMS--Stats"].timeOfDay.description)}</CardDescription>
+        <CardTitle className={styles["cardTitle"]}>{t((m) => m.cards.invoices.statistics.timeOfDay.title)}</CardTitle>
+        <CardDescription className={styles["cardDescription"]}>{t((m) => m.cards.invoices.statistics.timeOfDay.description)}</CardDescription>
       </CardHeader>
       <CardContent className={styles["cardContent"]}>
         <ChartContainer

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/TopProductsChart.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/views/statistics/TopProductsChart.tsx
@@ -101,12 +101,12 @@ export function TopProductsChart({data, currency}: Props): React.JSX.Element {
     return (
       <Card className={styles["card"]}>
         <CardHeader className={styles["cardHeader"]}>
-          <CardTitle className={styles["cardTitle"]}>{t((m) => m["IMS--Stats"].topProducts.title)}</CardTitle>
-          <CardDescription className={styles["cardDescription"]}>{t((m) => m["IMS--Stats"].topProducts.description)}</CardDescription>
+          <CardTitle className={styles["cardTitle"]}>{t((m) => m.cards.invoices.statistics.topProducts.title)}</CardTitle>
+          <CardDescription className={styles["cardDescription"]}>{t((m) => m.cards.invoices.statistics.topProducts.description)}</CardDescription>
         </CardHeader>
         <CardContent className={styles["cardContent"]}>
           <div className={styles["emptyState"]}>
-            <p className={styles["emptyText"]}>{t((m) => m["IMS--Stats"].topProducts.empty)}</p>
+            <p className={styles["emptyText"]}>{t((m) => m.cards.invoices.statistics.topProducts.empty)}</p>
           </div>
         </CardContent>
       </Card>
@@ -116,46 +116,46 @@ export function TopProductsChart({data, currency}: Props): React.JSX.Element {
   return (
     <Card className={styles["card"]}>
       <CardHeader className={styles["cardHeader"]}>
-        <CardTitle className={styles["cardTitle"]}>{t((m) => m["IMS--Stats"].topProducts.title)}</CardTitle>
-        <CardDescription className={styles["cardDescription"]}>{t((m) => m["IMS--Stats"].topProducts.description)}</CardDescription>
+        <CardTitle className={styles["cardTitle"]}>{t((m) => m.cards.invoices.statistics.topProducts.title)}</CardTitle>
+        <CardDescription className={styles["cardDescription"]}>{t((m) => m.cards.invoices.statistics.topProducts.description)}</CardDescription>
       </CardHeader>
       <CardContent className={styles["cardContent"]}>
         <div className={styles["tableWrapper"]}>
           <table
             className={styles["table"]}
             role='table'
-            aria-label={t((m) => m["IMS--Stats"].topProducts.ariaLabel)}>
+            aria-label={t((m) => m.cards.invoices.statistics.topProducts.ariaLabel)}>
             <thead>
               <tr>
                 <th
                   className={styles["headerRank"]}
                   scope='col'>
-                  {t((m) => m["IMS--Stats"].topProducts.headers.rank)}
+                  {t((m) => m.cards.invoices.statistics.topProducts.headers.rank)}
                 </th>
                 <th
                   className={styles["headerProduct"]}
                   scope='col'>
-                  {t((m) => m["IMS--Stats"].topProducts.headers.product)}
+                  {t((m) => m.cards.invoices.statistics.topProducts.headers.product)}
                 </th>
                 <th
                   className={styles["headerQuantity"]}
                   scope='col'>
-                  {t((m) => m["IMS--Stats"].topProducts.headers.quantity)}
+                  {t((m) => m.cards.invoices.statistics.topProducts.headers.quantity)}
                 </th>
                 <th
                   className={styles["headerSpent"]}
                   scope='col'>
-                  {t((m) => m["IMS--Stats"].topProducts.headers.totalSpent)}
+                  {t((m) => m.cards.invoices.statistics.topProducts.headers.totalSpent)}
                 </th>
                 <th
                   className={styles["headerCount"]}
                   scope='col'>
-                  {t((m) => m["IMS--Stats"].topProducts.headers.purchases)}
+                  {t((m) => m.cards.invoices.statistics.topProducts.headers.purchases)}
                 </th>
                 <th
                   className={styles["headerAverage"]}
                   scope='col'>
-                  {t((m) => m["IMS--Stats"].topProducts.headers.avgPrice)}
+                  {t((m) => m.cards.invoices.statistics.topProducts.headers.avgPrice)}
                 </th>
               </tr>
             </thead>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/island.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/island.tsx
@@ -85,17 +85,17 @@ export default function RenderViewInvoicesScreen(): React.JSX.Element {
               <TabsTrigger
                 value='invoices'
                 className={styles["tabTrigger"]}>
-                {t((m) => m["IMS--List"].viewInvoicesIsland.tabs.invoices)}
+                {t((m) => m.pages.invoices.viewInvoices.viewInvoicesIsland.tabs.invoices)}
               </TabsTrigger>
               <TabsTrigger
                 value='statistics'
                 className={styles["tabTrigger"]}>
-                {t((m) => m["IMS--List"].viewInvoicesIsland.tabs.statistics)}
+                {t((m) => m.pages.invoices.viewInvoices.viewInvoicesIsland.tabs.statistics)}
               </TabsTrigger>
               <TabsTrigger
                 value='liveAnalysis'
                 className={styles["tabTrigger"]}>
-                {t((m) => m["IMS--List"].viewInvoicesIsland.tabs.liveAnalysis)}
+                {t((m) => m.pages.invoices.viewInvoices.viewInvoicesIsland.tabs.liveAnalysis)}
               </TabsTrigger>
             </TabsList>
             <TabsContent

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/page.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/page.tsx
@@ -61,8 +61,8 @@ export async function generateMetadata(): Promise<Metadata> {
   const locale = await getLocale();
   return createMetadata({
     locale,
-    title: t((m) => m["IMS--List"].metadata.title),
-    description: t((m) => m["IMS--List"].metadata.description),
+    title: t((m) => m.pages.invoices.viewInvoices.metadata.title),
+    description: t((m) => m.pages.invoices.viewInvoices.metadata.description),
   });
 }
 
@@ -136,15 +136,15 @@ export default async function ViewInvoicesPage(_props: Readonly<PageProps<"/doma
   const t = await getTranslations();
   const tCommon = await getTranslations();
   const {user} = await fetchAaaSUserFromAuthService();
-  const username = user?.fullName ?? tCommon((m) => m["IMS--List"].viewInvoicesPage.guestName);
+  const username = user?.fullName ?? tCommon((m) => m.pages.invoices.viewInvoices.viewInvoicesPage.guestName);
 
   return (
     <div className={pageStyles["pageMain"]}>
       <section className={pageStyles["headerSection"]}>
-        <h1 className={pageStyles["title"]}>{t((m) => m["IMS--List"].title, {name: username})}</h1>
+        <h1 className={pageStyles["title"]}>{t((m) => m.pages.invoices.viewInvoices.title, {name: username})}</h1>
         <article className={pageStyles["subtitleArticle"]}>
           <RichText
-            sectionKey='IMS--List'
+            sectionKey='pages.invoices.viewInvoices'
             textKey='subtitle'
           />
         </article>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/page.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/page.tsx
@@ -18,7 +18,7 @@ import pageStyles from "./page.module.scss";
  * **Execution Context**: Server-side metadata generation function (Next.js App Router).
  *
  * **Internationalization**: Retrieves localized title and description from the
- * translation key `IMS--List.metadata`.
+ * translation key `pages.invoices.viewInvoices.metadata`.
  * This ensures consistent terminology for invoice listing and viewing across all locales.
  *
  * **SEO Optimization**: Uses the centralized `createMetadata` utility following RFC 1004

--- a/sites/arolariu.ro/src/app/domains/invoices/view-scans/_components/ScanGroupBanner.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-scans/_components/ScanGroupBanner.tsx
@@ -166,8 +166,8 @@ export default function ScanGroupBanner({initialVisible = true}: Readonly<ScanGr
           {remainingCount > 0 && <div className={styles["thumbnailMore"]}>+{remainingCount}</div>}
         </div>
         <div className={styles["text"]}>
-          <p className={styles["title"]}>{t((m) => m["IMS--ViewScans"].groupBanner.title, {count: String(scanGroup.length)})}</p>
-          <p className={styles["subtitle"]}>{t((m) => m["IMS--ViewScans"].groupBanner.subtitle)}</p>
+          <p className={styles["title"]}>{t((m) => m.pages.invoices.viewScans.groupBanner.title, {count: String(scanGroup.length)})}</p>
+          <p className={styles["subtitle"]}>{t((m) => m.pages.invoices.viewScans.groupBanner.subtitle)}</p>
         </div>
       </div>
       <div className={styles["actions"]}>
@@ -176,14 +176,14 @@ export default function ScanGroupBanner({initialVisible = true}: Readonly<ScanGr
           onClick={handleCombine}
           className={styles["createButton"]}>
           <TbCheck className={styles["checkIcon"]} />
-          {t((m) => m["IMS--ViewScans"].groupBanner.createInvoice)}
+          {t((m) => m.pages.invoices.viewScans.groupBanner.createInvoice)}
         </Button>
         <Button
           variant='ghost'
           size='sm'
           onClick={handleDismiss}
           className={styles["dismissButton"]}>
-          {t((m) => m["IMS--ViewScans"].groupBanner.dismiss)}
+          {t((m) => m.pages.invoices.viewScans.groupBanner.dismiss)}
         </Button>
       </div>
     </motion.div>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-scans/_components/ScanSelectionToolbar.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-scans/_components/ScanSelectionToolbar.tsx
@@ -66,18 +66,18 @@ export default function ScanSelectionToolbar({onCreateInvoice}: Readonly<ScanSel
       });
 
       if (failed === 0) {
-        toast.success(t((m) => m["IMS--ViewScans"].toolbar.delete.success, {count: String(succeeded)}));
+        toast.success(t((m) => m.pages.invoices.viewScans.toolbar.delete.success, {count: String(succeeded)}));
       } else if (succeeded > 0) {
-        toast.warning(t((m) => m["IMS--ViewScans"].toolbar.delete.partial, {success: String(succeeded), failed: String(failed)}));
+        toast.warning(t((m) => m.pages.invoices.viewScans.toolbar.delete.partial, {success: String(succeeded), failed: String(failed)}));
       } else {
-        toast.error(t((m) => m["IMS--ViewScans"].toolbar.delete.failed));
+        toast.error(t((m) => m.pages.invoices.viewScans.toolbar.delete.failed));
       }
 
       clearSelection(); // Clear the selection after deletion
       router.refresh(); // Refresh to update the scan list
     } catch (error) {
       console.error("Failed to delete scans:", error);
-      toast.error(t((m) => m["IMS--ViewScans"].toolbar.delete.error));
+      toast.error(t((m) => m.pages.invoices.viewScans.toolbar.delete.error));
     } finally {
       setIsDeleting(false);
     }
@@ -99,7 +99,7 @@ export default function ScanSelectionToolbar({onCreateInvoice}: Readonly<ScanSel
               transition={{type: "spring", stiffness: 300, damping: 20}}>
               {selectedScans.length}
             </motion.span>{" "}
-            {t((m) => m["IMS--ViewScans"].toolbar.selected)}
+            {t((m) => m.pages.invoices.viewScans.toolbar.selected)}
           </span>
           <TooltipProvider>
             <Tooltip>
@@ -111,11 +111,11 @@ export default function ScanSelectionToolbar({onCreateInvoice}: Readonly<ScanSel
                     onClick={clearSelection}
                     className={styles["clearButton"]}>
                     <TbX className={styles["clearIcon"]} />
-                    <span className={styles["hiddenMobile"]}>{t((m) => m["IMS--ViewScans"].toolbar.clearSelection)}</span>
+                    <span className={styles["hiddenMobile"]}>{t((m) => m.pages.invoices.viewScans.toolbar.clearSelection)}</span>
                   </Button>
                 }
               />
-              <TooltipContent>{t((m) => m["IMS--ViewScans"].toolbar.clearSelection)}</TooltipContent>
+              <TooltipContent>{t((m) => m.pages.invoices.viewScans.toolbar.clearSelection)}</TooltipContent>
             </Tooltip>
           </TooltipProvider>
         </div>
@@ -132,25 +132,25 @@ export default function ScanSelectionToolbar({onCreateInvoice}: Readonly<ScanSel
                         size='sm'
                         disabled={isDeleting}>
                         <TbTrash />
-                        <span className={styles["hiddenMobile"]}>{t((m) => m["IMS--ViewScans"].toolbar.delete.button, {count: String(selectedScans.length)})}</span>
+                        <span className={styles["hiddenMobile"]}>{t((m) => m.pages.invoices.viewScans.toolbar.delete.button, {count: String(selectedScans.length)})}</span>
                       </Button>
                     </AlertDialogTrigger>
                     <AlertDialogContent>
                       <AlertDialogHeader>
-                        <AlertDialogTitle>{t((m) => m["IMS--ViewScans"].toolbar.delete.confirmTitle)}</AlertDialogTitle>
+                        <AlertDialogTitle>{t((m) => m.pages.invoices.viewScans.toolbar.delete.confirmTitle)}</AlertDialogTitle>
                         <AlertDialogDescription>
-                          {t((m) => m["IMS--ViewScans"].toolbar.delete.confirmDescription, {count: String(selectedScans.length)})}
+                          {t((m) => m.pages.invoices.viewScans.toolbar.delete.confirmDescription, {count: String(selectedScans.length)})}
                         </AlertDialogDescription>
                       </AlertDialogHeader>
                       <AlertDialogFooter>
-                        <AlertDialogCancel>{t((m) => m["IMS--ViewScans"].toolbar.delete.cancel)}</AlertDialogCancel>
-                        <AlertDialogAction onClick={handleDeleteSelected}>{t((m) => m["IMS--ViewScans"].toolbar.delete.confirm)}</AlertDialogAction>
+                        <AlertDialogCancel>{t((m) => m.pages.invoices.viewScans.toolbar.delete.cancel)}</AlertDialogCancel>
+                        <AlertDialogAction onClick={handleDeleteSelected}>{t((m) => m.pages.invoices.viewScans.toolbar.delete.confirm)}</AlertDialogAction>
                       </AlertDialogFooter>
                     </AlertDialogContent>
                   </AlertDialog>
                 }
               />
-              <TooltipContent>{t((m) => m["IMS--ViewScans"].toolbar.delete.button, {count: String(selectedScans.length)})}</TooltipContent>
+              <TooltipContent>{t((m) => m.pages.invoices.viewScans.toolbar.delete.button, {count: String(selectedScans.length)})}</TooltipContent>
             </Tooltip>
           </TooltipProvider>
 
@@ -162,12 +162,12 @@ export default function ScanSelectionToolbar({onCreateInvoice}: Readonly<ScanSel
                     onClick={onCreateInvoice}
                     className={styles["createButton"]}>
                     <TbFileInvoice className={styles["createIcon"]} />
-                    <span className={styles["hiddenMobile"]}>{selectedScans.length > 1 ? t((m) => m["IMS--ViewScans"].toolbar.createInvoices) : t((m) => m["IMS--ViewScans"].toolbar.createInvoice)}</span>
-                    <span className={styles["visibleMobile"]}>{t((m) => m["IMS--ViewScans"].toolbar.createInvoice).split(" ")[0]}</span>
+                    <span className={styles["hiddenMobile"]}>{selectedScans.length > 1 ? t((m) => m.pages.invoices.viewScans.toolbar.createInvoices) : t((m) => m.pages.invoices.viewScans.toolbar.createInvoice)}</span>
+                    <span className={styles["visibleMobile"]}>{t((m) => m.pages.invoices.viewScans.toolbar.createInvoice).split(" ")[0]}</span>
                   </Button>
                 }
               />
-              <TooltipContent>{selectedScans.length > 1 ? t((m) => m["IMS--ViewScans"].toolbar.createInvoices) : t((m) => m["IMS--ViewScans"].toolbar.createInvoice)}</TooltipContent>
+              <TooltipContent>{selectedScans.length > 1 ? t((m) => m.pages.invoices.viewScans.toolbar.createInvoices) : t((m) => m.pages.invoices.viewScans.toolbar.createInvoice)}</TooltipContent>
             </Tooltip>
           </TooltipProvider>
         </div>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-scans/_components/ScansGrid.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-scans/_components/ScansGrid.tsx
@@ -109,14 +109,14 @@ export default function ScansGrid(): React.JSX.Element {
     return (
       <EmptyState
         icon={<TbCamera className={styles["emptyIcon"]} />}
-        title={t((m) => m["IMS--ViewScans"].emptyState.title)}
-        description={t((m) => m["IMS--ViewScans"].emptyState.description)}
+        title={t((m) => m.pages.invoices.viewScans.emptyState.title)}
+        description={t((m) => m.pages.invoices.viewScans.emptyState.description)}
         primaryAction={{
-          label: t((m) => m["IMS--ViewScans"].emptyState.uploadButton),
+          label: t((m) => m.pages.invoices.viewScans.emptyState.uploadButton),
           href: "/domains/invoices/upload-scans",
         }}
         secondaryAction={{
-          label: t((m) => m["IMS--ViewScans"].emptyState.learnMoreButton),
+          label: t((m) => m.pages.invoices.viewScans.emptyState.learnMoreButton),
           href: "/domains/invoices",
         }}
       />
@@ -154,17 +154,17 @@ export default function ScansGrid(): React.JSX.Element {
             onClick={handlePreviousPage}
             disabled={page === 0}>
             <TbChevronLeft />
-            {t((m) => m["IMS--ViewScans"].pagination.previous)}
+            {t((m) => m.pages.invoices.viewScans.pagination.previous)}
           </Button>
           <span className={styles["pageInfo"]}>
-            {t((m) => m["IMS--ViewScans"].pagination.pageInfo, {current: String(page + 1), total: String(totalPages), count: String(validScans.length)})}
+            {t((m) => m.pages.invoices.viewScans.pagination.pageInfo, {current: String(page + 1), total: String(totalPages), count: String(validScans.length)})}
           </span>
           <Button
             variant='outline'
             size='sm'
             onClick={handleNextPage}
             disabled={page >= totalPages - 1}>
-            {t((m) => m["IMS--ViewScans"].pagination.next)}
+            {t((m) => m.pages.invoices.viewScans.pagination.next)}
             <TbChevronRight />
           </Button>
         </div>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-scans/_components/ScansHeader.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-scans/_components/ScansHeader.tsx
@@ -49,7 +49,7 @@ export default function ScansHeader(): React.JSX.Element {
     <div className={styles["header"]}>
       <div className={styles["headerLeft"]}>
         <div>
-          <h1 className={styles["headerTitle"]}>{t((m) => m["IMS--ViewScans"].header.titleWithCount, {count: String(scans.length)})}</h1>
+          <h1 className={styles["headerTitle"]}>{t((m) => m.pages.invoices.viewScans.header.titleWithCount, {count: String(scans.length)})}</h1>
           {lastSyncTimestamp ? (
             <motion.p
               key={lastSyncTimestamp.getTime()}
@@ -57,7 +57,7 @@ export default function ScansHeader(): React.JSX.Element {
               animate={{backgroundColor: "transparent"}}
               transition={{duration: 1}}
               className={styles["lastSynced"]}>
-              {t((m) => m["IMS--ViewScans"].header.lastSynced, {time: formatRelativeTime(lastSyncTimestamp)})}
+              {t((m) => m.pages.invoices.viewScans.header.lastSynced, {time: formatRelativeTime(lastSyncTimestamp)})}
             </motion.p>
           ) : null}
         </div>
@@ -76,7 +76,7 @@ export default function ScansHeader(): React.JSX.Element {
             <TooltipContent
               side='right'
               className={styles["tooltipContent"]}>
-              <p>{t((m) => m["IMS--ViewScans"].header.tooltip)}</p>
+              <p>{t((m) => m.pages.invoices.viewScans.header.tooltip)}</p>
             </TooltipContent>
           </Tooltip>
         </TooltipProvider>
@@ -92,14 +92,14 @@ export default function ScansHeader(): React.JSX.Element {
                   render={
                     <Link href='/domains/invoices/upload-scans'>
                       <TbUpload className={styles["actionIcon"]} />
-                      <span className={styles["hiddenMobile"]}>{t((m) => m["IMS--ViewScans"].header.uploadMore)}</span>
-                      <span className={styles["visibleMobile"]}>{t((m) => m["IMS--ViewScans"].header.upload)}</span>
+                      <span className={styles["hiddenMobile"]}>{t((m) => m.pages.invoices.viewScans.header.uploadMore)}</span>
+                      <span className={styles["visibleMobile"]}>{t((m) => m.pages.invoices.viewScans.header.upload)}</span>
                     </Link>
                   }
                 />
               }
             />
-            <TooltipContent>{t((m) => m["IMS--ViewScans"].header.uploadTooltip)}</TooltipContent>
+            <TooltipContent>{t((m) => m.pages.invoices.viewScans.header.uploadTooltip)}</TooltipContent>
           </Tooltip>
         </TooltipProvider>
 
@@ -113,14 +113,14 @@ export default function ScansHeader(): React.JSX.Element {
                   render={
                     <Link href='/domains/invoices/view-invoices'>
                       <TbFileInvoice className={styles["actionIcon"]} />
-                      <span className={styles["hiddenMobile"]}>{t((m) => m["IMS--ViewScans"].header.myInvoices)}</span>
-                      <span className={styles["visibleMobile"]}>{t((m) => m["IMS--ViewScans"].header.invoices)}</span>
+                      <span className={styles["hiddenMobile"]}>{t((m) => m.pages.invoices.viewScans.header.myInvoices)}</span>
+                      <span className={styles["visibleMobile"]}>{t((m) => m.pages.invoices.viewScans.header.invoices)}</span>
                     </Link>
                   }
                 />
               }
             />
-            <TooltipContent>{t((m) => m["IMS--ViewScans"].header.myInvoicesTooltip)}</TooltipContent>
+            <TooltipContent>{t((m) => m.pages.invoices.viewScans.header.myInvoicesTooltip)}</TooltipContent>
           </Tooltip>
         </TooltipProvider>
 
@@ -134,11 +134,11 @@ export default function ScansHeader(): React.JSX.Element {
                   disabled={isSyncing}
                   className={styles["outlineButton"]}>
                   <TbRefresh className={`${styles["syncIcon"]} ${isSyncing ? styles["syncIconSpinning"] : ""}`} />
-                  <span className={styles["hiddenMobile"]}>{isSyncing ? t((m) => m["IMS--ViewScans"].header.syncing) : t((m) => m["IMS--ViewScans"].header.sync)}</span>
+                  <span className={styles["hiddenMobile"]}>{isSyncing ? t((m) => m.pages.invoices.viewScans.header.syncing) : t((m) => m.pages.invoices.viewScans.header.sync)}</span>
                 </Button>
               }
             />
-            <TooltipContent>{t((m) => m["IMS--ViewScans"].header.syncTooltip)}</TooltipContent>
+            <TooltipContent>{t((m) => m.pages.invoices.viewScans.header.syncTooltip)}</TooltipContent>
           </Tooltip>
         </TooltipProvider>
       </div>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-scans/_components/dialogs/CreateInvoiceDialog.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-scans/_components/dialogs/CreateInvoiceDialog.tsx
@@ -210,17 +210,17 @@ export default function CreateInvoiceDialog(): React.JSX.Element {
         // Show partial failure toast with first error details
         const [firstError] = result.errors;
         const errorMessage = firstError ? `${firstError.scanId}: ${firstError.error}` : "";
-        const partialFailMessage = t((m) => m["IMS--Dialogs"].createInvoiceDialog.errors.partialFail, {count: String(result.errors.length)});
+        const partialFailMessage = t((m) => m.dialogs.invoices.createInvoiceDialog.errors.partialFail, {count: String(result.errors.length)});
         toast.error(errorMessage ? `${partialFailMessage} ${errorMessage}` : partialFailMessage);
       }
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : t((m) => m["IMS--Dialogs"].createInvoiceDialog.errors.unknown);
+      const errorMessage = error instanceof Error ? error.message : t((m) => m.dialogs.invoices.createInvoiceDialog.errors.unknown);
       setErrors([{message: String(errorMessage), scanId: undefined, scanName: undefined}]);
       setCreatedCount(0);
       setProgress(100);
       setStep("complete");
       // Show error toast with backend details
-      toast.error(t((m) => m["IMS--Dialogs"].createInvoiceDialog.errors.createFailed, {message: errorMessage}));
+      toast.error(t((m) => m.dialogs.invoices.createInvoiceDialog.errors.createFailed, {message: errorMessage}));
     }
   };
 
@@ -256,19 +256,19 @@ export default function CreateInvoiceDialog(): React.JSX.Element {
       <DialogHeader>
         <DialogTitle className={styles["dialogTitle"]}>
           <TbFileInvoice className={styles["dialogTitleIcon"]} />
-          {selectedScans.length > 1 ? t((m) => m["IMS--Dialogs"].createInvoiceDialog.titlePlural) : t((m) => m["IMS--Dialogs"].createInvoiceDialog.title)}
+          {selectedScans.length > 1 ? t((m) => m.dialogs.invoices.createInvoiceDialog.titlePlural) : t((m) => m.dialogs.invoices.createInvoiceDialog.title)}
         </DialogTitle>
-        <DialogDescription>{t((m) => m["IMS--Dialogs"].createInvoiceDialog.description)}</DialogDescription>
+        <DialogDescription>{t((m) => m.dialogs.invoices.createInvoiceDialog.description)}</DialogDescription>
       </DialogHeader>
 
       {/* Scans Preview */}
       <div className={styles["scansPreviewBox"]}>
         <div className={styles["scansPreviewHeader"]}>
           <span className={styles["scansPreviewLabel"]}>
-            {t((m) => m["IMS--Dialogs"].createInvoiceDialog.selectedScans)} ({selectedScans.length})
+            {t((m) => m.dialogs.invoices.createInvoiceDialog.selectedScans)} ({selectedScans.length})
           </span>
           <span className={styles["scansPreviewSize"]}>
-            {formatFileSize(totalSize)} {t((m) => m["IMS--Dialogs"].createInvoiceDialog.totalSize)}
+            {formatFileSize(totalSize)} {t((m) => m.dialogs.invoices.createInvoiceDialog.totalSize)}
           </span>
         </div>
         <div className={styles["scansPreviewGrid"]}>
@@ -285,7 +285,7 @@ export default function CreateInvoiceDialog(): React.JSX.Element {
       {/* Mode Selection for multiple scans */}
       {selectedScans.length > 1 ? (
         <div className={styles["modeSection"]}>
-          <p className={styles["modeLabel"]}>{t((m) => m["IMS--Dialogs"].createInvoiceDialog.chooseMode)}</p>
+          <p className={styles["modeLabel"]}>{t((m) => m.dialogs.invoices.createInvoiceDialog.chooseMode)}</p>
           <RadioGroup
             value={mode}
             onValueChange={handleModeChange}>
@@ -301,9 +301,9 @@ export default function CreateInvoiceDialog(): React.JSX.Element {
               <div className={styles["modeOptionContent"]}>
                 <span className={styles["modeLabelText"]}>
                   <TbPhoto className={styles["modePurpleIcon"]} />
-                  {t((m) => m["IMS--Dialogs"].createInvoiceDialog.singleMode.title)}
+                  {t((m) => m.dialogs.invoices.createInvoiceDialog.singleMode.title)}
                 </span>
-                <p className={styles["modeOptionDescription"]}>{t((m) => m["IMS--Dialogs"].createInvoiceDialog.singleMode.description, {count: String(selectedScans.length)})}</p>
+                <p className={styles["modeOptionDescription"]}>{t((m) => m.dialogs.invoices.createInvoiceDialog.singleMode.description, {count: String(selectedScans.length)})}</p>
               </div>
             </Label>
             {/* Batch mode option */}
@@ -318,9 +318,9 @@ export default function CreateInvoiceDialog(): React.JSX.Element {
               <div className={styles["modeOptionContent"]}>
                 <span className={styles["modeLabelText"]}>
                   <TbStack2 className={styles["modeBlueIcon"]} />
-                  {t((m) => m["IMS--Dialogs"].createInvoiceDialog.batchMode.title)}
+                  {t((m) => m.dialogs.invoices.createInvoiceDialog.batchMode.title)}
                 </span>
-                <p className={styles["modeOptionDescription"]}>{t((m) => m["IMS--Dialogs"].createInvoiceDialog.batchMode.description, {count: String(selectedScans.length)})}</p>
+                <p className={styles["modeOptionDescription"]}>{t((m) => m.dialogs.invoices.createInvoiceDialog.batchMode.description, {count: String(selectedScans.length)})}</p>
               </div>
             </Label>
           </RadioGroup>
@@ -331,8 +331,8 @@ export default function CreateInvoiceDialog(): React.JSX.Element {
           <div className={styles["singleScanBannerContent"]}>
             <TbSparkles className={styles["singleScanBannerIcon"]} />
             <div>
-              <p className={styles["singleScanBannerTitle"]}>{t((m) => m["IMS--Dialogs"].createInvoiceDialog.singleScanInfo.title)}</p>
-              <p className={styles["singleScanBannerDescription"]}>{t((m) => m["IMS--Dialogs"].createInvoiceDialog.singleScanInfo.description)}</p>
+              <p className={styles["singleScanBannerTitle"]}>{t((m) => m.dialogs.invoices.createInvoiceDialog.singleScanInfo.title)}</p>
+              <p className={styles["singleScanBannerDescription"]}>{t((m) => m.dialogs.invoices.createInvoiceDialog.singleScanInfo.description)}</p>
             </div>
           </div>
         </div>
@@ -342,14 +342,14 @@ export default function CreateInvoiceDialog(): React.JSX.Element {
         <Button
           variant='outline'
           onClick={handleClose}>
-          {t((m) => m["IMS--Dialogs"].createInvoiceDialog.buttons.cancel)}
+          {t((m) => m.dialogs.invoices.createInvoiceDialog.buttons.cancel)}
         </Button>
         <Button
           onClick={handleCreate}
           className={styles["createButton"]}>
           {mode === "batch" || selectedScans.length === 1
-            ? t((m) => m["IMS--Dialogs"].createInvoiceDialog.buttons.createSingle)
-            : t((m) => m["IMS--Dialogs"].createInvoiceDialog.buttons.createMultiple, {count: String(selectedScans.length)})}
+            ? t((m) => m.dialogs.invoices.createInvoiceDialog.buttons.createSingle)
+            : t((m) => m.dialogs.invoices.createInvoiceDialog.buttons.createMultiple, {count: String(selectedScans.length)})}
           <TbArrowRight className={styles["arrowRightIcon"]} />
         </Button>
       </DialogFooter>
@@ -369,12 +369,12 @@ export default function CreateInvoiceDialog(): React.JSX.Element {
           <TbLoader2 className={styles["creatingSpinIcon"]} />
         </div>
         <h3 className={styles["creatingTitle"]}>
-          {mode === "single" && selectedScans.length > 1 ? t((m) => m["IMS--Dialogs"].createInvoiceDialog.creating.titlePlural) : t((m) => m["IMS--Dialogs"].createInvoiceDialog.creating.title)}
+          {mode === "single" && selectedScans.length > 1 ? t((m) => m.dialogs.invoices.createInvoiceDialog.creating.titlePlural) : t((m) => m.dialogs.invoices.createInvoiceDialog.creating.title)}
         </h3>
         <p className={styles["creatingDescription"]}>
           {selectedScans.length > 1
-            ? t((m) => m["IMS--Dialogs"].createInvoiceDialog.creating.processingPlural, {count: String(selectedScans.length)})
-            : t((m) => m["IMS--Dialogs"].createInvoiceDialog.creating.processing, {count: String(selectedScans.length)})}
+            ? t((m) => m.dialogs.invoices.createInvoiceDialog.creating.processingPlural, {count: String(selectedScans.length)})
+            : t((m) => m.dialogs.invoices.createInvoiceDialog.creating.processing, {count: String(selectedScans.length)})}
         </p>
       </div>
 
@@ -389,22 +389,22 @@ export default function CreateInvoiceDialog(): React.JSX.Element {
       <div className={styles["stepsSection"]}>
         <ProcessStep
           step={1}
-          title={t((m) => m["IMS--Dialogs"].createInvoiceDialog.creating.step1Title)}
-          description={t((m) => m["IMS--Dialogs"].createInvoiceDialog.creating.step1Description)}
+          title={t((m) => m.dialogs.invoices.createInvoiceDialog.creating.step1Title)}
+          description={t((m) => m.dialogs.invoices.createInvoiceDialog.creating.step1Description)}
           isActive={progress < 30}
           isComplete={progress >= 30}
         />
         <ProcessStep
           step={2}
-          title={t((m) => m["IMS--Dialogs"].createInvoiceDialog.creating.step2Title)}
-          description={t((m) => m["IMS--Dialogs"].createInvoiceDialog.creating.step2Description)}
+          title={t((m) => m.dialogs.invoices.createInvoiceDialog.creating.step2Title)}
+          description={t((m) => m.dialogs.invoices.createInvoiceDialog.creating.step2Description)}
           isActive={progress >= 30 && progress < 70}
           isComplete={progress >= 70}
         />
         <ProcessStep
           step={3}
-          title={t((m) => m["IMS--Dialogs"].createInvoiceDialog.creating.step3Title)}
-          description={t((m) => m["IMS--Dialogs"].createInvoiceDialog.creating.step3Description)}
+          title={t((m) => m.dialogs.invoices.createInvoiceDialog.creating.step3Title)}
+          description={t((m) => m.dialogs.invoices.createInvoiceDialog.creating.step3Description)}
           isActive={progress >= 70}
           isComplete={progress >= 100}
         />
@@ -430,8 +430,8 @@ export default function CreateInvoiceDialog(): React.JSX.Element {
           <div className={`${styles["completeIconCircle"]} ${styles["completeIconCircleError"]}`}>
             <TbAlertCircle className={styles["completeErrorIcon"]} />
           </div>
-          <h3 className={`${styles["completeTitle"]} ${styles["completeTitleError"]}`}>{t((m) => m["IMS--Dialogs"].createInvoiceDialog.complete.failureTitle)}</h3>
-          <p className={styles["completeDescription"]}>{t((m) => m["IMS--Dialogs"].createInvoiceDialog.complete.failureDescription)}</p>
+          <h3 className={`${styles["completeTitle"]} ${styles["completeTitleError"]}`}>{t((m) => m.dialogs.invoices.createInvoiceDialog.complete.failureTitle)}</h3>
+          <p className={styles["completeDescription"]}>{t((m) => m.dialogs.invoices.createInvoiceDialog.complete.failureDescription)}</p>
 
           {errors.length > 0 && (
             <div className={styles["completeErrorsList"]}>
@@ -453,12 +453,12 @@ export default function CreateInvoiceDialog(): React.JSX.Element {
             <Button
               variant='outline'
               onClick={handleClose}>
-              {t((m) => m["IMS--Dialogs"].createInvoiceDialog.buttons.cancel)}
+              {t((m) => m.dialogs.invoices.createInvoiceDialog.buttons.cancel)}
             </Button>
             <Button
               onClick={handleRetry}
               className={styles["retryButton"]}>
-              {t((m) => m["IMS--Dialogs"].createInvoiceDialog.complete.retryButton)}
+              {t((m) => m.dialogs.invoices.createInvoiceDialog.complete.retryButton)}
               <TbArrowRight className={styles["arrowRightIcon"]} />
             </Button>
           </DialogFooter>
@@ -478,16 +478,16 @@ export default function CreateInvoiceDialog(): React.JSX.Element {
             <TbAlertTriangle className={styles["completeWarningIcon"]} />
           </div>
           <h3 className={`${styles["completeTitle"]} ${styles["completeTitleWarning"]}`}>
-            {t((m) => m["IMS--Dialogs"].createInvoiceDialog.complete.partialTitle, {
+            {t((m) => m.dialogs.invoices.createInvoiceDialog.complete.partialTitle, {
               created: String(createdCount),
               total: String(selectedScans.length),
             })}
           </h3>
-          <p className={styles["completeDescription"]}>{t((m) => m["IMS--Dialogs"].createInvoiceDialog.complete.partialDescription)}</p>
+          <p className={styles["completeDescription"]}>{t((m) => m.dialogs.invoices.createInvoiceDialog.complete.partialDescription)}</p>
 
           {errors.length > 0 && (
             <div className={styles["completeErrorsList"]}>
-              <p className={styles["completeErrorsListTitle"]}>{t((m) => m["IMS--Dialogs"].createInvoiceDialog.complete.errorsLabel)}</p>
+              <p className={styles["completeErrorsListTitle"]}>{t((m) => m.dialogs.invoices.createInvoiceDialog.complete.errorsLabel)}</p>
               {errors.map((error) => (
                 <div
                   key={error.scanId ?? error.message ?? "unknown-error"}
@@ -503,12 +503,12 @@ export default function CreateInvoiceDialog(): React.JSX.Element {
             <Button
               variant='outline'
               onClick={handleClose}>
-              {t((m) => m["IMS--Dialogs"].createInvoiceDialog.buttons.close)}
+              {t((m) => m.dialogs.invoices.createInvoiceDialog.buttons.close)}
             </Button>
             <Button
               onClick={handleViewInvoices}
               className={styles["completeButton"]}>
-              {isPlural ? t((m) => m["IMS--Dialogs"].createInvoiceDialog.complete.viewButtonPlural) : t((m) => m["IMS--Dialogs"].createInvoiceDialog.complete.viewButton)}
+              {isPlural ? t((m) => m.dialogs.invoices.createInvoiceDialog.complete.viewButtonPlural) : t((m) => m.dialogs.invoices.createInvoiceDialog.complete.viewButton)}
               <TbArrowRight className={styles["arrowRightIcon"]} />
             </Button>
           </DialogFooter>
@@ -527,14 +527,14 @@ export default function CreateInvoiceDialog(): React.JSX.Element {
           <TbCheck className={styles["completeCheckIcon"]} />
         </div>
         <h3 className={styles["completeTitle"]}>
-          {isPlural ? t((m) => m["IMS--Dialogs"].createInvoiceDialog.complete.titlePlural, {count: String(createdCount)}) : t((m) => m["IMS--Dialogs"].createInvoiceDialog.complete.title, {count: String(createdCount)})}
+          {isPlural ? t((m) => m.dialogs.invoices.createInvoiceDialog.complete.titlePlural, {count: String(createdCount)}) : t((m) => m.dialogs.invoices.createInvoiceDialog.complete.title, {count: String(createdCount)})}
         </h3>
-        <p className={styles["completeDescription"]}>{isPlural ? t((m) => m["IMS--Dialogs"].createInvoiceDialog.complete.descriptionPlural) : t((m) => m["IMS--Dialogs"].createInvoiceDialog.complete.description)}</p>
+        <p className={styles["completeDescription"]}>{isPlural ? t((m) => m.dialogs.invoices.createInvoiceDialog.complete.descriptionPlural) : t((m) => m.dialogs.invoices.createInvoiceDialog.complete.description)}</p>
 
         <div className={styles["completeNextSteps"]}>
           <p className={styles["completeNextStepsText"]}>
-            <strong>{t((m) => m["IMS--Dialogs"].createInvoiceDialog.complete.nextSteps)}</strong>{" "}
-            {isPlural ? t((m) => m["IMS--Dialogs"].createInvoiceDialog.complete.nextStepsDescriptionPlural) : t((m) => m["IMS--Dialogs"].createInvoiceDialog.complete.nextStepsDescription)}
+            <strong>{t((m) => m.dialogs.invoices.createInvoiceDialog.complete.nextSteps)}</strong>{" "}
+            {isPlural ? t((m) => m.dialogs.invoices.createInvoiceDialog.complete.nextStepsDescriptionPlural) : t((m) => m.dialogs.invoices.createInvoiceDialog.complete.nextStepsDescription)}
           </p>
         </div>
 
@@ -542,12 +542,12 @@ export default function CreateInvoiceDialog(): React.JSX.Element {
           <Button
             variant='outline'
             onClick={handleClose}>
-            {t((m) => m["IMS--Dialogs"].createInvoiceDialog.buttons.close)}
+            {t((m) => m.dialogs.invoices.createInvoiceDialog.buttons.close)}
           </Button>
           <Button
             onClick={handleViewInvoices}
             className={styles["completeButton"]}>
-            {isPlural ? t((m) => m["IMS--Dialogs"].createInvoiceDialog.complete.viewButtonPlural) : t((m) => m["IMS--Dialogs"].createInvoiceDialog.complete.viewButton)}
+            {isPlural ? t((m) => m.dialogs.invoices.createInvoiceDialog.complete.viewButtonPlural) : t((m) => m.dialogs.invoices.createInvoiceDialog.complete.viewButton)}
             <TbArrowRight className={styles["arrowRightIcon"]} />
           </Button>
         </DialogFooter>

--- a/sites/arolariu.ro/src/app/domains/invoices/view-scans/island.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-scans/island.tsx
@@ -70,25 +70,25 @@ function ScanStats(): React.JSX.Element | null {
         <div className={styles["scanStatsGroup"]}>
           <StatsCard
             value={scans.length}
-            label={t((m) => m["IMS--ViewScans"].stats.totalScans)}
+            label={t((m) => m.pages.invoices.viewScans.stats.totalScans)}
             colorClass='statsCardValueDefault'
           />
           <StatsCard
             value={readyScans}
-            label={t((m) => m["IMS--ViewScans"].stats.ready)}
+            label={t((m) => m.pages.invoices.viewScans.stats.ready)}
             colorClass='statsCardValueGreen'
           />
           <StatsCard
             value={selectedScans.length}
-            label={t((m) => m["IMS--ViewScans"].stats.selected)}
+            label={t((m) => m.pages.invoices.viewScans.stats.selected)}
             colorClass='statsCardValuePurple'
           />
         </div>
 
         {selectedScans.length === 0 && scans.length > 0 && (
           <p className={styles["selectHint"]}>
-            <span className={styles["hiddenMobile"]}>{t((m) => m["IMS--ViewScans"].stats.selectHint)}</span>
-            <span className={styles["visibleMobile"]}>{t((m) => m["IMS--ViewScans"].stats.tapHint)}</span>
+            <span className={styles["hiddenMobile"]}>{t((m) => m.pages.invoices.viewScans.stats.selectHint)}</span>
+            <span className={styles["visibleMobile"]}>{t((m) => m.pages.invoices.viewScans.stats.tapHint)}</span>
           </p>
         )}
       </div>
@@ -108,22 +108,22 @@ function SidebarContent(): React.JSX.Element {
       {/* How to Use */}
       <Card>
         <CardContent className={styles["sidebarCardContent"]}>
-          <h3 className={styles["sidebarTitle"]}>{t((m) => m["IMS--ViewScans"].sidebar.howTo.title)}</h3>
+          <h3 className={styles["sidebarTitle"]}>{t((m) => m.pages.invoices.viewScans.sidebar.howTo.title)}</h3>
           <div className={styles["howToList"]}>
             <QuickTip
               icon={<TbClick className={styles["tipIcon"]} />}
-              title={t((m) => m["IMS--ViewScans"].sidebar.howTo.step1Title)}
-              description={t((m) => m["IMS--ViewScans"].sidebar.howTo.step1Description)}
+              title={t((m) => m.pages.invoices.viewScans.sidebar.howTo.step1Title)}
+              description={t((m) => m.pages.invoices.viewScans.sidebar.howTo.step1Description)}
             />
             <QuickTip
               icon={<TbStack2 className={styles["tipIcon"]} />}
-              title={t((m) => m["IMS--ViewScans"].sidebar.howTo.step2Title)}
-              description={t((m) => m["IMS--ViewScans"].sidebar.howTo.step2Description)}
+              title={t((m) => m.pages.invoices.viewScans.sidebar.howTo.step2Title)}
+              description={t((m) => m.pages.invoices.viewScans.sidebar.howTo.step2Description)}
             />
             <QuickTip
               icon={<TbFileInvoice className={styles["tipIcon"]} />}
-              title={t((m) => m["IMS--ViewScans"].sidebar.howTo.step3Title)}
-              description={t((m) => m["IMS--ViewScans"].sidebar.howTo.step3Description)}
+              title={t((m) => m.pages.invoices.viewScans.sidebar.howTo.step3Title)}
+              description={t((m) => m.pages.invoices.viewScans.sidebar.howTo.step3Description)}
             />
           </div>
         </CardContent>
@@ -143,10 +143,10 @@ function SidebarContent(): React.JSX.Element {
                 <div>
                   <p className={styles["selectionTitle"]}>
                     {selectedScans.length}{" "}
-                    {selectedScans.length > 1 ? t((m) => m["IMS--ViewScans"].sidebar.selectionStatus.plural) : t((m) => m["IMS--ViewScans"].sidebar.selectionStatus.singular)}
+                    {selectedScans.length > 1 ? t((m) => m.pages.invoices.viewScans.sidebar.selectionStatus.plural) : t((m) => m.pages.invoices.viewScans.sidebar.selectionStatus.singular)}
                   </p>
                   <p className={styles["selectionDescription"]}>
-                    {selectedScans.length > 1 ? t((m) => m["IMS--ViewScans"].sidebar.selectionStatus.readyPlural) : t((m) => m["IMS--ViewScans"].sidebar.selectionStatus.readySingular)}
+                    {selectedScans.length > 1 ? t((m) => m.pages.invoices.viewScans.sidebar.selectionStatus.readyPlural) : t((m) => m.pages.invoices.viewScans.sidebar.selectionStatus.readySingular)}
                   </p>
                 </div>
               </div>
@@ -163,14 +163,14 @@ function SidebarContent(): React.JSX.Element {
               <TbPhoto className={styles["quickUploadIcon"]} />
             </div>
             <div className={styles["quickUploadTextBlock"]}>
-              <p className={styles["quickUploadTitle"]}>{t((m) => m["IMS--ViewScans"].sidebar.quickUpload.title)}</p>
-              <p className={styles["quickUploadDescription"]}>{t((m) => m["IMS--ViewScans"].sidebar.quickUpload.description)}</p>
+              <p className={styles["quickUploadTitle"]}>{t((m) => m.pages.invoices.viewScans.sidebar.quickUpload.title)}</p>
+              <p className={styles["quickUploadDescription"]}>{t((m) => m.pages.invoices.viewScans.sidebar.quickUpload.description)}</p>
             </div>
             <Button
               asChild
               size='sm'
               variant='outline'>
-              <Link href='/domains/invoices/upload-scans'>{t((m) => m["IMS--ViewScans"].sidebar.quickUpload.button)}</Link>
+              <Link href='/domains/invoices/upload-scans'>{t((m) => m.pages.invoices.viewScans.sidebar.quickUpload.button)}</Link>
             </Button>
           </div>
         </CardContent>
@@ -249,7 +249,7 @@ function ViewScansContent(): React.JSX.Element {
           href='/domains/invoices'
           className={styles["breadcrumbLink"]}>
           <TbArrowLeft className={styles["breadcrumbIcon"]} />
-          {t((m) => m["IMS--ViewScans"].breadcrumb)}
+          {t((m) => m.pages.invoices.viewScans.breadcrumb)}
         </Link>
       </div>
 

--- a/sites/arolariu.ro/src/app/domains/invoices/view-scans/page.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-scans/page.tsx
@@ -7,9 +7,7 @@ import {redirect} from "next/navigation";
 import RenderViewScansScreen from "./island";
 import styles from "./page.module.scss";
 
-/**
- * Generates SEO metadata for the view scans page.
- */
+/** Generates SEO metadata for the view scans page. */
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations();
   const locale = await getLocale();

--- a/sites/arolariu.ro/src/app/domains/invoices/view-scans/page.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-scans/page.tsx
@@ -15,8 +15,8 @@ export async function generateMetadata(): Promise<Metadata> {
   const locale = await getLocale();
   return createMetadata({
     locale,
-    title: t((m) => m["IMS--ViewScans"].metadata.title),
-    description: t((m) => m["IMS--ViewScans"].metadata.description),
+    title: t((m) => m.pages.invoices.viewScans.metadata.title),
+    description: t((m) => m.pages.invoices.viewScans.metadata.description),
   });
 }
 

--- a/sites/arolariu.ro/src/app/domains/island.tsx
+++ b/sites/arolariu.ro/src/app/domains/island.tsx
@@ -43,7 +43,7 @@ export default function RenderDomainsScreen(): React.JSX.Element {
           <div className={styles["progressFill"]} />
         </div>
         <div className={styles["titleRow"]}>
-          <h1 className={styles["title"]}>{t((m) => m.Domains.title)}</h1>
+          <h1 className={styles["title"]}>{t((m) => m.pages.domains.title)}</h1>
           <article className={styles["subtitleArticle"]}>
             <RichText
               sectionKey='Domains'
@@ -58,7 +58,7 @@ export default function RenderDomainsScreen(): React.JSX.Element {
         <section className={styles["serviceCard"]}>
           <article className={styles["imageContainer"]}>
             <Image
-              alt={t((m) => m.Domains.services.invoices.card.imageAlt)}
+              alt={t((m) => m.pages.domains.services.invoices.card.imageAlt)}
               className={styles["cardImage"]}
               src='/images/domains/invoice-management-system.png'
               width='600'
@@ -66,12 +66,12 @@ export default function RenderDomainsScreen(): React.JSX.Element {
             />
           </article>
           <article>
-            <h2 className={styles["cardTitle"]}>{t((m) => m.Domains.services.invoices.card.title)}</h2>
-            <p className={styles["cardDescription"]}>{t((m) => m.Domains.services.invoices.card.description)}</p>
+            <h2 className={styles["cardTitle"]}>{t((m) => m.pages.domains.services.invoices.card.title)}</h2>
+            <p className={styles["cardDescription"]}>{t((m) => m.pages.domains.services.invoices.card.description)}</p>
             <Link
               href='/domains/invoices'
               className={styles["ctaLink"]}>
-              {t((m) => m.Domains.services.callToAction)}
+              {t((m) => m.pages.domains.services.callToAction)}
               <svg
                 fill='none'
                 stroke='currentColor'

--- a/sites/arolariu.ro/src/app/domains/page.tsx
+++ b/sites/arolariu.ro/src/app/domains/page.tsx
@@ -53,8 +53,8 @@ export async function generateMetadata(): Promise<Metadata> {
   const locale = await getLocale();
   return createMetadata({
     locale,
-    title: t((m) => m.Domains.metadata.title),
-    description: t((m) => m.Domains.metadata.description),
+    title: t((m) => m.pages.domains.metadata.title),
+    description: t((m) => m.pages.domains.metadata.description),
   });
 }
 

--- a/sites/arolariu.ro/src/app/error.test.tsx
+++ b/sites/arolariu.ro/src/app/error.test.tsx
@@ -10,8 +10,8 @@ describe("app/error.tsx", () => {
         reset={vi.fn()}
       />,
     );
-    expect(screen.getByText("Errors.globalError.hero.title")).toBeInTheDocument();
-    expect(screen.getByText("Errors.globalError.hero.subtitle")).toBeInTheDocument();
+    expect(screen.getByText("app.errors.globalError.hero.title")).toBeInTheDocument();
+    expect(screen.getByText("app.errors.globalError.hero.subtitle")).toBeInTheDocument();
   });
 
   it("calls reset when the try-again button is clicked", () => {
@@ -22,7 +22,7 @@ describe("app/error.tsx", () => {
         reset={reset}
       />,
     );
-    fireEvent.click(screen.getByRole("button", {name: "Errors.globalError.buttons.tryAgain"}));
+    fireEvent.click(screen.getByRole("button", {name: "app.errors.globalError.buttons.tryAgain"}));
     expect(reset).toHaveBeenCalledOnce();
   });
 

--- a/sites/arolariu.ro/src/app/error.tsx
+++ b/sites/arolariu.ro/src/app/error.tsx
@@ -19,17 +19,17 @@ export default function AppError({error, reset}: AppErrorProps): React.JSX.Eleme
     <section
       role='alert'
       aria-live='assertive'>
-      <h1>{t((m) => m.Errors.globalError.hero.title)}</h1>
-      <p>{t((m) => m.Errors.globalError.hero.subtitle)}</p>
+      <h1>{t((m) => m.app.errors.globalError.hero.title)}</h1>
+      <p>{t((m) => m.app.errors.globalError.hero.subtitle)}</p>
       {error.digest ? (
         <p>
-          <span>{t((m) => m.Errors.globalError.details.errorIdLabel)}</span> <code>{error.digest}</code>
+          <span>{t((m) => m.app.errors.globalError.details.errorIdLabel)}</span> <code>{error.digest}</code>
         </p>
       ) : null}
       <button
         type='button'
         onClick={reset}>
-        {t((m) => m.Errors.globalError.buttons.tryAgain)}
+        {t((m) => m.app.errors.globalError.buttons.tryAgain)}
       </button>
     </section>
   );

--- a/sites/arolariu.ro/src/app/global-error.tsx
+++ b/sites/arolariu.ro/src/app/global-error.tsx
@@ -44,7 +44,7 @@ function GlobalErrorDocumentTitle(): null {
   const t = useTranslations();
 
   useEffect(() => {
-    globalThis.document.title = t((m) => m.Errors.globalError.metadata.title);
+    globalThis.document.title = t((m) => m.app.errors.globalError.metadata.title);
   }, [t]);
 
   return null;
@@ -82,7 +82,7 @@ function GlobalErrorContent({error, reset}: Readonly<GlobalErrorProps>): React.J
         setIsCopied(false);
       }, 2000);
     } catch (clipboardError) {
-      console.error(t((m) => m.Errors.globalError.copyErrorConsoleMessage), clipboardError);
+      console.error(t((m) => m.app.errors.globalError.copyErrorConsoleMessage), clipboardError);
     }
   }, [error.digest, t]);
 
@@ -104,8 +104,8 @@ function GlobalErrorContent({error, reset}: Readonly<GlobalErrorProps>): React.J
           <div className={styles["iconCircle"]}>
             <TbAlertTriangle className={styles["heroIcon"]} />
           </div>
-          <h1 className={styles["heroTitle"]}>{t((m) => m.Errors.globalError.hero.title)}</h1>
-          <p className={styles["heroSubtitle"]}>{t((m) => m.Errors.globalError.hero.subtitle)}</p>
+          <h1 className={styles["heroTitle"]}>{t((m) => m.app.errors.globalError.hero.title)}</h1>
+          <p className={styles["heroSubtitle"]}>{t((m) => m.app.errors.globalError.hero.subtitle)}</p>
         </section>
 
         {/* Error Details Card */}
@@ -113,15 +113,15 @@ function GlobalErrorContent({error, reset}: Readonly<GlobalErrorProps>): React.J
           <CardHeader>
             <CardTitle className={styles["cardTitleWrapper"]}>
               <TbAlertTriangle className={styles["cardTitleIcon"]} />
-              {t((m) => m.Errors.globalError.details.title)}
+              {t((m) => m.app.errors.globalError.details.title)}
             </CardTitle>
             <CardDescription>
               {error.digest ? (
                 <>
-                  {t((m) => m.Errors.globalError.details.errorIdLabel)} <code className={styles["errorCode"]}>{error.digest}</code>
+                  {t((m) => m.app.errors.globalError.details.errorIdLabel)} <code className={styles["errorCode"]}>{error.digest}</code>
                 </>
               ) : (
-                t((m) => m.Errors.globalError.details.genericDescription)
+                t((m) => m.app.errors.globalError.details.genericDescription)
               )}
             </CardDescription>
           </CardHeader>
@@ -131,27 +131,27 @@ function GlobalErrorContent({error, reset}: Readonly<GlobalErrorProps>): React.J
             <Alert variant='destructive'>
               <AlertTitle className={styles["alertTitleInner"]}>
                 <TbAlertTriangle className={styles["alertIcon"]} />
-                {t((m) => m.Errors.globalError.details.whatHappenedTitle)}
+                {t((m) => m.app.errors.globalError.details.whatHappenedTitle)}
               </AlertTitle>
               <AlertDescription className={styles["alertDescription"]}>
-                <p className={styles["errorMessage"]}>{error.message || t((m) => m.Errors.globalError.details.unknownError)}</p>
+                <p className={styles["errorMessage"]}>{error.message || t((m) => m.app.errors.globalError.details.unknownError)}</p>
               </AlertDescription>
             </Alert>
 
             {/* What to do section */}
             <div className={styles["infoBox"]}>
-              <h3 className={styles["infoTitle"]}>{t((m) => m.Errors.globalError.actions.whatCanYouDoTitle)}</h3>
+              <h3 className={styles["infoTitle"]}>{t((m) => m.app.errors.globalError.actions.whatCanYouDoTitle)}</h3>
               <ul className={styles["infoList"]}>
-                <li>{t((m) => m.Errors.globalError.actions.step1)}</li>
-                <li>{t((m) => m.Errors.globalError.actions.step2)}</li>
-                <li>{t((m) => m.Errors.globalError.actions.step3)}</li>
+                <li>{t((m) => m.app.errors.globalError.actions.step1)}</li>
+                <li>{t((m) => m.app.errors.globalError.actions.step2)}</li>
+                <li>{t((m) => m.app.errors.globalError.actions.step3)}</li>
               </ul>
             </div>
 
             {/* QR Code with Diagnostic Data */}
             {Boolean(errorContext) && (
               <div className={styles["qrSection"]}>
-                <p className={styles["qrLabel"]}>{t((m) => m.Errors.globalError.diagnostics.scanLabel)}</p>
+                <p className={styles["qrLabel"]}>{t((m) => m.app.errors.globalError.diagnostics.scanLabel)}</p>
                 <QRCode
                   value={errorContext}
                   size={128}
@@ -162,14 +162,14 @@ function GlobalErrorContent({error, reset}: Readonly<GlobalErrorProps>): React.J
 
             {/* Technical Details (Collapsible) */}
             <details className={styles["technicalDetails"]}>
-              <summary className={styles["technicalSummary"]}>{t((m) => m.Errors.globalError.diagnostics.technicalSummary)}</summary>
+              <summary className={styles["technicalSummary"]}>{t((m) => m.app.errors.globalError.diagnostics.technicalSummary)}</summary>
               <div className={styles["technicalContent"]}>
                 <pre className={styles["preBlock"]}>
-                  <code>{errorContext || t((m) => m.Errors.globalError.diagnostics.loading)}</code>
+                  <code>{errorContext || t((m) => m.app.errors.globalError.diagnostics.loading)}</code>
                 </pre>
                 {Boolean(error.stack) && (
                   <>
-                    <h4 className={styles["stackTitle"]}>{t((m) => m.Errors.globalError.diagnostics.stackTraceLabel)}</h4>
+                    <h4 className={styles["stackTitle"]}>{t((m) => m.app.errors.globalError.diagnostics.stackTraceLabel)}</h4>
                     <pre className={styles["preBlock"]}>
                       <code>{error.stack}</code>
                     </pre>
@@ -187,7 +187,7 @@ function GlobalErrorContent({error, reset}: Readonly<GlobalErrorProps>): React.J
               size='default'
               className={styles["actionButton"]}>
               <TbRefresh className={styles["buttonIcon"]} />
-              {t((m) => m.Errors.globalError.buttons.tryAgain)}
+              {t((m) => m.app.errors.globalError.buttons.tryAgain)}
             </Button>
 
             {/* Secondary Action - Return Home */}
@@ -200,7 +200,7 @@ function GlobalErrorContent({error, reset}: Readonly<GlobalErrorProps>): React.J
                 href='/'
                 onClick={handleReset}>
                 <TbHome className={styles["buttonIcon"]} />
-                {t((m) => m.Errors.globalError.buttons.returnHome)}
+                {t((m) => m.app.errors.globalError.buttons.returnHome)}
               </Link>
             </Button>
 
@@ -211,16 +211,16 @@ function GlobalErrorContent({error, reset}: Readonly<GlobalErrorProps>): React.J
                 variant='ghost'
                 size='default'
                 className={styles["actionButton"]}
-                title={t((m) => m.Errors.globalError.buttons.copyErrorIdTitle)}>
+                title={t((m) => m.app.errors.globalError.buttons.copyErrorIdTitle)}>
                 {isCopied ? (
                   <>
                     <TbClipboardCheck className={styles["buttonIcon"]} />
-                    {t((m) => m.Errors.globalError.buttons.copied)}
+                    {t((m) => m.app.errors.globalError.buttons.copied)}
                   </>
                 ) : (
                   <>
                     <TbClipboard className={styles["buttonIcon"]} />
-                    {t((m) => m.Errors.globalError.buttons.copyErrorId)}
+                    {t((m) => m.app.errors.globalError.buttons.copyErrorId)}
                   </>
                 )}
               </Button>
@@ -231,7 +231,7 @@ function GlobalErrorContent({error, reset}: Readonly<GlobalErrorProps>): React.J
         {/* Additional Help Section */}
         <section className={styles["helpSection"]}>
           <p className={styles["helpText"]}>
-            {t((m) => m.Errors.globalError.support.contactPrefix)}{" "}
+            {t((m) => m.app.errors.globalError.support.contactPrefix)}{" "}
             <a
               href='mailto:support@arolariu.ro'
               className={styles["helpLink"]}>
@@ -240,7 +240,7 @@ function GlobalErrorContent({error, reset}: Readonly<GlobalErrorProps>): React.J
             {Boolean(error.digest) && (
               <>
                 {" "}
-                {t((m) => m.Errors.globalError.support.includeErrorId)} <code className={styles["helpErrorCode"]}>{error.digest}</code>
+                {t((m) => m.app.errors.globalError.support.includeErrorId)} <code className={styles["helpErrorCode"]}>{error.digest}</code>
               </>
             )}
           </p>

--- a/sites/arolariu.ro/src/app/global-not-found.tsx
+++ b/sites/arolariu.ro/src/app/global-not-found.tsx
@@ -55,26 +55,26 @@ export default async function NotFound(): Promise<React.JSX.Element> {
           <Header />
           <div className={styles["pageContainer"]}>
             <section className={styles["heroContent"]}>
-              <h1 className={styles["title"]}>{t((m) => m.Errors.notFound.title)}</h1>
-              <span className={styles["subtitle"]}>{t((m) => m.Errors.notFound.subtitle)}</span>
+              <h1 className={styles["title"]}>{t((m) => m.app.errors.notFound.title)}</h1>
+              <span className={styles["subtitle"]}>{t((m) => m.app.errors.notFound.subtitle)}</span>
             </section>
             <section className={styles["qrSection"]}>
-              <h2 className={styles["qrTitle"]}>{t((m) => m.Errors.notFound.additionalInfo)}</h2>
+              <h2 className={styles["qrTitle"]}>{t((m) => m.app.errors.notFound.additionalInfo)}</h2>
               <QRCode value={qrCodeData} />
             </section>
             <section className={styles["bottomSection"]}>
-              <span className={styles["falsePositive"]}>{t((m) => m.Errors.notFound.falsePositive)}</span>
+              <span className={styles["falsePositive"]}>{t((m) => m.app.errors.notFound.falsePositive)}</span>
               <div className={styles["buttonRow"]}>
                 <Button
                   asChild
                   variant='outline'
                   className={styles["actionButtonOutline"]}>
-                  <Link href='/'>{t((m) => m.Errors.notFound.buttons.submitErrorButton)}</Link>
+                  <Link href='/'>{t((m) => m.app.errors.notFound.buttons.submitErrorButton)}</Link>
                 </Button>
                 <Button
                   asChild
                   className={styles["actionButtonDefault"]}>
-                  <Link href='https://arolariu.ro/'>{t((m) => m.Errors.notFound.buttons.returnButton)}</Link>
+                  <Link href='https://arolariu.ro/'>{t((m) => m.app.errors.notFound.buttons.returnButton)}</Link>
                 </Button>
               </div>
             </section>

--- a/sites/arolariu.ro/src/app/my-profile/_components/ProfileHeader.tsx
+++ b/sites/arolariu.ro/src/app/my-profile/_components/ProfileHeader.tsx
@@ -69,23 +69,23 @@ export function ProfileHeader({user, userIdentifier}: Props): React.JSX.Element 
                 size='sm'
                 className={styles["editButton"]}>
                 <TbEdit className={styles["editIcon"]} />
-                {t((m) => m.Profile.header.editProfile)}
+                {t((m) => m.pages.profile.header.editProfile)}
               </Button>
             }
           />
           <SheetContent>
             <SheetHeader>
-              <SheetTitle>{t((m) => m.Profile.header.editProfileTitle)}</SheetTitle>
-              <SheetDescription>{t((m) => m.Profile.header.editProfileDescription)}</SheetDescription>
+              <SheetTitle>{t((m) => m.pages.profile.header.editProfileTitle)}</SheetTitle>
+              <SheetDescription>{t((m) => m.pages.profile.header.editProfileDescription)}</SheetDescription>
             </SheetHeader>
             <div className={styles["sheetBody"]}>
               <Button
                 className={styles["manageButton"]}
                 onClick={handleManageOnClerk}>
                 <TbShieldCheck className={styles["iconSmSize"]} />
-                {t((m) => m.Profile.header.manageOnClerk)}
+                {t((m) => m.pages.profile.header.manageOnClerk)}
               </Button>
-              <p className={styles["sheetNote"]}>{t((m) => m.Profile.header.editProfileClerkNote)}</p>
+              <p className={styles["sheetNote"]}>{t((m) => m.pages.profile.header.editProfileClerkNote)}</p>
             </div>
           </SheetContent>
         </Sheet>

--- a/sites/arolariu.ro/src/app/my-profile/_components/QuickStats.tsx
+++ b/sites/arolariu.ro/src/app/my-profile/_components/QuickStats.tsx
@@ -48,8 +48,8 @@ export function QuickStats({statistics}: Props): React.JSX.Element {
   return (
     <section className={styles["section"]}>
       <div className={styles["header"]}>
-        <h2>{t((m) => m.Profile.stats.title)}</h2>
-        <p>{t((m) => m.Profile.stats.description)}</p>
+        <h2>{t((m) => m.pages.profile.stats.title)}</h2>
+        <p>{t((m) => m.pages.profile.stats.description)}</p>
       </div>
 
       <div className={styles["grid"]}>
@@ -80,9 +80,9 @@ export function QuickStats({statistics}: Props): React.JSX.Element {
             <div className={styles["storageInfo"]}>
               <CardTitle className={styles["cardTitleBase"]}>
                 <TbCloud className={styles["iconSm"]} />
-                {t((m) => m.Profile.stats.storage.title)}
+                {t((m) => m.pages.profile.stats.storage.title)}
               </CardTitle>
-              <CardDescription>{t((m) => m.Profile.stats.storage.description)}</CardDescription>
+              <CardDescription>{t((m) => m.pages.profile.stats.storage.description)}</CardDescription>
             </div>
             <span className={styles["storageSize"]}>
               {formatStorageSize(statistics.storageUsed)} / {formatStorageSize(statistics.storageLimit)}
@@ -95,7 +95,7 @@ export function QuickStats({statistics}: Props): React.JSX.Element {
             className={styles["progressHeight"]}
           />
           <p className={styles["storageHint"]}>
-            {storagePercentage.toFixed(1)}% {t((m) => m.Profile.stats.storage.used)}
+            {storagePercentage.toFixed(1)}% {t((m) => m.pages.profile.stats.storage.used)}
           </p>
         </CardContent>
       </Card>

--- a/sites/arolariu.ro/src/app/my-profile/_components/SettingsAI.tsx
+++ b/sites/arolariu.ro/src/app/my-profile/_components/SettingsAI.tsx
@@ -80,8 +80,8 @@ export function SettingsAI({settings, onSettingsChange}: Props): React.JSX.Eleme
       animate={isInView ? {opacity: 1} : {opacity: 0}}
       transition={{duration: 0.3}}>
       <div className={styles["header"]}>
-        <h2>{t((m) => m.Profile.settings.ai.title)}</h2>
-        <p>{t((m) => m.Profile.settings.ai.description)}</p>
+        <h2>{t((m) => m.pages.profile.settings.ai.title)}</h2>
+        <p>{t((m) => m.pages.profile.settings.ai.description)}</p>
       </div>
 
       <div className={styles["grid"]}>
@@ -95,9 +95,9 @@ export function SettingsAI({settings, onSettingsChange}: Props): React.JSX.Eleme
             <CardHeader className={styles["cardHeaderPb"]}>
               <CardTitle className={styles["cardTitleBase"]}>
                 <TbRobot className={styles["iconSm"]} />
-                {t((m) => m.Profile.settings.ai.model.title)}
+                {t((m) => m.pages.profile.settings.ai.model.title)}
               </CardTitle>
-              <CardDescription>{t((m) => m.Profile.settings.ai.model.description)}</CardDescription>
+              <CardDescription>{t((m) => m.pages.profile.settings.ai.model.description)}</CardDescription>
             </CardHeader>
             <CardContent className={styles["cardContentSpaced"]}>
               <Select
@@ -142,9 +142,9 @@ export function SettingsAI({settings, onSettingsChange}: Props): React.JSX.Eleme
             <CardHeader className={styles["cardHeaderPb"]}>
               <CardTitle className={styles["cardTitleBase"]}>
                 <TbSparkles className={styles["iconSm"]} />
-                {t((m) => m.Profile.settings.ai.behavior.title)}
+                {t((m) => m.pages.profile.settings.ai.behavior.title)}
               </CardTitle>
-              <CardDescription>{t((m) => m.Profile.settings.ai.behavior.description)}</CardDescription>
+              <CardDescription>{t((m) => m.pages.profile.settings.ai.behavior.description)}</CardDescription>
             </CardHeader>
             <CardContent>
               <Select
@@ -177,15 +177,15 @@ export function SettingsAI({settings, onSettingsChange}: Props): React.JSX.Eleme
             <CardHeader className={styles["cardHeaderPb"]}>
               <CardTitle className={styles["cardTitleBase"]}>
                 <TbTemperature className={styles["iconSm"]} />
-                {t((m) => m.Profile.settings.ai.temperature.title)}
+                {t((m) => m.pages.profile.settings.ai.temperature.title)}
               </CardTitle>
-              <CardDescription>{t((m) => m.Profile.settings.ai.temperature.description)}</CardDescription>
+              <CardDescription>{t((m) => m.pages.profile.settings.ai.temperature.description)}</CardDescription>
             </CardHeader>
             <CardContent className={styles["cardContentSpaced"]}>
               <div className={styles["rangeLabels"]}>
-                <span>{t((m) => m.Profile.settings.ai.temperature.precise)}</span>
+                <span>{t((m) => m.pages.profile.settings.ai.temperature.precise)}</span>
                 <span>{settings.temperature.toFixed(1)}</span>
-                <span>{t((m) => m.Profile.settings.ai.temperature.creative)}</span>
+                <span>{t((m) => m.pages.profile.settings.ai.temperature.creative)}</span>
               </div>
               <Slider
                 value={[settings.temperature]}
@@ -208,9 +208,9 @@ export function SettingsAI({settings, onSettingsChange}: Props): React.JSX.Eleme
             <CardHeader className={styles["cardHeaderPb"]}>
               <CardTitle className={styles["cardTitleBase"]}>
                 <TbSettings className={styles["iconSm"]} />
-                {t((m) => m.Profile.settings.ai.maxTokens.title)}
+                {t((m) => m.pages.profile.settings.ai.maxTokens.title)}
               </CardTitle>
-              <CardDescription>{t((m) => m.Profile.settings.ai.maxTokens.description)}</CardDescription>
+              <CardDescription>{t((m) => m.pages.profile.settings.ai.maxTokens.description)}</CardDescription>
             </CardHeader>
             <CardContent className={styles["cardContentSpaced"]}>
               <div className={styles["rangeLabels"]}>
@@ -239,15 +239,15 @@ export function SettingsAI({settings, onSettingsChange}: Props): React.JSX.Eleme
             <CardHeader className={styles["cardHeaderPb"]}>
               <CardTitle className={styles["cardTitleBase"]}>
                 <TbBrain className={styles["iconSm"]} />
-                {t((m) => m.Profile.settings.ai.features.title)}
+                {t((m) => m.pages.profile.settings.ai.features.title)}
               </CardTitle>
-              <CardDescription>{t((m) => m.Profile.settings.ai.features.description)}</CardDescription>
+              <CardDescription>{t((m) => m.pages.profile.settings.ai.features.description)}</CardDescription>
             </CardHeader>
             <CardContent className={styles["cardContentSpaced"]}>
               <div className={styles["toggleRow"]}>
                 <div className={styles["toggleLabel"]}>
-                  <Label>{t((m) => m.Profile.settings.ai.features.autoSuggest)}</Label>
-                  <p>{t((m) => m.Profile.settings.ai.features.autoSuggestHint)}</p>
+                  <Label>{t((m) => m.pages.profile.settings.ai.features.autoSuggest)}</Label>
+                  <p>{t((m) => m.pages.profile.settings.ai.features.autoSuggestHint)}</p>
                 </div>
                 <Switch
                   nativeButton
@@ -258,8 +258,8 @@ export function SettingsAI({settings, onSettingsChange}: Props): React.JSX.Eleme
               <Separator />
               <div className={styles["toggleRow"]}>
                 <div className={styles["toggleLabel"]}>
-                  <Label>{t((m) => m.Profile.settings.ai.features.contextAwareness)}</Label>
-                  <p>{t((m) => m.Profile.settings.ai.features.contextAwarenessHint)}</p>
+                  <Label>{t((m) => m.pages.profile.settings.ai.features.contextAwareness)}</Label>
+                  <p>{t((m) => m.pages.profile.settings.ai.features.contextAwarenessHint)}</p>
                 </div>
                 <Switch
                   nativeButton
@@ -270,8 +270,8 @@ export function SettingsAI({settings, onSettingsChange}: Props): React.JSX.Eleme
               <Separator />
               <div className={styles["toggleRow"]}>
                 <div className={styles["toggleLabel"]}>
-                  <Label>{t((m) => m.Profile.settings.ai.features.memory)}</Label>
-                  <p>{t((m) => m.Profile.settings.ai.features.memoryHint)}</p>
+                  <Label>{t((m) => m.pages.profile.settings.ai.features.memory)}</Label>
+                  <p>{t((m) => m.pages.profile.settings.ai.features.memoryHint)}</p>
                 </div>
                 <Switch
                   nativeButton
@@ -292,15 +292,15 @@ export function SettingsAI({settings, onSettingsChange}: Props): React.JSX.Eleme
             <CardHeader className={styles["cardHeaderPb"]}>
               <CardTitle className={styles["cardTitleBase"]}>
                 <TbMicrophone className={styles["iconSm"]} />
-                {t((m) => m.Profile.settings.ai.voice.title)}
+                {t((m) => m.pages.profile.settings.ai.voice.title)}
               </CardTitle>
-              <CardDescription>{t((m) => m.Profile.settings.ai.voice.description)}</CardDescription>
+              <CardDescription>{t((m) => m.pages.profile.settings.ai.voice.description)}</CardDescription>
             </CardHeader>
             <CardContent>
               <div className={styles["toggleRow"]}>
                 <div className={styles["toggleLabel"]}>
-                  <Label>{t((m) => m.Profile.settings.ai.voice.enabled)}</Label>
-                  <p>{t((m) => m.Profile.settings.ai.voice.enabledHint)}</p>
+                  <Label>{t((m) => m.pages.profile.settings.ai.voice.enabled)}</Label>
+                  <p>{t((m) => m.pages.profile.settings.ai.voice.enabledHint)}</p>
                 </div>
                 <Switch
                   nativeButton

--- a/sites/arolariu.ro/src/app/my-profile/_components/SettingsAnalytics.tsx
+++ b/sites/arolariu.ro/src/app/my-profile/_components/SettingsAnalytics.tsx
@@ -68,8 +68,8 @@ export function SettingsAnalytics({settings, onSettingsChange}: Props): React.JS
       animate={isInView ? {opacity: 1} : {opacity: 0}}
       transition={{duration: 0.3}}>
       <div className={styles["header"]}>
-        <h2>{t((m) => m.Profile.settings.analytics.title)}</h2>
-        <p>{t((m) => m.Profile.settings.analytics.description)}</p>
+        <h2>{t((m) => m.pages.profile.settings.analytics.title)}</h2>
+        <p>{t((m) => m.pages.profile.settings.analytics.description)}</p>
       </div>
 
       <div className={styles["grid"]}>
@@ -83,15 +83,15 @@ export function SettingsAnalytics({settings, onSettingsChange}: Props): React.JS
             <CardHeader className={styles["cardHeaderPb"]}>
               <CardTitle className={styles["cardTitleBase"]}>
                 <TbChartBar className={styles["iconSm"]} />
-                {t((m) => m.Profile.settings.analytics.enabled.title)}
+                {t((m) => m.pages.profile.settings.analytics.enabled.title)}
               </CardTitle>
-              <CardDescription>{t((m) => m.Profile.settings.analytics.enabled.description)}</CardDescription>
+              <CardDescription>{t((m) => m.pages.profile.settings.analytics.enabled.description)}</CardDescription>
             </CardHeader>
             <CardContent>
               <div className={styles["toggleRow"]}>
                 <div className={styles["toggleLabel"]}>
-                  <Label>{t((m) => m.Profile.settings.analytics.enabled.label)}</Label>
-                  <p>{t((m) => m.Profile.settings.analytics.enabled.hint)}</p>
+                  <Label>{t((m) => m.pages.profile.settings.analytics.enabled.label)}</Label>
+                  <p>{t((m) => m.pages.profile.settings.analytics.enabled.hint)}</p>
                 </div>
                 <Switch
                   nativeButton
@@ -112,9 +112,9 @@ export function SettingsAnalytics({settings, onSettingsChange}: Props): React.JS
             <CardHeader className={styles["cardHeaderPb"]}>
               <CardTitle className={styles["cardTitleBase"]}>
                 <TbClock className={styles["iconSm"]} />
-                {t((m) => m.Profile.settings.analytics.granularity.title)}
+                {t((m) => m.pages.profile.settings.analytics.granularity.title)}
               </CardTitle>
-              <CardDescription>{t((m) => m.Profile.settings.analytics.granularity.description)}</CardDescription>
+              <CardDescription>{t((m) => m.pages.profile.settings.analytics.granularity.description)}</CardDescription>
             </CardHeader>
             <CardContent>
               <Select
@@ -147,9 +147,9 @@ export function SettingsAnalytics({settings, onSettingsChange}: Props): React.JS
             <CardHeader className={styles["cardHeaderPb"]}>
               <CardTitle className={styles["cardTitleBase"]}>
                 <TbDownload className={styles["iconSm"]} />
-                {t((m) => m.Profile.settings.analytics.export.title)}
+                {t((m) => m.pages.profile.settings.analytics.export.title)}
               </CardTitle>
-              <CardDescription>{t((m) => m.Profile.settings.analytics.export.description)}</CardDescription>
+              <CardDescription>{t((m) => m.pages.profile.settings.analytics.export.description)}</CardDescription>
             </CardHeader>
             <CardContent>
               <Select
@@ -177,15 +177,15 @@ export function SettingsAnalytics({settings, onSettingsChange}: Props): React.JS
             <CardHeader className={styles["cardHeaderPb"]}>
               <CardTitle className={styles["cardTitleBase"]}>
                 <TbChartPie className={styles["iconSm"]} />
-                {t((m) => m.Profile.settings.analytics.tracking.title)}
+                {t((m) => m.pages.profile.settings.analytics.tracking.title)}
               </CardTitle>
-              <CardDescription>{t((m) => m.Profile.settings.analytics.tracking.description)}</CardDescription>
+              <CardDescription>{t((m) => m.pages.profile.settings.analytics.tracking.description)}</CardDescription>
             </CardHeader>
             <CardContent className={styles["cardContentSpaced"]}>
               <div className={styles["toggleRow"]}>
                 <div className={styles["toggleLabel"]}>
-                  <Label>{t((m) => m.Profile.settings.analytics.tracking.spending)}</Label>
-                  <p>{t((m) => m.Profile.settings.analytics.tracking.spendingHint)}</p>
+                  <Label>{t((m) => m.pages.profile.settings.analytics.tracking.spending)}</Label>
+                  <p>{t((m) => m.pages.profile.settings.analytics.tracking.spendingHint)}</p>
                 </div>
                 <Switch
                   nativeButton
@@ -197,8 +197,8 @@ export function SettingsAnalytics({settings, onSettingsChange}: Props): React.JS
               <Separator />
               <div className={styles["toggleRow"]}>
                 <div className={styles["toggleLabel"]}>
-                  <Label>{t((m) => m.Profile.settings.analytics.tracking.categories)}</Label>
-                  <p>{t((m) => m.Profile.settings.analytics.tracking.categoriesHint)}</p>
+                  <Label>{t((m) => m.pages.profile.settings.analytics.tracking.categories)}</Label>
+                  <p>{t((m) => m.pages.profile.settings.analytics.tracking.categoriesHint)}</p>
                 </div>
                 <Switch
                   nativeButton
@@ -210,8 +210,8 @@ export function SettingsAnalytics({settings, onSettingsChange}: Props): React.JS
               <Separator />
               <div className={styles["toggleRow"]}>
                 <div className={styles["toggleLabel"]}>
-                  <Label>{t((m) => m.Profile.settings.analytics.tracking.merchants)}</Label>
-                  <p>{t((m) => m.Profile.settings.analytics.tracking.merchantsHint)}</p>
+                  <Label>{t((m) => m.pages.profile.settings.analytics.tracking.merchants)}</Label>
+                  <p>{t((m) => m.pages.profile.settings.analytics.tracking.merchantsHint)}</p>
                 </div>
                 <Switch
                   nativeButton
@@ -233,15 +233,15 @@ export function SettingsAnalytics({settings, onSettingsChange}: Props): React.JS
             <CardHeader className={styles["cardHeaderPb"]}>
               <CardTitle className={styles["cardTitleBase"]}>
                 <TbTrendingUp className={styles["iconSm"]} />
-                {t((m) => m.Profile.settings.analytics.advanced.title)}
+                {t((m) => m.pages.profile.settings.analytics.advanced.title)}
               </CardTitle>
-              <CardDescription>{t((m) => m.Profile.settings.analytics.advanced.description)}</CardDescription>
+              <CardDescription>{t((m) => m.pages.profile.settings.analytics.advanced.description)}</CardDescription>
             </CardHeader>
             <CardContent className={styles["cardContentSpaced"]}>
               <div className={styles["toggleRow"]}>
                 <div className={styles["toggleLabel"]}>
-                  <Label>{t((m) => m.Profile.settings.analytics.advanced.benchmarking)}</Label>
-                  <p>{t((m) => m.Profile.settings.analytics.advanced.benchmarkingHint)}</p>
+                  <Label>{t((m) => m.pages.profile.settings.analytics.advanced.benchmarking)}</Label>
+                  <p>{t((m) => m.pages.profile.settings.analytics.advanced.benchmarkingHint)}</p>
                 </div>
                 <Switch
                   nativeButton
@@ -253,8 +253,8 @@ export function SettingsAnalytics({settings, onSettingsChange}: Props): React.JS
               <Separator />
               <div className={styles["toggleRow"]}>
                 <div className={styles["toggleLabel"]}>
-                  <Label>{t((m) => m.Profile.settings.analytics.advanced.predictive)}</Label>
-                  <p>{t((m) => m.Profile.settings.analytics.advanced.predictiveHint)}</p>
+                  <Label>{t((m) => m.pages.profile.settings.analytics.advanced.predictive)}</Label>
+                  <p>{t((m) => m.pages.profile.settings.analytics.advanced.predictiveHint)}</p>
                 </div>
                 <Switch
                   nativeButton
@@ -277,12 +277,12 @@ export function SettingsAnalytics({settings, onSettingsChange}: Props): React.JS
             <CardHeader className={styles["cardHeaderPb"]}>
               <CardTitle className={styles["cardTitleBase"]}>
                 <TbDatabase className={styles["iconSm"]} />
-                {t((m) => m.Profile.settings.analytics.dataUsage.title)}
+                {t((m) => m.pages.profile.settings.analytics.dataUsage.title)}
               </CardTitle>
             </CardHeader>
             <CardContent>
               <div className={styles["infoBox"]}>
-                <p className={styles["dataUsageInfo"]}>{t((m) => m.Profile.settings.analytics.dataUsage.info)}</p>
+                <p className={styles["dataUsageInfo"]}>{t((m) => m.pages.profile.settings.analytics.dataUsage.info)}</p>
               </div>
             </CardContent>
           </Card>

--- a/sites/arolariu.ro/src/app/my-profile/_components/SettingsAppearance.tsx
+++ b/sites/arolariu.ro/src/app/my-profile/_components/SettingsAppearance.tsx
@@ -222,8 +222,8 @@ export function SettingsAppearance({settings, onSettingsChange}: Props): React.J
       animate={isInView ? {opacity: 1} : {opacity: 0}}
       transition={{duration: 0.3}}>
       <div className={styles["header"]}>
-        <h2>{t((m) => m.Profile.settings.appearance.title)}</h2>
-        <p>{t((m) => m.Profile.settings.appearance.description)}</p>
+        <h2>{t((m) => m.pages.profile.settings.appearance.title)}</h2>
+        <p>{t((m) => m.pages.profile.settings.appearance.description)}</p>
       </div>
 
       <div className={styles["grid"]}>
@@ -236,9 +236,9 @@ export function SettingsAppearance({settings, onSettingsChange}: Props): React.J
             <CardHeader className={styles["cardHeaderPb"]}>
               <CardTitle className={styles["cardTitleBase"]}>
                 <TbBrush className={styles["iconSm"]} />
-                {t((m) => m.Profile.settings.appearance.theme.title)}
+                {t((m) => m.pages.profile.settings.appearance.theme.title)}
               </CardTitle>
-              <CardDescription>{t((m) => m.Profile.settings.appearance.theme.description)}</CardDescription>
+              <CardDescription>{t((m) => m.pages.profile.settings.appearance.theme.description)}</CardDescription>
             </CardHeader>
             <CardContent className={styles["cardContentSpaced3"]}>
               <div className={styles["themeButtons"]}>
@@ -248,7 +248,7 @@ export function SettingsAppearance({settings, onSettingsChange}: Props): React.J
                   className={styles["flex1Cursor"]}
                   onClick={handleThemeLightClick}>
                   <TbSun className={styles["buttonIconSm"]} />
-                  {t((m) => m.Profile.settings.appearance.theme.light)}
+                  {t((m) => m.pages.profile.settings.appearance.theme.light)}
                 </Button>
                 <Button
                   variant={theme === "dark" ? "default" : "outline"}
@@ -256,7 +256,7 @@ export function SettingsAppearance({settings, onSettingsChange}: Props): React.J
                   className={styles["flex1Cursor"]}
                   onClick={handleThemeDarkClick}>
                   <TbMoon className={styles["buttonIconSm"]} />
-                  {t((m) => m.Profile.settings.appearance.theme.dark)}
+                  {t((m) => m.pages.profile.settings.appearance.theme.dark)}
                 </Button>
                 <Button
                   variant={theme === "system" ? "default" : "outline"}
@@ -264,10 +264,10 @@ export function SettingsAppearance({settings, onSettingsChange}: Props): React.J
                   className={styles["flex1Cursor"]}
                   onClick={handleThemeSystemClick}>
                   <TbSettings className={styles["buttonIconSm"]} />
-                  {t((m) => m.Profile.settings.appearance.theme.system)}
+                  {t((m) => m.pages.profile.settings.appearance.theme.system)}
                 </Button>
               </div>
-              <p className={styles["cardHint"]}>{t((m) => m.Profile.settings.appearance.theme.hint)}</p>
+              <p className={styles["cardHint"]}>{t((m) => m.pages.profile.settings.appearance.theme.hint)}</p>
             </CardContent>
           </Card>
         </motion.div>
@@ -281,9 +281,9 @@ export function SettingsAppearance({settings, onSettingsChange}: Props): React.J
             <CardHeader className={styles["cardHeaderPb"]}>
               <CardTitle className={styles["cardTitleBase"]}>
                 <TbTypography className={styles["iconSm"]} />
-                {t((m) => m.Profile.settings.appearance.font.title)}
+                {t((m) => m.pages.profile.settings.appearance.font.title)}
               </CardTitle>
-              <CardDescription>{t((m) => m.Profile.settings.appearance.font.description)}</CardDescription>
+              <CardDescription>{t((m) => m.pages.profile.settings.appearance.font.description)}</CardDescription>
             </CardHeader>
             <CardContent className={styles["cardContentSpaced3"]}>
               <div className={styles["fontButtons"]}>
@@ -292,17 +292,17 @@ export function SettingsAppearance({settings, onSettingsChange}: Props): React.J
                   size='sm'
                   className={styles["flex1Cursor"]}
                   onClick={handleFontNormalClick}>
-                  {t((m) => m.Profile.settings.appearance.font.normal)}
+                  {t((m) => m.pages.profile.settings.appearance.font.normal)}
                 </Button>
                 <Button
                   variant={fontType === "dyslexic" ? "default" : "outline"}
                   size='sm'
                   className={styles["flex1Cursor"]}
                   onClick={handleFontDyslexicClick}>
-                  {t((m) => m.Profile.settings.appearance.font.dyslexic)}
+                  {t((m) => m.pages.profile.settings.appearance.font.dyslexic)}
                 </Button>
               </div>
-              <p className={styles["cardHint"]}>{t((m) => m.Profile.settings.appearance.font.dyslexicHint)}</p>
+              <p className={styles["cardHint"]}>{t((m) => m.pages.profile.settings.appearance.font.dyslexicHint)}</p>
             </CardContent>
           </Card>
         </motion.div>
@@ -317,9 +317,9 @@ export function SettingsAppearance({settings, onSettingsChange}: Props): React.J
             <CardHeader className={styles["cardHeaderPb"]}>
               <CardTitle className={styles["cardTitleBase"]}>
                 <TbPalette className={styles["iconSm"]} />
-                {t((m) => m.Profile.settings.appearance.presets.title)}
+                {t((m) => m.pages.profile.settings.appearance.presets.title)}
               </CardTitle>
-              <CardDescription>{t((m) => m.Profile.settings.appearance.presets.description)}</CardDescription>
+              <CardDescription>{t((m) => m.pages.profile.settings.appearance.presets.description)}</CardDescription>
             </CardHeader>
             <CardContent>
               <div className={styles["presetGrid"]}>
@@ -350,8 +350,8 @@ export function SettingsAppearance({settings, onSettingsChange}: Props): React.J
                   data-selected={themePreset === "custom"}
                   onClick={handleCustomPresetClick}>
                   <TbBrush className={styles["iconMd"]} />
-                  <span className={styles["presetName"]}>{t((m) => m.Profile.settings.appearance.presets.custom)}</span>
-                  <span className={styles["presetDescription"]}>{t((m) => m.Profile.settings.appearance.presets.customDescription)}</span>
+                  <span className={styles["presetName"]}>{t((m) => m.pages.profile.settings.appearance.presets.custom)}</span>
+                  <span className={styles["presetDescription"]}>{t((m) => m.pages.profile.settings.appearance.presets.customDescription)}</span>
                 </button>
               </div>
             </CardContent>
@@ -369,15 +369,15 @@ export function SettingsAppearance({settings, onSettingsChange}: Props): React.J
               <CardHeader className={styles["cardHeaderPb"]}>
                 <CardTitle className={styles["cardTitleBase"]}>
                   <TbPalette className={styles["iconSm"]} />
-                  {t((m) => m.Profile.settings.appearance.colors.title)}
+                  {t((m) => m.pages.profile.settings.appearance.colors.title)}
                 </CardTitle>
-                <CardDescription>{t((m) => m.Profile.settings.appearance.colors.description)}</CardDescription>
+                <CardDescription>{t((m) => m.pages.profile.settings.appearance.colors.description)}</CardDescription>
               </CardHeader>
               <CardContent className={styles["cardContentSpaced"]}>
                 <div className={styles["colorGrid"]}>
                   {/* Primary Color — full color picker */}
                   <div className={styles["customColorField"]}>
-                    <Label htmlFor='custom-primary-color'>{t((m) => m.Profile.settings.appearance.colors.primary)}</Label>
+                    <Label htmlFor='custom-primary-color'>{t((m) => m.pages.profile.settings.appearance.colors.primary)}</Label>
                     <label
                       className={styles["customColorSwatch"]}
                       style={{backgroundColor: settings.primaryColor}}
@@ -395,7 +395,7 @@ export function SettingsAppearance({settings, onSettingsChange}: Props): React.J
 
                   {/* Intermediary Color — full color picker */}
                   <div className={styles["customColorField"]}>
-                    <Label htmlFor='custom-tertiary-color'>{t((m) => m.Profile.settings.appearance.colors.intermediary)}</Label>
+                    <Label htmlFor='custom-tertiary-color'>{t((m) => m.pages.profile.settings.appearance.colors.intermediary)}</Label>
                     <label
                       className={styles["customColorSwatch"]}
                       style={{backgroundColor: settings.tertiaryColor || DEFAULT_INTERMEDIARY_COLOR}}
@@ -413,7 +413,7 @@ export function SettingsAppearance({settings, onSettingsChange}: Props): React.J
 
                   {/* Secondary Color — full color picker */}
                   <div className={styles["customColorField"]}>
-                    <Label htmlFor='custom-secondary-color'>{t((m) => m.Profile.settings.appearance.colors.secondary)}</Label>
+                    <Label htmlFor='custom-secondary-color'>{t((m) => m.pages.profile.settings.appearance.colors.secondary)}</Label>
                     <label
                       className={styles["customColorSwatch"]}
                       style={{backgroundColor: settings.secondaryColor}}
@@ -433,7 +433,7 @@ export function SettingsAppearance({settings, onSettingsChange}: Props): React.J
                 {/* Gradient Preview — primary → intermediary → secondary */}
                 <Separator />
                 <div className={styles["gradientPreview"]}>
-                  <Label>{t((m) => m.Profile.settings.appearance.colors.preview)}</Label>
+                  <Label>{t((m) => m.pages.profile.settings.appearance.colors.preview)}</Label>
                   <div
                     className={styles["gradientBar"]}
                     style={{
@@ -445,7 +445,7 @@ export function SettingsAppearance({settings, onSettingsChange}: Props): React.J
                     style={{
                       backgroundImage: `linear-gradient(to right, ${settings.primaryColor}, ${settings.tertiaryColor || DEFAULT_INTERMEDIARY_COLOR}, ${settings.secondaryColor})`,
                     }}>
-                    {t((m) => m.Profile.settings.appearance.colors.previewText)}
+                    {t((m) => m.pages.profile.settings.appearance.colors.previewText)}
                   </p>
                 </div>
               </CardContent>
@@ -462,9 +462,9 @@ export function SettingsAppearance({settings, onSettingsChange}: Props): React.J
             <CardHeader className={styles["cardHeaderPb"]}>
               <CardTitle className={styles["cardTitleBase"]}>
                 <TbGlobe className={styles["iconSm"]} />
-                {t((m) => m.Profile.settings.appearance.locale.title)}
+                {t((m) => m.pages.profile.settings.appearance.locale.title)}
               </CardTitle>
-              <CardDescription>{t((m) => m.Profile.settings.appearance.locale.description)}</CardDescription>
+              <CardDescription>{t((m) => m.pages.profile.settings.appearance.locale.description)}</CardDescription>
             </CardHeader>
             <CardContent>
               <div className={styles["localeList"]}>
@@ -498,15 +498,15 @@ export function SettingsAppearance({settings, onSettingsChange}: Props): React.J
             <CardHeader className={styles["cardHeaderPb"]}>
               <CardTitle className={styles["cardTitleBase"]}>
                 <TbSettings className={styles["iconSm"]} />
-                {t((m) => m.Profile.settings.appearance.advanced.title)}
+                {t((m) => m.pages.profile.settings.appearance.advanced.title)}
               </CardTitle>
-              <CardDescription>{t((m) => m.Profile.settings.appearance.advanced.description)}</CardDescription>
+              <CardDescription>{t((m) => m.pages.profile.settings.appearance.advanced.description)}</CardDescription>
             </CardHeader>
             <CardContent className={styles["cardContentSpaced"]}>
               <div className={styles["toggleRow"]}>
                 <div className={styles["toggleLabel"]}>
-                  <Label>{t((m) => m.Profile.settings.appearance.advanced.compactMode)}</Label>
-                  <p>{t((m) => m.Profile.settings.appearance.advanced.compactModeHint)}</p>
+                  <Label>{t((m) => m.pages.profile.settings.appearance.advanced.compactMode)}</Label>
+                  <p>{t((m) => m.pages.profile.settings.appearance.advanced.compactModeHint)}</p>
                 </div>
                 <Switch
                   nativeButton
@@ -517,8 +517,8 @@ export function SettingsAppearance({settings, onSettingsChange}: Props): React.J
               <Separator />
               <div className={styles["toggleRow"]}>
                 <div className={styles["toggleLabel"]}>
-                  <Label>{t((m) => m.Profile.settings.appearance.advanced.animations)}</Label>
-                  <p>{t((m) => m.Profile.settings.appearance.advanced.animationsHint)}</p>
+                  <Label>{t((m) => m.pages.profile.settings.appearance.advanced.animations)}</Label>
+                  <p>{t((m) => m.pages.profile.settings.appearance.advanced.animationsHint)}</p>
                 </div>
                 <Switch
                   nativeButton

--- a/sites/arolariu.ro/src/app/my-profile/_components/SettingsData.tsx
+++ b/sites/arolariu.ro/src/app/my-profile/_components/SettingsData.tsx
@@ -63,8 +63,8 @@ export function SettingsData({settings, onSettingsChange}: Props): React.JSX.Ele
       animate={isInView ? {opacity: 1} : {opacity: 0}}
       transition={{duration: 0.3}}>
       <div className={styles["header"]}>
-        <h2>{t((m) => m.Profile.settings.data.title)}</h2>
-        <p>{t((m) => m.Profile.settings.data.description)}</p>
+        <h2>{t((m) => m.pages.profile.settings.data.title)}</h2>
+        <p>{t((m) => m.pages.profile.settings.data.description)}</p>
       </div>
 
       <div className={styles["grid"]}>
@@ -77,9 +77,9 @@ export function SettingsData({settings, onSettingsChange}: Props): React.JSX.Ele
             <CardHeader className={styles["cardHeaderPb"]}>
               <CardTitle className={styles["cardTitleBase"]}>
                 <TbDatabase className={styles["iconSm"]} />
-                {t((m) => m.Profile.settings.data.retention.title)}
+                {t((m) => m.pages.profile.settings.data.retention.title)}
               </CardTitle>
-              <CardDescription>{t((m) => m.Profile.settings.data.retention.description)}</CardDescription>
+              <CardDescription>{t((m) => m.pages.profile.settings.data.retention.description)}</CardDescription>
             </CardHeader>
             <CardContent>
               <Select
@@ -98,7 +98,7 @@ export function SettingsData({settings, onSettingsChange}: Props): React.JSX.Ele
                   ))}
                 </SelectContent>
               </Select>
-              <p className={styles["retentionHint"]}>{t((m) => m.Profile.settings.data.retention.hint)}</p>
+              <p className={styles["retentionHint"]}>{t((m) => m.pages.profile.settings.data.retention.hint)}</p>
             </CardContent>
           </Card>
         </motion.div>
@@ -112,15 +112,15 @@ export function SettingsData({settings, onSettingsChange}: Props): React.JSX.Ele
             <CardHeader className={styles["cardHeaderPb"]}>
               <CardTitle className={styles["cardTitleBase"]}>
                 <TbCloud className={styles["iconSm"]} />
-                {t((m) => m.Profile.settings.data.backup.title)}
+                {t((m) => m.pages.profile.settings.data.backup.title)}
               </CardTitle>
-              <CardDescription>{t((m) => m.Profile.settings.data.backup.description)}</CardDescription>
+              <CardDescription>{t((m) => m.pages.profile.settings.data.backup.description)}</CardDescription>
             </CardHeader>
             <CardContent className={styles["cardContentSpaced"]}>
               <div className={styles["toggleRow"]}>
                 <div className={styles["toggleLabel"]}>
-                  <Label>{t((m) => m.Profile.settings.data.backup.autoBackup)}</Label>
-                  <p>{t((m) => m.Profile.settings.data.backup.autoBackupHint)}</p>
+                  <Label>{t((m) => m.pages.profile.settings.data.backup.autoBackup)}</Label>
+                  <p>{t((m) => m.pages.profile.settings.data.backup.autoBackupHint)}</p>
                 </div>
                 <Switch
                   nativeButton
@@ -130,7 +130,7 @@ export function SettingsData({settings, onSettingsChange}: Props): React.JSX.Ele
               </div>
               <Separator />
               <div>
-                <Label>{t((m) => m.Profile.settings.data.backup.frequency)}</Label>
+                <Label>{t((m) => m.pages.profile.settings.data.backup.frequency)}</Label>
                 <Select
                   value={settings.backupFrequency}
                   onValueChange={handleBackupFrequencyChange}
@@ -162,15 +162,15 @@ export function SettingsData({settings, onSettingsChange}: Props): React.JSX.Ele
             <CardHeader className={styles["cardHeaderPb"]}>
               <CardTitle className={styles["cardTitleBase"]}>
                 <TbShieldCheck className={styles["iconSm"]} />
-                {t((m) => m.Profile.settings.data.privacy.title)}
+                {t((m) => m.pages.profile.settings.data.privacy.title)}
               </CardTitle>
-              <CardDescription>{t((m) => m.Profile.settings.data.privacy.description)}</CardDescription>
+              <CardDescription>{t((m) => m.pages.profile.settings.data.privacy.description)}</CardDescription>
             </CardHeader>
             <CardContent>
               <div className={styles["toggleRow"]}>
                 <div className={styles["toggleLabel"]}>
-                  <Label>{t((m) => m.Profile.settings.data.privacy.shareAnonymous)}</Label>
-                  <p>{t((m) => m.Profile.settings.data.privacy.shareAnonymousHint)}</p>
+                  <Label>{t((m) => m.pages.profile.settings.data.privacy.shareAnonymous)}</Label>
+                  <p>{t((m) => m.pages.profile.settings.data.privacy.shareAnonymousHint)}</p>
                 </div>
                 <Switch
                   nativeButton
@@ -191,18 +191,18 @@ export function SettingsData({settings, onSettingsChange}: Props): React.JSX.Ele
             <CardHeader className={styles["cardHeaderPb"]}>
               <CardTitle className={styles["cardTitleBase"]}>
                 <TbDownload className={styles["iconSm"]} />
-                {t((m) => m.Profile.settings.data.export.title)}
+                {t((m) => m.pages.profile.settings.data.export.title)}
               </CardTitle>
-              <CardDescription>{t((m) => m.Profile.settings.data.export.description)}</CardDescription>
+              <CardDescription>{t((m) => m.pages.profile.settings.data.export.description)}</CardDescription>
             </CardHeader>
             <CardContent className={styles["cardContentSpaced3"]}>
               <Button
                 variant='outline'
                 className={styles["buttonFullCursor"]}>
                 <TbDownload className={styles["buttonIcon"]} />
-                {t((m) => m.Profile.settings.data.export.downloadAll)}
+                {t((m) => m.pages.profile.settings.data.export.downloadAll)}
               </Button>
-              <p className={styles["exportHint"]}>{t((m) => m.Profile.settings.data.export.hint)}</p>
+              <p className={styles["exportHint"]}>{t((m) => m.pages.profile.settings.data.export.hint)}</p>
             </CardContent>
           </Card>
         </motion.div>
@@ -217,27 +217,27 @@ export function SettingsData({settings, onSettingsChange}: Props): React.JSX.Ele
             <CardHeader className={styles["cardHeaderPb"]}>
               <CardTitle className={styles["dangerTitle"]}>
                 <TbAlertTriangle className={styles["iconSm"]} />
-                {t((m) => m.Profile.settings.data.danger.title)}
+                {t((m) => m.pages.profile.settings.data.danger.title)}
               </CardTitle>
-              <CardDescription>{t((m) => m.Profile.settings.data.danger.description)}</CardDescription>
+              <CardDescription>{t((m) => m.pages.profile.settings.data.danger.description)}</CardDescription>
             </CardHeader>
             <CardContent className={styles["cardContentSpaced"]}>
               <div className={styles["dangerRow"]}>
                 <div className={styles["dangerRowText"]}>
-                  <p>{t((m) => m.Profile.settings.data.danger.deleteData)}</p>
-                  <p>{t((m) => m.Profile.settings.data.danger.deleteDataHint)}</p>
+                  <p>{t((m) => m.pages.profile.settings.data.danger.deleteData)}</p>
+                  <p>{t((m) => m.pages.profile.settings.data.danger.deleteDataHint)}</p>
                 </div>
                 <Button
                   variant='destructive'
                   className={styles["selectCursor"]}>
                   <TbTrash className={styles["buttonIcon"]} />
-                  {t((m) => m.Profile.settings.data.danger.deleteButton)}
+                  {t((m) => m.pages.profile.settings.data.danger.deleteButton)}
                 </Button>
               </div>
               <div className={styles["dangerRow"]}>
                 <div className={styles["dangerRowText"]}>
-                  <p>{t((m) => m.Profile.settings.data.danger.deleteAccount)}</p>
-                  <p>{t((m) => m.Profile.settings.data.danger.deleteAccountHint)}</p>
+                  <p>{t((m) => m.pages.profile.settings.data.danger.deleteAccount)}</p>
+                  <p>{t((m) => m.pages.profile.settings.data.danger.deleteAccountHint)}</p>
                 </div>
                 <Button
                   variant='outline'
@@ -247,7 +247,7 @@ export function SettingsData({settings, onSettingsChange}: Props): React.JSX.Ele
                     href='https://accounts.arolariu.ro/user'
                     target='_blank'
                     rel='noopener noreferrer'>
-                    {t((m) => m.Profile.settings.data.danger.manageAccount)}
+                    {t((m) => m.pages.profile.settings.data.danger.manageAccount)}
                   </a>
                 </Button>
               </div>

--- a/sites/arolariu.ro/src/app/my-profile/_components/SettingsNotifications.tsx
+++ b/sites/arolariu.ro/src/app/my-profile/_components/SettingsNotifications.tsx
@@ -68,8 +68,8 @@ export function SettingsNotifications({settings, onSettingsChange}: Props): Reac
       animate={isInView ? {opacity: 1} : {opacity: 0}}
       transition={{duration: 0.3}}>
       <div className={styles["header"]}>
-        <h2>{t((m) => m.Profile.settings.notifications.title)}</h2>
-        <p>{t((m) => m.Profile.settings.notifications.description)}</p>
+        <h2>{t((m) => m.pages.profile.settings.notifications.title)}</h2>
+        <p>{t((m) => m.pages.profile.settings.notifications.description)}</p>
       </div>
 
       <div className={styles["grid"]}>
@@ -83,15 +83,15 @@ export function SettingsNotifications({settings, onSettingsChange}: Props): Reac
             <CardHeader className={styles["cardHeaderPb"]}>
               <CardTitle className={styles["cardTitleBase"]}>
                 <TbMail className={styles["iconSm"]} />
-                {t((m) => m.Profile.settings.notifications.email.title)}
+                {t((m) => m.pages.profile.settings.notifications.email.title)}
               </CardTitle>
-              <CardDescription>{t((m) => m.Profile.settings.notifications.email.description)}</CardDescription>
+              <CardDescription>{t((m) => m.pages.profile.settings.notifications.email.description)}</CardDescription>
             </CardHeader>
             <CardContent>
               <div className={styles["toggleRow"]}>
                 <div className={styles["toggleLabel"]}>
-                  <Label>{t((m) => m.Profile.settings.notifications.email.enabled)}</Label>
-                  <p>{t((m) => m.Profile.settings.notifications.email.enabledHint)}</p>
+                  <Label>{t((m) => m.pages.profile.settings.notifications.email.enabled)}</Label>
+                  <p>{t((m) => m.pages.profile.settings.notifications.email.enabledHint)}</p>
                 </div>
                 <Switch
                   nativeButton
@@ -112,9 +112,9 @@ export function SettingsNotifications({settings, onSettingsChange}: Props): Reac
             <CardHeader className={styles["cardHeaderPb"]}>
               <CardTitle className={styles["cardTitleBase"]}>
                 <TbReport className={styles["iconSm"]} />
-                {t((m) => m.Profile.settings.notifications.reports.title)}
+                {t((m) => m.pages.profile.settings.notifications.reports.title)}
               </CardTitle>
-              <CardDescription>{t((m) => m.Profile.settings.notifications.reports.description)}</CardDescription>
+              <CardDescription>{t((m) => m.pages.profile.settings.notifications.reports.description)}</CardDescription>
             </CardHeader>
             <CardContent className={styles["cardContentSpaced"]}>
               <Select
@@ -137,8 +137,8 @@ export function SettingsNotifications({settings, onSettingsChange}: Props): Reac
               <Separator />
               <div className={styles["toggleRow"]}>
                 <div className={styles["toggleLabel"]}>
-                  <Label>{t((m) => m.Profile.settings.notifications.reports.weeklyDigest)}</Label>
-                  <p>{t((m) => m.Profile.settings.notifications.reports.weeklyDigestHint)}</p>
+                  <Label>{t((m) => m.pages.profile.settings.notifications.reports.weeklyDigest)}</Label>
+                  <p>{t((m) => m.pages.profile.settings.notifications.reports.weeklyDigestHint)}</p>
                 </div>
                 <Switch
                   nativeButton
@@ -150,8 +150,8 @@ export function SettingsNotifications({settings, onSettingsChange}: Props): Reac
               <Separator />
               <div className={styles["toggleRow"]}>
                 <div className={styles["toggleLabel"]}>
-                  <Label>{t((m) => m.Profile.settings.notifications.reports.monthlyReport)}</Label>
-                  <p>{t((m) => m.Profile.settings.notifications.reports.monthlyReportHint)}</p>
+                  <Label>{t((m) => m.pages.profile.settings.notifications.reports.monthlyReport)}</Label>
+                  <p>{t((m) => m.pages.profile.settings.notifications.reports.monthlyReportHint)}</p>
                 </div>
                 <Switch
                   nativeButton
@@ -173,15 +173,15 @@ export function SettingsNotifications({settings, onSettingsChange}: Props): Reac
             <CardHeader className={styles["cardHeaderPb"]}>
               <CardTitle className={styles["cardTitleBase"]}>
                 <TbWallet className={styles["iconSm"]} />
-                {t((m) => m.Profile.settings.notifications.financial.title)}
+                {t((m) => m.pages.profile.settings.notifications.financial.title)}
               </CardTitle>
-              <CardDescription>{t((m) => m.Profile.settings.notifications.financial.description)}</CardDescription>
+              <CardDescription>{t((m) => m.pages.profile.settings.notifications.financial.description)}</CardDescription>
             </CardHeader>
             <CardContent className={styles["cardContentSpaced"]}>
               <div className={styles["toggleRow"]}>
                 <div className={styles["toggleLabel"]}>
-                  <Label>{t((m) => m.Profile.settings.notifications.financial.spendingAlerts)}</Label>
-                  <p>{t((m) => m.Profile.settings.notifications.financial.spendingAlertsHint)}</p>
+                  <Label>{t((m) => m.pages.profile.settings.notifications.financial.spendingAlerts)}</Label>
+                  <p>{t((m) => m.pages.profile.settings.notifications.financial.spendingAlertsHint)}</p>
                 </div>
                 <Switch
                   nativeButton
@@ -193,8 +193,8 @@ export function SettingsNotifications({settings, onSettingsChange}: Props): Reac
               <Separator />
               <div className={styles["toggleRow"]}>
                 <div className={styles["toggleLabel"]}>
-                  <Label>{t((m) => m.Profile.settings.notifications.financial.budgetAlerts)}</Label>
-                  <p>{t((m) => m.Profile.settings.notifications.financial.budgetAlertsHint)}</p>
+                  <Label>{t((m) => m.pages.profile.settings.notifications.financial.budgetAlerts)}</Label>
+                  <p>{t((m) => m.pages.profile.settings.notifications.financial.budgetAlertsHint)}</p>
                 </div>
                 <Switch
                   nativeButton
@@ -216,15 +216,15 @@ export function SettingsNotifications({settings, onSettingsChange}: Props): Reac
             <CardHeader className={styles["cardHeaderPb"]}>
               <CardTitle className={styles["cardTitleBase"]}>
                 <TbSparkles className={styles["iconSm"]} />
-                {t((m) => m.Profile.settings.notifications.updates.title)}
+                {t((m) => m.pages.profile.settings.notifications.updates.title)}
               </CardTitle>
-              <CardDescription>{t((m) => m.Profile.settings.notifications.updates.description)}</CardDescription>
+              <CardDescription>{t((m) => m.pages.profile.settings.notifications.updates.description)}</CardDescription>
             </CardHeader>
             <CardContent className={styles["cardContentSpaced"]}>
               <div className={styles["toggleRow"]}>
                 <div className={styles["toggleLabel"]}>
-                  <Label>{t((m) => m.Profile.settings.notifications.updates.newFeatures)}</Label>
-                  <p>{t((m) => m.Profile.settings.notifications.updates.newFeaturesHint)}</p>
+                  <Label>{t((m) => m.pages.profile.settings.notifications.updates.newFeatures)}</Label>
+                  <p>{t((m) => m.pages.profile.settings.notifications.updates.newFeaturesHint)}</p>
                 </div>
                 <Switch
                   nativeButton
@@ -236,8 +236,8 @@ export function SettingsNotifications({settings, onSettingsChange}: Props): Reac
               <Separator />
               <div className={styles["toggleRow"]}>
                 <div className={styles["toggleLabel"]}>
-                  <Label>{t((m) => m.Profile.settings.notifications.updates.marketing)}</Label>
-                  <p>{t((m) => m.Profile.settings.notifications.updates.marketingHint)}</p>
+                  <Label>{t((m) => m.pages.profile.settings.notifications.updates.marketing)}</Label>
+                  <p>{t((m) => m.pages.profile.settings.notifications.updates.marketingHint)}</p>
                 </div>
                 <Switch
                   nativeButton
@@ -259,15 +259,15 @@ export function SettingsNotifications({settings, onSettingsChange}: Props): Reac
             <CardHeader className={styles["cardHeaderPb"]}>
               <CardTitle className={styles["cardTitleBase"]}>
                 <TbShield className={styles["iconSm"]} />
-                {t((m) => m.Profile.settings.notifications.security.title)}
+                {t((m) => m.pages.profile.settings.notifications.security.title)}
               </CardTitle>
-              <CardDescription>{t((m) => m.Profile.settings.notifications.security.description)}</CardDescription>
+              <CardDescription>{t((m) => m.pages.profile.settings.notifications.security.description)}</CardDescription>
             </CardHeader>
             <CardContent>
               <div className={styles["toggleRow"]}>
                 <div className={styles["toggleLabel"]}>
-                  <Label>{t((m) => m.Profile.settings.notifications.security.securityAlerts)}</Label>
-                  <p>{t((m) => m.Profile.settings.notifications.security.securityAlertsHint)}</p>
+                  <Label>{t((m) => m.pages.profile.settings.notifications.security.securityAlerts)}</Label>
+                  <p>{t((m) => m.pages.profile.settings.notifications.security.securityAlertsHint)}</p>
                 </div>
                 <Switch
                   nativeButton
@@ -278,7 +278,7 @@ export function SettingsNotifications({settings, onSettingsChange}: Props): Reac
               <div className={styles["alwaysOnNote"]}>
                 <p>
                   <TbBell />
-                  {t((m) => m.Profile.settings.notifications.security.alwaysOnNote)}
+                  {t((m) => m.pages.profile.settings.notifications.security.alwaysOnNote)}
                 </p>
               </div>
             </CardContent>

--- a/sites/arolariu.ro/src/app/my-profile/_components/SettingsSecurity.tsx
+++ b/sites/arolariu.ro/src/app/my-profile/_components/SettingsSecurity.tsx
@@ -65,8 +65,8 @@ export function SettingsSecurity({settings, onSettingsChange}: Props): React.JSX
       animate={isInView ? {opacity: 1} : {opacity: 0}}
       transition={{duration: 0.3}}>
       <div className={styles["header"]}>
-        <h2>{t((m) => m.Profile.settings.security.title)}</h2>
-        <p>{t((m) => m.Profile.settings.security.description)}</p>
+        <h2>{t((m) => m.pages.profile.settings.security.title)}</h2>
+        <p>{t((m) => m.pages.profile.settings.security.description)}</p>
       </div>
 
       <div className={styles["grid"]}>
@@ -80,15 +80,15 @@ export function SettingsSecurity({settings, onSettingsChange}: Props): React.JSX
             <CardHeader className={styles["cardHeaderPb"]}>
               <CardTitle className={styles["cardTitleBase"]}>
                 <TbKey className={styles["iconSm"]} />
-                {t((m) => m.Profile.settings.security.twoFactor.title)}
+                {t((m) => m.pages.profile.settings.security.twoFactor.title)}
               </CardTitle>
-              <CardDescription>{t((m) => m.Profile.settings.security.twoFactor.description)}</CardDescription>
+              <CardDescription>{t((m) => m.pages.profile.settings.security.twoFactor.description)}</CardDescription>
             </CardHeader>
             <CardContent>
               <div className={styles["toggleRow"]}>
                 <div className={styles["toggleLabel"]}>
-                  <Label>{t((m) => m.Profile.settings.security.twoFactor.enabled)}</Label>
-                  <p>{t((m) => m.Profile.settings.security.twoFactor.enabledHint)}</p>
+                  <Label>{t((m) => m.pages.profile.settings.security.twoFactor.enabled)}</Label>
+                  <p>{t((m) => m.pages.profile.settings.security.twoFactor.enabledHint)}</p>
                 </div>
                 <Switch
                   nativeButton
@@ -100,7 +100,7 @@ export function SettingsSecurity({settings, onSettingsChange}: Props): React.JSX
                 <div className={styles["twoFactorActive"]}>
                   <p>
                     <TbShieldCheck />
-                    {t((m) => m.Profile.settings.security.twoFactor.activeMessage)}
+                    {t((m) => m.pages.profile.settings.security.twoFactor.activeMessage)}
                   </p>
                 </div>
               ) : null}
@@ -117,13 +117,13 @@ export function SettingsSecurity({settings, onSettingsChange}: Props): React.JSX
             <CardHeader className={styles["cardHeaderPb"]}>
               <CardTitle className={styles["cardTitleBase"]}>
                 <TbClock className={styles["iconSm"]} />
-                {t((m) => m.Profile.settings.security.session.title)}
+                {t((m) => m.pages.profile.settings.security.session.title)}
               </CardTitle>
-              <CardDescription>{t((m) => m.Profile.settings.security.session.description)}</CardDescription>
+              <CardDescription>{t((m) => m.pages.profile.settings.security.session.description)}</CardDescription>
             </CardHeader>
             <CardContent className={styles["cardContentSpaced"]}>
               <div>
-                <Label>{t((m) => m.Profile.settings.security.session.timeout)}</Label>
+                <Label>{t((m) => m.pages.profile.settings.security.session.timeout)}</Label>
                 <Select
                   value={settings.sessionTimeout.toString()}
                   onValueChange={handleSessionTimeoutChange}>
@@ -131,19 +131,19 @@ export function SettingsSecurity({settings, onSettingsChange}: Props): React.JSX
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value='15'>15 {t((m) => m.Profile.settings.security.session.minutes)}</SelectItem>
-                    <SelectItem value='30'>30 {t((m) => m.Profile.settings.security.session.minutes)}</SelectItem>
-                    <SelectItem value='60'>1 {t((m) => m.Profile.settings.security.session.hour)}</SelectItem>
-                    <SelectItem value='120'>2 {t((m) => m.Profile.settings.security.session.hours)}</SelectItem>
-                    <SelectItem value='480'>8 {t((m) => m.Profile.settings.security.session.hours)}</SelectItem>
+                    <SelectItem value='15'>15 {t((m) => m.pages.profile.settings.security.session.minutes)}</SelectItem>
+                    <SelectItem value='30'>30 {t((m) => m.pages.profile.settings.security.session.minutes)}</SelectItem>
+                    <SelectItem value='60'>1 {t((m) => m.pages.profile.settings.security.session.hour)}</SelectItem>
+                    <SelectItem value='120'>2 {t((m) => m.pages.profile.settings.security.session.hours)}</SelectItem>
+                    <SelectItem value='480'>8 {t((m) => m.pages.profile.settings.security.session.hours)}</SelectItem>
                   </SelectContent>
                 </Select>
               </div>
               <Separator />
               <div className={styles["toggleRow"]}>
                 <div className={styles["toggleLabel"]}>
-                  <Label>{t((m) => m.Profile.settings.security.session.loginNotifications)}</Label>
-                  <p>{t((m) => m.Profile.settings.security.session.loginNotificationsHint)}</p>
+                  <Label>{t((m) => m.pages.profile.settings.security.session.loginNotifications)}</Label>
+                  <p>{t((m) => m.pages.profile.settings.security.session.loginNotificationsHint)}</p>
                 </div>
                 <Switch
                   nativeButton
@@ -164,9 +164,9 @@ export function SettingsSecurity({settings, onSettingsChange}: Props): React.JSX
             <CardHeader className={styles["cardHeaderPb"]}>
               <CardTitle className={styles["cardTitleBase"]}>
                 <TbLock className={styles["iconSm"]} />
-                {t((m) => m.Profile.settings.security.password.title)}
+                {t((m) => m.pages.profile.settings.security.password.title)}
               </CardTitle>
-              <CardDescription>{t((m) => m.Profile.settings.security.password.description)}</CardDescription>
+              <CardDescription>{t((m) => m.pages.profile.settings.security.password.description)}</CardDescription>
             </CardHeader>
             <CardContent className={styles["cardContentSpaced"]}>
               <Button
@@ -177,10 +177,10 @@ export function SettingsSecurity({settings, onSettingsChange}: Props): React.JSX
                   href='https://accounts.arolariu.ro/user/security'
                   target='_blank'
                   rel='noopener noreferrer'>
-                  {t((m) => m.Profile.settings.security.password.changePassword)}
+                  {t((m) => m.pages.profile.settings.security.password.changePassword)}
                 </a>
               </Button>
-              <p className={styles["clerkNote"]}>{t((m) => m.Profile.settings.security.password.clerkNote)}</p>
+              <p className={styles["clerkNote"]}>{t((m) => m.pages.profile.settings.security.password.clerkNote)}</p>
             </CardContent>
           </Card>
         </motion.div>
@@ -195,9 +195,9 @@ export function SettingsSecurity({settings, onSettingsChange}: Props): React.JSX
             <CardHeader className={styles["cardHeaderPb"]}>
               <CardTitle className={styles["cardTitleBase"]}>
                 <TbDevices className={styles["iconSm"]} />
-                {t((m) => m.Profile.settings.security.devices.title)}
+                {t((m) => m.pages.profile.settings.security.devices.title)}
               </CardTitle>
-              <CardDescription>{t((m) => m.Profile.settings.security.devices.description)}</CardDescription>
+              <CardDescription>{t((m) => m.pages.profile.settings.security.devices.description)}</CardDescription>
             </CardHeader>
             <CardContent>
               {settings.trustedDevices.length > 0 ? (
@@ -209,12 +209,12 @@ export function SettingsSecurity({settings, onSettingsChange}: Props): React.JSX
                       <div className={styles["deviceInfo"]}>
                         <p>{device.name}</p>
                         <p>
-                          {t((m) => m.Profile.settings.security.devices.lastUsed)}: {new Date(device.lastUsed).toLocaleDateString()}
+                          {t((m) => m.pages.profile.settings.security.devices.lastUsed)}: {new Date(device.lastUsed).toLocaleDateString()}
                         </p>
                       </div>
                       <div className={styles["deviceActions"]}>
                         {device.isCurrent ? (
-                          <Badge variant='secondary'>{t((m) => m.Profile.settings.security.devices.current)}</Badge>
+                          <Badge variant='secondary'>{t((m) => m.pages.profile.settings.security.devices.current)}</Badge>
                         ) : (
                           <Button
                             variant='ghost'
@@ -234,7 +234,7 @@ export function SettingsSecurity({settings, onSettingsChange}: Props): React.JSX
                 </div>
               ) : (
                 <div className={styles["devicesEmpty"]}>
-                  <p>{t((m) => m.Profile.settings.security.devices.empty)}</p>
+                  <p>{t((m) => m.pages.profile.settings.security.devices.empty)}</p>
                 </div>
               )}
             </CardContent>

--- a/sites/arolariu.ro/src/app/my-profile/error.tsx
+++ b/sites/arolariu.ro/src/app/my-profile/error.tsx
@@ -20,17 +20,17 @@ export default function ProfileError({error, reset}: ProfileErrorProps): React.J
       role='alert'
       aria-live='assertive'
       data-scope='my-profile'>
-      <h1>{t((m) => m.Errors.globalError.hero.title)}</h1>
-      <p>{t((m) => m.Errors.globalError.hero.subtitle)}</p>
+      <h1>{t((m) => m.app.errors.globalError.hero.title)}</h1>
+      <p>{t((m) => m.app.errors.globalError.hero.subtitle)}</p>
       {error.digest ? (
         <p>
-          <span>{t((m) => m.Errors.globalError.details.errorIdLabel)}</span> <code>{error.digest}</code>
+          <span>{t((m) => m.app.errors.globalError.details.errorIdLabel)}</span> <code>{error.digest}</code>
         </p>
       ) : null}
       <button
         type='button'
         onClick={reset}>
-        {t((m) => m.Errors.globalError.buttons.tryAgain)}
+        {t((m) => m.app.errors.globalError.buttons.tryAgain)}
       </button>
     </section>
   );

--- a/sites/arolariu.ro/src/app/my-profile/island.tsx
+++ b/sites/arolariu.ro/src/app/my-profile/island.tsx
@@ -212,7 +212,7 @@ export default function RenderMyProfileScreen({user}: Props): React.JSX.Element 
         {/* Desktop Sidebar */}
         <nav
           className={styles["sidebar"]}
-          aria-label={tStats((m) => m.Profile.island.settingsNavigationAriaLabel)}>
+          aria-label={tStats((m) => m.pages.profile.island.settingsNavigationAriaLabel)}>
           {TAB_CONFIG.map(({id, icon: Icon, key}) => (
             <button
               key={id}

--- a/sites/arolariu.ro/src/app/my-profile/page.tsx
+++ b/sites/arolariu.ro/src/app/my-profile/page.tsx
@@ -38,8 +38,8 @@ export async function generateMetadata(): Promise<Metadata> {
   const locale = await getLocale();
   return createMetadata({
     locale,
-    title: t((m) => m.Profile.metadata.title),
-    description: t((m) => m.Profile.metadata.description),
+    title: t((m) => m.pages.profile.metadata.title),
+    description: t((m) => m.pages.profile.metadata.description),
   });
 }
 

--- a/sites/arolariu.ro/src/app/not-found.test.tsx
+++ b/sites/arolariu.ro/src/app/not-found.test.tsx
@@ -5,13 +5,13 @@ import NotFound from "./not-found";
 describe("app/not-found.tsx", () => {
   it("renders the 404 title and subtitle keys", () => {
     render(<NotFound />);
-    expect(screen.getByText("Errors.notFound.title")).toBeInTheDocument();
-    expect(screen.getByText("Errors.notFound.subtitle")).toBeInTheDocument();
+    expect(screen.getByText("app.errors.notFound.title")).toBeInTheDocument();
+    expect(screen.getByText("app.errors.notFound.subtitle")).toBeInTheDocument();
   });
 
   it("renders a link back to the home page", () => {
     render(<NotFound />);
-    const link = screen.getByRole("link", {name: "Errors.notFound.buttons.returnButton"});
+    const link = screen.getByRole("link", {name: "app.errors.notFound.buttons.returnButton"});
     expect(link).toBeInTheDocument();
     expect(link).toHaveAttribute("href", "/");
   });

--- a/sites/arolariu.ro/src/app/not-found.tsx
+++ b/sites/arolariu.ro/src/app/not-found.tsx
@@ -7,9 +7,9 @@ export default function NotFound(): React.JSX.Element {
   const t = useTranslations();
   return (
     <section>
-      <h1>{t((m) => m.Errors.notFound.title)}</h1>
-      <p>{t((m) => m.Errors.notFound.subtitle)}</p>
-      <Link href='/'>{t((m) => m.Errors.notFound.buttons.returnButton)}</Link>
+      <h1>{t((m) => m.app.errors.notFound.title)}</h1>
+      <p>{t((m) => m.app.errors.notFound.subtitle)}</p>
+      <Link href='/'>{t((m) => m.app.errors.notFound.buttons.returnButton)}</Link>
     </section>
   );
 }

--- a/sites/arolariu.ro/src/components/Buttons/ThemeButton.tsx
+++ b/sites/arolariu.ro/src/components/Buttons/ThemeButton.tsx
@@ -110,7 +110,7 @@ export default function ThemeButton(): React.JSX.Element {
     <motion.button
       className={styles["themeButton"]}
       onClick={handleSetTheme}
-      aria-label={t((m) => m.Common.accessibility.toggleTheme)}
+      aria-label={t((m) => m.shared.accessibility.toggleTheme)}
       whileTap={{scale: 0.95}}>
       {theme === "dark" ? <SunIcon /> : <MoonIcon />}
     </motion.button>

--- a/sites/arolariu.ro/src/components/Commander.tsx
+++ b/sites/arolariu.ro/src/components/Commander.tsx
@@ -293,108 +293,108 @@ function Commander(): React.JSX.Element {
     <CommandDialog
       open={open}
       onOpenChange={setOpen}>
-      <CommandInput placeholder={t((m) => m.Commander.placeholder)} />
+      <CommandInput placeholder={t((m) => m.app.commander.placeholder)} />
       <CommandList>
-        <CommandEmpty>{t((m) => m.Commander.noResults)}</CommandEmpty>
+        <CommandEmpty>{t((m) => m.app.commander.noResults)}</CommandEmpty>
 
-        <CommandGroup heading={t((m) => m.Commander.groups.navigation)}>
+        <CommandGroup heading={t((m) => m.app.commander.groups.navigation)}>
           <CommandItem onSelect={onSelectHome}>
             <div className={styles["commandItemContent"]}>
               <TbHome className={styles["commandIcon"]} />
-              <span>{t((m) => m.Commander.items.homepage)}</span>
+              <span>{t((m) => m.app.commander.items.homepage)}</span>
             </div>
             <CommandShortcut>H</CommandShortcut>
           </CommandItem>
         </CommandGroup>
 
-        <CommandGroup heading={t((m) => m.Commander.groups.theme)}>
+        <CommandGroup heading={t((m) => m.app.commander.groups.theme)}>
           <CommandItem onSelect={onSelectThemeLight}>
             <div className={styles["commandItemContent"]}>
               <TbSun className={styles["commandIcon"]} />
-              <span>{t((m) => m.Commander.items.light)}</span>
+              <span>{t((m) => m.app.commander.items.light)}</span>
             </div>
             <CommandShortcut>L</CommandShortcut>
           </CommandItem>
           <CommandItem onSelect={onSelectThemeDark}>
             <div className={styles["commandItemContent"]}>
               <TbMoon className={styles["commandIcon"]} />
-              <span>{t((m) => m.Commander.items.dark)}</span>
+              <span>{t((m) => m.app.commander.items.dark)}</span>
             </div>
             <CommandShortcut>D</CommandShortcut>
           </CommandItem>
           <CommandItem onSelect={onSelectThemeSystem}>
             <div className={styles["commandItemContent"]}>
               <TbSettings className={styles["commandIcon"]} />
-              <span>{t((m) => m.Commander.items.system)}</span>
+              <span>{t((m) => m.app.commander.items.system)}</span>
             </div>
           </CommandItem>
         </CommandGroup>
 
-        <CommandGroup heading={t((m) => m.Commander.groups.language)}>
+        <CommandGroup heading={t((m) => m.app.commander.groups.language)}>
           <CommandItem onSelect={onSelectLangEnglish}>
             <div className={styles["commandItemContent"]}>
               <TbLanguage className={styles["commandIcon"]} />
-              <span>{t((m) => m.Commander.items.english)}</span>
+              <span>{t((m) => m.app.commander.items.english)}</span>
             </div>
             <CommandShortcut>EN</CommandShortcut>
           </CommandItem>
           <CommandItem onSelect={onSelectLangRomanian}>
             <div className={styles["commandItemContent"]}>
               <TbLanguage className={styles["commandIcon"]} />
-              <span>{t((m) => m.Commander.items.romanian)}</span>
+              <span>{t((m) => m.app.commander.items.romanian)}</span>
             </div>
             <CommandShortcut>RO</CommandShortcut>
           </CommandItem>
           <CommandItem onSelect={onSelectLangFrench}>
             <div className={styles["commandItemContent"]}>
               <TbLanguage className={styles["commandIcon"]} />
-              <span>{t((m) => m.Commander.items.french)}</span>
+              <span>{t((m) => m.app.commander.items.french)}</span>
             </div>
             <CommandShortcut>FR</CommandShortcut>
           </CommandItem>
         </CommandGroup>
 
-        <CommandGroup heading={t((m) => m.Commander.groups.accessibility)}>
+        <CommandGroup heading={t((m) => m.app.commander.groups.accessibility)}>
           <CommandItem onSelect={onSelectFontNormal}>
             <div className={styles["commandItemContent"]}>
               <TbTypeface className={styles["commandIcon"]} />
-              <span>{t((m) => m.Commander.items.fontNormal)}</span>
+              <span>{t((m) => m.app.commander.items.fontNormal)}</span>
             </div>
           </CommandItem>
           <CommandItem onSelect={onSelectFontDyslexic}>
             <div className={styles["commandItemContent"]}>
               <TbAccessible className={styles["commandIcon"]} />
-              <span>{t((m) => m.Commander.items.fontDyslexic)}</span>
+              <span>{t((m) => m.app.commander.items.fontDyslexic)}</span>
             </div>
           </CommandItem>
         </CommandGroup>
 
-        <CommandGroup heading={t((m) => m.Commander.groups.fun)}>
+        <CommandGroup heading={t((m) => m.app.commander.groups.fun)}>
           <CommandItem onSelect={onSelectRainbow}>
             <div className={styles["commandItemContent"]}>
               <TbPalette className={styles["commandIcon"]} />
-              <span>{t((m) => m.Commander.items.rainbow)}</span>
+              <span>{t((m) => m.app.commander.items.rainbow)}</span>
             </div>
           </CommandItem>
           <CommandItem onSelect={onSelectDisco}>
             <div className={styles["commandItemContent"]}>
               <TbConfetti className={styles["commandIcon"]} />
-              <span>{t((m) => m.Commander.items.disco)}</span>
+              <span>{t((m) => m.app.commander.items.disco)}</span>
             </div>
           </CommandItem>
           <CommandItem onSelect={onSelectMatrix}>
             <div className={styles["commandItemContent"]}>
               <TbCode className={styles["commandIcon"]} />
-              <span>{t((m) => m.Commander.items.matrix)}</span>
+              <span>{t((m) => m.app.commander.items.matrix)}</span>
             </div>
           </CommandItem>
         </CommandGroup>
 
-        <CommandGroup heading={t((m) => m.Commander.groups.links)}>
+        <CommandGroup heading={t((m) => m.app.commander.groups.links)}>
           <CommandItem onSelect={onSelectGithub}>
             <div className={styles["commandItemContent"]}>
               <TbBrandGithub className={styles["commandIcon"]} />
-              <span>{t((m) => m.Commander.items.github)}</span>
+              <span>{t((m) => m.app.commander.items.github)}</span>
             </div>
             <CommandShortcut>G</CommandShortcut>
           </CommandItem>

--- a/sites/arolariu.ro/src/components/Footer.tsx
+++ b/sites/arolariu.ro/src/components/Footer.tsx
@@ -117,12 +117,12 @@ function Footer(): React.JSX.Element {
           <div className='footer__brand-section'>
             <Link
               href='/'
-              aria-label={t((m) => m.Footer.accessibility.goHome)}
-              title={t((m) => m.Footer.accessibility.brandTitle)}
+              aria-label={t((m) => m.app.footer.accessibility.goHome)}
+              title={t((m) => m.app.footer.accessibility.brandTitle)}
               className='footer__brand-link'>
               <Image
                 src={logo}
-                alt={t((m) => m.Footer.accessibility.logoAlt)}
+                alt={t((m) => m.app.footer.accessibility.logoAlt)}
                 className='footer__logo'
                 width={40}
                 height={40}
@@ -139,7 +139,7 @@ function Footer(): React.JSX.Element {
           </div>
           <div className='footer__nav-section'>
             <div>
-              <p className='footer__nav-title'>{t((m) => m.Footer.navigation.subdomains)}</p>
+              <p className='footer__nav-title'>{t((m) => m.app.footer.navigation.subdomains)}</p>
               <ul className='footer__nav-list'>
                 <li>
                   <Link
@@ -182,34 +182,34 @@ function Footer(): React.JSX.Element {
               </ul>
             </div>
             <div>
-              <p className='footer__nav-title'>{t((m) => m.Footer.navigation.about)}</p>
+              <p className='footer__nav-title'>{t((m) => m.app.footer.navigation.about)}</p>
               <ul className='footer__nav-list'>
                 <li>
                   <Link
                     href='/about'
                     className='footer__nav-link'>
-                    {t((m) => m.Footer.navigation.what)}
+                    {t((m) => m.app.footer.navigation.what)}
                   </Link>
                 </li>
                 <li>
                   <Link
                     href='/acknowledgements'
                     className='footer__nav-link'>
-                    {t((m) => m.Footer.navigation.acknowledgements)}
+                    {t((m) => m.app.footer.navigation.acknowledgements)}
                   </Link>
                 </li>
                 <li>
                   <Link
                     href='/terms-of-service'
                     className='footer__nav-link'>
-                    {t((m) => m.Footer.navigation.termsOfService)}
+                    {t((m) => m.app.footer.navigation.termsOfService)}
                   </Link>
                 </li>
                 <li>
                   <Link
                     href='/privacy-policy'
                     className='footer__nav-link'>
-                    {t((m) => m.Footer.navigation.privacyPolicy)}
+                    {t((m) => m.app.footer.navigation.privacyPolicy)}
                   </Link>
                 </li>
               </ul>
@@ -220,15 +220,15 @@ function Footer(): React.JSX.Element {
         {/* Footer metadata information */}
         <div className='footer__meta'>
           <p className='footer__copyright'>
-            &copy; {t((m) => m.Footer.copyright)} 2022-{new Date().getFullYear()} Alexandru-Razvan Olariu. <br />
+            &copy; {t((m) => m.app.footer.copyright)} 2022-{new Date().getFullYear()} Alexandru-Razvan Olariu. <br />
             <span className='footer__source-prefix'>
-              {t((m) => m.Footer.sourceCode)}
+              {t((m) => m.app.footer.sourceCode)}
               <Link
                 href='https://github.com/arolariu/arolariu.ro/'
                 target='_blank'
                 rel='noopener noreferrer'
                 className='footer__source-link'>
-                {t((m) => m.Footer.sourceCodeAnchor)}
+                {t((m) => m.app.footer.sourceCodeAnchor)}
               </Link>
             </span>
           </p>
@@ -238,7 +238,7 @@ function Footer(): React.JSX.Element {
               target='_blank'
               rel='noopener noreferrer'
               about='GitHub'
-              aria-label={t((m) => m.Footer.socialLinks.github)}>
+              aria-label={t((m) => m.app.footer.socialLinks.github)}>
               <TbBrandGithub className='footer__social-icon' />
             </Link>
             <Link
@@ -246,7 +246,7 @@ function Footer(): React.JSX.Element {
               target='_blank'
               rel='noopener noreferrer'
               about='LinkedIn'
-              aria-label={t((m) => m.Footer.socialLinks.linkedin)}>
+              aria-label={t((m) => m.app.footer.socialLinks.linkedin)}>
               <TbBrandLinkedin className='footer__social-icon' />
             </Link>
           </div>
@@ -254,7 +254,7 @@ function Footer(): React.JSX.Element {
         <div className='footer__build-info'>
           <TooltipProvider>
             <Tooltip>
-              <TooltipTrigger render={<span className='footer__build-tooltip'>{`${t((m) => m.Footer.builtOn)} ${TIMESTAMP.split("T")[0]}`}</span>} />
+              <TooltipTrigger render={<span className='footer__build-tooltip'>{`${t((m) => m.app.footer.builtOn)} ${TIMESTAMP.split("T")[0]}`}</span>} />
               <TooltipContent>
                 <code className='footer__build-tooltip'>{new Date(TIMESTAMP).toUTCString()}</code>
               </TooltipContent>
@@ -262,7 +262,7 @@ function Footer(): React.JSX.Element {
           </TooltipProvider>
           <br />
           <span>
-            {t((m) => m.Footer.commitSha)}{" "}
+            {t((m) => m.app.footer.commitSha)}{" "}
             <Link
               href={`https://github.com/arolariu/arolariu.ro/commit/${COMMIT_SHA}`}
               target='_blank'

--- a/sites/arolariu.ro/src/components/Header.tsx
+++ b/sites/arolariu.ro/src/components/Header.tsx
@@ -77,7 +77,7 @@ import {DesktopNavigation, MobileNavigation} from "./Navigation";
  * - Translation bundle loaded via NextIntlClientProvider in parent layout
  *
  * **Accessibility:**
- * - Logo has proper alt text from i18n translations (`Common.accessibility.logoAlt`)
+ * - Logo has proper alt text from i18n translations (`shared.accessibility.logoAlt`)
  * - Brand link is keyboard navigable with semantic HTML
  * - Navigation sections properly structured with semantic `<header>` and `<nav>` tags
  * - Responsive design maintains usability across all device sizes
@@ -124,7 +124,7 @@ function Header(): React.JSX.Element {
             className='header__brand'>
             <Image
               src={logo}
-              alt={t((m) => m.Common.accessibility.logoAlt)}
+              alt={t((m) => m.shared.accessibility.logoAlt)}
               className='header__logo'
               width={40}
               height={40}

--- a/sites/arolariu.ro/src/components/Navigation.test.tsx
+++ b/sites/arolariu.ro/src/components/Navigation.test.tsx
@@ -69,18 +69,18 @@ vi.mock("next-intl", () => ({
 vi.mock("next-intl-selector", async (importOriginal) => {
   const actual = await importOriginal<typeof import("next-intl-selector")>();
   const translations: Record<string, string> = {
-    "Navigation.domains": "Domains",
-    "Navigation.invoices": "Invoices",
-    "Navigation.uploadScans": "Upload Scans",
-    "Navigation.viewScans": "View Scans",
-    "Navigation.myInvoices": "My Invoices",
-    "Navigation.about": "About",
-    "Navigation.thePlatform": "The Platform",
-    "Navigation.theAuthor": "The Author",
-    "Navigation.myProfile": "My Profile",
-    "Navigation.mobile.openNavigation": "Open navigation",
-    "Navigation.mobile.closeNavigation": "Close navigation",
-    "Navigation.mobile.title": "Navigation",
+    "app.navigation.domains": "Domains",
+    "app.navigation.invoices": "Invoices",
+    "app.navigation.uploadScans": "Upload Scans",
+    "app.navigation.viewScans": "View Scans",
+    "app.navigation.myInvoices": "My Invoices",
+    "app.navigation.about": "About",
+    "app.navigation.thePlatform": "The Platform",
+    "app.navigation.theAuthor": "The Author",
+    "app.navigation.myProfile": "My Profile",
+    "app.navigation.mobile.openNavigation": "Open navigation",
+    "app.navigation.mobile.closeNavigation": "Close navigation",
+    "app.navigation.mobile.title": "Navigation",
   };
 
   return {

--- a/sites/arolariu.ro/src/components/Navigation.tsx
+++ b/sites/arolariu.ro/src/components/Navigation.tsx
@@ -21,23 +21,23 @@ function useNavigationItems(): ReadonlyArray<NavigationItem> {
   return useMemo(() => {
     const items: NavigationItem[] = [
       {
-        label: t((m) => m.Navigation.domains),
+        label: t((m) => m.app.navigation.domains),
         href: "/domains",
         children: [
           {
-            label: t((m) => m.Navigation.invoices),
+            label: t((m) => m.app.navigation.invoices),
             href: "/domains/invoices",
             children: [
               {
-                label: t((m) => m.Navigation.uploadScans),
+                label: t((m) => m.app.navigation.uploadScans),
                 href: "/domains/invoices/upload-scans",
               },
               {
-                label: t((m) => m.Navigation.viewScans),
+                label: t((m) => m.app.navigation.viewScans),
                 href: "/domains/invoices/view-scans",
               },
               {
-                label: t((m) => m.Navigation.myInvoices),
+                label: t((m) => m.app.navigation.myInvoices),
                 href: "/domains/invoices/view-invoices",
               },
             ],
@@ -45,15 +45,15 @@ function useNavigationItems(): ReadonlyArray<NavigationItem> {
         ],
       },
       {
-        label: t((m) => m.Navigation.about),
+        label: t((m) => m.app.navigation.about),
         href: "/about",
         children: [
           {
-            label: t((m) => m.Navigation.thePlatform),
+            label: t((m) => m.app.navigation.thePlatform),
             href: "/about/the-platform",
           },
           {
-            label: t((m) => m.Navigation.theAuthor),
+            label: t((m) => m.app.navigation.theAuthor),
             href: "/about/the-author",
           },
         ],
@@ -63,7 +63,7 @@ function useNavigationItems(): ReadonlyArray<NavigationItem> {
     // Add My Profile when signed in
     if (isSignedIn) {
       items.push({
-        label: t((m) => m.Navigation.myProfile),
+        label: t((m) => m.app.navigation.myProfile),
         href: "/my-profile",
       });
     }
@@ -245,7 +245,7 @@ function MobileNavigationComponent(): React.JSX.Element {
         aria-expanded={mobileOpen}
         aria-controls='mobile-navigation'
         className='mobile-nav__toggle'>
-        <span className={styles["srOnly"]}>{t((m) => m.Navigation.mobile.openNavigation)}</span>
+        <span className={styles["srOnly"]}>{t((m) => m.app.navigation.mobile.openNavigation)}</span>
         <TbMenu className='mobile-nav__toggle-icon' />
       </Button>
 
@@ -254,21 +254,21 @@ function MobileNavigationComponent(): React.JSX.Element {
           <button
             type='button'
             className='mobile-nav__backdrop'
-            aria-label={t((m) => m.Navigation.mobile.closeNavigation)}
+            aria-label={t((m) => m.app.navigation.mobile.closeNavigation)}
             onClick={toggleMobile}
           />
           <aside
             id='mobile-navigation'
             role='dialog'
             aria-modal='true'
-            aria-label={t((m) => m.Navigation.mobile.title)}
+            aria-label={t((m) => m.app.navigation.mobile.title)}
             className='mobile-nav__panel'>
             <div className='mobile-nav__header'>
-              <h3 className='mobile-nav__title'>{t((m) => m.Navigation.mobile.title)}</h3>
+              <h3 className='mobile-nav__title'>{t((m) => m.app.navigation.mobile.title)}</h3>
               <Button
                 variant='ghost'
                 onClick={toggleMobile}
-                aria-label={t((m) => m.Navigation.mobile.closeNavigation)}
+                aria-label={t((m) => m.app.navigation.mobile.closeNavigation)}
                 className='mobile-nav__close'>
                 ✕
               </Button>

--- a/sites/arolariu.ro/src/lib/actions/email/sendEmail.test.ts
+++ b/sites/arolariu.ro/src/lib/actions/email/sendEmail.test.ts
@@ -18,11 +18,11 @@ const {mockWelcomeTemplate, mockWelcomeSubject, mockInactivityTemplate, mockInac
 
 vi.mock("@/../emails/_registry", () => {
   const welcome = Object.assign(mockWelcomeTemplate, {
-    namespace: "email.welcome",
+    namespace: "emails.welcome",
     getSubject: mockWelcomeSubject,
   });
   const inactivity = Object.assign(mockInactivityTemplate, {
-    namespace: "email.invoiceInactivity",
+    namespace: "emails.invoiceInactivity",
     getSubject: mockInactivitySubject,
   });
   return {

--- a/sites/arolariu.ro/src/lib/email/emailService.test.ts
+++ b/sites/arolariu.ro/src/lib/email/emailService.test.ts
@@ -118,7 +118,7 @@ describe("emailService.sendEmail", () => {
       locale: "en",
     });
 
-    expect(mockWithSpan).toHaveBeenCalledWith("api.email.send", expect.any(Function));
+    expect(mockWithSpan).toHaveBeenCalledWith("api.emails.send", expect.any(Function));
   });
 
   it("throws when Resend returns an error", async () => {

--- a/sites/arolariu.ro/src/lib/email/emailService.ts
+++ b/sites/arolariu.ro/src/lib/email/emailService.ts
@@ -51,7 +51,7 @@ type SendEmailOptions = {
  *
  * @remarks
  * Wraps the underlying `resend.emails.send` call in:
- * - An OpenTelemetry span (`api.email.send`).
+ * - An OpenTelemetry span (`api.emails.send`).
  * - Structured logs at info (success) and error (failure) levels.
  * - Three tags on every send: `template`, `locale`, `env`.
  *
@@ -71,7 +71,7 @@ type SendEmailOptions = {
  * ```
  */
 async function sendEmail(options: SendEmailOptions): Promise<void> {
-  return withSpan("api.email.send", async () => {
+  return withSpan("api.emails.send", async () => {
     const resend = await getResendClient();
 
     // Pre-render to HTML via `react-email`'s exported `render` instead of

--- a/sites/arolariu.ro/src/presentation/ForbiddenScreen.tsx
+++ b/sites/arolariu.ro/src/presentation/ForbiddenScreen.tsx
@@ -51,15 +51,15 @@ export default function RenderForbiddenScreen(): React.JSX.Element {
         height={500}
       />
       <article className={styles["content"]}>
-        <h1 className={styles["title"]}>{t((m) => m.Common.states.forbidden.title)}</h1>
+        <h1 className={styles["title"]}>{t((m) => m.shared.legacy.common.states.forbidden.title)}</h1>
         <span className={styles["emoji"]}>😭</span>
-        <p className={styles["description"]}>{t((m) => m.Common.states.forbidden.description)}</p>
+        <p className={styles["description"]}>{t((m) => m.shared.legacy.common.states.forbidden.description)}</p>
       </article>
       <article className={styles["ctaWrapper"]}>
         <Link
           href='/auth'
           className={styles["ctaLink"]}>
-          {t((m) => m.Common.states.forbidden.callToAction)}
+          {t((m) => m.shared.legacy.common.states.forbidden.callToAction)}
         </Link>
       </article>
     </section>


### PR DESCRIPTION
## Summary
- Reorganizes `sites/arolariu.ro/messages/{en,ro,fr}.json` into the approved UI-surface message taxonomy.
- Rewrites selector call sites to the new message tree paths.
- Adds message-tree migration utilities, reports, key map, and taxonomy validation wired into i18n generation.

## Validation
- [x] `node scripts/migrations/message-tree/validateMessages.ts`
- [x] `npm run generate:i18n`
- [x] `node scripts/migrations/next-intl-selector/check.ts`
- [x] `npm run typecheck` in `sites/arolariu.ro`
- [x] `npm run test:unit` in `sites/arolariu.ro`
- [x] `npm run build:website`

## Dependency note
Depends on selector migration being merged into `preview` (#800). Invoice hooks remain pending until this PR merges.

## Supersedes
Part of the split replacement for #792.