### PR TITLE
refactor(invoices): isolate scan upload flow

### DIFF
--- a/sites/arolariu.ro/src/app/domains/invoices/upload-scans/_components/UploadArea.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/upload-scans/_components/UploadArea.tsx
@@ -16,64 +16,9 @@ import {useTranslations} from "next-intl-selector";
 import {useCallback, useEffect, useRef, useState} from "react";
 import {TbUpload} from "react-icons/tb";
 import {useScanUpload} from "../_context/ScanUploadContext";
+import {ACCEPTED_UPLOAD_EXTENSIONS} from "../_utils/uploadTypes";
+import {extractFilesFromDataTransferItems} from "../_utils/uploadValidation";
 import styles from "./UploadArea.module.scss";
-
-/** Accepted MIME types for file uploads */
-const ACCEPTED_TYPES = new Set(["image/jpeg", "image/png", "application/pdf"]);
-
-/** Accepted file extensions */
-const ACCEPTED_EXTENSIONS = ".jpg,.jpeg,.png,.pdf";
-
-/** Valid file extensions for programmatic validation */
-const VALID_EXTENSIONS = new Set(["jpg", "jpeg", "png", "pdf"]);
-
-/** Maximum file size in bytes (10MB) */
-const MAX_FILE_SIZE = 10 * 1024 * 1024;
-
-/**
- * Checks if a file is valid based on type, extension, and size constraints.
- * @param file - The file to validate
- * @returns True if the file passes all validation checks
- */
-function isValidFile(file: File): boolean {
-  const extension = file.name.split(".").pop()?.toLowerCase();
-  return ACCEPTED_TYPES.has(file.type) && file.size <= MAX_FILE_SIZE && extension !== undefined && VALID_EXTENSIONS.has(extension);
-}
-
-/**
- * Extracts a file from a DataTransferItem.
- * @param item - The DataTransferItem
- * @returns The file if valid, null otherwise
- */
-function extractFileFromDataTransferItem(item: DataTransferItem): File | null {
-  const file = item.getAsFile();
-  if (file && isValidFile(file)) {
-    return file;
-  }
-  return null;
-}
-
-/**
- * Filters and validates files from a DataTransferItemList.
- * @param items - The DataTransferItemList to filter
- * @returns An array of valid files
- */
-function filterValidFilesFromDataTransfer(items: DataTransferItemList): File[] {
-  const validFiles: File[] = [];
-  // Convert DataTransferItemList to array for iteration
-  const itemsArray = Array.from({length: items.length}, (_, index) => items[index]);
-
-  for (const item of itemsArray) {
-    if (item) {
-      const file = extractFileFromDataTransferItem(item);
-      if (file) {
-        validFiles.push(file);
-      }
-    }
-  }
-
-  return validFiles;
-}
 
 /**
  * Returns true if the active element is one where pasting should be left alone
@@ -174,13 +119,9 @@ export default function UploadArea(): React.JSX.Element {
 
       if (isUploading) return;
 
-      const droppedFiles = filterValidFilesFromDataTransfer(event.dataTransfer.items);
+      const droppedFiles = extractFilesFromDataTransferItems(event.dataTransfer.items);
       if (droppedFiles.length > 0) {
-        const dataTransfer = new DataTransfer();
-        for (const file of droppedFiles) {
-          dataTransfer.items.add(file);
-        }
-        void addFiles(dataTransfer.files).catch((error) => {
+        void addFiles(droppedFiles).catch((error) => {
           console.error("Failed to add files:", error);
         }); // Fire-and-forget async operation
       }
@@ -199,15 +140,11 @@ export default function UploadArea(): React.JSX.Element {
       if (isEditableTarget(event.target)) return;
       if (!event.clipboardData) return;
 
-      const pastedFiles = filterValidFilesFromDataTransfer(event.clipboardData.items);
+      const pastedFiles = extractFilesFromDataTransferItems(event.clipboardData.items);
       if (pastedFiles.length === 0) return;
 
       event.preventDefault();
-      const dataTransfer = new DataTransfer();
-      for (const file of pastedFiles) {
-        dataTransfer.items.add(file);
-      }
-      void addFiles(dataTransfer.files).catch((error) => {
+      void addFiles(pastedFiles).catch((error) => {
         console.error("Failed to add pasted files:", error);
       });
     };
@@ -224,7 +161,7 @@ export default function UploadArea(): React.JSX.Element {
         <input
           ref={fileInputRef}
           type='file'
-          accept={ACCEPTED_EXTENSIONS}
+          accept={ACCEPTED_UPLOAD_EXTENSIONS}
           multiple
           onChange={handleFileChange}
           className={styles["hiddenInput"]}
@@ -291,7 +228,7 @@ export default function UploadArea(): React.JSX.Element {
       <input
         ref={fileInputRef}
         type='file'
-        accept={ACCEPTED_EXTENSIONS}
+        accept={ACCEPTED_UPLOAD_EXTENSIONS}
         multiple
         onChange={handleFileChange}
         className={styles["hiddenInput"]}

--- a/sites/arolariu.ro/src/app/domains/invoices/upload-scans/_components/UploadPreview.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/upload-scans/_components/UploadPreview.tsx
@@ -15,6 +15,7 @@ import {useCallback, useEffect, useState} from "react";
 import {TbCheck, TbChevronLeft, TbChevronRight, TbFileTypePdf, TbLoader2, TbTrash, TbX} from "react-icons/tb";
 import {StaggerContainer, StaggerItem} from "../../_components/StaggerContainer";
 import {useScanUpload} from "../_context/ScanUploadContext";
+import type {PendingUploadStatus} from "../_utils/uploadTypes";
 import styles from "./UploadPreview.module.scss";
 
 /**
@@ -25,11 +26,6 @@ function formatFileSize(bytes: number): string {
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
-
-/**
- * Status of a pending upload
- */
-type PendingUploadStatus = "idle" | "uploading" | "retrying" | "completed" | "failed";
 
 /**
  * Represents a file pending upload for the card component

--- a/sites/arolariu.ro/src/app/domains/invoices/upload-scans/_context/ScanUploadContext.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/upload-scans/_context/ScanUploadContext.tsx
@@ -1,420 +1,230 @@
 "use client";
 
 /**
- * @fileoverview Context provider for managing scan upload state.
+ * @fileoverview Context provider for managing route-scoped scan upload state.
  * @module app/domains/invoices/upload-scans/_context/ScanUploadContext
  *
  * @remarks
- * Simplified version of InvoiceCreatorContext that only handles uploading
- * scans to Azure Blob Storage. Does not create invoices.
+ * Keeps transient browser upload state in memory while delegating validation,
+ * reducer transitions, and one-file upload orchestration to focused utilities.
  */
 
-import {generateUploadSasUrl, registerScan, uploadScan} from "@/app/domains/invoices/_actions/scans";
 import {withConcurrencyLimit} from "@/lib/concurrency.client";
-import {useScansStore} from "@/stores";
-import type {CachedScan} from "@/types/scans";
 import {toast} from "@arolariu/components";
-import {createContext, use, useCallback, useMemo, useRef, useState} from "react";
+import {createContext, use, useCallback, useEffect, useMemo, useReducer, useRef, type ReactNode} from "react";
 import {v4 as uuidv4} from "uuid";
+import {generateUploadSasUrl, registerScan, uploadScan} from "../../_actions/scans";
+import {initialUploadState, selectUploadableItems, uploadReducer} from "../_utils/uploadReducer";
+import {readFileAsBase64, uploadPendingScan} from "../_utils/uploadRunner";
+import {
+  COMPLETED_UPLOAD_REMOVAL_DELAY_MS,
+  UPLOAD_CONCURRENCY_LIMIT,
+  type PendingUpload,
+  type SessionStats,
+  type UploadCompletionSummary,
+  type UploadProgressEvent,
+  type UploadRunnerDependencies,
+} from "../_utils/uploadTypes";
+import {validateUploadFiles} from "../_utils/uploadValidation";
 
-/**
- * Status of a pending upload
- */
-type PendingUploadStatus = "idle" | "uploading" | "retrying" | "completed" | "failed";
-
-/**
- * Represents a file pending upload
- */
-interface PendingUpload {
-  id: string;
-  name: string;
-  file: File | null; // null after upload completes to free memory
-  mimeType: string;
-  size: number;
-  preview: string;
-  status: PendingUploadStatus;
-  progress: number;
-  attempts: number;
-  error?: string;
-  blobUrl?: string; // Azure blob URL after successful upload
-}
-
-/**
- * Session statistics for tracking upload progress
- */
-interface SessionStats {
-  /** Total files added this session */
-  totalAdded: number;
-  /** Successfully uploaded files this session */
-  totalCompleted: number;
-  /** Failed uploads this session */
-  totalFailed: number;
-}
+type TimeoutHandle = ReturnType<typeof globalThis.setTimeout>;
 
 interface ScanUploadContextType {
-  /** Files pending upload */
-  pendingUploads: PendingUpload[];
-  /** Whether any uploads are in progress */
-  isUploading: boolean;
-  /** Session statistics that persist through the upload flow */
-  sessionStats: SessionStats;
-  /** Add files to the upload queue (async due to batching) */
-  addFiles: (files: FileList) => Promise<void>;
-  /** Remove files from the upload queue */
-  removeFiles: (ids: string[]) => void;
-  /** Clear all pending files */
-  clearAll: () => void;
-  /** Rename a pending file */
-  renameFile: (id: string, newName: string) => void;
-  /** Upload all pending files to Azure */
-  uploadAll: () => Promise<void>;
-  /** Reset session statistics */
-  resetSessionStats: () => void;
+  /** Files currently tracked by the upload route. */
+  readonly pendingUploads: PendingUpload[];
+  /** Whether a batch upload is currently running. */
+  readonly isUploading: boolean;
+  /** Upload statistics for the current route session. */
+  readonly sessionStats: SessionStats;
+  /** Latest successfully uploaded scans for the post-upload prompt. */
+  readonly completedBatch: UploadCompletionSummary[];
+  /** Add files to the upload queue. */
+  readonly addFiles: (files: FileList | File[]) => Promise<void>;
+  /** Remove idle or failed files from the upload queue. */
+  readonly removeFiles: (ids: string[]) => void;
+  /** Clear all idle or failed files. Active uploads remain locked. */
+  readonly clearAll: () => void;
+  /** Rename an idle or failed file. */
+  readonly renameFile: (id: string, newName: string) => void;
+  /** Upload all idle and failed files. */
+  readonly uploadAll: () => Promise<void>;
+  /** Reset route session statistics. */
+  readonly resetSessionStats: () => void;
+  /** Clear the post-upload prompt completion summary. */
+  readonly clearCompletedBatch: () => void;
 }
 
 const ScanUploadContext = createContext<ScanUploadContextType | undefined>(undefined);
 
 /**
- * Revokes the object URL for a pending upload to free memory.
+ * Provides route-scoped scan upload state and actions.
+ *
+ * @param props - Provider props.
+ * @param props.children - Route subtree that consumes upload state.
+ * @returns Provider wrapping the upload route subtree.
  */
-function revokePreview(upload: PendingUpload): void {
-  if (upload.preview) {
-    URL.revokeObjectURL(upload.preview);
-  }
-}
+export function ScanUploadProvider({children}: Readonly<{children: ReactNode}>): React.JSX.Element {
+  const [state, dispatch] = useReducer(uploadReducer, initialUploadState);
+  const removalTimersRef = useRef<Set<TimeoutHandle>>(new Set());
+  const progressFrameRef = useRef<number | null>(null);
+  const pendingProgressEventsRef = useRef<Map<string, UploadProgressEvent>>(new Map());
+  const revokedPreviewUrlsRef = useRef<Set<string>>(new Set());
+  const latestUploadsRef = useRef<PendingUpload[]>([]);
 
-/**
- * Removes an upload from the list by ID, revoking its preview first.
- */
-function removeUploadFromList(uploads: PendingUpload[], uploadId: string): PendingUpload[] {
-  const toRemove = uploads.find((u) => u.id === uploadId);
-  if (toRemove) revokePreview(toRemove);
-  return uploads.filter((u) => u.id !== uploadId);
-}
-
-/**
- * Converts a File to base64 string.
- */
-async function fileToBase64(file: File): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.addEventListener("load", () => resolve(reader.result as string));
-    reader.addEventListener("error", () => reject(reader.error));
-    reader.readAsDataURL(file);
-  });
-}
-
-const initialSessionStats: SessionStats = {
-  totalAdded: 0,
-  totalCompleted: 0,
-  totalFailed: 0,
-};
-
-export function ScanUploadProvider({children}: Readonly<{children: React.ReactNode}>): React.JSX.Element {
-  const [pendingUploads, setPendingUploads] = useState<PendingUpload[]>([]);
-  const [isUploading, setIsUploading] = useState(false);
-  const [sessionStats, setSessionStats] = useState<SessionStats>(initialSessionStats);
-  const addScan = useScansStore((state) => state.addScan);
-
-  // Batched progress updates to reduce React re-renders during concurrent uploads
-  const pendingProgressUpdatesRef = useRef<Map<string, {status: PendingUploadStatus; progress: number; error?: string; blobUrl?: string}>>(
-    new Map(),
-  );
-  const rafIdRef = useRef<number | null>(null);
-
-  /**
-   * Add files to the upload queue.
-   * Uses batching to prevent DOM overload when dropping 50+ files.
-   */
-  const addFiles = useCallback(async (files: FileList) => {
-    const newUploads: PendingUpload[] = [];
-
-    for (const file of files) {
-      const isImage = file.type.startsWith("image/");
-      const isPdf = file.type === "application/pdf";
-
-      if (!isImage && !isPdf) {
-        toast.error(`Unsupported file type: ${file.type}`);
-      } else if (file.size > 10 * 1024 * 1024) {
-        // Check file size (max 10MB)
-        toast.error(`File too large: ${file.name} (max 10MB)`);
-      } else {
-        const id = uuidv4();
-        const preview = URL.createObjectURL(file);
-
-        newUploads.push({
-          id,
-          name: file.name,
-          file,
-          mimeType: file.type,
-          size: file.size,
-          preview,
-          status: "idle",
-          progress: 0,
-          attempts: 0,
-        });
-      }
-    }
-
-    if (newUploads.length > 0) {
-      // Batch updates to prevent DOM overload with large file counts
-      const BATCH_SIZE = 5;
-      for (let i = 0; i < newUploads.length; i += BATCH_SIZE) {
-        const batch = newUploads.slice(i, i + BATCH_SIZE);
-        // Yield to the browser (macrotask) so it can paint/respond between batches.
-        // Note: an awaited Promise that resolves synchronously only yields a microtask,
-        // which is NOT enough for the browser to render between batches.
-        await new Promise<void>((resolve) => {
-          setTimeout(resolve, 0);
-        });
-        setPendingUploads((prev) => [...prev, ...batch]);
-      }
-
-      setSessionStats((prev) => ({
-        ...prev,
-        totalAdded: prev.totalAdded + newUploads.length,
-      }));
-      toast.success(`Added ${newUploads.length} file(s) to upload queue`);
+  const revokePreviewUrl = useCallback((preview: string): void => {
+    if (preview && preview.startsWith("blob:") && !revokedPreviewUrlsRef.current.has(preview)) {
+      URL.revokeObjectURL(preview);
+      revokedPreviewUrlsRef.current.add(preview);
     }
   }, []);
 
-  /**
-   * Remove files from the upload queue.
-   */
-  const removeFiles = useCallback((ids: string[]) => {
-    setPendingUploads((prev) => {
-      const idsSet = new Set(ids);
-      const toRemove = prev.filter((u) => idsSet.has(u.id));
-
-      for (const upload of toRemove) {
-        revokePreview(upload);
-      }
-
-      return prev.filter((u) => !idsSet.has(u.id));
-    });
-  }, []);
-
-  /**
-   * Clear all pending files.
-   */
-  const clearAll = useCallback(() => {
-    setPendingUploads((prev) => {
-      for (const upload of prev) {
-        revokePreview(upload);
-      }
-      return [];
-    });
-    toast.info("All files cleared");
-  }, []);
-
-  /**
-   * Rename a pending file.
-   */
-  const renameFile = useCallback((id: string, newName: string) => {
-    setPendingUploads((prev) => prev.map((u) => (u.id === id ? {...u, name: newName} : u)));
-  }, []);
-
-  /**
-   * Batched progress update function to reduce React re-renders during concurrent uploads.
-   * Uses requestAnimationFrame to batch multiple progress updates into a single state update.
-   */
-  const batchedUpdateProgress = useCallback(
-    (id: string, status: PendingUploadStatus, progress: number, error?: string, blobUrl?: string) => {
-      pendingProgressUpdatesRef.current.set(id, {status, progress, error, blobUrl});
-
-      if (rafIdRef.current === null) {
-        rafIdRef.current = requestAnimationFrame(() => {
-          const updates = new Map(pendingProgressUpdatesRef.current);
-          pendingProgressUpdatesRef.current.clear();
-          rafIdRef.current = null;
-
-          setPendingUploads((prev) =>
-            prev.map((u) => {
-              const update = updates.get(u.id);
-              return update
-                ? {
-                    ...u,
-                    status: update.status,
-                    progress: update.progress,
-                    ...(update.error && {error: update.error}),
-                    ...(update.blobUrl && {blobUrl: update.blobUrl}),
-                  }
-                : u;
-            }),
-          );
-        });
+  const revokePreviews = useCallback(
+    (uploads: PendingUpload[]): void => {
+      for (const upload of uploads) {
+        revokePreviewUrl(upload.preview);
       }
     },
-    [],
+    [revokePreviewUrl],
   );
 
-  /**
-   * Update a single upload's status, progress, and optionally its blobUrl.
-   * Use this for final/critical states (completed, error).
-   * Use batchedUpdateProgress for intermediate progress updates.
-   */
-  const updateUploadStatus = useCallback((id: string, status: PendingUploadStatus, progress: number, error?: string, blobUrl?: string) => {
-    setPendingUploads((prev) => prev.map((u) => (u.id === id ? {...u, status, progress, error, ...(blobUrl && {blobUrl})} : u)));
+  useEffect(() => {
+    latestUploadsRef.current = state.pendingUploads;
+  }, [state.pendingUploads]);
+
+  useEffect(() => {
+    return () => {
+      if (progressFrameRef.current !== null) {
+        cancelAnimationFrame(progressFrameRef.current);
+      }
+
+      for (const timerId of removalTimersRef.current) {
+        globalThis.clearTimeout(timerId);
+      }
+
+      revokePreviews(latestUploadsRef.current);
+    };
+  }, [revokePreviews]);
+
+  const addFiles = useCallback(async (files: FileList | File[]): Promise<void> => {
+    const validation = validateUploadFiles(Array.from(files));
+
+    for (const invalidFile of validation.invalidFiles) {
+      toast.error(invalidFile.message);
+    }
+
+    const uploads: PendingUpload[] = validation.validFiles.map((file) => ({
+      id: uuidv4(),
+      name: file.name,
+      file,
+      mimeType: file.type,
+      size: file.size,
+      preview: URL.createObjectURL(file),
+      status: "idle",
+      progress: 0,
+      attempts: 0,
+    }));
+
+    if (uploads.length === 0) {
+      return;
+    }
+
+    dispatch({type: "uploads-added", uploads});
+    toast.success(`Added ${uploads.length} file(s) to upload queue`);
   }, []);
 
-  /**
-   * Remove a completed upload from the pending list after a delay.
-   */
-  const scheduleUploadRemoval = useCallback((uploadId: string, delayMs: number) => {
-    setTimeout(() => {
-      setPendingUploads((prev) => removeUploadFromList(prev, uploadId));
-    }, delayMs);
+  const removeFiles = useCallback(
+    (ids: string[]): void => {
+      const idsSet = new Set(ids);
+      const removableUploads = state.pendingUploads.filter(
+        (upload) => idsSet.has(upload.id) && (upload.status === "idle" || upload.status === "failed"),
+      );
+      revokePreviews(removableUploads);
+      dispatch({type: "uploads-removed", ids});
+    },
+    [revokePreviews, state.pendingUploads],
+  );
+
+  const clearAll = useCallback((): void => {
+    const removableUploads = state.pendingUploads.filter((upload) => upload.status === "idle" || upload.status === "failed");
+    revokePreviews(removableUploads);
+    dispatch({type: "uploads-cleared"});
+    toast.info("All files cleared");
+  }, [revokePreviews, state.pendingUploads]);
+
+  const renameFile = useCallback((id: string, newName: string): void => {
+    dispatch({type: "upload-renamed", id, name: newName});
   }, []);
 
-  /**
-   * Upload all pending files to Azure.
-   * Uses parallel direct-to-Azure uploads with SAS tokens for better performance.
-   * Falls back to server-side upload if SAS generation fails.
-   */
+  const dispatchProgress = useCallback((event: UploadProgressEvent): void => {
+    pendingProgressEventsRef.current.set(event.uploadId, event);
+
+    if (progressFrameRef.current === null) {
+      progressFrameRef.current = requestAnimationFrame(() => {
+        const events = Array.from(pendingProgressEventsRef.current.values());
+        pendingProgressEventsRef.current.clear();
+        progressFrameRef.current = null;
+
+        for (const progressEvent of events) {
+          dispatch({
+            type: "upload-progressed",
+            id: progressEvent.uploadId,
+            status: progressEvent.status,
+            progress: progressEvent.progress,
+            attempts: progressEvent.attempts,
+            ...(progressEvent.error === undefined ? {} : {error: progressEvent.error}),
+            ...(progressEvent.blobUrl === undefined ? {} : {blobUrl: progressEvent.blobUrl}),
+          });
+        }
+      });
+    }
+  }, []);
+
+  const scheduleUploadRemoval = useCallback((uploadId: string): void => {
+    const timerId = globalThis.setTimeout(() => {
+      dispatch({type: "upload-removed-after-completion", id: uploadId});
+      removalTimersRef.current.delete(timerId);
+    }, COMPLETED_UPLOAD_REMOVAL_DELAY_MS);
+
+    removalTimersRef.current.add(timerId);
+  }, []);
+
   const uploadAll = useCallback(async (): Promise<void> => {
-    const uploadsToProcess = pendingUploads.filter((u) => u.status === "idle" || u.status === "failed");
+    const uploadsToProcess = selectUploadableItems(state);
 
     if (uploadsToProcess.length === 0) {
       toast.info("No files to upload");
       return;
     }
 
-    setIsUploading(true);
+    dispatch({type: "batch-started"});
 
-    // Mark all as uploading
-    for (const upload of uploadsToProcess) {
-      updateUploadStatus(upload.id, "uploading", 0);
-    }
+    const dependencies: UploadRunnerDependencies = {
+      generateUploadSasUrl,
+      registerScan,
+      uploadScan,
+      fetchImpl: fetch,
+      readFileAsBase64,
+    };
 
-    let successCount = 0;
-    let failCount = 0;
-
-    // Create upload tasks with concurrency limit (max 5 parallel)
-    // Attempts direct Azure upload via SAS URL first (fast, no server bottleneck).
-    // Falls back to server-side upload if SAS fails (CORS not deployed yet, etc.)
     const uploadTasks = uploadsToProcess.map((upload) => async () => {
-      try {
-        // Guard against null file reference
-        if (!upload.file) {
-          updateUploadStatus(upload.id, "failed", 0, "File reference lost");
-          failCount++;
-          return {success: false, uploadId: upload.id, error: "File reference lost"};
-        }
+      const result = await uploadPendingScan(upload, dependencies, {onProgress: dispatchProgress});
 
-        // Step 1: Preparing SAS URL (0% → 30%)
-        batchedUpdateProgress(upload.id, "uploading", 0);
-
-        const sasResult = await generateUploadSasUrl({
-          fileName: upload.name,
-          mimeType: upload.mimeType,
-        });
-
-        batchedUpdateProgress(upload.id, "uploading", 30);
-
-        if (sasResult.success && sasResult.data.sasUrl && sasResult.data.scanId && sasResult.data.blobUrl) {
-          // Step 2: Upload file directly to Azure using SAS URL (30% → 70%)
-          const uploadResponse = await fetch(sasResult.data.sasUrl, {
-            method: "PUT",
-            body: upload.file,
-            headers: {
-              "x-ms-blob-type": "BlockBlob",
-              "Content-Type": upload.mimeType,
-            },
-          });
-
-          batchedUpdateProgress(upload.id, "uploading", 70);
-
-          if (uploadResponse.ok) {
-            // Step 3: Register scan metadata with server (70% → 90%)
-            const registerResult = await registerScan({
-              scanId: sasResult.data.scanId,
-              blobUrl: sasResult.data.blobUrl,
-              fileName: upload.name,
-              mimeType: upload.mimeType,
-              sizeInBytes: upload.size,
-            });
-
-            batchedUpdateProgress(upload.id, "uploading", 90);
-
-            if (registerResult.success && registerResult.scan) {
-              const cachedScan: CachedScan = {
-                ...registerResult.scan,
-                cachedAt: new Date(),
-              };
-              addScan(cachedScan);
-              // Step 4: Complete (100%)
-              updateUploadStatus(upload.id, "completed", 100, undefined, registerResult.scan.blobUrl);
-
-              // FIX 1: Immediately revoke the object URL to free memory
-              if (upload.preview) {
-                URL.revokeObjectURL(upload.preview);
-              }
-
-              // FIX 2: Clear file reference to free memory
-              setPendingUploads((prev) => prev.map((u) => (u.id === upload.id ? {...u, file: null, preview: ""} : u)));
-
-              successCount++;
-              scheduleUploadRemoval(upload.id, 1000);
-              return {success: true, uploadId: upload.id};
-            }
-          }
-          // If direct upload or registration failed, fall through to server upload
-        }
-
-        // Fallback: Server-side upload (works without CORS)
-        // Reset progress for fallback path
-        batchedUpdateProgress(upload.id, "uploading", 50);
-
-        const base64Data = await fileToBase64(upload.file);
-        const result = await uploadScan({
-          base64Data,
-          fileName: upload.name,
-          mimeType: upload.mimeType,
-        });
-
-        batchedUpdateProgress(upload.id, "uploading", 90);
-
-        if (result.success && result.data.status === 201) {
-          const cachedScan: CachedScan = {
-            ...result.data.scan,
-            cachedAt: new Date(),
-          };
-          addScan(cachedScan);
-          updateUploadStatus(upload.id, "completed", 100, undefined, result.data.scan.blobUrl);
-
-          // FIX 1: Immediately revoke the object URL to free memory
-          if (upload.preview) {
-            URL.revokeObjectURL(upload.preview);
-          }
-
-          // FIX 2: Clear file reference to free memory
-          setPendingUploads((prev) => prev.map((u) => (u.id === upload.id ? {...u, file: null, preview: ""} : u)));
-
-          successCount++;
-          scheduleUploadRemoval(upload.id, 1000);
-          return {success: true, uploadId: upload.id};
-        } else {
-          throw new Error(result.success ? `Upload failed with status ${result.data.status}` : result.error.message);
-        }
-      } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : "Unknown error";
-        updateUploadStatus(upload.id, "failed", 0, errorMessage);
-        failCount++;
-        return {success: false, uploadId: upload.id, error: errorMessage};
+      if (result.success) {
+        revokePreviewUrl(upload.preview);
+        dispatch({type: "upload-completed", id: upload.id, attempts: result.attempts, blobUrl: result.blobUrl});
+        scheduleUploadRemoval(upload.id);
+      } else {
+        dispatch({type: "upload-failed", id: upload.id, attempts: result.attempts, error: result.error});
       }
+
+      return result;
     });
 
-    // Execute uploads with concurrency limit (5 parallel uploads)
-    await withConcurrencyLimit(uploadTasks, 5);
+    const results = await withConcurrencyLimit(uploadTasks, UPLOAD_CONCURRENCY_LIMIT);
+    dispatch({type: "batch-finished"});
 
-    setIsUploading(false);
-
-    // Update session stats
-    setSessionStats((prev) => ({
-      ...prev,
-      totalCompleted: prev.totalCompleted + successCount,
-      totalFailed: prev.totalFailed + failCount,
-    }));
+    const successCount = results.filter((result) => result?.success === true).length;
+    const failCount = results.filter((result) => result?.success === false).length;
 
     if (successCount > 0) {
       toast.success(`Successfully uploaded ${successCount} scan(s)`);
@@ -422,37 +232,47 @@ export function ScanUploadProvider({children}: Readonly<{children: React.ReactNo
     if (failCount > 0) {
       toast.error(`Failed to upload ${failCount} scan(s)`);
     }
-  }, [pendingUploads, updateUploadStatus, batchedUpdateProgress, addScan, scheduleUploadRemoval]);
+  }, [dispatchProgress, revokePreviewUrl, scheduleUploadRemoval, state]);
 
-  /**
-   * Reset session statistics.
-   */
-  const resetSessionStats = useCallback(() => {
-    setSessionStats(initialSessionStats);
+  const resetSessionStats = useCallback((): void => {
+    dispatch({type: "session-stats-reset"});
+  }, []);
+
+  const clearCompletedBatch = useCallback((): void => {
+    dispatch({type: "completed-batch-cleared"});
   }, []);
 
   const value = useMemo<ScanUploadContextType>(
     () => ({
-      pendingUploads,
-      sessionStats,
-      isUploading,
+      pendingUploads: state.pendingUploads,
+      sessionStats: state.sessionStats,
+      completedBatch: state.completedBatch,
+      isUploading: state.isUploading,
       addFiles,
       removeFiles,
       clearAll,
       renameFile,
       uploadAll,
       resetSessionStats,
+      clearCompletedBatch,
     }),
-    [pendingUploads, sessionStats, isUploading, addFiles, removeFiles, clearAll, renameFile, uploadAll, resetSessionStats],
+    [addFiles, clearAll, clearCompletedBatch, removeFiles, renameFile, resetSessionStats, state, uploadAll],
   );
 
   return <ScanUploadContext value={value}>{children}</ScanUploadContext>;
 }
 
+/**
+ * Reads scan upload context.
+ *
+ * @returns Current scan upload context value.
+ * @throws When used outside `ScanUploadProvider`.
+ */
 export function useScanUpload(): ScanUploadContextType {
   const context = use(ScanUploadContext);
   if (context === undefined) {
     throw new Error("useScanUpload must be used within a ScanUploadProvider");
   }
+
   return context;
 }

--- a/sites/arolariu.ro/src/app/domains/invoices/upload-scans/_utils/uploadReducer.test.ts
+++ b/sites/arolariu.ro/src/app/domains/invoices/upload-scans/_utils/uploadReducer.test.ts
@@ -1,0 +1,230 @@
+/**
+ * @fileoverview Unit tests for the scan upload reducer state machine.
+ * @module app/domains/invoices/upload-scans/_utils/uploadReducer.test
+ */
+
+import {describe, expect, it} from "vitest";
+import type {PendingUpload} from "./uploadTypes";
+import {initialUploadState, selectUploadableItems, uploadReducer} from "./uploadReducer";
+
+/**
+ * Creates a pending upload test fixture.
+ *
+ * @param overrides - Properties to override on the default upload.
+ * @returns Pending upload fixture.
+ */
+function createUpload(overrides: Partial<PendingUpload> = {}): PendingUpload {
+  const file = new File([new Uint8Array(4)], "receipt.jpg", {type: "image/jpeg"});
+  return {
+    id: "upload-1",
+    name: "receipt.jpg",
+    file,
+    mimeType: "image/jpeg",
+    size: file.size,
+    preview: "blob:preview",
+    status: "idle",
+    progress: 0,
+    attempts: 0,
+    ...overrides,
+  };
+}
+
+describe("uploadReducer", () => {
+  it("adds uploads and increments totalAdded", () => {
+    const upload = createUpload();
+
+    const state = uploadReducer(initialUploadState, {type: "uploads-added", uploads: [upload]});
+
+    expect(state.pendingUploads).toEqual([upload]);
+    expect(state.sessionStats.totalAdded).toBe(1);
+  });
+
+  it("removes only idle and failed uploads", () => {
+    const idle = createUpload({id: "idle", status: "idle"});
+    const failed = createUpload({id: "failed", status: "failed"});
+    const active = createUpload({id: "active", status: "uploading"});
+    const state = uploadReducer(initialUploadState, {type: "uploads-added", uploads: [idle, failed, active]});
+
+    const next = uploadReducer(state, {type: "uploads-removed", ids: ["idle", "failed", "active"]});
+
+    expect(next.pendingUploads.map((upload) => upload.id)).toEqual(["active"]);
+  });
+
+  it("tracks retry attempt state", () => {
+    const upload = createUpload();
+    const withUpload = uploadReducer(initialUploadState, {type: "uploads-added", uploads: [upload]});
+
+    const retrying = uploadReducer(withUpload, {
+      type: "upload-progressed",
+      id: upload.id,
+      status: "retrying",
+      progress: 30,
+      attempts: 2,
+    });
+
+    expect(retrying.pendingUploads[0]).toMatchObject({
+      status: "retrying",
+      progress: 30,
+      attempts: 2,
+    });
+    expect(retrying.pendingUploads[0]?.error).toBeUndefined();
+  });
+
+  it("records completion summary and releases local file reference", () => {
+    const upload = createUpload();
+    const withUpload = uploadReducer(initialUploadState, {type: "uploads-added", uploads: [upload]});
+
+    const completed = uploadReducer(withUpload, {
+      type: "upload-completed",
+      id: upload.id,
+      attempts: 1,
+      blobUrl: "https://storage/scans/upload-1.jpg",
+    });
+
+    expect(completed.pendingUploads[0]).toMatchObject({
+      file: null,
+      preview: "",
+      status: "completed",
+      progress: 100,
+      attempts: 1,
+      blobUrl: "https://storage/scans/upload-1.jpg",
+    });
+    expect(completed.completedBatch).toEqual([
+      {
+        id: upload.id,
+        name: upload.name,
+        preview: "https://storage/scans/upload-1.jpg",
+      },
+    ]);
+  });
+
+  it("records failed uploads and increments failed stats", () => {
+    const upload = createUpload();
+    const withUpload = uploadReducer(initialUploadState, {type: "uploads-added", uploads: [upload]});
+
+    const failed = uploadReducer(withUpload, {
+      type: "upload-failed",
+      id: upload.id,
+      attempts: 3,
+      error: "Server upload failed",
+    });
+
+    expect(failed.pendingUploads[0]).toMatchObject({
+      status: "failed",
+      progress: 0,
+      attempts: 3,
+      error: "Server upload failed",
+    });
+    expect(failed.sessionStats.totalFailed).toBe(1);
+  });
+
+  it("clears only removable uploads", () => {
+    const idle = createUpload({id: "idle", status: "idle"});
+    const active = createUpload({id: "active", status: "uploading"});
+    const failed = createUpload({id: "failed", status: "failed"});
+    const state = uploadReducer(initialUploadState, {type: "uploads-added", uploads: [idle, active, failed]});
+
+    const cleared = uploadReducer(state, {type: "uploads-cleared"});
+
+    expect(cleared.pendingUploads.map((upload) => upload.id)).toEqual(["active"]);
+  });
+
+  it("renames only removable uploads", () => {
+    const idle = createUpload({id: "idle", status: "idle"});
+    const active = createUpload({id: "active", status: "uploading", name: "active.jpg"});
+    const state = uploadReducer(initialUploadState, {type: "uploads-added", uploads: [idle, active]});
+
+    const renamedIdle = uploadReducer(state, {type: "upload-renamed", id: "idle", name: "renamed.jpg"});
+    const renamedActive = uploadReducer(renamedIdle, {type: "upload-renamed", id: "active", name: "blocked.jpg"});
+
+    expect(renamedActive.pendingUploads.find((upload) => upload.id === "idle")?.name).toBe("renamed.jpg");
+    expect(renamedActive.pendingUploads.find((upload) => upload.id === "active")?.name).toBe("active.jpg");
+  });
+
+  it("sets batch uploading state and clears previous completion summaries", () => {
+    const upload = createUpload();
+    const withUpload = uploadReducer(initialUploadState, {type: "uploads-added", uploads: [upload]});
+    const completed = uploadReducer(withUpload, {
+      type: "upload-completed",
+      id: upload.id,
+      attempts: 1,
+      blobUrl: "https://storage/scans/upload-1.jpg",
+    });
+
+    const started = uploadReducer(completed, {type: "batch-started"});
+    const finished = uploadReducer(started, {type: "batch-finished"});
+
+    expect(started.isUploading).toBe(true);
+    expect(started.completedBatch).toEqual([]);
+    expect(finished.isUploading).toBe(false);
+  });
+
+  it("stores optional progress errors and blob URLs", () => {
+    const upload = createUpload();
+    const withUpload = uploadReducer(initialUploadState, {type: "uploads-added", uploads: [upload]});
+
+    const progressed = uploadReducer(withUpload, {
+      type: "upload-progressed",
+      id: upload.id,
+      status: "uploading",
+      progress: 70,
+      attempts: 1,
+      error: "slow network",
+      blobUrl: "https://storage/scans/upload-1.jpg",
+    });
+
+    expect(progressed.pendingUploads[0]).toMatchObject({
+      status: "uploading",
+      progress: 70,
+      attempts: 1,
+      error: "slow network",
+      blobUrl: "https://storage/scans/upload-1.jpg",
+    });
+  });
+
+  it("removes completed uploads after the display delay", () => {
+    const upload = createUpload({status: "completed"});
+    const state = uploadReducer(initialUploadState, {type: "uploads-added", uploads: [upload]});
+
+    const next = uploadReducer(state, {type: "upload-removed-after-completion", id: upload.id});
+
+    expect(next.pendingUploads).toEqual([]);
+  });
+
+  it("resets session stats and clears completed batch", () => {
+    const upload = createUpload();
+    const withUpload = uploadReducer(initialUploadState, {type: "uploads-added", uploads: [upload]});
+    const completed = uploadReducer(withUpload, {
+      type: "upload-completed",
+      id: upload.id,
+      attempts: 1,
+      blobUrl: "https://storage/scans/upload-1.jpg",
+    });
+
+    const reset = uploadReducer(completed, {type: "session-stats-reset"});
+    const withoutCompletedBatch = uploadReducer(reset, {type: "completed-batch-cleared"});
+
+    expect(reset.sessionStats).toEqual({
+      totalAdded: 0,
+      totalCompleted: 0,
+      totalFailed: 0,
+    });
+    expect(withoutCompletedBatch.completedBatch).toEqual([]);
+  });
+});
+
+describe("selectUploadableItems", () => {
+  it("selects idle and failed uploads only", () => {
+    const state = uploadReducer(initialUploadState, {
+      type: "uploads-added",
+      uploads: [
+        createUpload({id: "idle", status: "idle"}),
+        createUpload({id: "failed", status: "failed"}),
+        createUpload({id: "uploading", status: "uploading"}),
+        createUpload({id: "completed", status: "completed"}),
+      ],
+    });
+
+    expect(selectUploadableItems(state).map((upload) => upload.id)).toEqual(["idle", "failed"]);
+  });
+});

--- a/sites/arolariu.ro/src/app/domains/invoices/upload-scans/_utils/uploadReducer.ts
+++ b/sites/arolariu.ro/src/app/domains/invoices/upload-scans/_utils/uploadReducer.ts
@@ -1,0 +1,178 @@
+/**
+ * @fileoverview Pure reducer for the route-scoped scan upload state machine.
+ * @module app/domains/invoices/upload-scans/_utils/uploadReducer
+ *
+ * @remarks
+ * The reducer has no side effects. Object URL cleanup, timers, toasts, and
+ * network operations remain in the context/provider layer.
+ */
+
+import type {PendingUpload, SessionStats, UploadAction, UploadState} from "./uploadTypes";
+
+/** Initial upload statistics for a route session. */
+const initialSessionStats: SessionStats = {
+  totalAdded: 0,
+  totalCompleted: 0,
+  totalFailed: 0,
+};
+
+/** Initial route-scoped upload state. */
+export const initialUploadState: UploadState = {
+  pendingUploads: [],
+  isUploading: false,
+  sessionStats: initialSessionStats,
+  completedBatch: [],
+};
+
+/**
+ * Determines whether an upload may be removed by user actions.
+ *
+ * @param upload - Upload queue item to inspect.
+ * @returns `true` when the upload is idle or failed.
+ */
+function isRemovable(upload: PendingUpload): boolean {
+  return upload.status === "idle" || upload.status === "failed";
+}
+
+/**
+ * Updates one upload item while preserving queue order.
+ *
+ * @param uploads - Current upload queue.
+ * @param uploadId - Identifier of the upload to update.
+ * @param update - Mapping function for the matching upload.
+ * @returns Updated upload queue.
+ */
+function updateUpload(uploads: PendingUpload[], uploadId: string, update: (upload: PendingUpload) => PendingUpload): PendingUpload[] {
+  return uploads.map((upload) => (upload.id === uploadId ? update(upload) : upload));
+}
+
+/**
+ * Selects uploads that can be started by the next batch.
+ *
+ * @param state - Current upload state.
+ * @returns Idle and failed uploads, preserving queue order.
+ */
+export function selectUploadableItems(state: UploadState): PendingUpload[] {
+  return state.pendingUploads.filter((upload) => upload.status === "idle" || upload.status === "failed");
+}
+
+/**
+ * Applies one upload state-machine action.
+ *
+ * @param state - Current upload state.
+ * @param action - State transition action.
+ * @returns Next upload state.
+ */
+export function uploadReducer(state: UploadState, action: UploadAction): UploadState {
+  switch (action.type) {
+    case "uploads-added":
+      return {
+        ...state,
+        pendingUploads: [...state.pendingUploads, ...action.uploads],
+        sessionStats: {
+          ...state.sessionStats,
+          totalAdded: state.sessionStats.totalAdded + action.uploads.length,
+        },
+      };
+
+    case "uploads-removed": {
+      const ids = new Set(action.ids);
+      return {
+        ...state,
+        pendingUploads: state.pendingUploads.filter((upload) => !ids.has(upload.id) || !isRemovable(upload)),
+      };
+    }
+
+    case "uploads-cleared":
+      return {
+        ...state,
+        pendingUploads: state.pendingUploads.filter((upload) => !isRemovable(upload)),
+      };
+
+    case "upload-renamed":
+      return {
+        ...state,
+        pendingUploads: updateUpload(state.pendingUploads, action.id, (upload) =>
+          isRemovable(upload) ? {...upload, name: action.name} : upload,
+        ),
+      };
+
+    case "batch-started":
+      return {...state, isUploading: true, completedBatch: []};
+
+    case "batch-finished":
+      return {...state, isUploading: false};
+
+    case "upload-progressed":
+      return {
+        ...state,
+        pendingUploads: updateUpload(state.pendingUploads, action.id, (upload) => ({
+          ...upload,
+          status: action.status,
+          progress: action.progress,
+          attempts: action.attempts,
+          ...(action.error === undefined ? {} : {error: action.error}),
+          ...(action.blobUrl === undefined ? {} : {blobUrl: action.blobUrl}),
+        })),
+      };
+
+    case "upload-completed":
+      return {
+        ...state,
+        pendingUploads: updateUpload(state.pendingUploads, action.id, (upload) => {
+          const {error: _error, ...uploadWithoutError} = upload;
+          return {
+            ...uploadWithoutError,
+            file: null,
+            preview: "",
+            status: "completed",
+            progress: 100,
+            attempts: action.attempts,
+            blobUrl: action.blobUrl,
+          };
+        }),
+        completedBatch: [
+          ...state.completedBatch,
+          ...state.pendingUploads
+            .filter((upload) => upload.id === action.id)
+            .map((upload) => ({
+              id: upload.id,
+              name: upload.name,
+              preview: action.blobUrl || upload.preview,
+            })),
+        ],
+        sessionStats: {
+          ...state.sessionStats,
+          totalCompleted: state.sessionStats.totalCompleted + 1,
+        },
+      };
+
+    case "upload-failed":
+      return {
+        ...state,
+        pendingUploads: updateUpload(state.pendingUploads, action.id, (upload) => ({
+          ...upload,
+          status: "failed",
+          progress: 0,
+          attempts: action.attempts,
+          error: action.error,
+        })),
+        sessionStats: {
+          ...state.sessionStats,
+          totalFailed: state.sessionStats.totalFailed + 1,
+        },
+      };
+
+    case "upload-removed-after-completion":
+      return {
+        ...state,
+        pendingUploads: state.pendingUploads.filter((upload) => upload.id !== action.id),
+      };
+
+    case "session-stats-reset":
+      return {...state, sessionStats: initialSessionStats};
+
+    case "completed-batch-cleared":
+      return {...state, completedBatch: []};
+  }
+}

--- a/sites/arolariu.ro/src/app/domains/invoices/upload-scans/_utils/uploadRunner.test.ts
+++ b/sites/arolariu.ro/src/app/domains/invoices/upload-scans/_utils/uploadRunner.test.ts
@@ -1,0 +1,321 @@
+/**
+ * @fileoverview Unit tests for the scan upload runner.
+ * @module app/domains/invoices/upload-scans/_utils/uploadRunner.test
+ */
+
+import {describe, expect, it, vi} from "vitest";
+import type {Scan} from "../../../../../types/scans";
+import type {PendingUpload, UploadProgressEvent, UploadRunnerDependencies} from "./uploadTypes";
+import {readFileAsBase64, uploadPendingScan} from "./uploadRunner";
+
+/**
+ * Creates a scan returned by mocked upload dependencies.
+ *
+ * @param overrides - Properties to override on the default scan.
+ * @returns Scan fixture.
+ */
+function createScan(overrides: Partial<Scan> = {}): Scan {
+  return {
+    id: "scan-1",
+    userIdentifier: "user-1",
+    name: "receipt.jpg",
+    blobUrl: "https://storage/scans/scan-1.jpg",
+    mimeType: "image/jpeg",
+    sizeInBytes: 4,
+    scanType: "JPEG",
+    uploadedAt: new Date("2026-05-26T00:00:00.000Z"),
+    status: "ready",
+    metadata: {},
+    ...overrides,
+  };
+}
+
+/**
+ * Creates a pending upload test fixture.
+ *
+ * @param overrides - Properties to override on the default upload.
+ * @returns Pending upload fixture.
+ */
+function createUpload(overrides: Partial<PendingUpload> = {}): PendingUpload {
+  const file = new File([new Uint8Array(4)], "receipt.jpg", {type: "image/jpeg"});
+  return {
+    id: "upload-1",
+    name: "receipt.jpg",
+    file,
+    mimeType: "image/jpeg",
+    size: file.size,
+    preview: "blob:preview",
+    status: "idle",
+    progress: 0,
+    attempts: 0,
+    ...overrides,
+  };
+}
+
+/**
+ * Creates upload runner dependencies backed by test doubles.
+ *
+ * @param overrides - Dependency implementations to override.
+ * @returns Complete dependency fixture for the upload runner.
+ */
+function createDependencies(overrides: Partial<UploadRunnerDependencies> = {}): UploadRunnerDependencies {
+  const scan = createScan();
+  return {
+    generateUploadSasUrl: vi.fn().mockResolvedValue({
+      success: true,
+      data: {
+        sasUrl: "https://storage/upload?sas=1",
+        blobName: "scans/user-1/scan-1.jpg",
+        blobUrl: scan.blobUrl,
+        scanId: scan.id,
+      },
+    }),
+    registerScan: vi.fn().mockResolvedValue({success: true, scan}),
+    uploadScan: vi.fn().mockResolvedValue({success: true, data: {status: 201, scan}}),
+    fetchImpl: vi.fn().mockResolvedValue({ok: true}),
+    readFileAsBase64: vi.fn().mockResolvedValue("data:image/jpeg;base64,AAAA"),
+    ...overrides,
+  };
+}
+
+describe("uploadPendingScan", () => {
+  it("uploads directly with SAS and registers the scan", async () => {
+    const dependencies = createDependencies();
+    const progressEvents: UploadProgressEvent[] = [];
+
+    const result = await uploadPendingScan(createUpload(), dependencies, {
+      onProgress: (event) => progressEvents.push(event),
+    });
+
+    expect(result).toMatchObject({
+      success: true,
+      uploadId: "upload-1",
+      attempts: 1,
+      blobUrl: "https://storage/scans/scan-1.jpg",
+    });
+    expect(dependencies.fetchImpl).toHaveBeenCalledWith(
+      "https://storage/upload?sas=1",
+      expect.objectContaining({
+        method: "PUT",
+        headers: {
+          "x-ms-blob-type": "BlockBlob",
+          "Content-Type": "image/jpeg",
+        },
+      }),
+    );
+    expect(dependencies.uploadScan).not.toHaveBeenCalled();
+    expect(progressEvents.map((event) => event.progress)).toEqual([0, 30, 70, 90]);
+  });
+
+  it("uses server upload fallback when SAS generation fails", async () => {
+    const scan = createScan({id: "fallback-scan"});
+    const dependencies = createDependencies({
+      generateUploadSasUrl: vi.fn().mockResolvedValue({success: false, error: {message: "SAS unavailable"}}),
+      uploadScan: vi.fn().mockResolvedValue({success: true, data: {status: 201, scan}}),
+    });
+
+    const result = await uploadPendingScan(createUpload(), dependencies, {onProgress: vi.fn()});
+
+    expect(result).toMatchObject({
+      success: true,
+      attempts: 1,
+      blobUrl: scan.blobUrl,
+    });
+    expect(dependencies.uploadScan).toHaveBeenCalledWith({
+      base64Data: "data:image/jpeg;base64,AAAA",
+      fileName: "receipt.jpg",
+      mimeType: "image/jpeg",
+    });
+  });
+
+  it("uses server upload fallback when direct Azure upload fails", async () => {
+    const scan = createScan({id: "fallback-after-put"});
+    const dependencies = createDependencies({
+      fetchImpl: vi.fn().mockResolvedValue({ok: false}),
+      uploadScan: vi.fn().mockResolvedValue({success: true, data: {status: 201, scan}}),
+    });
+
+    const result = await uploadPendingScan(createUpload(), dependencies, {onProgress: vi.fn()});
+
+    expect(result).toMatchObject({
+      success: true,
+      attempts: 1,
+      blobUrl: scan.blobUrl,
+    });
+    expect(dependencies.uploadScan).toHaveBeenCalledOnce();
+  });
+
+  it("uses server upload fallback when scan registration fails", async () => {
+    const scan = createScan({id: "fallback-after-register"});
+    const dependencies = createDependencies({
+      registerScan: vi.fn().mockResolvedValue({success: false, error: "Registration failed"}),
+      uploadScan: vi.fn().mockResolvedValue({success: true, data: {status: 201, scan}}),
+    });
+
+    const result = await uploadPendingScan(createUpload(), dependencies, {onProgress: vi.fn()});
+
+    expect(result).toMatchObject({
+      success: true,
+      attempts: 1,
+      blobUrl: scan.blobUrl,
+    });
+    expect(dependencies.uploadScan).toHaveBeenCalledOnce();
+  });
+
+  it("retries up to three attempts before failing", async () => {
+    const dependencies = createDependencies({
+      generateUploadSasUrl: vi.fn().mockResolvedValue({success: false, error: {message: "SAS unavailable"}}),
+      uploadScan: vi.fn().mockResolvedValue({success: false, error: {message: "Fallback failed"}}),
+    });
+    const progressEvents: UploadProgressEvent[] = [];
+
+    const result = await uploadPendingScan(createUpload(), dependencies, {
+      onProgress: (event) => progressEvents.push(event),
+    });
+
+    expect(result).toEqual({
+      success: false,
+      uploadId: "upload-1",
+      attempts: 3,
+      reason: "server-upload-failed",
+      error: "Fallback failed",
+    });
+    expect(dependencies.uploadScan).toHaveBeenCalledTimes(3);
+    expect(progressEvents.map((event) => event.status)).toContain("retrying");
+    expect(progressEvents.at(-1)).toMatchObject({attempts: 3});
+  });
+
+  it("fails immediately when the File reference is missing", async () => {
+    const result = await uploadPendingScan(createUpload({file: null}), createDependencies(), {onProgress: vi.fn()});
+
+    expect(result).toEqual({
+      success: false,
+      uploadId: "upload-1",
+      attempts: 0,
+      reason: "missing-file",
+      error: "File reference lost",
+    });
+  });
+
+  it("returns an unexpected-error result when every attempt throws", async () => {
+    const dependencies = createDependencies({
+      generateUploadSasUrl: vi.fn().mockRejectedValue(new Error("SAS service down")),
+    });
+
+    const result = await uploadPendingScan(createUpload(), dependencies, {onProgress: vi.fn()});
+
+    expect(result).toEqual({
+      success: false,
+      uploadId: "upload-1",
+      attempts: 3,
+      reason: "unexpected-error",
+      error: "SAS service down",
+    });
+  });
+
+  it("normalizes non-Error exceptions from upload dependencies", async () => {
+    const dependencies = createDependencies({
+      generateUploadSasUrl: vi.fn().mockRejectedValue("SAS service down"),
+    });
+
+    const result = await uploadPendingScan(createUpload(), dependencies, {onProgress: vi.fn()});
+
+    expect(result).toEqual({
+      success: false,
+      uploadId: "upload-1",
+      attempts: 3,
+      reason: "unexpected-error",
+      error: "Unexpected upload error",
+    });
+  });
+});
+
+describe("readFileAsBase64", () => {
+  it("reads files as data URLs", async () => {
+    await expect(readFileAsBase64(new File(["hello"], "hello.txt", {type: "text/plain"}))).resolves.toBe("data:text/plain;base64,aGVsbG8=");
+  });
+
+  it("rejects when FileReader emits an error", async () => {
+    const originalFileReader = globalThis.FileReader;
+
+    class FailingFileReader {
+      public readonly error = new Error("read failed");
+      private errorListener: (() => void) | null = null;
+
+      public addEventListener(type: "load" | "error", listener: () => void): void {
+        if (type === "error") {
+          this.errorListener = listener;
+        }
+      }
+
+      public readAsDataURL(): void {
+        this.errorListener?.();
+      }
+    }
+
+    vi.stubGlobal("FileReader", FailingFileReader);
+
+    try {
+      await expect(readFileAsBase64(new File(["hello"], "hello.txt", {type: "text/plain"}))).rejects.toThrow("read failed");
+    } finally {
+      vi.stubGlobal("FileReader", originalFileReader);
+    }
+  });
+
+  it("uses a fallback error when FileReader emits error without details", async () => {
+    const originalFileReader = globalThis.FileReader;
+
+    class FailingFileReaderWithoutError {
+      public readonly error = null;
+      private errorListener: (() => void) | null = null;
+
+      public addEventListener(type: "load" | "error", listener: () => void): void {
+        if (type === "error") {
+          this.errorListener = listener;
+        }
+      }
+
+      public readAsDataURL(): void {
+        this.errorListener?.();
+      }
+    }
+
+    vi.stubGlobal("FileReader", FailingFileReaderWithoutError);
+
+    try {
+      await expect(readFileAsBase64(new File(["hello"], "hello.txt", {type: "text/plain"}))).rejects.toThrow("Unable to read file");
+    } finally {
+      vi.stubGlobal("FileReader", originalFileReader);
+    }
+  });
+
+  it("rejects when FileReader load result is not a string", async () => {
+    const originalFileReader = globalThis.FileReader;
+
+    class NonStringFileReader {
+      public readonly result = new ArrayBuffer(0);
+      public readonly error = null;
+      private loadListener: (() => void) | null = null;
+
+      public addEventListener(type: "load" | "error", listener: () => void): void {
+        if (type === "load") {
+          this.loadListener = listener;
+        }
+      }
+
+      public readAsDataURL(): void {
+        this.loadListener?.();
+      }
+    }
+
+    vi.stubGlobal("FileReader", NonStringFileReader);
+
+    try {
+      await expect(readFileAsBase64(new File(["hello"], "hello.txt", {type: "text/plain"}))).rejects.toThrow(
+        "Unable to read file as base64",
+      );
+    } finally {
+      vi.stubGlobal("FileReader", originalFileReader);
+    }
+  });
+});

--- a/sites/arolariu.ro/src/app/domains/invoices/upload-scans/_utils/uploadRunner.ts
+++ b/sites/arolariu.ro/src/app/domains/invoices/upload-scans/_utils/uploadRunner.ts
@@ -1,0 +1,213 @@
+/**
+ * @fileoverview Single-file upload runner for the scan upload route.
+ * @module app/domains/invoices/upload-scans/_utils/uploadRunner
+ *
+ * @remarks
+ * The runner performs one pending upload's server journey with explicit
+ * dependency injection so network, server actions, and file reading remain
+ * testable.
+ */
+
+import {
+  MAX_UPLOAD_ATTEMPTS,
+  type PendingUpload,
+  type UploadFailureReason,
+  type UploadRunnerCallbacks,
+  type UploadRunnerDependencies,
+  type UploadRunnerResult,
+} from "./uploadTypes";
+
+type AttemptFailure = Readonly<{
+  reason: UploadFailureReason;
+  error: string;
+}>;
+
+type FileBackedUpload = PendingUpload & Readonly<{file: File}>;
+
+/**
+ * Reads a browser file as a base64 data URL for the server-side fallback path.
+ *
+ * @param file - Browser file to encode.
+ * @returns Base64 data URL.
+ */
+export async function readFileAsBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.addEventListener("load", () => {
+      if (typeof reader.result === "string") {
+        resolve(reader.result);
+      } else {
+        reject(new Error("Unable to read file as base64"));
+      }
+    });
+    reader.addEventListener("error", () => reject(reader.error ?? new Error("Unable to read file")));
+    reader.readAsDataURL(file);
+  });
+}
+
+/**
+ * Maps the current attempt number to the UI status used for progress events.
+ *
+ * @param attempt - One-based upload attempt number.
+ * @returns `uploading` for the first attempt; `retrying` for later attempts.
+ */
+function progressStatusForAttempt(attempt: number): "uploading" | "retrying" {
+  return attempt === 1 ? "uploading" : "retrying";
+}
+
+/**
+ * Narrows upload runner output to a successful result.
+ *
+ * @param result - Upload attempt result or attempt failure.
+ * @returns Whether the result is a successful upload result.
+ */
+function isSuccessfulUploadResult(result: UploadRunnerResult | AttemptFailure): result is Extract<UploadRunnerResult, {success: true}> {
+  return "success" in result && result.success;
+}
+
+/**
+ * Uploads through the server-side fallback action.
+ *
+ * @param upload - File-backed pending upload.
+ * @param dependencies - Runner dependencies.
+ * @returns Upload success result or a typed attempt failure.
+ */
+async function uploadWithServerFallback(upload: FileBackedUpload, dependencies: UploadRunnerDependencies): Promise<UploadRunnerResult | AttemptFailure> {
+  const base64Data = await dependencies.readFileAsBase64(upload.file);
+  const result = await dependencies.uploadScan({
+    base64Data,
+    fileName: upload.name,
+    mimeType: upload.mimeType,
+  });
+
+  if (!result.success) {
+    return {reason: "server-upload-failed", error: result.error.message};
+  }
+
+  return {
+    success: true,
+    uploadId: upload.id,
+    attempts: 1,
+    scan: result.data.scan,
+    blobUrl: result.data.scan.blobUrl,
+  };
+}
+
+/**
+ * Runs one upload attempt using direct Azure upload first, then server fallback.
+ *
+ * @param upload - File-backed pending upload.
+ * @param attempt - One-based attempt number.
+ * @param dependencies - Runner dependencies.
+ * @param callbacks - Progress callbacks.
+ * @returns Upload success result or a typed attempt failure.
+ */
+async function runSingleAttempt(
+  upload: FileBackedUpload,
+  attempt: number,
+  dependencies: UploadRunnerDependencies,
+  callbacks: UploadRunnerCallbacks,
+): Promise<UploadRunnerResult | AttemptFailure> {
+  const status = progressStatusForAttempt(attempt);
+  callbacks.onProgress({uploadId: upload.id, status, progress: 0, attempts: attempt});
+
+  const sasResult = await dependencies.generateUploadSasUrl({
+    fileName: upload.name,
+    mimeType: upload.mimeType,
+  });
+
+  callbacks.onProgress({uploadId: upload.id, status, progress: 30, attempts: attempt});
+
+  if (sasResult.success) {
+    const uploadResponse = await dependencies.fetchImpl(sasResult.data.sasUrl, {
+      method: "PUT",
+      body: upload.file,
+      headers: {
+        "x-ms-blob-type": "BlockBlob",
+        "Content-Type": upload.mimeType,
+      },
+    });
+
+    callbacks.onProgress({uploadId: upload.id, status, progress: 70, attempts: attempt});
+
+    if (uploadResponse.ok) {
+      const registerResult = await dependencies.registerScan({
+        scanId: sasResult.data.scanId,
+        blobUrl: sasResult.data.blobUrl,
+        fileName: upload.name,
+        mimeType: upload.mimeType,
+        sizeInBytes: upload.size,
+      });
+
+      callbacks.onProgress({uploadId: upload.id, status, progress: 90, attempts: attempt});
+
+      if (registerResult.success && registerResult.scan) {
+        return {
+          success: true,
+          uploadId: upload.id,
+          attempts: attempt,
+          scan: registerResult.scan,
+          blobUrl: registerResult.scan.blobUrl,
+        };
+      }
+
+      const fallbackResult = await uploadWithServerFallback(upload, dependencies);
+      return isSuccessfulUploadResult(fallbackResult) ? {...fallbackResult, attempts: attempt} : fallbackResult;
+    }
+
+    const fallbackResult = await uploadWithServerFallback(upload, dependencies);
+    return isSuccessfulUploadResult(fallbackResult) ? {...fallbackResult, attempts: attempt} : fallbackResult;
+  }
+
+  const fallbackResult = await uploadWithServerFallback(upload, dependencies);
+  return isSuccessfulUploadResult(fallbackResult) ? {...fallbackResult, attempts: attempt} : fallbackResult;
+}
+
+/**
+ * Uploads a pending scan with automatic retry up to the configured max attempt count.
+ *
+ * @param upload - Pending upload item from the route queue.
+ * @param dependencies - Network, server action, and file-reading dependencies.
+ * @param callbacks - Progress callbacks consumed by the context provider.
+ * @returns Final upload result after success or exhausted attempts.
+ */
+export async function uploadPendingScan(
+  upload: PendingUpload,
+  dependencies: UploadRunnerDependencies,
+  callbacks: UploadRunnerCallbacks,
+): Promise<UploadRunnerResult> {
+  if (!upload.file) {
+    return {
+      success: false,
+      uploadId: upload.id,
+      attempts: 0,
+      reason: "missing-file",
+      error: "File reference lost",
+    };
+  }
+
+  let lastFailure: AttemptFailure = {reason: "unexpected-error", error: "Upload failed"};
+
+  for (let attempt = 1; attempt <= MAX_UPLOAD_ATTEMPTS; attempt += 1) {
+    try {
+      const result = await runSingleAttempt({...upload, file: upload.file}, attempt, dependencies, callbacks);
+      if (isSuccessfulUploadResult(result)) {
+        return {...result, attempts: attempt};
+      }
+      lastFailure = result;
+    } catch (error) {
+      lastFailure = {
+        reason: "unexpected-error",
+        error: error instanceof Error ? error.message : "Unexpected upload error",
+      };
+    }
+  }
+
+  return {
+    success: false,
+    uploadId: upload.id,
+    attempts: MAX_UPLOAD_ATTEMPTS,
+    reason: lastFailure.reason,
+    error: lastFailure.error,
+  };
+}

--- a/sites/arolariu.ro/src/app/domains/invoices/upload-scans/_utils/uploadTypes.ts
+++ b/sites/arolariu.ro/src/app/domains/invoices/upload-scans/_utils/uploadTypes.ts
@@ -1,0 +1,219 @@
+/**
+ * @fileoverview Shared types and constants for the route-scoped scan upload workflow.
+ * @module app/domains/invoices/upload-scans/_utils/uploadTypes
+ *
+ * @remarks
+ * This module intentionally contains no React state. It defines the public
+ * contracts used by the upload context, reducer, validation helpers, runner,
+ * and presentation components.
+ */
+
+import type {Scan} from "@/types/scans";
+
+/** Maximum number of scan uploads that may run in parallel. */
+export const UPLOAD_CONCURRENCY_LIMIT = 5;
+
+/** Maximum number of attempts for a single scan upload before it is marked failed. */
+export const MAX_UPLOAD_ATTEMPTS = 3;
+
+/** Maximum accepted upload size in bytes. */
+export const MAX_UPLOAD_FILE_SIZE_BYTES = 10 * 1024 * 1024;
+
+/** File input accept attribute value for supported scan upload formats. */
+export const ACCEPTED_UPLOAD_EXTENSIONS = ".jpg,.jpeg,.png,.pdf";
+
+/** MIME types accepted by the scan upload route. */
+export const ACCEPTED_UPLOAD_MIME_TYPES: ReadonlySet<string> = new Set(["image/jpeg", "image/png", "application/pdf"]);
+
+/** File extensions accepted by the scan upload route. */
+export const ACCEPTED_UPLOAD_FILE_EXTENSIONS: ReadonlySet<string> = new Set(["jpg", "jpeg", "png", "pdf"]);
+
+/** Delay before removing a completed upload card from the route queue. */
+export const COMPLETED_UPLOAD_REMOVAL_DELAY_MS = 1000;
+
+/** Delay before showing the post-upload prompt after a batch completes. */
+export const POST_UPLOAD_PROMPT_DELAY_MS = 500;
+
+/** Status values for an individual client-side pending upload. */
+export type PendingUploadStatus = "idle" | "uploading" | "retrying" | "completed" | "failed";
+
+/**
+ * A scan file tracked by the upload route before and during upload.
+ *
+ * @remarks
+ * This is intentionally route-scoped and should not be persisted because it can
+ * contain a live `File` reference and object URL.
+ */
+export type PendingUpload = Readonly<{
+  /** Client-side queue identifier. */
+  id: string;
+  /** Display name and server registration file name. */
+  name: string;
+  /** Browser file reference; released after successful upload. */
+  file: File | null;
+  /** Browser-reported MIME type. */
+  mimeType: string;
+  /** File size in bytes. */
+  size: number;
+  /** Object URL preview while the upload is local. */
+  preview: string;
+  /** Current upload lifecycle status. */
+  status: PendingUploadStatus;
+  /** User-visible upload progress from 0 to 100. */
+  progress: number;
+  /** Number of attempts already made. */
+  attempts: number;
+  /** Last per-file upload error, if any. */
+  error?: string;
+  /** Server blob URL after successful upload and registration. */
+  blobUrl?: string;
+}>;
+
+/** Minimal completed upload data needed by the post-upload prompt. */
+export type UploadCompletionSummary = Readonly<{
+  /** Client-side upload identifier. */
+  id: string;
+  /** Display name for the uploaded scan. */
+  name: string;
+  /** Preview URL, preferably the server blob URL when available. */
+  preview: string;
+}>;
+
+/** Session-level upload counters displayed by the route. */
+export type SessionStats = Readonly<{
+  /** Number of valid files added during this route session. */
+  totalAdded: number;
+  /** Number of scans uploaded successfully during this route session. */
+  totalCompleted: number;
+  /** Number of scans that reached a failed state during this route session. */
+  totalFailed: number;
+}>;
+
+/** Machine-readable validation error reasons for rejected upload files. */
+export type UploadValidationErrorReason = "unsupported-type" | "unsupported-extension" | "file-too-large";
+
+/** Validation result for one candidate upload file. */
+export type UploadValidationResult =
+  | Readonly<{isValid: true; file: File}>
+  | Readonly<{
+      isValid: false;
+      file: File;
+      reason: UploadValidationErrorReason;
+      message: string;
+    }>;
+
+/** Valid and invalid files produced by batch upload validation. */
+export type UploadBatchValidationResult = Readonly<{
+  validFiles: File[];
+  invalidFiles: Array<Extract<UploadValidationResult, {isValid: false}>>;
+}>;
+
+/** Result returned by the SAS-generation server action. */
+export type GenerateUploadSasUrlResult =
+  | Readonly<{
+      success: true;
+      data: Readonly<{
+        sasUrl: string;
+        blobName: string;
+        blobUrl: string;
+        scanId: string;
+      }>;
+    }>
+  | Readonly<{success: false; error: Readonly<{message: string}>}>;
+
+/** Result returned by the post-direct-upload scan registration action. */
+export type RegisterScanResult = Readonly<{success: boolean; scan?: Scan; error?: string}>;
+
+/** Result returned by the server-side fallback upload action. */
+export type ServerUploadScanResult =
+  | Readonly<{success: true; data: Readonly<{status: number; scan: Scan}>}>
+  | Readonly<{success: false; error: Readonly<{message: string}>}>;
+
+/** Dependencies injected into the upload runner for testable side effects. */
+export type UploadRunnerDependencies = Readonly<{
+  generateUploadSasUrl: (input: Readonly<{fileName: string; mimeType: string}>) => Promise<GenerateUploadSasUrlResult>;
+  registerScan: (
+    input: Readonly<{
+      scanId: string;
+      blobUrl: string;
+      fileName: string;
+      mimeType: string;
+      sizeInBytes: number;
+    }>,
+  ) => Promise<RegisterScanResult>;
+  uploadScan: (input: Readonly<{base64Data: string; fileName: string; mimeType: string}>) => Promise<ServerUploadScanResult>;
+  fetchImpl: typeof fetch;
+  readFileAsBase64: (file: File) => Promise<string>;
+}>;
+
+/** Progress event emitted by the upload runner for a single upload. */
+export type UploadProgressEvent = Readonly<{
+  uploadId: string;
+  status: PendingUploadStatus;
+  progress: number;
+  attempts: number;
+  error?: string;
+  blobUrl?: string;
+}>;
+
+/** Callbacks used by the upload runner to report progress. */
+export type UploadRunnerCallbacks = Readonly<{
+  onProgress: (event: UploadProgressEvent) => void;
+}>;
+
+/** Failure categories returned by the upload runner. */
+export type UploadFailureReason =
+  | "missing-file"
+  | "sas-generation-failed"
+  | "direct-upload-failed"
+  | "registration-failed"
+  | "server-upload-failed"
+  | "unexpected-error";
+
+/** Final result for one pending scan upload. */
+export type UploadRunnerResult =
+  | Readonly<{
+      success: true;
+      uploadId: string;
+      attempts: number;
+      scan: Scan;
+      blobUrl: string;
+    }>
+  | Readonly<{
+      success: false;
+      uploadId: string;
+      attempts: number;
+      reason: UploadFailureReason;
+      error: string;
+    }>;
+
+/** Complete route-scoped upload state owned by the reducer. */
+export type UploadState = Readonly<{
+  pendingUploads: PendingUpload[];
+  isUploading: boolean;
+  sessionStats: SessionStats;
+  completedBatch: UploadCompletionSummary[];
+}>;
+
+/** Actions accepted by the upload reducer state machine. */
+export type UploadAction =
+  | Readonly<{type: "uploads-added"; uploads: PendingUpload[]}>
+  | Readonly<{type: "uploads-removed"; ids: string[]}>
+  | Readonly<{type: "uploads-cleared"}>
+  | Readonly<{type: "upload-renamed"; id: string; name: string}>
+  | Readonly<{type: "batch-started"}>
+  | Readonly<{type: "batch-finished"}>
+  | Readonly<{
+      type: "upload-progressed";
+      id: string;
+      status: PendingUploadStatus;
+      progress: number;
+      attempts: number;
+      error?: string;
+      blobUrl?: string;
+    }>
+  | Readonly<{type: "upload-completed"; id: string; attempts: number; blobUrl: string}>
+  | Readonly<{type: "upload-failed"; id: string; attempts: number; error: string}>
+  | Readonly<{type: "upload-removed-after-completion"; id: string}>
+  | Readonly<{type: "session-stats-reset"}>
+  | Readonly<{type: "completed-batch-cleared"}>;

--- a/sites/arolariu.ro/src/app/domains/invoices/upload-scans/_utils/uploadValidation.test.ts
+++ b/sites/arolariu.ro/src/app/domains/invoices/upload-scans/_utils/uploadValidation.test.ts
@@ -1,0 +1,125 @@
+/**
+ * @fileoverview Unit tests for scan upload validation helpers.
+ * @module app/domains/invoices/upload-scans/_utils/uploadValidation.test
+ */
+
+import {describe, expect, it} from "vitest";
+import {MAX_UPLOAD_FILE_SIZE_BYTES} from "./uploadTypes";
+import {extractFilesFromDataTransferItems, validateUploadFile, validateUploadFiles} from "./uploadValidation";
+
+/**
+ * Creates a browser `File` for validation tests.
+ *
+ * @param name - File name to expose to validation.
+ * @param type - MIME type to expose to validation.
+ * @param size - File size in bytes.
+ * @returns Test file with deterministic byte content.
+ */
+function createFile(name: string, type: string, size = 4): File {
+  return new File([new Uint8Array(size)], name, {type});
+}
+
+describe("validateUploadFile", () => {
+  it("accepts JPEG, PNG, and PDF files within the size limit", () => {
+    const files = [
+      createFile("receipt.jpg", "image/jpeg"),
+      createFile("receipt.png", "image/png"),
+      createFile("receipt.pdf", "application/pdf"),
+    ];
+
+    const results = files.map((file) => validateUploadFile(file));
+
+    expect(results).toEqual(files.map((file) => ({isValid: true, file})));
+  });
+
+  it("rejects unsupported MIME types", () => {
+    const file = createFile("receipt.txt", "text/plain");
+
+    expect(validateUploadFile(file)).toEqual({
+      isValid: false,
+      file,
+      reason: "unsupported-type",
+      message: "Unsupported file type: text/plain",
+    });
+  });
+
+  it("reports unknown when the browser does not provide a MIME type", () => {
+    const file = createFile("receipt.jpg", "");
+
+    expect(validateUploadFile(file)).toEqual({
+      isValid: false,
+      file,
+      reason: "unsupported-type",
+      message: "Unsupported file type: unknown",
+    });
+  });
+
+  it("rejects supported MIME types with invalid extensions", () => {
+    const file = createFile("receipt.gif", "image/png");
+
+    expect(validateUploadFile(file)).toEqual({
+      isValid: false,
+      file,
+      reason: "unsupported-extension",
+      message: "Unsupported file extension: receipt.gif",
+    });
+  });
+
+  it("rejects files without an extension", () => {
+    const file = createFile("receipt", "image/png");
+
+    expect(validateUploadFile(file)).toEqual({
+      isValid: false,
+      file,
+      reason: "unsupported-extension",
+      message: "Unsupported file extension: receipt",
+    });
+  });
+
+  it("rejects files larger than 10 MB", () => {
+    const file = createFile("large.pdf", "application/pdf", MAX_UPLOAD_FILE_SIZE_BYTES + 1);
+
+    expect(validateUploadFile(file)).toEqual({
+      isValid: false,
+      file,
+      reason: "file-too-large",
+      message: "File too large: large.pdf (max 10MB)",
+    });
+  });
+});
+
+describe("validateUploadFiles", () => {
+  it("splits valid files and validation errors", () => {
+    const validFile = createFile("receipt.jpg", "image/jpeg");
+    const invalidFile = createFile("receipt.txt", "text/plain");
+
+    expect(validateUploadFiles([validFile, invalidFile])).toEqual({
+      validFiles: [validFile],
+      invalidFiles: [
+        {
+          isValid: false,
+          file: invalidFile,
+          reason: "unsupported-type",
+          message: "Unsupported file type: text/plain",
+        },
+      ],
+    });
+  });
+});
+
+describe("extractFilesFromDataTransferItems", () => {
+  it("extracts file objects from data transfer items", () => {
+    const file = createFile("receipt.jpg", "image/jpeg");
+    const dataTransfer = new DataTransfer();
+    dataTransfer.items.add(file);
+
+    expect(extractFilesFromDataTransferItems(dataTransfer.items)).toEqual([file]);
+  });
+
+  it("skips string data transfer items", () => {
+    const dataTransfer = new DataTransfer();
+    dataTransfer.items.add("not-a-file", "text/plain");
+
+    expect(extractFilesFromDataTransferItems(dataTransfer.items)).toEqual([]);
+  });
+});

--- a/sites/arolariu.ro/src/app/domains/invoices/upload-scans/_utils/uploadValidation.ts
+++ b/sites/arolariu.ro/src/app/domains/invoices/upload-scans/_utils/uploadValidation.ts
@@ -1,0 +1,107 @@
+/**
+ * @fileoverview File validation helpers for the scan upload route.
+ * @module app/domains/invoices/upload-scans/_utils/uploadValidation
+ *
+ * @remarks
+ * These helpers are shared by the context and browser event handlers so input,
+ * drag/drop, and paste paths enforce identical upload constraints.
+ */
+
+import {
+  ACCEPTED_UPLOAD_FILE_EXTENSIONS,
+  ACCEPTED_UPLOAD_MIME_TYPES,
+  MAX_UPLOAD_FILE_SIZE_BYTES,
+  type UploadBatchValidationResult,
+  type UploadValidationResult,
+} from "./uploadTypes";
+
+/**
+ * Extracts a lowercase extension from a file name.
+ *
+ * @param fileName - Name reported by the browser for the candidate file.
+ * @returns The extension without the dot, or `null` when no usable extension exists.
+ */
+function getFileExtension(fileName: string): string | null {
+  const extension = fileName.split(".").pop()?.toLowerCase();
+  return extension && extension.length > 0 ? extension : null;
+}
+
+/**
+ * Validates a single candidate scan upload file.
+ *
+ * @param file - Browser `File` selected, dropped, or pasted by the user.
+ * @returns A typed validation result with a user-facing error message on failure.
+ */
+export function validateUploadFile(file: File): UploadValidationResult {
+  if (!ACCEPTED_UPLOAD_MIME_TYPES.has(file.type)) {
+    return {
+      isValid: false,
+      file,
+      reason: "unsupported-type",
+      message: `Unsupported file type: ${file.type || "unknown"}`,
+    };
+  }
+
+  const extension = getFileExtension(file.name);
+  if (extension === null || !ACCEPTED_UPLOAD_FILE_EXTENSIONS.has(extension)) {
+    return {
+      isValid: false,
+      file,
+      reason: "unsupported-extension",
+      message: `Unsupported file extension: ${file.name}`,
+    };
+  }
+
+  if (file.size > MAX_UPLOAD_FILE_SIZE_BYTES) {
+    return {
+      isValid: false,
+      file,
+      reason: "file-too-large",
+      message: `File too large: ${file.name} (max 10MB)`,
+    };
+  }
+
+  return {isValid: true, file};
+}
+
+/**
+ * Validates a batch of candidate scan upload files.
+ *
+ * @param files - Iterable collection of browser files.
+ * @returns Split valid files and invalid validation results.
+ */
+export function validateUploadFiles(files: Iterable<File>): UploadBatchValidationResult {
+  const validFiles: File[] = [];
+  const invalidFiles: UploadBatchValidationResult["invalidFiles"] = [];
+
+  for (const file of files) {
+    const result = validateUploadFile(file);
+    if (result.isValid) {
+      validFiles.push(result.file);
+    } else {
+      invalidFiles.push(result);
+    }
+  }
+
+  return {validFiles, invalidFiles};
+}
+
+/**
+ * Extracts files from a `DataTransferItemList`.
+ *
+ * @param items - Drag/drop or clipboard transfer items.
+ * @returns File objects present in the transfer list; non-file items are ignored.
+ */
+export function extractFilesFromDataTransferItems(items: DataTransferItemList): File[] {
+  const files: File[] = [];
+  for (let index = 0; index < items.length; index += 1) {
+    const item = items[index];
+    if (item?.kind === "file") {
+      const file = item.getAsFile();
+      if (file) {
+        files.push(file);
+      }
+    }
+  }
+  return files;
+}

--- a/sites/arolariu.ro/src/app/domains/invoices/upload-scans/island.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/upload-scans/island.tsx
@@ -29,6 +29,7 @@ import PostUploadPrompt from "./_components/PostUploadPrompt";
 import UploadArea from "./_components/UploadArea";
 import UploadPreview from "./_components/UploadPreview";
 import {ScanUploadProvider, useScanUpload} from "./_context/ScanUploadContext";
+import {POST_UPLOAD_PROMPT_DELAY_MS} from "./_utils/uploadTypes";
 import styles from "./island.module.scss";
 
 /**
@@ -72,45 +73,34 @@ function TipItem({children}: Readonly<{children: React.ReactNode}>): React.JSX.E
 function UploadContent(): React.JSX.Element {
   const t = useTranslations();
   const router = useRouter();
-  const {pendingUploads, sessionStats} = useScanUpload();
+  const {pendingUploads, sessionStats, completedBatch, clearCompletedBatch} = useScanUpload();
   const [showPrompt, setShowPrompt] = useState(false);
   const [completedScans, setCompletedScans] = useState<Array<{id: string; preview: string; name: string}>>([]);
-  const completedScansRef = useRef<Array<{id: string; preview: string; name: string}>>([]);
   const hasPromptedRef = useRef(false);
 
-  /**
-   * Effect to collect completed scans before they're removed from the queue.
-   * Use blobUrl (from Azure) if available, otherwise fallback to preview (blob URL).
-   */
   useEffect(() => {
-    const completed = pendingUploads
-      .filter((u) => u.status === "completed")
-      .map((u) => ({id: u.id, preview: u.blobUrl || u.preview, name: u.name}));
-    if (completed.length > 0) {
-      completedScansRef.current = completed;
-    }
-    // Reset the prompted flag when a new upload batch starts
     if (pendingUploads.length > 0) {
       hasPromptedRef.current = false;
     }
-  }, [pendingUploads]);
+  }, [pendingUploads.length]);
 
   /**
    * Effect to detect when all uploads complete and show the prompt once per batch.
    */
   useEffect(() => {
-    const allDone = pendingUploads.length === 0 && sessionStats.totalCompleted > 0;
+    const allDone = pendingUploads.length === 0 && sessionStats.totalCompleted > 0 && completedBatch.length > 0;
 
     if (allDone && !hasPromptedRef.current) {
       hasPromptedRef.current = true;
-      setCompletedScans(completedScansRef.current);
+      setCompletedScans(completedBatch);
       const timer = setTimeout(() => {
         setShowPrompt(true);
-      }, 500);
+        clearCompletedBatch();
+      }, POST_UPLOAD_PROMPT_DELAY_MS);
       return () => clearTimeout(timer);
     }
     return;
-  }, [pendingUploads, sessionStats.totalCompleted]);
+  }, [clearCompletedBatch, completedBatch, pendingUploads.length, sessionStats.totalCompleted]);
 
   /** Navigates to the create invoice page after dismissing the prompt. */
   const handleCreateInvoice = useCallback((): void => {

--- a/sites/arolariu.ro/src/app/domains/invoices/view-scans/_hooks/useScans.test.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-scans/_hooks/useScans.test.tsx
@@ -401,13 +401,16 @@ describe("useScans", () => {
       });
     });
 
-    it("should not auto-sync when lastSyncTimestamp exists", () => {
+    it("should auto-sync even when lastSyncTimestamp exists (always background-sync)", async () => {
       mockStoreState.hasHydrated = true;
       mockStoreState.lastSyncTimestamp = new Date();
+      mockFetchScans.mockResolvedValue({success: true, data: []});
 
       renderHook(() => useScans());
 
-      expect(mockFetchScans).not.toHaveBeenCalled();
+      await waitFor(() => {
+        expect(mockFetchScans).toHaveBeenCalled();
+      });
     });
 
     it("should not auto-sync when not hydrated", () => {

--- a/sites/arolariu.ro/src/app/domains/invoices/view-scans/_hooks/useScans.tsx
+++ b/sites/arolariu.ro/src/app/domains/invoices/view-scans/_hooks/useScans.tsx
@@ -5,12 +5,12 @@
  * @module app/domains/invoices/view-scans/_hooks/useScans
  */
 
-import {fetchScans} from "@/app/domains/invoices/_actions/scans";
 import {useScansStore} from "@/stores";
 import {type CachedScan, ScanStatus} from "@/types/scans";
 import {toast} from "@arolariu/components";
 import {useCallback, useEffect, useRef} from "react";
 import {useShallow} from "zustand/react/shallow";
+import { fetchScans } from "../../_actions/scans";
 
 /**
  * Hook output type
@@ -107,22 +107,21 @@ export function useScans(): UseScansOutput {
           includeArchived: false,
         });
 
-        if (!result.success) {
-          throw new Error(result.error.message);
-        }
+        if (result.success && result.data) {
+          const fetchedScans = result.data;
+          // Convert to cached scans with cache timestamp
+          const cachedScans: CachedScan[] = fetchedScans.map((scan) => ({
+            ...scan,
+            cachedAt: new Date(),
+          }));
 
-        // Convert to cached scans with cache timestamp
-        const cachedScans: CachedScan[] = result.data.map((scan) => ({
-          ...scan,
-          cachedAt: new Date(),
-        }));
+          setScans(cachedScans);
+          setLastSyncTimestamp(new Date());
 
-        setScans(cachedScans);
-        setLastSyncTimestamp(new Date());
-
-        // Only show success toast for manual sync
-        if (manual && isMountedRef.current) {
-          toast.success("Scans synced successfully");
+          // Only show success toast for manual sync
+          if (manual && isMountedRef.current) {
+            toast.success("Scans synced successfully");
+          }
         }
       } catch (error) {
         console.error("Failed to sync scans:", error);
@@ -139,12 +138,12 @@ export function useScans(): UseScansOutput {
     [setIsSyncing, setScans, setLastSyncTimestamp],
   );
 
-  // Auto-sync on mount when hydrated
+  // Always background-sync after IndexedDB hydration. Cached scans still render immediately.
   useEffect(() => {
-    if (hasHydrated && !lastSyncTimestamp) {
+    if (hasHydrated) {
       syncScans();
     }
-  }, [hasHydrated, lastSyncTimestamp, syncScans]);
+  }, [hasHydrated, syncScans]);
 
   // Cleanup: mark component as unmounted
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Extract scan upload validation, reducer, and runner utilities.
- Keep transient upload state route-scoped in ScanUploadContext.
- Background-sync view-scans after hydration so newly uploaded scans appear after navigation.

## Validation
- `npm run test:unit -- uploadValidation.test.ts uploadReducer.test.ts uploadRunner.test.ts` from `sites/arolariu.ro`: **33/33 tests passed, 100% coverage**
- `npm run typecheck` from `sites/arolariu.ro`: **PASS**
- `npm run test:unit` from `sites/arolariu.ro`: **1833/1833 tests passed, 91.01% coverage**
- `npm run build:website`: **PASS**
- `npm run test:website` baseline note: unit phase passes; known unrelated E2E/a11y baseline failures may remain

## Scope
Wave 2 scan upload context PR only. No filter-card or recipe-dialog changes.