### PR TITLE
refactor(invoices): split filter cards

### DIFF
--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/AmountFilterCard.module.scss
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/AmountFilterCard.module.scss
@@ -1,0 +1,69 @@
+@use '../../../../../../styles/abstracts' as *;
+
+.amountRangeInputs {
+  display: flex;
+  flex-direction: column;
+  gap: space(2);
+
+  @include respond-to('sm') {
+    flex-direction: row;
+  }
+}
+
+.amountInputWrapper {
+  position: relative;
+  flex: 1;
+}
+
+.currencyIcon {
+  position: absolute;
+  top: 50%;
+  left: space(3);
+  transform: translateY(-50%);
+  @include icon-size(space(4));
+  color: color('muted-foreground');
+  pointer-events: none;
+}
+
+.amountInput {
+  padding-left: space(8);
+  width: 100%;
+}
+
+.amountPresetRow {
+  display: flex;
+  gap: space(1.5);
+  flex-wrap: wrap;
+  margin-top: space(2);
+}
+
+.presetButton {
+  background-color: color('background');
+  border: 1px solid color('border');
+  border-radius: radius('md');
+  padding: space(1) space(2.5);
+  font-size: font-size('xs');
+  color: color('foreground');
+  cursor: pointer;
+  @include transition((background-color, border-color));
+
+  @include respond-below('md') {
+    min-height: space(11);
+    flex: 1;
+  }
+
+  &:hover {
+    background-color: color('muted');
+  }
+}
+
+.presetButtonActive {
+  background-color: color('primary');
+  color: color('primary-foreground');
+  border-color: color('primary');
+
+  &:hover {
+    background-color: color('primary');
+    opacity: 0.9;
+  }
+}

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/AmountFilterCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/AmountFilterCard.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import {selectorFromPath} from "next-intl-selector";
+
+import {Input} from "@arolariu/components";
+import {useTranslations} from "next-intl-selector";
+import {useCallback, useMemo} from "react";
+import {TbCurrencyDollar} from "react-icons/tb";
+import type {FilterState} from "../../_hooks/useInvoiceFilters";
+import {FilterCardFrame} from "./FilterCardFrame";
+import styles from "./AmountFilterCard.module.scss";
+
+type Props = {
+  readonly filters: FilterState;
+  readonly onFiltersChange: (filters: Partial<FilterState>) => void;
+};
+
+type AmountPresetKey = "0-50" | "50-100" | "100-500" | "500+";
+
+const AMOUNT_PRESETS = [
+  {key: "0-50", labelKey: "value0to50", min: 0, max: 50},
+  {key: "50-100", labelKey: "value50to100", min: 50, max: 100},
+  {key: "100-500", labelKey: "value100to500", min: 100, max: 500},
+  {key: "500+", labelKey: "value500plus", min: 500, max: null},
+] as const satisfies ReadonlyArray<{key: AmountPresetKey; labelKey: string; min: number; max: number | null}>;
+
+/**
+ * Amount-range card for invoice filters.
+ *
+ * @param props - Current filter state and URL-backed filter updater.
+ * @returns The rendered amount filter card.
+ */
+export function AmountFilterCard({filters, onFiltersChange}: Readonly<Props>): React.JSX.Element {
+  const t = useTranslations();
+  const isAmountActive = filters.amountMin !== null || filters.amountMax !== null;
+
+  const activeAmountPreset = useMemo<AmountPresetKey | null>(() => {
+    for (const preset of AMOUNT_PRESETS) {
+      if (filters.amountMin === preset.min && filters.amountMax === preset.max) return preset.key;
+    }
+
+    return null;
+  }, [filters.amountMin, filters.amountMax]);
+
+  const activeValue = useMemo((): string | null => {
+    if (!isAmountActive) return null;
+    if (filters.amountMin !== null && filters.amountMax !== null) return `${filters.amountMin} – ${filters.amountMax}`;
+    if (filters.amountMin !== null) return `≥ ${filters.amountMin}`;
+    if (filters.amountMax !== null) return `≤ ${filters.amountMax}`;
+    return null;
+  }, [filters.amountMax, filters.amountMin, isAmountActive]);
+
+  const handleAmountMinChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const value = event.target.value ? Number.parseFloat(event.target.value) : null;
+      onFiltersChange({amountMin: value});
+    },
+    [onFiltersChange],
+  );
+
+  const handleAmountMaxChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const value = event.target.value ? Number.parseFloat(event.target.value) : null;
+      onFiltersChange({amountMax: value});
+    },
+    [onFiltersChange],
+  );
+
+  const handleAmountPresetClick = useCallback(
+    (presetKey: AmountPresetKey) => {
+      if (activeAmountPreset === presetKey) {
+        onFiltersChange({amountMin: null, amountMax: null});
+        return;
+      }
+
+      const preset = AMOUNT_PRESETS.find((candidate) => candidate.key === presetKey);
+      if (preset) onFiltersChange({amountMin: preset.min, amountMax: preset.max});
+    },
+    [activeAmountPreset, onFiltersChange],
+  );
+
+  return (
+    <FilterCardFrame
+      title={
+        <>
+          <TbCurrencyDollar /> {t((m) => m.forms.invoices.filters.amountRange)}
+        </>
+      }
+      active={isAmountActive}
+      activeValue={activeValue}
+      inactiveLabel={t((m) => m.forms.invoices.filters.anyValue)}>
+      <div className={styles["amountRangeInputs"]}>
+        <div className={styles["amountInputWrapper"]}>
+          <TbCurrencyDollar className={styles["currencyIcon"]} />
+          <Input
+            type='number'
+            placeholder={t((m) => m.forms.invoices.filters.amountMin)}
+            value={filters.amountMin ?? ""}
+            onChange={handleAmountMinChange}
+            className={styles["amountInput"]}
+          />
+        </div>
+        <div className={styles["amountInputWrapper"]}>
+          <TbCurrencyDollar className={styles["currencyIcon"]} />
+          <Input
+            type='number'
+            placeholder={t((m) => m.forms.invoices.filters.amountMax)}
+            value={filters.amountMax ?? ""}
+            onChange={handleAmountMaxChange}
+            className={styles["amountInput"]}
+          />
+        </div>
+      </div>
+      <div className={styles["amountPresetRow"]}>
+        {AMOUNT_PRESETS.map(({key: presetKey, labelKey}) => (
+          <button
+            key={presetKey}
+            type='button'
+            aria-pressed={activeAmountPreset === presetKey}
+            className={`${styles["presetButton"]} ${activeAmountPreset === presetKey ? styles["presetButtonActive"] : ""}`}
+            // eslint-disable-next-line react/jsx-no-bind -- presetKey is a stable literal from AMOUNT_PRESETS
+            onClick={() => handleAmountPresetClick(presetKey)}>
+            {t(selectorFromPath(`forms.invoices.filters.amountPresets.${labelKey}`))}
+          </button>
+        ))}
+      </div>
+    </FilterCardFrame>
+  );
+}

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/CategoryFilterCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/CategoryFilterCard.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import type {InvoiceCategory} from "@/types/invoices";
+import {Badge} from "@arolariu/components";
+import {useTranslations} from "next-intl-selector";
+import {useCallback, useMemo} from "react";
+import type {FilterState} from "../../_hooks/useInvoiceFilters";
+import styles from "./DynamicChipFilterCard.module.scss";
+import {FilterCardFrame} from "./FilterCardFrame";
+
+type Props = {
+  readonly filters: FilterState;
+  readonly availableCategories: ReadonlyArray<InvoiceCategory>;
+  readonly getCategoryLabel: (category: InvoiceCategory) => string;
+  readonly onFiltersChange: (filters: Partial<FilterState>) => void;
+};
+
+/**
+ * Category chip card for invoice filters.
+ *
+ * @param props - Current filters, available categories, label formatter, and filter updater.
+ * @returns The rendered category card, or an empty fragment when no options exist.
+ */
+export function CategoryFilterCard({
+  filters,
+  availableCategories,
+  getCategoryLabel,
+  onFiltersChange,
+}: Readonly<Props>): React.JSX.Element {
+  const t = useTranslations();
+  const isCategoryActive = filters.categories.length > 0;
+
+  const activeValue = useMemo((): string | null => {
+    if (!isCategoryActive) return null;
+    return filters.categories.map((category) => getCategoryLabel(category as InvoiceCategory)).join(", ");
+  }, [filters.categories, getCategoryLabel, isCategoryActive]);
+
+  const handleCategoryToggle = useCallback(
+    (category: InvoiceCategory) => {
+      const newCategories = filters.categories.includes(category)
+        ? filters.categories.filter((candidate) => candidate !== category)
+        : [...filters.categories, category];
+      onFiltersChange({categories: newCategories});
+    },
+    [filters.categories, onFiltersChange],
+  );
+
+  if (availableCategories.length === 0) return <></>;
+
+  return (
+    <FilterCardFrame
+      title={<>📂 {t((m) => m.forms.invoices.filters.categories)}</>}
+      active={isCategoryActive}
+      activeValue={activeValue}
+      inactiveLabel={t((m) => m.forms.invoices.filters.anyValue)}
+      dynamicHintLabel={t((m) => m.forms.invoices.filters.dynamicHint)}>
+      <div className={styles["categoryChips"]}>
+        {availableCategories.map((category) => (
+          <button
+            key={category}
+            type='button'
+            aria-pressed={filters.categories.includes(category)}
+            className={styles["chipButton"]}
+            // eslint-disable-next-line react/jsx-no-bind -- category is a stable enum value from availableCategories
+            onClick={() => handleCategoryToggle(category)}>
+            <Badge
+              variant={filters.categories.includes(category) ? "default" : "outline"}
+              className={styles["categoryChip"]}>
+              {getCategoryLabel(category)}
+            </Badge>
+          </button>
+        ))}
+      </div>
+    </FilterCardFrame>
+  );
+}

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/CurrencyFilterCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/CurrencyFilterCard.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import {Badge} from "@arolariu/components";
+import {useTranslations} from "next-intl-selector";
+import {useCallback, useMemo} from "react";
+import type {FilterState} from "../../_hooks/useInvoiceFilters";
+import styles from "./DynamicChipFilterCard.module.scss";
+import {FilterCardFrame} from "./FilterCardFrame";
+
+type Props = {
+  readonly filters: FilterState;
+  readonly availableCurrencies: ReadonlyArray<string>;
+  readonly onFiltersChange: (filters: Partial<FilterState>) => void;
+};
+
+/**
+ * Currency chip card for invoice filters.
+ *
+ * @param props - Current filters, available currency codes, and filter updater.
+ * @returns The rendered currency card, or an empty fragment when no options exist.
+ */
+export function CurrencyFilterCard({filters, availableCurrencies, onFiltersChange}: Readonly<Props>): React.JSX.Element {
+  const t = useTranslations();
+  const isCurrencyActive = filters.currencies.length > 0;
+
+  const activeValue = useMemo((): string | null => {
+    if (!isCurrencyActive) return null;
+    return filters.currencies.length <= 2
+      ? filters.currencies.join(", ")
+      : `${filters.currencies.slice(0, 2).join(", ")}, +${filters.currencies.length - 2}`;
+  }, [filters.currencies, isCurrencyActive]);
+
+  const handleCurrencyToggle = useCallback(
+    (code: string) => {
+      const next = filters.currencies.includes(code) ? filters.currencies.filter((currency) => currency !== code) : [...filters.currencies, code];
+      onFiltersChange({currencies: next});
+    },
+    [filters.currencies, onFiltersChange],
+  );
+
+  if (availableCurrencies.length === 0) return <></>;
+
+  return (
+    <FilterCardFrame
+      title={<>💵 {t((m) => m.forms.invoices.filters.currency)}</>}
+      active={isCurrencyActive}
+      activeValue={activeValue}
+      inactiveLabel={t((m) => m.forms.invoices.filters.currencyAny)}
+      dynamicHintLabel={t((m) => m.forms.invoices.filters.dynamicHint)}>
+      <div className={styles["categoryChips"]}>
+        {availableCurrencies.map((code) => (
+          <button
+            key={code}
+            type='button'
+            aria-pressed={filters.currencies.includes(code)}
+            className={styles["chipButton"]}
+            // eslint-disable-next-line react/jsx-no-bind -- code is a stable literal from availableCurrencies
+            onClick={() => handleCurrencyToggle(code)}>
+            <Badge
+              variant={filters.currencies.includes(code) ? "default" : "outline"}
+              className={styles["categoryChip"]}>
+              {code}
+            </Badge>
+          </button>
+        ))}
+      </div>
+    </FilterCardFrame>
+  );
+}

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/DateFilterCard.module.scss
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/DateFilterCard.module.scss
@@ -1,0 +1,67 @@
+@use '../../../../../../styles/abstracts' as *;
+
+.presetRow {
+  display: flex;
+  gap: space(1.5);
+  flex-wrap: wrap;
+  margin-bottom: space(2);
+}
+
+.presetButton {
+  background-color: color('background');
+  border: 1px solid color('border');
+  border-radius: radius('md');
+  padding: space(1) space(2.5);
+  font-size: font-size('xs');
+  color: color('foreground');
+  cursor: pointer;
+  @include transition((background-color, border-color));
+
+  @include respond-below('md') {
+    min-height: space(11);
+    flex: 1;
+  }
+
+  &:hover {
+    background-color: color('muted');
+  }
+}
+
+.presetButtonActive {
+  background-color: color('primary');
+  color: color('primary-foreground');
+  border-color: color('primary');
+
+  &:hover {
+    background-color: color('primary');
+    opacity: 0.9;
+  }
+}
+
+.dateRangeInputs {
+  display: flex;
+  flex-direction: column;
+  gap: space(2);
+
+  @include respond-to('sm') {
+    flex-direction: row;
+  }
+}
+
+.dateButton {
+  display: flex;
+  align-items: center;
+  gap: space(2);
+  justify-content: flex-start;
+  width: 100%;
+  cursor: pointer;
+}
+
+.dateIcon {
+  @include icon-size(space(4));
+  color: color('muted-foreground');
+}
+
+.calendarPopover {
+  width: auto;
+}

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/DateFilterCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/DateFilterCard.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import {selectorFromPath} from "next-intl-selector";
+
+import {formatDate} from "@/lib/utils.generic";
+import {Button, Calendar, Popover, PopoverContent, PopoverTrigger} from "@arolariu/components";
+import {useLocale} from "next-intl";
+import {useTranslations} from "next-intl-selector";
+import {useCallback, useMemo} from "react";
+import {TbCalendar} from "react-icons/tb";
+import type {FilterState} from "../../_hooks/useInvoiceFilters";
+import {computePresetRange, deriveActivePreset, type DatePresetKey} from "../../_utils/datePresets";
+import {FilterCardFrame} from "./FilterCardFrame";
+import styles from "./DateFilterCard.module.scss";
+
+type Props = {
+  readonly filters: FilterState;
+  readonly onFiltersChange: (filters: Partial<FilterState>) => void;
+};
+
+const DATE_PRESETS = ["30d", "90d", "ytd", "all"] as const satisfies ReadonlyArray<DatePresetKey>;
+
+function getDatePresetLabelKey(preset: DatePresetKey): string {
+  return preset === "30d" || preset === "90d" ? `value${preset}` : preset;
+}
+
+function formatLocalDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+/**
+ * Date-range card for invoice filters.
+ *
+ * @param props - Current filter state and URL-backed filter updater.
+ * @returns The rendered date filter card.
+ */
+export function DateFilterCard({filters, onFiltersChange}: Readonly<Props>): React.JSX.Element {
+  const t = useTranslations();
+  const locale = useLocale();
+  const isDateActive = filters.dateFrom !== null || filters.dateTo !== null;
+  const activeDatePreset = useMemo(
+    () => deriveActivePreset(filters.dateFrom, filters.dateTo, new Date()),
+    [filters.dateFrom, filters.dateTo],
+  );
+
+  const activeValue = useMemo((): string | null => {
+    if (!isDateActive) return null;
+    if (activeDatePreset === "30d") return t((m) => m.forms.invoices.filters.datePresets.value30d);
+    if (activeDatePreset === "90d") return t((m) => m.forms.invoices.filters.datePresets.value90d);
+    if (activeDatePreset === "ytd") return t((m) => m.forms.invoices.filters.datePresets.ytd);
+    if (filters.dateFrom && filters.dateTo) return `${formatDate(filters.dateFrom, {locale})} – ${formatDate(filters.dateTo, {locale})}`;
+    if (filters.dateFrom) return `≥ ${formatDate(filters.dateFrom, {locale})}`;
+    if (filters.dateTo) return `≤ ${formatDate(filters.dateTo, {locale})}`;
+    return null;
+  }, [activeDatePreset, filters.dateFrom, filters.dateTo, isDateActive, locale, t]);
+
+  const handleDateFromChange = useCallback(
+    (date: Date | undefined) => {
+      onFiltersChange({dateFrom: date ? formatLocalDate(date) : null});
+    },
+    [onFiltersChange],
+  );
+
+  const handleDateToChange = useCallback(
+    (date: Date | undefined) => {
+      onFiltersChange({dateTo: date ? formatLocalDate(date) : null});
+    },
+    [onFiltersChange],
+  );
+
+  const handlePresetClick = useCallback(
+    (preset: DatePresetKey) => {
+      const range = computePresetRange(preset, new Date());
+      onFiltersChange({dateFrom: range.from, dateTo: range.to});
+    },
+    [onFiltersChange],
+  );
+
+  return (
+    <FilterCardFrame
+      title={
+        <>
+          <TbCalendar /> {t((m) => m.forms.invoices.filters.dateRange)}
+        </>
+      }
+      active={isDateActive}
+      activeValue={activeValue}
+      inactiveLabel={t((m) => m.forms.invoices.filters.anyValue)}>
+      <div className={styles["presetRow"]}>
+        {DATE_PRESETS.map((preset) => (
+          <button
+            key={preset}
+            type='button'
+            aria-pressed={activeDatePreset === preset}
+            className={`${styles["presetButton"]} ${activeDatePreset === preset ? styles["presetButtonActive"] : ""}`}
+            // eslint-disable-next-line react/jsx-no-bind -- preset is a stable literal from DATE_PRESETS
+            onClick={() => handlePresetClick(preset)}>
+            {t(selectorFromPath(`forms.invoices.filters.datePresets.${getDatePresetLabelKey(preset)}`))}
+          </button>
+        ))}
+      </div>
+      <div className={styles["dateRangeInputs"]}>
+        <Popover>
+          <PopoverTrigger
+            render={
+              <Button
+                variant='outline'
+                className={styles["dateButton"]}>
+                <TbCalendar className={styles["dateIcon"]} />
+                {filters.dateFrom ? formatDate(filters.dateFrom, {locale}) : t((m) => m.forms.invoices.filters.dateFrom)}
+              </Button>
+            }
+          />
+          <PopoverContent className={styles["calendarPopover"]}>
+            <Calendar
+              mode='single'
+              selected={filters.dateFrom ? new Date(filters.dateFrom) : undefined}
+              onSelect={handleDateFromChange}
+            />
+          </PopoverContent>
+        </Popover>
+        <Popover>
+          <PopoverTrigger
+            render={
+              <Button
+                variant='outline'
+                className={styles["dateButton"]}>
+                <TbCalendar className={styles["dateIcon"]} />
+                {filters.dateTo ? formatDate(filters.dateTo, {locale}) : t((m) => m.forms.invoices.filters.dateTo)}
+              </Button>
+            }
+          />
+          <PopoverContent className={styles["calendarPopover"]}>
+            <Calendar
+              mode='single'
+              selected={filters.dateTo ? new Date(filters.dateTo) : undefined}
+              onSelect={handleDateToChange}
+            />
+          </PopoverContent>
+        </Popover>
+      </div>
+    </FilterCardFrame>
+  );
+}

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/DynamicChipFilterCard.module.scss
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/DynamicChipFilterCard.module.scss
@@ -1,0 +1,44 @@
+@use '../../../../../../styles/abstracts' as *;
+
+.categoryChips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: space(2);
+
+  @include respond-below('md') {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+    padding-block: space(2);
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
+}
+
+.categoryChip {
+  cursor: pointer;
+  transition: all 0.2s ease;
+
+  &:hover {
+    opacity: 0.8;
+  }
+}
+
+.chipButton {
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  cursor: pointer;
+  color: inherit;
+  border-radius: radius('full');
+
+  &:focus-visible {
+    outline: 2px solid color('primary');
+    outline-offset: 2px;
+  }
+}

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/FilterBar.module.scss
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/FilterBar.module.scss
@@ -1,11 +1,5 @@
-// ===========================================
-// FILTER BAR STYLES
-// ===========================================
 @use '../../../../../../styles/abstracts' as *;
 
-// ===========================================
-// CONTAINER & LAYOUT
-// ===========================================
 .container {
   display: flex;
   flex-direction: column;
@@ -28,9 +22,6 @@
   }
 }
 
-// ===========================================
-// SEARCH INPUT
-// ===========================================
 .searchWrapper {
   position: relative;
   flex: 1;
@@ -40,11 +31,9 @@
     min-width: 300px;
   }
 
-  // Sticky on mobile for better UX
   @include respond-below('md') {
     position: sticky;
     top: 0;
-    // z-index removed — dialogs/drawers use portal with z('modal')
     background-color: color('background');
     padding-block: space(2);
     margin-inline: calc(-1 * space(2));
@@ -63,18 +52,12 @@
 }
 
 .searchInput {
-
-  // Higher specificity (&&) needed to override @arolariu/components `.input` padding shorthand
-  // which loads later in the cascade and otherwise wipes out our left padding.
   &.searchInput {
     padding: space(1) space(3) space(1) space(9);
     width: 100%;
   }
 }
 
-// ===========================================
-// FILTER BUTTON & BADGE
-// ===========================================
 .filterButton {
   display: flex;
   align-items: center;
@@ -96,16 +79,7 @@
   border-radius: radius('full');
 }
 
-// ===========================================
-// CLEAR FILTERS BUTTON
-// ===========================================
-.clearFiltersButton {
-  display: flex;
-  align-items: center;
-  gap: space(2);
-  cursor: pointer;
-}
-
+.clearFiltersButton,
 .clearButton {
   display: flex;
   align-items: center;
@@ -117,9 +91,6 @@
   @include icon-size(space(4));
 }
 
-// ===========================================
-// VIEW TOGGLE
-// ===========================================
 .viewToggle {
   display: flex;
   border-radius: radius('md');
@@ -145,53 +116,11 @@
   cursor: pointer;
 }
 
-// ===========================================
-// ACTIVE FILTERS BAR
-// ===========================================
-.activeFiltersBar {
-  display: flex;
-  align-items: center;
-  padding: space(2) space(3);
-  background-color: color('muted');
-  border-radius: radius('md');
-  border: 1px solid color('border');
-}
-
-.activeFiltersText {
-  font-size: 0.875rem;
-  color: color('muted-foreground');
-}
-
-// ===========================================
-// FILTER PANEL (POPOVER & SHEET CONTENT)
-// ===========================================
-.filterPanel {
-  display: flex;
-  flex-direction: column;
-  gap: space(4);
-  padding: space(2);
-  max-height: 70vh;
-  overflow-y: auto;
-
-  @include respond-to('sm') {
-    max-height: 600px;
-  }
-}
-
-.filterPopover {
-  width: 400px;
-  max-width: 90vw;
-}
-
 .filterSheet {
   display: flex;
   flex-direction: column;
 }
 
-// ===========================================
-// INLINE FILTER PANEL (DESKTOP)
-// Replaces the popover; opens in-flow below the search bar.
-// ===========================================
 .inlineFilterPanel {
   margin-top: space(3);
   padding: space(4);
@@ -200,7 +129,8 @@
   border-radius: space(2);
 }
 
-.inlineFilterHeader {
+.inlineFilterHeader,
+.sheetHeader {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -209,7 +139,8 @@
   border-bottom: 1px solid color('border');
 }
 
-.inlineFilterTitle {
+.inlineFilterTitle,
+.sheetTitle {
   font-size: 1rem;
   font-weight: 600;
   color: color('foreground');
@@ -221,183 +152,6 @@
   gap: space(2);
 }
 
-.popoverHeader,
-.sheetHeader {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: space(4);
-  padding-bottom: space(3);
-  border-bottom: 1px solid color('border');
-}
-
-.popoverTitle,
-.sheetTitle {
-  font-size: 1rem;
-  font-weight: 600;
-  color: color('foreground');
-}
-
-// ===========================================
-// FILTER SECTIONS
-// ===========================================
-.filterSection {
-  display: flex;
-  flex-direction: column;
-  gap: space(3);
-}
-
-.filterLabel {
-  font-size: 0.875rem;
-  font-weight: 500;
-  color: color('foreground');
-}
-
-// ===========================================
-// DATE RANGE INPUTS
-// ===========================================
-.dateRangeInputs {
-  display: flex;
-  flex-direction: column;
-  gap: space(2);
-
-  @include respond-to('sm') {
-    flex-direction: row;
-  }
-}
-
-.dateButton {
-  display: flex;
-  align-items: center;
-  gap: space(2);
-  justify-content: flex-start;
-  width: 100%;
-  cursor: pointer;
-}
-
-.dateIcon {
-  @include icon-size(space(4));
-  color: color('muted-foreground');
-}
-
-.calendarPopover {
-  width: auto;
-}
-
-// ===========================================
-// AMOUNT RANGE INPUTS
-// ===========================================
-.amountRangeInputs {
-  display: flex;
-  flex-direction: column;
-  gap: space(2);
-
-  @include respond-to('sm') {
-    flex-direction: row;
-  }
-}
-
-.amountInputWrapper {
-  position: relative;
-  flex: 1;
-}
-
-.currencyIcon {
-  position: absolute;
-  top: 50%;
-  left: space(3);
-  transform: translateY(-50%);
-  @include icon-size(space(4));
-  color: color('muted-foreground');
-  pointer-events: none;
-}
-
-.amountInput {
-  padding-left: space(8);
-  width: 100%;
-}
-
-// ===========================================
-// CATEGORY CHIPS
-// ===========================================
-.categoryChips {
-  display: flex;
-  flex-wrap: wrap;
-  gap: space(2);
-
-  // Horizontal scroll on mobile for better UX
-  @include respond-below('md') {
-    flex-wrap: nowrap;
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
-    scrollbar-width: none;
-    padding-block: space(2);
-
-    &::-webkit-scrollbar {
-      display: none;
-    }
-  }
-}
-
-.categoryChip {
-  cursor: pointer;
-  transition: all 0.2s ease;
-
-  &:hover {
-    opacity: 0.8;
-  }
-}
-
-.chipButton {
-  background: none;
-  border: none;
-  padding: 0;
-  margin: 0;
-  font: inherit;
-  cursor: pointer;
-  color: inherit;
-  border-radius: radius('full');
-
-  &:focus-visible {
-    outline: 2px solid color('primary');
-    outline-offset: 2px;
-  }
-}
-
-// ===========================================
-// PAYMENT TYPE LIST
-// ===========================================
-.paymentTypeList {
-  display: flex;
-  flex-direction: column;
-  gap: space(2);
-}
-
-.checkboxItem {
-  display: flex;
-  align-items: center;
-  gap: space(2);
-}
-
-.checkboxLabel {
-  font-size: 0.875rem;
-  color: color('foreground');
-  cursor: pointer;
-}
-
-// ===========================================
-// SORT SELECT
-// ===========================================
-.sortSelect {
-  width: 100%;
-  cursor: pointer;
-}
-
-
-// ===========================================
-// NEW PANEL — variant J (2026-05-21 overhaul)
-// ===========================================
-
 .panelGrid {
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -406,110 +160,6 @@
   @include respond-below('md') {
     grid-template-columns: 1fr;
     gap: space(3);
-  }
-}
-
-.cardSection {
-  border: 1px solid color('border');
-  border-radius: radius('lg');
-  padding: space(3);
-  background-color: color('background');
-  @include transition((border-color, background-color));
-}
-
-.cardSectionActive {
-  border-color: color-alpha('primary', 0.3);
-  background-color: color-alpha('primary', 0.04);
-}
-
-.cardSectionHeader {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: space(2);
-}
-
-.cardSectionTitle {
-  font-size: font-size('sm');
-  font-weight: font-weight('semibold');
-  color: color('foreground');
-  display: inline-flex;
-  align-items: center;
-  gap: space(1.5);
-}
-
-.dynamicHintIcon {
-  color: color('muted-foreground');
-  cursor: help;
-  display: inline-flex;
-  align-items: center;
-  @include transition(color);
-
-  &:hover,
-  &:focus-visible {
-    color: color('foreground');
-  }
-}
-
-.activeValuePill {
-  background-color: color-alpha('primary', 0.1);
-  color: color('primary');
-  border: 1px solid color-alpha('primary', 0.3);
-  border-radius: radius('sm');
-  padding: space(0.5) space(2);
-  font-size: font-size('xs');
-  font-weight: font-weight('medium');
-  max-width: 12rem;
-  @include truncate;
-}
-
-.inactiveLabel {
-  color: color('muted-foreground');
-  font-size: font-size('xs');
-}
-
-.presetRow {
-  display: flex;
-  gap: space(1.5);
-  flex-wrap: wrap;
-  margin-bottom: space(2);
-}
-
-.amountPresetRow {
-  display: flex;
-  gap: space(1.5);
-  flex-wrap: wrap;
-  margin-top: space(2);
-}
-
-.presetButton {
-  background-color: color('background');
-  border: 1px solid color('border');
-  border-radius: radius('md');
-  padding: space(1) space(2.5);
-  font-size: font-size('xs');
-  color: color('foreground');
-  cursor: pointer;
-  @include transition((background-color, border-color));
-
-  @include respond-below('md') {
-    min-height: space(11);
-    flex: 1;
-  }
-
-  &:hover {
-    background-color: color('muted');
-  }
-}
-
-.presetButtonActive {
-  background-color: color('primary');
-  color: color('primary-foreground');
-  border-color: color('primary');
-
-  &:hover {
-    background-color: color('primary');
-    opacity: 0.9;
   }
 }
 

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/FilterBar.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/FilterBar.tsx
@@ -1,22 +1,11 @@
-"use client";import {selectorFromPath} from "next-intl-selector";
+"use client";
 
-
-import {formatDate} from "@/lib/utils.generic";
 import {useInvoicesStore} from "@/stores";
 import {InvoiceCategory, PaymentType} from "@/types/invoices";
 import {
   Badge,
   Button,
-  Calendar,
   Input,
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
   Sheet,
   SheetContent,
   SheetTrigger,
@@ -28,12 +17,16 @@ import {
   useWindowSize,
 } from "@arolariu/components";
 import {useTranslations} from "next-intl-selector";
-import {useLocale} from "next-intl";
 import {useCallback, useEffect, useMemo, useState} from "react";
-import {TbCalendar, TbCards, TbCurrencyDollar, TbFilter, TbInfoCircle, TbSearch, TbTable, TbX} from "react-icons/tb";
+import {TbCards, TbFilter, TbSearch, TbTable, TbX} from "react-icons/tb";
 import type {FilterState} from "../../_hooks/useInvoiceFilters";
-import {computePresetRange, deriveActivePreset, type DatePresetKey} from "../../_utils/datePresets";
 import {computeAvailableCategories, computeAvailableCurrencies, computeAvailablePaymentTypes} from "../../_utils/filterOptions";
+import {AmountFilterCard} from "./AmountFilterCard";
+import {CategoryFilterCard} from "./CategoryFilterCard";
+import {CurrencyFilterCard} from "./CurrencyFilterCard";
+import {DateFilterCard} from "./DateFilterCard";
+import {PaymentTypeFilterCard} from "./PaymentTypeFilterCard";
+import {SortFilterCard} from "./SortFilterCard";
 import styles from "./FilterBar.module.scss";
 
 /**
@@ -55,49 +48,11 @@ type Props = {
 };
 
 /**
- * Quick-amount presets shown as chips beneath the Min/Max number inputs.
- * Each preset writes both bounds to filters when clicked (or clears them
- * when the preset is already active — tap-to-toggle).
- */
-type AmountPresetKey = "0-50" | "50-100" | "100-500" | "500+";
-
-const AMOUNT_PRESETS = [
-  {key: "0-50", labelKey: "0to50", min: 0, max: 50},
-  {key: "50-100", labelKey: "50to100", min: 50, max: 100},
-  {key: "100-500", labelKey: "100to500", min: 100, max: 500},
-  {key: "500+", labelKey: "500plus", min: 500, max: null},
-] as const satisfies ReadonlyArray<{key: AmountPresetKey; labelKey: string; min: number; max: number | null}>;
-
-/**
  * Advanced filter bar component for the invoice list, with URL-based state
- * management and a card-based panel UX (variant J, spec
- * `2026-05-21-view-invoices-filter-overhaul-design.md`).
+ * management and a card-based panel UX.
  *
- * @remarks
- * Outer shell (search input, view toggle, mobile Sheet wrapper, desktop
- * inline-panel container) matches the prior design. The panel internals are
- * a 2-column card grid (single column on mobile) with six cards: Date Range,
- * Amount Range, Currency, Categories, Payment Types, Sort By.
- *
- * **Active state**: each card highlights with a tinted background + colored
- * border + a small active-value pill in its header when its filter is set.
- *
- * **Dynamic option lists**: Currency, Categories, Payment Types are derived
- * from the FULL unfiltered invoice array (not the post-filter set) so that
- * filtering down doesn't dead-end the chip rails. Cards with empty derived
- * lists are hidden entirely.
- *
- * **Date presets**: 4 quick-buttons (30d / 90d / YTD / All time) control
- * the From/To Calendar popovers as a true controlled component via
- * `computePresetRange`. Active preset is derived from current From/To via
- * `deriveActivePreset` — no extra URL state.
- *
- * **Sort default**: defaults to "Date (newest first)"; the dropdown has no
- * "none" option.
- *
- * **Mobile**: sticky "Show N results" CTA at the bottom of the Sheet —
- * tactile thumb-reach affordance to close the sheet (filters still apply
- * reactively as the user edits).
+ * @param props - Filter state, filter update callbacks, view mode state, and filtered count.
+ * @returns The rendered invoice filter bar.
  */
 export default function FilterBar({
   filters,
@@ -108,48 +63,25 @@ export default function FilterBar({
   filteredCount,
 }: Readonly<Props>): React.JSX.Element {
   const t = useTranslations();
-  const locale = useLocale();
   const {isMobile} = useWindowSize();
-  // Read full unfiltered invoice list straight from the store — matches the
-  // established pattern in this directory (BulkActionsToolbar, ExportDialog,
-  // GridView, TableView all read state.entities directly; useInvoices() is
-  // called once upstream in island.tsx and triggers the fetch).
   const invoices = useInvoicesStore((state) => state.entities);
   const [searchInput, setSearchInput] = useState<string>(filters.search);
   const [isFilterOpen, setIsFilterOpen] = useState<boolean>(false);
 
-  // Debounce search input (300ms)
   const debouncedSearch = useDebounce(searchInput, 300);
 
-  // Update filters when debounced search changes
   useEffect(() => {
     if (debouncedSearch !== filters.search) {
       onFiltersChange({search: debouncedSearch});
     }
   }, [debouncedSearch, filters.search, onFiltersChange]);
 
-  // ── Dynamic option lists, derived from the FULL invoice set ──
   const availableCurrencies = useMemo(() => computeAvailableCurrencies(invoices), [invoices]);
   const availableCategories = useMemo(() => computeAvailableCategories(invoices), [invoices]);
   const availablePaymentTypes = useMemo(() => computeAvailablePaymentTypes(invoices), [invoices]);
 
-  // ── Date-preset active state ──
-  const activeDatePreset = useMemo(
-    () => deriveActivePreset(filters.dateFrom, filters.dateTo, new Date()),
-    [filters.dateFrom, filters.dateTo],
-  );
-
-  // ── Per-card active predicates ──
-  const isDateActive = filters.dateFrom !== null || filters.dateTo !== null;
-  const isAmountActive = filters.amountMin !== null || filters.amountMax !== null;
-  const isCurrencyActive = filters.currencies.length > 0;
-  const isCategoryActive = filters.categories.length > 0;
-  const isPaymentActive = filters.paymentTypes.length > 0;
-  const isSortActive = !(filters.sortBy === "date" && filters.sortOrder === "desc");
-
-  // ── Handlers ──
-  const handleSearchChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    setSearchInput(e.target.value);
+  const handleSearchChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchInput(event.target.value);
   }, []);
 
   const handleClearFilters = useCallback(() => {
@@ -168,157 +100,9 @@ export default function FilterBar({
     });
   }, [onFiltersChange]);
 
-  // Format a local Date as YYYY-MM-DD using local (not UTC) components so a
-  // user in a positive timezone doesn't see their picked calendar day shifted
-  // back by one. Same shape datePresets.ts uses internally for its UTC-safe
-  // ranges; here we want the LOCAL calendar day the picker actually showed.
-  const formatLocalDate = useCallback((date: Date): string => {
-    const y = date.getFullYear();
-    const m = String(date.getMonth() + 1).padStart(2, "0");
-    const d = String(date.getDate()).padStart(2, "0");
-    return `${y}-${m}-${d}`;
-  }, []);
-
-  const handleDateFromChange = useCallback(
-    (date: Date | undefined) => {
-      onFiltersChange({dateFrom: date ? formatLocalDate(date) : null});
-    },
-    [onFiltersChange, formatLocalDate],
-  );
-
-  const handleDateToChange = useCallback(
-    (date: Date | undefined) => {
-      onFiltersChange({dateTo: date ? formatLocalDate(date) : null});
-    },
-    [onFiltersChange, formatLocalDate],
-  );
-
-  const handleAmountMinChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      const value = e.target.value ? Number.parseFloat(e.target.value) : null;
-      onFiltersChange({amountMin: value});
-    },
-    [onFiltersChange],
-  );
-
-  const handleAmountMaxChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      const value = e.target.value ? Number.parseFloat(e.target.value) : null;
-      onFiltersChange({amountMax: value});
-    },
-    [onFiltersChange],
-  );
-
-  // ── Amount preset (chip) active-state derivation + click handler ──
-  const activeAmountPreset = useMemo<AmountPresetKey | null>(() => {
-    for (const preset of AMOUNT_PRESETS) {
-      if (filters.amountMin === preset.min && filters.amountMax === preset.max) return preset.key;
-    }
-    return null;
-  }, [filters.amountMin, filters.amountMax]);
-
-  const handleAmountPresetClick = useCallback(
-    (presetKey: AmountPresetKey) => {
-      // Tap-to-toggle: clicking the already-active preset clears the amount filter.
-      if (activeAmountPreset === presetKey) {
-        onFiltersChange({amountMin: null, amountMax: null});
-        return;
-      }
-      const preset = AMOUNT_PRESETS.find((p) => p.key === presetKey);
-      if (preset) onFiltersChange({amountMin: preset.min, amountMax: preset.max});
-    },
-    [activeAmountPreset, onFiltersChange],
-  );
-
-  const handleCategoryToggle = useCallback(
-    (category: number) => {
-      const newCategories = filters.categories.includes(category)
-        ? filters.categories.filter((c) => c !== category)
-        : [...filters.categories, category];
-      onFiltersChange({categories: newCategories});
-    },
-    [filters.categories, onFiltersChange],
-  );
-
-  const handlePaymentTypeToggle = useCallback(
-    (paymentType: number) => {
-      const newPaymentTypes = filters.paymentTypes.includes(paymentType)
-        ? filters.paymentTypes.filter((p) => p !== paymentType)
-        : [...filters.paymentTypes, paymentType];
-      onFiltersChange({paymentTypes: newPaymentTypes});
-    },
-    [filters.paymentTypes, onFiltersChange],
-  );
-
-  const handleCurrencyToggle = useCallback(
-    (code: string) => {
-      const next = filters.currencies.includes(code) ? filters.currencies.filter((c) => c !== code) : [...filters.currencies, code];
-      onFiltersChange({currencies: next});
-    },
-    [filters.currencies, onFiltersChange],
-  );
-
-  const handlePresetClick = useCallback(
-    (preset: DatePresetKey) => {
-      const range = computePresetRange(preset, new Date());
-      onFiltersChange({dateFrom: range.from, dateTo: range.to});
-    },
-    [onFiltersChange],
-  );
-
-  const handleSortChange = useCallback(
-    (value: string) => {
-      const parts = value.split("-");
-      const direction = parts.pop() as "asc" | "desc";
-      const field = parts.join("-") as Exclude<FilterState["sortBy"], null>;
-      onFiltersChange({sortBy: field, sortOrder: direction});
-    },
-    [onFiltersChange],
-  );
-
-  /**
-   * Factory: returns a stable click handler for date preset chips.
-   * Each preset button gets its own callback to avoid re-rendering on unrelated state changes.
-   */
-  const createPresetClickHandler = useCallback(
-    (preset: DatePresetKey) => {
-      return () => handlePresetClick(preset);
-    },
-    [handlePresetClick],
-  );
-
-  /**
-   * Factory: returns a stable click handler for amount preset chips.
-   * Each preset button gets its own callback to avoid re-rendering on unrelated state changes.
-   */
-  const createAmountPresetClickHandler = useCallback(
-    (presetKey: AmountPresetKey) => {
-      return () => handleAmountPresetClick(presetKey);
-    },
-    [handleAmountPresetClick],
-  );
-
-  /**
-   * Factory: returns a stable toggle handler for currency chips.
-   * Each currency chip gets its own callback to avoid re-rendering on unrelated state changes.
-   */
-  const createCurrencyToggleHandler = useCallback(
-    (code: string) => {
-      return () => handleCurrencyToggle(code);
-    },
-    [handleCurrencyToggle],
-  );
-
-  // ── Label helpers (kept inline so they pick up the right `t` namespace) ──
-  const formatCurrencyList = useCallback(
-    (codes: ReadonlyArray<string>): string =>
-      codes.length <= 2 ? codes.join(", ") : `${codes.slice(0, 2).join(", ")}, +${codes.length - 2}`,
-    [],
-  );
-
   const getCategoryLabel = useCallback(
-    (cat: InvoiceCategory): string => {
-      switch (cat) {
+    (category: InvoiceCategory): string => {
+      switch (category) {
         case InvoiceCategory.GROCERY:
           return t((m) => m.pages.invoices.viewInvoices.invoicesView.categories.groceries);
         case InvoiceCategory.FAST_FOOD:
@@ -335,8 +119,8 @@ export default function FilterBar({
   );
 
   const getPaymentTypeLabel = useCallback(
-    (pt: PaymentType): string => {
-      switch (pt) {
+    (paymentType: PaymentType): string => {
+      switch (paymentType) {
         case PaymentType.Cash:
           return t((m) => m.forms.invoices.filters.paymentTypeLabels.cash);
         case PaymentType.Card:
@@ -354,320 +138,45 @@ export default function FilterBar({
     [t],
   );
 
-  const getSortLabel = useCallback(
-    (sortBy: FilterState["sortBy"], sortOrder: FilterState["sortOrder"]): string => {
-      if (sortBy === "date" && sortOrder === "desc") return t((m) => m.forms.invoices.filters.sortOptions.dateNewest);
-      if (sortBy === "date" && sortOrder === "asc") return t((m) => m.forms.invoices.filters.sortOptions.dateOldest);
-      if (sortBy === "amount" && sortOrder === "desc") return t((m) => m.forms.invoices.filters.sortOptions.amountHighToLow);
-      if (sortBy === "amount" && sortOrder === "asc") return t((m) => m.forms.invoices.filters.sortOptions.amountLowToHigh);
-      if (sortBy === "name" && sortOrder === "asc") return t((m) => m.forms.invoices.filters.sortOptions.nameAZ);
-      if (sortBy === "name" && sortOrder === "desc") return t((m) => m.forms.invoices.filters.sortOptions.nameZA);
-      return "";
-    },
-    [t],
-  );
-
-  const dateActivePillText = useMemo(() => {
-    if (!isDateActive) return null;
-    if (activeDatePreset === "30d") return t((m) => m.forms.invoices.filters.datePresets.value30d);
-    if (activeDatePreset === "90d") return t((m) => m.forms.invoices.filters.datePresets.value90d);
-    if (activeDatePreset === "ytd") return t((m) => m.forms.invoices.filters.datePresets.ytd);
-    if (filters.dateFrom && filters.dateTo) return `${formatDate(filters.dateFrom, {locale})} – ${formatDate(filters.dateTo, {locale})}`;
-    if (filters.dateFrom) return `≥ ${formatDate(filters.dateFrom, {locale})}`;
-    if (filters.dateTo) return `≤ ${formatDate(filters.dateTo, {locale})}`;
-    return null;
-  }, [isDateActive, activeDatePreset, filters.dateFrom, filters.dateTo, locale, t]);
-
-  const amountActivePillText = useMemo(() => {
-    if (!isAmountActive) return null;
-    if (filters.amountMin !== null && filters.amountMax !== null) return `${filters.amountMin} – ${filters.amountMax}`;
-    if (filters.amountMin !== null) return `≥ ${filters.amountMin}`;
-    if (filters.amountMax !== null) return `≤ ${filters.amountMax}`;
-    return null;
-  }, [isAmountActive, filters.amountMin, filters.amountMax]);
-
-  // Small (i) tooltip rendered next to the title of every dynamically-populated
-  // filter card (Currency, Categories, Payment Types) — explains that the chip
-  // set reflects the user's own data rather than a fixed taxonomy.
-  const dynamicHint = (
-    <Tooltip>
-      <TooltipTrigger
-        render={
-          <span
-            className={styles["dynamicHintIcon"]}
-            aria-label={t((m) => m.forms.invoices.filters.dynamicHint)}>
-            <TbInfoCircle aria-hidden='true' />
-          </span>
-        }
-      />
-      <TooltipContent>{t((m) => m.forms.invoices.filters.dynamicHint)}</TooltipContent>
-    </Tooltip>
-  );
-
-  // ────────────────────────────────────────────────────────────
-  // Panel body — card grid (single-column on mobile via SCSS)
-  // ────────────────────────────────────────────────────────────
-  // eslint-disable-next-line sonarjs/cognitive-complexity, complexity -- six conditionally-rendered card sections; extracting per-card sub-components would obscure the linear visual order without simplifying logic
   const renderFilterPanel = (): React.JSX.Element => (
     <TooltipProvider>
       <div className={styles["panelGrid"]}>
-        {/* ─────── Date Range ─────── */}
-        <div className={`${styles["cardSection"]} ${isDateActive ? styles["cardSectionActive"] : ""}`}>
-          <div className={styles["cardSectionHeader"]}>
-            <span className={styles["cardSectionTitle"]}>
-              <TbCalendar /> {t((m) => m.forms.invoices.filters.dateRange)}
-            </span>
-            {dateActivePillText ? (
-              <span className={styles["activeValuePill"]}>{dateActivePillText}</span>
-            ) : (
-              <span className={styles["inactiveLabel"]}>{t((m) => m.forms.invoices.filters.anyValue)}</span>
-            )}
-          </div>
-          <div className={styles["presetRow"]}>
-            {(["30d", "90d", "ytd", "all"] as const).map((preset) => (
-              <button
-                key={preset}
-                type='button'
-                aria-pressed={activeDatePreset === preset}
-                className={`${styles["presetButton"]} ${activeDatePreset === preset ? styles["presetButtonActive"] : ""}`}
-                // eslint-disable-next-line react/jsx-no-bind -- preset is a stable literal
-                onClick={createPresetClickHandler(preset)}>
-                {t(selectorFromPath(`filters.datePresets.${preset}`))}
-              </button>
-            ))}
-          </div>
-          <div className={styles["dateRangeInputs"]}>
-            <Popover>
-              <PopoverTrigger
-                render={
-                  <Button
-                    variant='outline'
-                    className={styles["dateButton"]}>
-                    <TbCalendar className={styles["dateIcon"]} />
-                    {filters.dateFrom ? formatDate(filters.dateFrom, {locale}) : t((m) => m.forms.invoices.filters.dateFrom)}
-                  </Button>
-                }
-              />
-              <PopoverContent className={styles["calendarPopover"]}>
-                <Calendar
-                  mode='single'
-                  selected={filters.dateFrom ? new Date(filters.dateFrom) : undefined}
-                  onSelect={handleDateFromChange}
-                />
-              </PopoverContent>
-            </Popover>
-            <Popover>
-              <PopoverTrigger
-                render={
-                  <Button
-                    variant='outline'
-                    className={styles["dateButton"]}>
-                    <TbCalendar className={styles["dateIcon"]} />
-                    {filters.dateTo ? formatDate(filters.dateTo, {locale}) : t((m) => m.forms.invoices.filters.dateTo)}
-                  </Button>
-                }
-              />
-              <PopoverContent className={styles["calendarPopover"]}>
-                <Calendar
-                  mode='single'
-                  selected={filters.dateTo ? new Date(filters.dateTo) : undefined}
-                  onSelect={handleDateToChange}
-                />
-              </PopoverContent>
-            </Popover>
-          </div>
-        </div>
-
-        {/* ─────── Amount Range ─────── */}
-        <div className={`${styles["cardSection"]} ${isAmountActive ? styles["cardSectionActive"] : ""}`}>
-          <div className={styles["cardSectionHeader"]}>
-            <span className={styles["cardSectionTitle"]}>
-              <TbCurrencyDollar /> {t((m) => m.forms.invoices.filters.amountRange)}
-            </span>
-            {amountActivePillText ? (
-              <span className={styles["activeValuePill"]}>{amountActivePillText}</span>
-            ) : (
-              <span className={styles["inactiveLabel"]}>{t((m) => m.forms.invoices.filters.anyValue)}</span>
-            )}
-          </div>
-          <div className={styles["amountRangeInputs"]}>
-            <div className={styles["amountInputWrapper"]}>
-              <TbCurrencyDollar className={styles["currencyIcon"]} />
-              <Input
-                type='number'
-                placeholder={t((m) => m.forms.invoices.filters.amountMin)}
-                value={filters.amountMin ?? ""}
-                onChange={handleAmountMinChange}
-                className={styles["amountInput"]}
-              />
-            </div>
-            <div className={styles["amountInputWrapper"]}>
-              <TbCurrencyDollar className={styles["currencyIcon"]} />
-              <Input
-                type='number'
-                placeholder={t((m) => m.forms.invoices.filters.amountMax)}
-                value={filters.amountMax ?? ""}
-                onChange={handleAmountMaxChange}
-                className={styles["amountInput"]}
-              />
-            </div>
-          </div>
-          <div className={styles["amountPresetRow"]}>
-            {AMOUNT_PRESETS.map(({key: presetKey, labelKey}) => (
-              <button
-                key={presetKey}
-                type='button'
-                aria-pressed={activeAmountPreset === presetKey}
-                className={`${styles["presetButton"]} ${activeAmountPreset === presetKey ? styles["presetButtonActive"] : ""}`}
-                // eslint-disable-next-line react/jsx-no-bind -- presetKey is a stable literal
-                onClick={createAmountPresetClickHandler(presetKey)}>
-                {t(selectorFromPath(`filters.amountPresets.${labelKey}`))}
-              </button>
-            ))}
-          </div>
-        </div>
-
-        {/* ─────── Currency (dynamic) ─────── */}
-        {availableCurrencies.length > 0 && (
-          <div className={`${styles["cardSection"]} ${isCurrencyActive ? styles["cardSectionActive"] : ""}`}>
-            <div className={styles["cardSectionHeader"]}>
-              <span className={styles["cardSectionTitle"]}>
-                💵 {t((m) => m.forms.invoices.filters.currency)}
-                {dynamicHint}
-              </span>
-              {isCurrencyActive ? (
-                <span className={styles["activeValuePill"]}>{formatCurrencyList(filters.currencies)}</span>
-              ) : (
-                <span className={styles["inactiveLabel"]}>{t((m) => m.forms.invoices.filters.currencyAny)}</span>
-              )}
-            </div>
-            <div className={styles["categoryChips"]}>
-              {availableCurrencies.map((code) => (
-                <button
-                  key={code}
-                  type='button'
-                  aria-pressed={filters.currencies.includes(code)}
-                  className={styles["chipButton"]}
-                  // eslint-disable-next-line react/jsx-no-bind -- code is a stable literal
-                  onClick={createCurrencyToggleHandler(code)}>
-                  <Badge
-                    variant={filters.currencies.includes(code) ? "default" : "outline"}
-                    className={styles["categoryChip"]}>
-                    {code}
-                  </Badge>
-                </button>
-              ))}
-            </div>
-          </div>
-        )}
-
-        {/* ─────── Categories (dynamic) ─────── */}
-        {availableCategories.length > 0 && (
-          <div className={`${styles["cardSection"]} ${isCategoryActive ? styles["cardSectionActive"] : ""}`}>
-            <div className={styles["cardSectionHeader"]}>
-              <span className={styles["cardSectionTitle"]}>
-                📂 {t((m) => m.forms.invoices.filters.categories)}
-                {dynamicHint}
-              </span>
-              {isCategoryActive ? (
-                <span className={styles["activeValuePill"]}>
-                  {filters.categories.map((c) => getCategoryLabel(c as InvoiceCategory)).join(", ")}
-                </span>
-              ) : (
-                <span className={styles["inactiveLabel"]}>{t((m) => m.forms.invoices.filters.anyValue)}</span>
-              )}
-            </div>
-            <div className={styles["categoryChips"]}>
-              {availableCategories.map((cat) => (
-                <button
-                  key={cat}
-                  type='button'
-                  aria-pressed={filters.categories.includes(cat)}
-                  className={styles["chipButton"]}
-                  // eslint-disable-next-line react/jsx-no-bind -- cat is a stable enum value
-                  onClick={() => handleCategoryToggle(cat)}>
-                  <Badge
-                    variant={filters.categories.includes(cat) ? "default" : "outline"}
-                    className={styles["categoryChip"]}>
-                    {getCategoryLabel(cat)}
-                  </Badge>
-                </button>
-              ))}
-            </div>
-          </div>
-        )}
-
-        {/* ─────── Payment Types (dynamic) ─────── */}
-        {availablePaymentTypes.length > 0 && (
-          <div className={`${styles["cardSection"]} ${isPaymentActive ? styles["cardSectionActive"] : ""}`}>
-            <div className={styles["cardSectionHeader"]}>
-              <span className={styles["cardSectionTitle"]}>
-                💳 {t((m) => m.forms.invoices.filters.paymentTypes)}
-                {dynamicHint}
-              </span>
-              {isPaymentActive ? (
-                <span className={styles["activeValuePill"]}>
-                  {filters.paymentTypes.map((p) => getPaymentTypeLabel(p as PaymentType)).join(", ")}
-                </span>
-              ) : (
-                <span className={styles["inactiveLabel"]}>{t((m) => m.forms.invoices.filters.anyValue)}</span>
-              )}
-            </div>
-            <div className={styles["categoryChips"]}>
-              {availablePaymentTypes.map((pt) => (
-                <button
-                  key={pt}
-                  type='button'
-                  aria-pressed={filters.paymentTypes.includes(pt)}
-                  className={styles["chipButton"]}
-                  // eslint-disable-next-line react/jsx-no-bind -- pt is a stable enum value
-                  onClick={() => handlePaymentTypeToggle(pt)}>
-                  <Badge
-                    variant={filters.paymentTypes.includes(pt) ? "default" : "outline"}
-                    className={styles["categoryChip"]}>
-                    {getPaymentTypeLabel(pt)}
-                  </Badge>
-                </button>
-              ))}
-            </div>
-          </div>
-        )}
-
-        {/* ─────── Sort By ─────── */}
-        <div className={`${styles["cardSection"]} ${isSortActive ? styles["cardSectionActive"] : ""}`}>
-          <div className={styles["cardSectionHeader"]}>
-            <span className={styles["cardSectionTitle"]}>↕ {t((m) => m.forms.invoices.filters.sortBy)}</span>
-            {isSortActive ? (
-              <span className={styles["activeValuePill"]}>{getSortLabel(filters.sortBy, filters.sortOrder)}</span>
-            ) : (
-              <span className={styles["inactiveLabel"]}>{t((m) => m.forms.invoices.filters.defaultValue)}</span>
-            )}
-          </div>
-          <Select
-            value={`${filters.sortBy}-${filters.sortOrder}`}
-            onValueChange={handleSortChange}>
-            <SelectTrigger className={styles["sortSelect"]}>
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value='date-desc'>{t((m) => m.forms.invoices.filters.sortOptions.dateNewest)}</SelectItem>
-              <SelectItem value='date-asc'>{t((m) => m.forms.invoices.filters.sortOptions.dateOldest)}</SelectItem>
-              <SelectItem value='amount-desc'>{t((m) => m.forms.invoices.filters.sortOptions.amountHighToLow)}</SelectItem>
-              <SelectItem value='amount-asc'>{t((m) => m.forms.invoices.filters.sortOptions.amountLowToHigh)}</SelectItem>
-              <SelectItem value='name-asc'>{t((m) => m.forms.invoices.filters.sortOptions.nameAZ)}</SelectItem>
-              <SelectItem value='name-desc'>{t((m) => m.forms.invoices.filters.sortOptions.nameZA)}</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
+        <DateFilterCard
+          filters={filters}
+          onFiltersChange={onFiltersChange}
+        />
+        <AmountFilterCard
+          filters={filters}
+          onFiltersChange={onFiltersChange}
+        />
+        <CurrencyFilterCard
+          filters={filters}
+          availableCurrencies={availableCurrencies}
+          onFiltersChange={onFiltersChange}
+        />
+        <CategoryFilterCard
+          filters={filters}
+          availableCategories={availableCategories}
+          getCategoryLabel={getCategoryLabel}
+          onFiltersChange={onFiltersChange}
+        />
+        <PaymentTypeFilterCard
+          filters={filters}
+          availablePaymentTypes={availablePaymentTypes}
+          getPaymentTypeLabel={getPaymentTypeLabel}
+          onFiltersChange={onFiltersChange}
+        />
+        <SortFilterCard
+          filters={filters}
+          onFiltersChange={onFiltersChange}
+        />
       </div>
     </TooltipProvider>
   );
 
   return (
     <div className={styles["container"]}>
-      {/* Always visible controls */}
       <div className={styles["topBar"]}>
-        {/* Search Input */}
         <div className={styles["searchWrapper"]}>
           <TbSearch className={styles["searchIcon"]} />
           <Input
@@ -678,7 +187,6 @@ export default function FilterBar({
           />
         </div>
 
-        {/* Filter Button — mobile opens Sheet, desktop toggles inline panel */}
         {isMobile ? (
           <Sheet
             open={isFilterOpen}
@@ -736,7 +244,7 @@ export default function FilterBar({
             size='sm'
             className={styles["filterButton"]}
             // eslint-disable-next-line react/jsx-no-bind -- inline toggle handler
-            onClick={() => setIsFilterOpen((prev) => !prev)}
+            onClick={() => setIsFilterOpen((previous) => !previous)}
             aria-expanded={isFilterOpen}
             aria-controls='inline-filter-panel'>
             <TbFilter className={styles["filterIcon"]} />
@@ -751,7 +259,6 @@ export default function FilterBar({
           </Button>
         )}
 
-        {/* Clear Filters Button (when filters active) */}
         {activeFilterCount > 0 && !isMobile && (
           <Button
             variant='ghost'
@@ -763,7 +270,6 @@ export default function FilterBar({
           </Button>
         )}
 
-        {/* View Toggle */}
         <div className={styles["viewToggle"]}>
           <TooltipProvider>
             <Tooltip>
@@ -802,7 +308,6 @@ export default function FilterBar({
         </div>
       </div>
 
-      {/* Inline filter panel (desktop only) — collapses below the search bar */}
       {!isMobile && isFilterOpen ? (
         <div
           id='inline-filter-panel'

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/FilterCardFrame.module.scss
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/FilterCardFrame.module.scss
@@ -1,0 +1,60 @@
+@use '../../../../../../styles/abstracts' as *;
+
+.cardSection {
+  border: 1px solid color('border');
+  border-radius: radius('lg');
+  padding: space(3);
+  background-color: color('background');
+  @include transition((border-color, background-color));
+}
+
+.cardSectionActive {
+  border-color: color-alpha('primary', 0.3);
+  background-color: color-alpha('primary', 0.04);
+}
+
+.cardSectionHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: space(2);
+}
+
+.cardSectionTitle {
+  font-size: font-size('sm');
+  font-weight: font-weight('semibold');
+  color: color('foreground');
+  display: inline-flex;
+  align-items: center;
+  gap: space(1.5);
+}
+
+.dynamicHintIcon {
+  color: color('muted-foreground');
+  cursor: help;
+  display: inline-flex;
+  align-items: center;
+  @include transition(color);
+
+  &:hover,
+  &:focus-visible {
+    color: color('foreground');
+  }
+}
+
+.activeValuePill {
+  background-color: color-alpha('primary', 0.1);
+  color: color('primary');
+  border: 1px solid color-alpha('primary', 0.3);
+  border-radius: radius('sm');
+  padding: space(0.5) space(2);
+  font-size: font-size('xs');
+  font-weight: font-weight('medium');
+  max-width: 12rem;
+  @include truncate;
+}
+
+.inactiveLabel {
+  color: color('muted-foreground');
+  font-size: font-size('xs');
+}

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/FilterCardFrame.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/FilterCardFrame.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import type {ReactNode} from "react";
+import {Tooltip, TooltipContent, TooltipTrigger} from "@arolariu/components";
+import {TbInfoCircle} from "react-icons/tb";
+import styles from "./FilterCardFrame.module.scss";
+
+type Props = {
+  readonly title: ReactNode;
+  readonly active: boolean;
+  readonly activeValue: string | null;
+  readonly inactiveLabel: string;
+  readonly children: ReactNode;
+  readonly dynamicHintLabel?: string;
+};
+
+/**
+ * Shared visual frame for a single filter card in the invoice filter panel.
+ *
+ * @param props - Card title, active state, active summary, and card content.
+ * @returns The rendered filter card frame.
+ */
+export function FilterCardFrame({
+  title,
+  active,
+  activeValue,
+  inactiveLabel,
+  children,
+  dynamicHintLabel,
+}: Readonly<Props>): React.JSX.Element {
+  return (
+    <div className={`${styles["cardSection"]} ${active ? styles["cardSectionActive"] : ""}`}>
+      <div className={styles["cardSectionHeader"]}>
+        <span className={styles["cardSectionTitle"]}>
+          {title}
+          {dynamicHintLabel ? (
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <span
+                    className={styles["dynamicHintIcon"]}
+                    aria-label={dynamicHintLabel}>
+                    <TbInfoCircle aria-hidden='true' />
+                  </span>
+                }
+              />
+              <TooltipContent>{dynamicHintLabel}</TooltipContent>
+            </Tooltip>
+          ) : null}
+        </span>
+        {activeValue !== null ? (
+          <span className={styles["activeValuePill"]}>{activeValue}</span>
+        ) : (
+          <span className={styles["inactiveLabel"]}>{inactiveLabel}</span>
+        )}
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/PaymentTypeFilterCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/PaymentTypeFilterCard.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import type {PaymentType} from "@/types/invoices";
+import {Badge} from "@arolariu/components";
+import {useTranslations} from "next-intl-selector";
+import {useCallback, useMemo} from "react";
+import type {FilterState} from "../../_hooks/useInvoiceFilters";
+import styles from "./DynamicChipFilterCard.module.scss";
+import {FilterCardFrame} from "./FilterCardFrame";
+
+type Props = {
+  readonly filters: FilterState;
+  readonly availablePaymentTypes: ReadonlyArray<PaymentType>;
+  readonly getPaymentTypeLabel: (paymentType: PaymentType) => string;
+  readonly onFiltersChange: (filters: Partial<FilterState>) => void;
+};
+
+/**
+ * Payment-type chip card for invoice filters.
+ *
+ * @param props - Current filters, available payment types, label formatter, and filter updater.
+ * @returns The rendered payment-type card, or an empty fragment when no options exist.
+ */
+export function PaymentTypeFilterCard({
+  filters,
+  availablePaymentTypes,
+  getPaymentTypeLabel,
+  onFiltersChange,
+}: Readonly<Props>): React.JSX.Element {
+  const t = useTranslations();
+  const isPaymentActive = filters.paymentTypes.length > 0;
+
+  const activeValue = useMemo((): string | null => {
+    if (!isPaymentActive) return null;
+    return filters.paymentTypes.map((paymentType) => getPaymentTypeLabel(paymentType as PaymentType)).join(", ");
+  }, [filters.paymentTypes, getPaymentTypeLabel, isPaymentActive]);
+
+  const handlePaymentTypeToggle = useCallback(
+    (paymentType: PaymentType) => {
+      const newPaymentTypes = filters.paymentTypes.includes(paymentType)
+        ? filters.paymentTypes.filter((candidate) => candidate !== paymentType)
+        : [...filters.paymentTypes, paymentType];
+      onFiltersChange({paymentTypes: newPaymentTypes});
+    },
+    [filters.paymentTypes, onFiltersChange],
+  );
+
+  if (availablePaymentTypes.length === 0) return <></>;
+
+  return (
+    <FilterCardFrame
+      title={<>💳 {t((m) => m.forms.invoices.filters.paymentTypes)}</>}
+      active={isPaymentActive}
+      activeValue={activeValue}
+      inactiveLabel={t((m) => m.forms.invoices.filters.anyValue)}
+      dynamicHintLabel={t((m) => m.forms.invoices.filters.dynamicHint)}>
+      <div className={styles["categoryChips"]}>
+        {availablePaymentTypes.map((paymentType) => (
+          <button
+            key={paymentType}
+            type='button'
+            aria-pressed={filters.paymentTypes.includes(paymentType)}
+            className={styles["chipButton"]}
+            // eslint-disable-next-line react/jsx-no-bind -- paymentType is a stable enum value from availablePaymentTypes
+            onClick={() => handlePaymentTypeToggle(paymentType)}>
+            <Badge
+              variant={filters.paymentTypes.includes(paymentType) ? "default" : "outline"}
+              className={styles["categoryChip"]}>
+              {getPaymentTypeLabel(paymentType)}
+            </Badge>
+          </button>
+        ))}
+      </div>
+    </FilterCardFrame>
+  );
+}

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/SortFilterCard.module.scss
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/SortFilterCard.module.scss
@@ -1,0 +1,4 @@
+.sortSelect {
+  width: 100%;
+  cursor: pointer;
+}

--- a/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/SortFilterCard.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-invoices/_components/filters/SortFilterCard.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from "@arolariu/components";
+import {selectorFromPath, useTranslations} from "next-intl-selector";
+import {useCallback, useMemo} from "react";
+import type {FilterState} from "../../_hooks/useInvoiceFilters";
+import {FilterCardFrame} from "./FilterCardFrame";
+import styles from "./SortFilterCard.module.scss";
+
+type Props = {
+  readonly filters: FilterState;
+  readonly onFiltersChange: (filters: Partial<FilterState>) => void;
+};
+
+type TranslationFunction = ReturnType<typeof useTranslations>;
+
+function getSortLabel(t: TranslationFunction, sortBy: FilterState["sortBy"], sortOrder: FilterState["sortOrder"]): string {
+  if (sortBy === "date" && sortOrder === "desc") return t(selectorFromPath("forms.invoices.filters.sortOptions.dateNewest"));
+  if (sortBy === "date" && sortOrder === "asc") return t(selectorFromPath("forms.invoices.filters.sortOptions.dateOldest"));
+  if (sortBy === "amount" && sortOrder === "desc") return t(selectorFromPath("forms.invoices.filters.sortOptions.amountHighToLow"));
+  if (sortBy === "amount" && sortOrder === "asc") return t(selectorFromPath("forms.invoices.filters.sortOptions.amountLowToHigh"));
+  if (sortBy === "name" && sortOrder === "asc") return t(selectorFromPath("forms.invoices.filters.sortOptions.nameAZ"));
+  if (sortBy === "name" && sortOrder === "desc") return t(selectorFromPath("forms.invoices.filters.sortOptions.nameZA"));
+  return "";
+}
+
+/**
+ * Sort selection card for invoice filters.
+ *
+ * @param props - Current filter state and URL-backed filter updater.
+ * @returns The rendered sort filter card.
+ */
+export function SortFilterCard({filters, onFiltersChange}: Readonly<Props>): React.JSX.Element {
+  const t = useTranslations();
+  const isSortActive = !(filters.sortBy === "date" && filters.sortOrder === "desc");
+  const activeValue = useMemo(
+    () => (isSortActive ? getSortLabel(t, filters.sortBy, filters.sortOrder) : null),
+    [filters.sortBy, filters.sortOrder, isSortActive, t],
+  );
+
+  const handleSortChange = useCallback(
+    (value: string) => {
+      const parts = value.split("-");
+      const direction = parts.pop() as "asc" | "desc";
+      const field = parts.join("-") as Exclude<FilterState["sortBy"], null>;
+      onFiltersChange({sortBy: field, sortOrder: direction});
+    },
+    [onFiltersChange],
+  );
+
+  return (
+    <FilterCardFrame
+      title={<>↕ {t((m) => m.forms.invoices.filters.sortBy)}</>}
+      active={isSortActive}
+      activeValue={activeValue}
+      inactiveLabel={t((m) => m.forms.invoices.filters.defaultValue)}>
+      <Select
+        value={`${filters.sortBy}-${filters.sortOrder}`}
+        onValueChange={handleSortChange}>
+        <SelectTrigger className={styles["sortSelect"]}>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value='date-desc'>{t((m) => m.forms.invoices.filters.sortOptions.dateNewest)}</SelectItem>
+          <SelectItem value='date-asc'>{t((m) => m.forms.invoices.filters.sortOptions.dateOldest)}</SelectItem>
+          <SelectItem value='amount-desc'>{t((m) => m.forms.invoices.filters.sortOptions.amountHighToLow)}</SelectItem>
+          <SelectItem value='amount-asc'>{t((m) => m.forms.invoices.filters.sortOptions.amountLowToHigh)}</SelectItem>
+          <SelectItem value='name-asc'>{t((m) => m.forms.invoices.filters.sortOptions.nameAZ)}</SelectItem>
+          <SelectItem value='name-desc'>{t((m) => m.forms.invoices.filters.sortOptions.nameZA)}</SelectItem>
+        </SelectContent>
+      </Select>
+    </FilterCardFrame>
+  );
+}


### PR DESCRIPTION
## Summary
- Split the invoice FilterBar card internals into focused card components.
- Keep FilterBar as the shell for search, clear-all, view mode, mobile sheet, and derived option orchestration.
- Split shell/card styles into smaller SCSS modules.

## Validation
- `npm run typecheck` from `sites/arolariu.ro`
- `npm run test:website` from `sites/arolariu.ro`
- `npm run build:website`

## Scope
Wave 2 filter-card PR only. No scan upload or recipe dialog changes.