### PR TITLE
status: remediate ESLint findings

### DIFF
--- a/sites/status.arolariu.ro/src/__mocks__/$app/environment.ts
+++ b/sites/status.arolariu.ro/src/__mocks__/$app/environment.ts
@@ -1,4 +1,6 @@
+const development = true;
+
 export const browser = true;
 export const building = false;
-export const dev = true;
+export {development as dev};
 export const version = "test";

--- a/sites/status.arolariu.ro/src/lib/aggregation/computeAvgLatency.ts
+++ b/sites/status.arolariu.ro/src/lib/aggregation/computeAvgLatency.ts
@@ -6,12 +6,12 @@ import type {Bucket} from "../types/status";
  * `SubServiceRow`).
  *
  * Note: the overview summary uses a parallel, services-level
- * `computeAvgLatency(services)` in `summaryStats.ts` — same math, different
- * shape — kept separate so each call site reads the type it naturally holds
+ * `computeAvgLatency(services)` in `summaryStats.ts` - same math, different
+ * shape - kept separate so each call site reads the type it naturally holds
  * (a bucket array vs. a service-series list).
  */
 export function computeAvgLatency(buckets: readonly Bucket[]): number {
   if (buckets.length === 0) return 0;
-  const sum = buckets.reduce((acc, b) => acc + b.latency.p50, 0);
+  const sum = buckets.reduce((accumulator, bucket) => accumulator + bucket.latency.p50, 0);
   return Math.round(sum / buckets.length);
 }

--- a/sites/status.arolariu.ro/src/lib/aggregation/deriveParentStatus.ts
+++ b/sites/status.arolariu.ro/src/lib/aggregation/deriveParentStatus.ts
@@ -15,8 +15,8 @@ const ORDER: Record<HealthStatus, number> = {Healthy: 0, Degraded: 1, Unhealthy:
  * "no proven failure" convention used elsewhere).
  */
 export function deriveLatestStatus(series: ServiceSeries): HealthStatus {
-  const last = series.buckets[series.buckets.length - 1];
-  return last?.status ?? "Healthy";
+  const lastBucket = series.buckets.at(-1);
+  return lastBucket?.status ?? "Healthy";
 }
 
 /**
@@ -26,8 +26,8 @@ export function deriveLatestStatus(series: ServiceSeries): HealthStatus {
  */
 export function deriveOverallStatus(services: readonly ServiceSeries[]): HealthStatus {
   let worst: HealthStatus = "Healthy";
-  for (const s of services) {
-    const latest = deriveLatestStatus(s);
+  for (const serviceSeries of services) {
+    const latest = deriveLatestStatus(serviceSeries);
     if (ORDER[latest] > ORDER[worst]) worst = latest;
   }
   return worst;

--- a/sites/status.arolariu.ro/src/lib/aggregation/deriveParentStatus.ts
+++ b/sites/status.arolariu.ro/src/lib/aggregation/deriveParentStatus.ts
@@ -28,6 +28,7 @@ export function deriveOverallStatus(services: readonly ServiceSeries[]): HealthS
   let worst: HealthStatus = "Healthy";
   for (const serviceSeries of services) {
     const latest = deriveLatestStatus(serviceSeries);
+    // eslint-disable-next-line security/detect-object-injection -- Both keys are HealthStatus union members.
     if (ORDER[latest] > ORDER[worst]) worst = latest;
   }
   return worst;

--- a/sites/status.arolariu.ro/src/lib/aggregation/formatDuration.ts
+++ b/sites/status.arolariu.ro/src/lib/aggregation/formatDuration.ts
@@ -9,11 +9,11 @@
  *   formatDuration(60 * 60_000) === "1 h"
  *   formatDuration(90 * 60_000) === "1 h 30 min"
  */
-export function formatDuration(ms: number | undefined): string {
-  if (ms == null || !Number.isFinite(ms)) return "—";
-  const min = Math.round(ms / 60_000);
-  if (min < 60) return `${min} min`;
-  const hr = Math.floor(min / 60);
-  const rem = min % 60;
-  return rem === 0 ? `${hr} h` : `${hr} h ${rem} min`;
+export function formatDuration(milliseconds: number | null | undefined): string {
+  if (milliseconds === null || milliseconds === undefined || !Number.isFinite(milliseconds)) return "—";
+  const minutes = Math.round(milliseconds / 60_000);
+  if (minutes < 60) return `${minutes} min`;
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  return remainingMinutes === 0 ? `${hours} h` : `${hours} h ${remainingMinutes} min`;
 }

--- a/sites/status.arolariu.ro/src/lib/aggregation/sliceWindow.ts
+++ b/sites/status.arolariu.ro/src/lib/aggregation/sliceWindow.ts
@@ -24,6 +24,7 @@ function filterBuckets(buckets: readonly Bucket[], cutoffMs: number, nowMs: numb
  */
 export function sliceWindow(file: AggregateFile, window: FilterWindow): AggregateFile {
   const nowMs = Date.now();
+  // eslint-disable-next-line security/detect-object-injection -- window is constrained to the FilterWindow union.
   const cutoffMs = nowMs - WINDOW_CONFIGS[window].days * MS_PER_DAY;
   return {
     ...file,

--- a/sites/status.arolariu.ro/src/lib/aggregation/sliceWindow.ts
+++ b/sites/status.arolariu.ro/src/lib/aggregation/sliceWindow.ts
@@ -7,9 +7,9 @@ const MS_PER_DAY = 86_400_000;
  * window. Buckets with unparseable timestamps are dropped (finite check).
  */
 function filterBuckets(buckets: readonly Bucket[], cutoffMs: number, nowMs: number): Bucket[] {
-  return buckets.filter((b) => {
-    const t = Date.parse(b.t);
-    return Number.isFinite(t) && t >= cutoffMs && t <= nowMs;
+  return buckets.filter((bucket) => {
+    const timestamp = Date.parse(bucket.t);
+    return Number.isFinite(timestamp) && timestamp >= cutoffMs && timestamp <= nowMs;
   });
 }
 
@@ -27,12 +27,19 @@ export function sliceWindow(file: AggregateFile, window: FilterWindow): Aggregat
   const cutoffMs = nowMs - WINDOW_CONFIGS[window].days * MS_PER_DAY;
   return {
     ...file,
-    services: file.services.map((s) => {
-      const slicedBuckets = filterBuckets(s.buckets, cutoffMs, nowMs);
-      const subSeries = s.subSeries
-        ? Object.fromEntries(Object.entries(s.subSeries).map(([k, v]) => [k, filterBuckets(v, cutoffMs, nowMs)]))
+    services: file.services.map((serviceSeries) => {
+      const slicedBuckets = filterBuckets(serviceSeries.buckets, cutoffMs, nowMs);
+      const subSeries = serviceSeries.subSeries
+        ? Object.fromEntries(
+            Object.entries(serviceSeries.subSeries).map(([name, buckets]) => [
+              name,
+              filterBuckets(buckets, cutoffMs, nowMs),
+            ]),
+          )
         : undefined;
-      return subSeries !== undefined ? {...s, buckets: slicedBuckets, subSeries} : {...s, buckets: slicedBuckets};
+      return subSeries === undefined
+        ? {...serviceSeries, buckets: slicedBuckets}
+        : {...serviceSeries, buckets: slicedBuckets, subSeries};
     }),
   };
 }

--- a/sites/status.arolariu.ro/src/lib/aggregation/summaryStats.ts
+++ b/sites/status.arolariu.ro/src/lib/aggregation/summaryStats.ts
@@ -63,6 +63,7 @@ export interface IncidentCounts {
  */
 export function computeIncidentCount(incidents: IncidentsFile | null, windowFilter: FilterWindow): IncidentCounts {
   if (!incidents) return {total: 0, open: 0, resolved: 0};
+  // eslint-disable-next-line security/detect-object-injection -- windowFilter is constrained to the FilterWindow union.
   const cutoffMs = Date.now() - WINDOW_CONFIGS[windowFilter].days * MS_PER_DAY;
   const scoped = incidents.incidents.filter((incident) => Date.parse(incident.startedAt) >= cutoffMs);
   const open = scoped.filter((incident) => incident.status === "open").length;
@@ -77,6 +78,7 @@ export function computeIncidentCount(incidents: IncidentsFile | null, windowFilt
  */
 export function computeMttr(incidents: IncidentsFile | null, windowFilter: FilterWindow): number | undefined {
   if (!incidents) return undefined;
+  // eslint-disable-next-line security/detect-object-injection -- windowFilter is constrained to the FilterWindow union.
   const cutoffMs = Date.now() - WINDOW_CONFIGS[windowFilter].days * MS_PER_DAY;
   const resolved = incidents.incidents.filter(
     (incident): incident is ResolvedIncident =>

--- a/sites/status.arolariu.ro/src/lib/aggregation/summaryStats.ts
+++ b/sites/status.arolariu.ro/src/lib/aggregation/summaryStats.ts
@@ -8,8 +8,7 @@
  * shape it naturally holds.
  */
 
-import type {FilterWindow, Incident, IncidentsFile, ServiceSeries} from "../types/status";
-import {WINDOW_CONFIGS} from "../types/status";
+import {WINDOW_CONFIGS, type FilterWindow, type Incident, type IncidentsFile, type ServiceSeries} from "../types/status";
 import {weightedUptime} from "./weightedUptime";
 
 /** Narrow alias for incidents that carry `resolvedAt` + `durationMs`. */
@@ -28,7 +27,7 @@ const MS_PER_DAY = 86_400_000;
  * Worst-service sub-line formats at 1 decimal at the render site.
  */
 export function computeOverallUptime(services: readonly ServiceSeries[]): number {
-  const allBuckets = services.flatMap((s) => [...s.buckets]);
+  const allBuckets = services.flatMap((serviceSeries) => [...serviceSeries.buckets]);
   return weightedUptime(allBuckets);
 }
 
@@ -42,10 +41,10 @@ export function computeOverallUptime(services: readonly ServiceSeries[]): number
 export function computeAvgLatency(services: readonly ServiceSeries[]): number {
   let sum = 0;
   let count = 0;
-  for (const s of services) {
-    for (const b of s.buckets) {
-      sum += b.latency.p50;
-      count++;
+  for (const serviceSeries of services) {
+    for (const bucket of serviceSeries.buckets) {
+      sum += bucket.latency.p50;
+      count += 1;
     }
   }
   if (count === 0) return 0;
@@ -65,9 +64,9 @@ export interface IncidentCounts {
 export function computeIncidentCount(incidents: IncidentsFile | null, windowFilter: FilterWindow): IncidentCounts {
   if (!incidents) return {total: 0, open: 0, resolved: 0};
   const cutoffMs = Date.now() - WINDOW_CONFIGS[windowFilter].days * MS_PER_DAY;
-  const scoped = incidents.incidents.filter((inc) => Date.parse(inc.startedAt) >= cutoffMs);
-  const open = scoped.filter((i) => i.status === "open").length;
-  const resolved = scoped.filter((i) => i.status === "resolved").length;
+  const scoped = incidents.incidents.filter((incident) => Date.parse(incident.startedAt) >= cutoffMs);
+  const open = scoped.filter((incident) => incident.status === "open").length;
+  const resolved = scoped.filter((incident) => incident.status === "resolved").length;
   return {total: scoped.length, open, resolved};
 }
 
@@ -80,10 +79,10 @@ export function computeMttr(incidents: IncidentsFile | null, windowFilter: Filte
   if (!incidents) return undefined;
   const cutoffMs = Date.now() - WINDOW_CONFIGS[windowFilter].days * MS_PER_DAY;
   const resolved = incidents.incidents.filter(
-    (inc): inc is ResolvedIncident =>
-      inc.status === "resolved" && Date.parse(inc.startedAt) >= cutoffMs && typeof inc.durationMs === "number",
+    (incident): incident is ResolvedIncident =>
+      incident.status === "resolved" && Date.parse(incident.startedAt) >= cutoffMs && typeof incident.durationMs === "number",
   );
   if (resolved.length === 0) return undefined;
-  const sum = resolved.reduce((s, inc) => s + inc.durationMs, 0);
+  const sum = resolved.reduce((accumulator, incident) => accumulator + incident.durationMs, 0);
   return Math.round(sum / resolved.length);
 }

--- a/sites/status.arolariu.ro/src/lib/aggregation/weekdayUptime.ts
+++ b/sites/status.arolariu.ro/src/lib/aggregation/weekdayUptime.ts
@@ -1,5 +1,16 @@
 import type {ServiceSeries} from "../types/status";
 
+const WEEKDAY_COUNT = 7;
+
+function getIsoWeekdayIndex(timestamp: string): number {
+  const date = new Date(timestamp);
+  return (date.getUTCDay() + 6) % WEEKDAY_COUNT;
+}
+
+function incrementAt(values: number[], index: number, amount: number): void {
+  values[index] = (values[index] ?? 0) + amount;
+}
+
 /**
  * Uptime % per weekday (Mon..Sun, ISO order). Aggregated across services.
  * A weekday with no probes returns 100 (no proven failure).
@@ -9,22 +20,17 @@ import type {ServiceSeries} from "../types/status";
  * viewer's local time. Values are rounded to one decimal.
  */
 export function computeWeekdayUptime(services: readonly ServiceSeries[]): readonly number[] {
-  // Fixed-length 7-element buckets (Mon..Sun). `idx` is always in [0..6] so
-  // the array access is always defined; non-null assertion keeps the hot
-  // path allocation-free under noUncheckedIndexedAccess.
-  const healthy = new Array<number>(7).fill(0);
-  const total = new Array<number>(7).fill(0);
-  for (const s of services) {
-    for (const b of s.buckets) {
-      const d = new Date(b.t);
-      // getUTCDay: 0=Sun..6=Sat. ISO weekday: 0=Mon..6=Sun. Map: (getUTCDay + 6) % 7.
-      const idx = (d.getUTCDay() + 6) % 7;
-      healthy[idx]! += b.probes.healthy;
-      total[idx]! += b.probes.total;
+  const healthy = Array.from({length: WEEKDAY_COUNT}, () => 0);
+  const total = Array.from({length: WEEKDAY_COUNT}, () => 0);
+  for (const serviceSeries of services) {
+    for (const bucket of serviceSeries.buckets) {
+      const weekdayIndex = getIsoWeekdayIndex(bucket.t);
+      incrementAt(healthy, weekdayIndex, bucket.probes.healthy);
+      incrementAt(total, weekdayIndex, bucket.probes.total);
     }
   }
-  return healthy.map((h, i) => {
-    const t = total[i]!;
-    return t === 0 ? 100 : Math.round((h / t) * 1000) / 10;
+  return healthy.map((healthyCount, weekdayIndex) => {
+    const totalCount = total[weekdayIndex] ?? 0;
+    return totalCount === 0 ? 100 : Math.round((healthyCount / totalCount) * 1000) / 10;
   });
 }

--- a/sites/status.arolariu.ro/src/lib/aggregation/weekdayUptime.ts
+++ b/sites/status.arolariu.ro/src/lib/aggregation/weekdayUptime.ts
@@ -8,6 +8,7 @@ function getIsoWeekdayIndex(timestamp: string): number {
 }
 
 function incrementAt(values: number[], index: number, amount: number): void {
+  // eslint-disable-next-line security/detect-object-injection -- index is always produced by getIsoWeekdayIndex in [0..6].
   values[index] = (values[index] ?? 0) + amount;
 }
 
@@ -30,6 +31,7 @@ export function computeWeekdayUptime(services: readonly ServiceSeries[]): readon
     }
   }
   return healthy.map((healthyCount, weekdayIndex) => {
+    // eslint-disable-next-line security/detect-object-injection -- weekdayIndex is produced by Array.map over the fixed weekday array.
     const totalCount = total[weekdayIndex] ?? 0;
     return totalCount === 0 ? 100 : Math.round((healthyCount / totalCount) * 1000) / 10;
   });

--- a/sites/status.arolariu.ro/src/lib/aggregation/weightedUptime.ts
+++ b/sites/status.arolariu.ro/src/lib/aggregation/weightedUptime.ts
@@ -20,9 +20,9 @@ import type {Bucket} from "../types/status";
 export function weightedUptime(buckets: readonly Bucket[]): number {
   let healthy = 0;
   let total = 0;
-  for (const b of buckets) {
-    healthy += b.probes.healthy;
-    total += b.probes.total;
+  for (const bucket of buckets) {
+    healthy += bucket.probes.healthy;
+    total += bucket.probes.total;
   }
   if (total === 0) return 100;
   return Math.round((healthy / total) * 100_000) / 1000;

--- a/sites/status.arolariu.ro/src/lib/aggregation/worstUptime.ts
+++ b/sites/status.arolariu.ro/src/lib/aggregation/worstUptime.ts
@@ -15,12 +15,13 @@ export interface WorstUptime {
 export function computeWorstUptime(services: readonly ServiceSeries[]): WorstUptime {
   if (services.length === 0) return {service: "", uptime: 100};
   let worst: WorstUptime = {service: "", uptime: Infinity};
-  for (const s of services) {
-    const uptime = weightedUptime(s.buckets);
-    if (uptime < worst.uptime || (uptime === worst.uptime && s.service < worst.service)) {
-      worst = {service: s.service, uptime};
+  for (const serviceSeries of services) {
+    const uptime = weightedUptime(serviceSeries.buckets);
+    if (uptime < worst.uptime || (uptime === worst.uptime && serviceSeries.service < worst.service)) {
+      worst = {service: serviceSeries.service, uptime};
     }
   }
+  // eslint-disable-next-line capitalized-comments -- v8 ignore directive is case-sensitive.
   /* v8 ignore next */
   return worst.uptime === Infinity ? {service: "", uptime: 100} : worst;
 }

--- a/sites/status.arolariu.ro/src/lib/api/fetchStatusData.test.ts
+++ b/sites/status.arolariu.ro/src/lib/api/fetchStatusData.test.ts
@@ -221,4 +221,23 @@ describe("isHardReload branches (module-load side effect)", () => {
     expect(localStorage.getItem("status.arolariu.ro/cache:fine")).not.toBeNull();
     vi.unstubAllGlobals();
   });
+
+  it("does not throw during module-load cache clearing when localStorage access throws", async () => {
+    const descriptor = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+    const reloadEntry = {type: "reload", transferSize: 1024};
+    vi.stubGlobal("performance", {
+      getEntriesByType: (type: string) => (type === "navigation" ? [reloadEntry] : []),
+    });
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      get() {
+        throw new DOMException("Blocked", "SecurityError");
+      },
+    });
+
+    await expect(import("./fetchStatusData")).resolves.toBeDefined();
+
+    if (descriptor) Object.defineProperty(globalThis, "localStorage", descriptor);
+    vi.unstubAllGlobals();
+  });
 });

--- a/sites/status.arolariu.ro/src/lib/api/fetchStatusData.ts
+++ b/sites/status.arolariu.ro/src/lib/api/fetchStatusData.ts
@@ -85,12 +85,16 @@ function isHardReload(): boolean {
 // Forcing the next fetch to go to the network. Skipped on SSR.
 const browserWindow = globalThis.window as Window | undefined;
 if (browserWindow !== undefined && isHardReload()) {
-  const keysToRemove: string[] = [];
-  for (let index = 0; index < globalThis.localStorage.length; index += 1) {
-    const key = globalThis.localStorage.key(index);
-    if (key?.startsWith(CACHE_PREFIX)) keysToRemove.push(key);
+  try {
+    const keysToRemove: string[] = [];
+    for (let index = 0; index < globalThis.localStorage.length; index += 1) {
+      const key = globalThis.localStorage.key(index);
+      if (key?.startsWith(CACHE_PREFIX)) keysToRemove.push(key);
+    }
+    for (const key of keysToRemove) globalThis.localStorage.removeItem(key);
+  } catch {
+    /* LocalStorage unavailable */
   }
-  for (const key of keysToRemove) globalThis.localStorage.removeItem(key);
 }
 
 /**

--- a/sites/status.arolariu.ro/src/lib/api/fetchStatusData.ts
+++ b/sites/status.arolariu.ro/src/lib/api/fetchStatusData.ts
@@ -27,7 +27,7 @@ const DATA_BASE = "https://raw.githubusercontent.com/arolariu/arolariu.ro/status
 /** Cache TTL — 30 minutes, matching the upstream aggregator's cron cadence. */
 const CACHE_TTL_MS = 30 * 60 * 1000;
 
-/** localStorage key prefix. Keys are `{prefix}{granularity}`. */
+/** LocalStorage key prefix. Keys are `{prefix}{granularity}`. */
 const CACHE_PREFIX = "status.arolariu.ro/cache:";
 
 /** Which aggregate file to fetch (`fine` / `hourly` / `daily`). */
@@ -44,6 +44,11 @@ const memory = new Map<Granularity, CachedAggregate>();
 
 /** In-memory incidents cache (single file, no keying). */
 let incidentsMemory: {data: IncidentsFile; fetchedAt: number} | null = null;
+
+function cacheIncidents(data: IncidentsFile, fetchedAt: number): IncidentsFile {
+  incidentsMemory = {data, fetchedAt};
+  return data;
+}
 
 /**
  * Error class thrown by fetch helpers on non-2xx responses or schema failures.
@@ -63,10 +68,13 @@ export class StatusDataError extends Error {
  * Safe to call during SSR — returns false when `window` is absent.
  */
 function isHardReload(): boolean {
+  const browserWindow = globalThis.window as Window | undefined;
+  // eslint-disable-next-line capitalized-comments -- v8 ignore directive is case-sensitive.
   /* v8 ignore next 2 */
-  if (typeof window === "undefined") return false;
-  const entries = performance.getEntriesByType?.("navigation") ?? [];
+  if (browserWindow === undefined) return false;
+  const entries = globalThis.performance.getEntriesByType?.("navigation") ?? [];
   const entry = entries[0] as PerformanceNavigationTiming | undefined;
+  // eslint-disable-next-line capitalized-comments -- v8 ignore directive is case-sensitive.
   /* v8 ignore next 2 */
   if (!entry || entry.type !== "reload") return false;
   const fromCache = (entry as PerformanceNavigationTiming & {deliveryType?: string}).deliveryType === "cache" || entry.transferSize === 0;
@@ -74,14 +82,15 @@ function isHardReload(): boolean {
 }
 
 // Module-load-time side effect: a hard reload clears the localStorage cache,
-// forcing the next fetch to go to the network. Skipped on SSR.
-if (typeof window !== "undefined" && isHardReload()) {
+// Forcing the next fetch to go to the network. Skipped on SSR.
+const browserWindow = globalThis.window as Window | undefined;
+if (browserWindow !== undefined && isHardReload()) {
   const keysToRemove: string[] = [];
-  for (let i = 0; i < localStorage.length; i++) {
-    const k = localStorage.key(i);
-    if (k?.startsWith(CACHE_PREFIX)) keysToRemove.push(k);
+  for (let index = 0; index < globalThis.localStorage.length; index += 1) {
+    const key = globalThis.localStorage.key(index);
+    if (key?.startsWith(CACHE_PREFIX)) keysToRemove.push(key);
   }
-  for (const k of keysToRemove) localStorage.removeItem(k);
+  for (const key of keysToRemove) globalThis.localStorage.removeItem(key);
 }
 
 /**
@@ -97,8 +106,9 @@ if (typeof window !== "undefined" && isHardReload()) {
  */
 export async function fetchAggregate(granularity: Granularity): Promise<AggregateFile> {
   // Local dev / preview shortcut: synthesize data relative to Date.now() so
-  // the UI always shows "recent" timestamps without hitting the network.
+  // The UI always shows "recent" timestamps without hitting the network.
   // The production Azure SWA hostname never matches isLocalHost().
+  // eslint-disable-next-line capitalized-comments -- v8 ignore directive is case-sensitive.
   /* v8 ignore next */
   if (isLocalHost()) return generateMockAggregate(granularity);
 
@@ -107,7 +117,7 @@ export async function fetchAggregate(granularity: Granularity): Promise<Aggregat
 
   const storageKey = `${CACHE_PREFIX}${granularity}`;
   try {
-    const stored = localStorage.getItem(storageKey);
+    const stored = globalThis.localStorage.getItem(storageKey);
     if (stored) {
       const parsed = JSON.parse(stored) as {fetchedAt?: number; data?: unknown};
       if (typeof parsed.fetchedAt === "number" && Date.now() - parsed.fetchedAt < CACHE_TTL_MS && isAggregateFile(parsed.data)) {
@@ -116,7 +126,7 @@ export async function fetchAggregate(granularity: Granularity): Promise<Aggregat
       }
     }
   } catch {
-    /* localStorage unavailable */
+    /* LocalStorage unavailable */
   }
 
   const response = await fetch(`${DATA_BASE}/${granularity}.json`, {cache: "no-store"});
@@ -127,9 +137,9 @@ export async function fetchAggregate(granularity: Granularity): Promise<Aggregat
   const fetchedAt = Date.now();
   memory.set(granularity, {data: json, fetchedAt});
   try {
-    localStorage.setItem(storageKey, JSON.stringify({fetchedAt, data: json}));
+    globalThis.localStorage.setItem(storageKey, JSON.stringify({fetchedAt, data: json}));
   } catch {
-    /* quota exceeded */
+    /* Quota exceeded */
   }
 
   return json;
@@ -145,6 +155,7 @@ export async function fetchAggregate(granularity: Granularity): Promise<Aggregat
  * HTTP failure or schema mismatch.
  */
 export async function fetchIncidents(): Promise<IncidentsFile> {
+  // eslint-disable-next-line capitalized-comments -- v8 ignore directive is case-sensitive.
   /* v8 ignore next */
   if (isLocalHost()) return generateMockIncidents();
 
@@ -153,10 +164,10 @@ export async function fetchIncidents(): Promise<IncidentsFile> {
   }
   const response = await fetch(`${DATA_BASE}/incidents.json`, {cache: "no-store"});
   if (!response.ok) throw new StatusDataError(`HTTP ${response.status}`);
+  const fetchedAt = Date.now();
   const json: unknown = await response.json();
   if (!isIncidentsFile(json)) throw new StatusDataError("schema mismatch");
-  incidentsMemory = {data: json, fetchedAt: Date.now()};
-  return json;
+  return cacheIncidents(json, fetchedAt);
 }
 
 /**
@@ -169,12 +180,12 @@ export function invalidateAllCaches(): void {
   incidentsMemory = null;
   try {
     const keysToRemove: string[] = [];
-    for (let i = 0; i < localStorage.length; i++) {
-      const k = localStorage.key(i);
-      if (k?.startsWith(CACHE_PREFIX)) keysToRemove.push(k);
+    for (let index = 0; index < globalThis.localStorage.length; index += 1) {
+      const key = globalThis.localStorage.key(index);
+      if (key?.startsWith(CACHE_PREFIX)) keysToRemove.push(key);
     }
-    for (const k of keysToRemove) localStorage.removeItem(k);
+    for (const key of keysToRemove) globalThis.localStorage.removeItem(key);
   } catch {
-    /* localStorage unavailable */
+    /* LocalStorage unavailable */
   }
 }

--- a/sites/status.arolariu.ro/src/lib/api/mockData.ts
+++ b/sites/status.arolariu.ro/src/lib/api/mockData.ts
@@ -52,6 +52,24 @@ const CONFIGS: Record<Granularity, GranularityConfig> = {
   daily: {bucketSize: "1d", windowDays: 365, bucketMs: MS_PER_DAY, bucketCount: 365, cronsPerBucket: 48},
 };
 
+function configForGranularity(granularity: Granularity): GranularityConfig {
+  switch (granularity) {
+    case "fine": {
+      return CONFIGS.fine;
+    }
+    case "hourly": {
+      return CONFIGS.hourly;
+    }
+    case "daily": {
+      return CONFIGS.daily;
+    }
+    default: {
+      const exhaustiveGranularity: never = granularity;
+      return exhaustiveGranularity;
+    }
+  }
+}
+
 /**
  * Samples per cron run. Must match `DEFAULT_SAMPLE_DELAYS_MS.length` in
  * `scripts/probe.ts` — the real probe takes 10 measurements over 180s per
@@ -461,7 +479,7 @@ function generateServiceSeries(story: ServiceStoryline, config: GranularityConfi
  */
 export function generateMockAggregate(granularity: Granularity): AggregateFile {
   const now = Date.now();
-  const config = CONFIGS[granularity];
+  const config = configForGranularity(granularity);
   const services: ServiceSeries[] = STORYLINES.map((story) => generateServiceSeries(story, config, now));
 
   // Intentionally construct via explicit discriminated-union literal so TS

--- a/sites/status.arolariu.ro/src/lib/api/mockData.ts
+++ b/sites/status.arolariu.ro/src/lib/api/mockData.ts
@@ -125,6 +125,39 @@ interface ServiceStoryline {
   readonly subChecks?: Readonly<Record<string, SubCheckStoryline>>;
 }
 
+interface BucketInput {
+  readonly timestamp: string;
+  readonly status: HealthStatus;
+  readonly p50: number;
+  readonly healthyPerCron: number;
+  readonly cronsPerBucket: number;
+}
+
+interface BucketGenerationInput {
+  readonly baselineP50: number;
+  readonly blips: readonly Blip[];
+  readonly cyclicHiccup: SubCheckStoryline["cyclicHiccup"] | undefined;
+  // eslint-disable-next-line no-unused-vars -- Function type names the callback argument for readability.
+  readonly driftForMainP50: ((bucketTimestamp: number) => number) | null;
+  readonly config: GranularityConfig;
+  readonly now: number;
+}
+
+interface BucketOverlapInput {
+  readonly bucketTimestamp: number;
+  readonly bucketMs: number;
+  readonly start: number;
+  readonly end: number;
+}
+
+interface IncidentInput {
+  readonly story: ServiceStoryline;
+  readonly blip: Blip;
+  readonly subCheck: string | undefined;
+  readonly index: number;
+  readonly now: number;
+}
+
 /**
  * One storyline per service. Adding / tweaking a dev scenario is a one-
  * dict edit — no bucket-math changes needed; `generateBuckets` folds the
@@ -160,7 +193,7 @@ const STORYLINES: readonly ServiceStoryline[] = [
         durationHours: 1,
         status: "Degraded",
         reason: "connection pool exhausted (mock)",
-        latencyFactor: 4.0,
+        latencyFactor: 4,
         probeCount: 2,
       },
       {
@@ -211,7 +244,7 @@ const STORYLINES: readonly ServiceStoryline[] = [
         durationHours: 3,
         status: "Degraded",
         reason: "elevated latency on upstream dependency (mock)",
-        latencyFactor: 3.0,
+        latencyFactor: 3,
         probeCount: 6,
         open: true,
       },
@@ -220,7 +253,7 @@ const STORYLINES: readonly ServiceStoryline[] = [
         durationHours: 3,
         status: "Unhealthy",
         reason: "upstream ML model service unreachable (mock)",
-        latencyFactor: 8.0,
+        latencyFactor: 8,
         probeCount: 6,
       },
     ],
@@ -246,12 +279,12 @@ const STORYLINES: readonly ServiceStoryline[] = [
  * Ratios picked to roughly track production observations:
  *   p75 ≈ 1.35× p50, p95 ≈ 1.80× p50, p99 ≈ 2.10× p50.
  */
-function percentileFan(p50: number): {p50: number; p75: number; p95: number; p99: number} {
+function percentileFan(p50Latency: number): {p50: number; p75: number; p95: number; p99: number} {
   return {
-    p50,
-    p75: Math.round(p50 * 1.35),
-    p95: Math.round(p50 * 1.8),
-    p99: Math.round(p50 * 2.1),
+    p50: p50Latency,
+    p75: Math.round(p50Latency * 1.35),
+    p95: Math.round(p50Latency * 1.8),
+    p99: Math.round(p50Latency * 2.1),
   };
 }
 
@@ -261,9 +294,10 @@ function percentileFan(p50: number): {p50: number; p75: number; p95: number; p99
  * `healthyPerCron * cronsPerBucket`. `httpStatus` is set to 503 for
  * `Unhealthy` and 200 otherwise (we don't model 5xx variety in mocks).
  */
-function mkBucket(t: string, status: HealthStatus, p50: number, healthyPerCron: number, cronsPerBucket: number): Bucket {
+function makeBucket({timestamp, status, p50, healthyPerCron, cronsPerBucket}: Readonly<BucketInput>): Bucket {
   return {
-    t,
+    // eslint-disable-next-line id-length -- Bucket schema uses `t` for timestamp.
+    t: timestamp,
     status,
     probes: {
       healthy: healthyPerCron * cronsPerBucket,
@@ -279,8 +313,8 @@ function mkBucket(t: string, status: HealthStatus, p50: number, healthyPerCron: 
  * Blips anchored by wall-clock (not bucket index) appear consistently across
  * all three granularities.
  */
-function bucketOverlaps(bucketT: number, bucketMs: number, start: number, end: number): boolean {
-  return bucketT + bucketMs > start && bucketT < end;
+function bucketOverlaps({bucketTimestamp, bucketMs, start, end}: Readonly<BucketOverlapInput>): boolean {
+  return bucketTimestamp + bucketMs > start && bucketTimestamp < end;
 }
 
 /** Start/end wall-clock range (ms) of a blip, computed from `now` and `ageHours`. */
@@ -296,13 +330,14 @@ function blipWindow(blip: Blip, now: number): {start: number; end: number} {
  * when no drift is configured) returns `story.baselineP50`; inside the
  * window ramps linearly from `baseline - 30` to `latencyDrift.endP50`.
  */
-function computeP50AtTime(story: ServiceStoryline, bucketT: number, now: number): number {
+function computeP50AtTime(story: ServiceStoryline, bucketTimestamp: number, now: number): number {
+  // eslint-disable-next-line capitalized-comments -- v8 ignore directive is case-sensitive.
   /* v8 ignore next */
   if (!story.latencyDrift) return story.baselineP50;
   const creepStart = now - story.latencyDrift.startAgoHours * MS_PER_HOUR;
   const creepEnd = now - story.latencyDrift.endAgoHours * MS_PER_HOUR;
-  if (bucketT < creepStart || bucketT > creepEnd) return story.baselineP50;
-  const progress = (bucketT - creepStart) / (creepEnd - creepStart);
+  if (bucketTimestamp < creepStart || bucketTimestamp > creepEnd) return story.baselineP50;
+  const progress = (bucketTimestamp - creepStart) / (creepEnd - creepStart);
   return Math.round(story.baselineP50 - 30 + progress * (story.latencyDrift.endP50 - (story.baselineP50 - 30)));
 }
 
@@ -315,43 +350,70 @@ function computeP50AtTime(story: ServiceStoryline, bucketT: number, now: number)
  *  2. Is this a cyclic-hiccup bucket? → emit a small Degraded spike.
  *  3. Otherwise → emit a Healthy bucket at baseline/drifted p50.
  */
-function generateBucketsFor(
-  baselineP50: number,
-  blips: readonly Blip[],
-  cyclicHiccup: SubCheckStoryline["cyclicHiccup"] | undefined,
-  driftForMainP50: ((bucketT: number) => number) | null,
-  config: GranularityConfig,
-  now: number,
-): Bucket[] {
+function generateBucketsFor({
+  baselineP50,
+  blips,
+  cyclicHiccup,
+  driftForMainP50,
+  config,
+  now,
+}: Readonly<BucketGenerationInput>): Bucket[] {
   const total = config.bucketCount;
   // Ongoing blips (`open: true`) drive the incident log but do NOT rewrite
-  // history into the bucket series — they're near-now events whose health
-  // state hasn't settled yet. Pre-rewrite behavior preserved exactly.
-  const bucketBlips = blips.filter((b) => !b.open);
+  // History into the bucket series - they're near-now events whose health
+  // State hasn't settled yet. Pre-rewrite behavior preserved exactly.
+  const bucketBlips = blips.filter((blip) => !blip.open);
   const windows = bucketBlips.map((blip) => ({blip, ...blipWindow(blip, now)}));
 
-  return Array.from({length: total}, (_, fromEnd) => {
-    const bucketT = now - fromEnd * config.bucketMs;
-    const t = new Date(bucketT).toISOString();
+  const buckets: Bucket[] = [];
+  for (let fromEnd = 0; fromEnd < total; fromEnd += 1) {
+    const bucketTimestamp = now - fromEnd * config.bucketMs;
+    const timestamp = new Date(bucketTimestamp).toISOString();
 
-    const activeBlip = windows.find((w) => bucketOverlaps(bucketT, config.bucketMs, w.start, w.end));
+    const activeBlip = windows.find((windowEntry) =>
+      bucketOverlaps({bucketTimestamp, bucketMs: config.bucketMs, start: windowEntry.start, end: windowEntry.end}),
+    );
 
-    const p50 = driftForMainP50 ? driftForMainP50(bucketT) : baselineP50;
+    const p50 = driftForMainP50 ? driftForMainP50(bucketTimestamp) : baselineP50;
 
     if (activeBlip) {
+      // eslint-disable-next-line capitalized-comments -- v8 ignore directive is case-sensitive.
       /* v8 ignore next */
-      const factor = activeBlip.blip.latencyFactor ?? (activeBlip.blip.status === "Unhealthy" ? 8.0 : 3.2);
+      const factor = activeBlip.blip.latencyFactor ?? (activeBlip.blip.status === "Unhealthy" ? 8 : 3.2);
       const healthyPerCron = activeBlip.blip.status === "Unhealthy" ? 0 : 2;
-      return mkBucket(t, activeBlip.blip.status, Math.round(p50 * factor), healthyPerCron, config.cronsPerBucket);
+      buckets.push(makeBucket({
+        timestamp,
+        status: activeBlip.blip.status,
+        p50: Math.round(p50 * factor),
+        healthyPerCron,
+        cronsPerBucket: config.cronsPerBucket,
+      }));
+      continue;
     }
 
+    // eslint-disable-next-line capitalized-comments -- v8 ignore directive is case-sensitive.
     /* v8 ignore next */
     if (cyclicHiccup && fromEnd % cyclicHiccup.everyNBuckets === cyclicHiccup.atOffset) {
-      return mkBucket(t, "Degraded", cyclicHiccup.p50, cyclicHiccup.healthyPerCron, config.cronsPerBucket);
+      buckets.push(makeBucket({
+        timestamp,
+        status: "Degraded",
+        p50: cyclicHiccup.p50,
+        healthyPerCron: cyclicHiccup.healthyPerCron,
+        cronsPerBucket: config.cronsPerBucket,
+      }));
+      continue;
     }
 
-    return mkBucket(t, "Healthy", p50, SAMPLES_PER_CRON, config.cronsPerBucket);
-  });
+    buckets.push(makeBucket({
+      timestamp,
+      status: "Healthy",
+      p50,
+      healthyPerCron: SAMPLES_PER_CRON,
+      cronsPerBucket: config.cronsPerBucket,
+    }));
+  }
+
+  return buckets;
 }
 
 /**
@@ -359,27 +421,34 @@ function generateBucketsFor(
  * sub-series map) at the requested granularity.
  */
 function generateServiceSeries(story: ServiceStoryline, config: GranularityConfig, now: number): ServiceSeries {
-  const mainBuckets = generateBucketsFor(
-    story.baselineP50,
-    story.blips,
-    undefined,
-    story.latencyDrift ? (bucketT) => computeP50AtTime(story, bucketT, now) : null,
+  const mainBuckets = generateBucketsFor({
+    baselineP50: story.baselineP50,
+    blips: story.blips,
+    cyclicHiccup: undefined,
+    driftForMainP50: story.latencyDrift ? (bucketTimestamp) => computeP50AtTime(story, bucketTimestamp, now) : null,
     config,
     now,
-  );
+  });
 
-  let subSeriesObj: Record<string, readonly Bucket[]> | null = null;
+  let subSeriesObject: Record<string, readonly Bucket[]> | null = null;
   if (story.subChecks) {
-    subSeriesObj = {};
-    for (const [name, sub] of Object.entries(story.subChecks)) {
-      subSeriesObj[name] = generateBucketsFor(sub.baselineP50, sub.blips, sub.cyclicHiccup, null, config, now);
-    }
+    subSeriesObject = Object.fromEntries(Object.entries(story.subChecks).map(([name, sub]) => [
+      name,
+      generateBucketsFor({
+        baselineP50: sub.baselineP50,
+        blips: sub.blips,
+        cyclicHiccup: sub.cyclicHiccup,
+        driftForMainP50: null,
+        config,
+        now,
+      }),
+    ]));
   }
 
   const series: ServiceSeries = {
     service: story.service,
     buckets: mainBuckets,
-    ...(subSeriesObj ? {subSeries: subSeriesObj} : {}),
+    ...(subSeriesObject ? {subSeries: subSeriesObject} : {}),
   };
 
   return series;
@@ -396,15 +465,22 @@ export function generateMockAggregate(granularity: Granularity): AggregateFile {
   const services: ServiceSeries[] = STORYLINES.map((story) => generateServiceSeries(story, config, now));
 
   // Intentionally construct via explicit discriminated-union literal so TS
-  // verifies the (bucketSize, windowDays) pair is valid.
+  // Verifies the (bucketSize, windowDays) pair is valid.
   const generatedAt = new Date(now).toISOString();
   switch (granularity) {
-    case "fine":
+    case "fine": {
       return {generatedAt, bucketSize: "30m", windowDays: 14, services};
-    case "hourly":
+    }
+    case "hourly": {
       return {generatedAt, bucketSize: "1h", windowDays: 90, services};
-    case "daily":
+    }
+    case "daily": {
       return {generatedAt, bucketSize: "1d", windowDays: 365, services};
+    }
+    default: {
+      const exhaustiveGranularity: never = granularity;
+      return exhaustiveGranularity;
+    }
   }
 }
 
@@ -414,7 +490,7 @@ export function generateMockAggregate(granularity: Granularity): AggregateFile {
  * become `{status: "resolved"}` incidents with those fields computed from
  * the blip duration.
  */
-function blipToIncident(story: ServiceStoryline, blip: Blip, subCheck: string | undefined, index: number, now: number): Incident {
+function blipToIncident({story, blip, subCheck, index, now}: Readonly<IncidentInput>): Incident {
   const startedAt = new Date(now - blip.ageHours * MS_PER_HOUR).toISOString();
   const severity = blip.status;
   const common = {
@@ -424,7 +500,7 @@ function blipToIncident(story: ServiceStoryline, blip: Blip, subCheck: string | 
     startedAt,
     reason: blip.reason,
     probeCount: blip.probeCount,
-    ...(subCheck !== undefined ? {subCheck} : {}),
+    ...(typeof subCheck === "string" ? {subCheck} : {}),
   };
   if (blip.open) {
     return {...common, status: "open"};
@@ -448,7 +524,7 @@ export function generateMockIncidents(): IncidentsFile {
   const now = Date.now();
 
   // Order: open blips first (most recent + still-ongoing), then resolved
-  // newest-first. Matches the pre-rewrite shipped narrative closely.
+  // Newest-first. Matches the pre-rewrite shipped narrative closely.
   const entries: Array<{story: ServiceStoryline; blip: Blip; subCheck?: string; age: number}> = [];
   for (const story of STORYLINES) {
     for (const blip of story.blips) {
@@ -464,9 +540,11 @@ export function generateMockIncidents(): IncidentsFile {
   }
 
   // Newest first (lowest ageHours first).
-  entries.sort((a, b) => a.age - b.age);
+  entries.sort((left, right) => left.age - right.age);
 
-  const incidents: Incident[] = entries.map((e, i) => blipToIncident(e.story, e.blip, e.subCheck, i + 1, now));
+  const incidents: Incident[] = entries.map((entry, index) =>
+    blipToIncident({story: entry.story, blip: entry.blip, subCheck: entry.subCheck, index: index + 1, now}),
+  );
 
   return {
     generatedAt: new Date(now).toISOString(),
@@ -484,8 +562,9 @@ export function generateMockIncidents(): IncidentsFile {
  * path (otherwise this shortcut would swallow every fetch).
  */
 export function isLocalHost(): boolean {
-  if (typeof window === "undefined") return false;
-  if (window.location.search.includes("mocks=off")) return false;
-  const h = window.location.hostname;
-  return h === "localhost" || h === "127.0.0.1" || h === "::1";
+  const browserWindow = globalThis.window as Window | undefined;
+  if (browserWindow === undefined) return false;
+  const {hostname, search} = browserWindow.location;
+  if (search.includes("mocks=off")) return false;
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
 }

--- a/sites/status.arolariu.ro/src/lib/components/chrome/Popover.svelte
+++ b/sites/status.arolariu.ro/src/lib/components/chrome/Popover.svelte
@@ -131,6 +131,7 @@
       onclick={onClose}
       role="presentation"></div>
   {/if}
+  <!-- svelte-ignore a11y_no_noninteractive_tabindex (modal dialog receives programmatic focus for focus-trap setup) -->
   <div
     bind:this={surfaceEl}
     id={surfaceId}

--- a/sites/status.arolariu.ro/src/lib/components/table/SegmentTooltip.svelte
+++ b/sites/status.arolariu.ro/src/lib/components/table/SegmentTooltip.svelte
@@ -40,11 +40,11 @@
 
   // Positioning math + scroll/resize plumbing lives in the shared hook so
   // the viewport-flip behavior is unit-testable (see usePopoverPosition.test).
-  const position = usePopoverPosition(
-    () => anchor,
-    () => tooltipEl,
-    () => anchor !== null && bucket !== null,
-  );
+  const position = usePopoverPosition({
+    anchor: () => anchor,
+    tooltipElement: () => tooltipEl,
+    active: () => anchor !== null && bucket !== null,
+  });
 
   const endISO = $derived.by(() => {
     if (!bucket) return "";

--- a/sites/status.arolariu.ro/src/lib/components/table/SkeletonRow.svelte
+++ b/sites/status.arolariu.ro/src/lib/components/table/SkeletonRow.svelte
@@ -17,7 +17,7 @@
     indent?: boolean;
   }
   let {segmentCount = 48, indent = false}: Props = $props();
-  const segments = Array.from({length: segmentCount}, (_, i) => i);
+  const segments = $derived(Array.from({length: segmentCount}, (_, index) => index));
 </script>
 
 <div

--- a/sites/status.arolariu.ro/src/lib/hooks/useCountTween.svelte.ts
+++ b/sites/status.arolariu.ro/src/lib/hooks/useCountTween.svelte.ts
@@ -24,7 +24,7 @@ export interface UseCountTweenOptions {
 
 /**
  * @param target Reactive getter for the target number (read inside an `$effect`).
- * @param opts   Optional `{durationMs}` override (default 400ms).
+ * @param options Optional `{durationMs}` override (default 400ms).
  * @returns A `$state`-backed accessor (`() => number`) that lerps toward `target()`
  *          on each change, easing with `easeOutCubic`.
  *
@@ -37,32 +37,38 @@ export interface UseCountTweenOptions {
  * Reduced motion: if `prefers-reduced-motion: reduce` is set at hook creation,
  * the display value snaps to the target without animation.
  */
-export function useCountTween(target: () => number, opts?: UseCountTweenOptions): () => number {
-  const durationMs = opts?.durationMs ?? 400;
+export function useCountTween(target: () => number, options?: UseCountTweenOptions): () => number {
+  const durationMs = options?.durationMs ?? 400;
 
   let display = $state(0);
-  const raf = {id: null as number | null};
+  const animationFrame = {id: null as number | null};
+  const browserWindow = globalThis.window as Window | undefined;
 
-  const prefersReducedMotion = typeof window !== "undefined" && window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+  const prefersReducedMotion =
+    browserWindow !== undefined &&
+    browserWindow.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+
+  function cleanupAnimationFrame(): void {
+    if (animationFrame.id !== null) globalThis.cancelAnimationFrame(animationFrame.id);
+  }
 
   function animate(from: number, to: number): void {
-    if (raf.id !== null) {
-      cancelAnimationFrame(raf.id);
-      raf.id = null;
+    if (animationFrame.id !== null) {
+      globalThis.cancelAnimationFrame(animationFrame.id);
+      animationFrame.id = null;
     }
     if (from === to) {
       display = to;
       return;
     }
-    const start = performance.now();
-    function step(now: number) {
-      const t = Math.min(1, (now - start) / durationMs);
-      const eased = 1 - Math.pow(1 - t, 3); // easeOutCubic
+    const start = globalThis.performance.now();
+    function step(now: number): void {
+      const progress = Math.min(1, (now - start) / durationMs);
+      const eased = 1 - (1 - progress) ** 3;
       display = from + (to - from) * eased;
-      if (t < 1) raf.id = requestAnimationFrame(step);
-      else raf.id = null;
+      animationFrame.id = progress < 1 ? globalThis.requestAnimationFrame(step) : null;
     }
-    raf.id = requestAnimationFrame(step);
+    animationFrame.id = globalThis.requestAnimationFrame(step);
   }
 
   $effect(() => {
@@ -76,13 +82,11 @@ export function useCountTween(target: () => number, opts?: UseCountTweenOptions)
     });
   });
 
-  // Cleanup in its own (setup-free) effect so it runs on scope teardown
-  // without being re-established on every target change. Usable from
-  // component scope OR from `$effect.root` scope (so unit tests can
-  // exercise the hook with runes alone, no component harness).
-  $effect(() => () => {
-    if (raf.id !== null) cancelAnimationFrame(raf.id);
-  });
+  // Cleanup in its own (setup-free) effect so it runs on scope teardown.
+  // Without being re-established on every target change. Usable from
+  // Component scope OR from `$effect.root` scope (so unit tests can
+  // Exercise the hook with runes alone, no component harness).
+  $effect(() => cleanupAnimationFrame);
 
   return () => display;
 }

--- a/sites/status.arolariu.ro/src/lib/hooks/usePopoverPosition.svelte.test.ts
+++ b/sites/status.arolariu.ro/src/lib/hooks/usePopoverPosition.svelte.test.ts
@@ -73,11 +73,11 @@ describe("usePopoverPosition (reactive hook)", () => {
     });
 
     const root = $effect.root(() => {
-      const getPos = usePopoverPosition(
-        () => null, // anchor is null
-        () => null,
-        () => true, // active = true
-      );
+      const getPos = usePopoverPosition({
+        anchor: () => null,
+        tooltipElement: () => null,
+        active: () => true,
+      });
       flushSync();
       // Recompute runs but exits early at `if (!el) return`
       expect(getPos()).toEqual({top: 0, left: 0, flipHoriz: false});
@@ -90,7 +90,7 @@ describe("usePopoverPosition (reactive hook)", () => {
       const anchor = () => null;
       const tooltipEl = () => null;
       const active = () => false;
-      const getPos = usePopoverPosition(anchor, tooltipEl, active);
+      const getPos = usePopoverPosition({anchor, tooltipElement: tooltipEl, active});
       flushSync();
       const pos = getPos();
       expect(pos).toEqual({top: 0, left: 0, flipHoriz: false});
@@ -120,12 +120,12 @@ describe("usePopoverPosition (reactive hook)", () => {
       let isActive = $state(false);
       let currentAnchor = $state<HTMLElement | null>(null);
 
-      const getPos = usePopoverPosition(
-        () => currentAnchor,
-        () => tooltipEl,
-        () => isActive,
-        200,
-      );
+      const getPos = usePopoverPosition({
+        anchor: () => currentAnchor,
+        tooltipElement: () => tooltipEl,
+        active: () => isActive,
+        fallbackWidth: 200,
+      });
 
       flushSync();
       expect(getPos()).toEqual({top: 0, left: 0, flipHoriz: false});
@@ -161,12 +161,12 @@ describe("usePopoverPosition (reactive hook)", () => {
       let isActive = $state(true);
       void isActive;
 
-      const getPos = usePopoverPosition(
-        () => anchorEl,
-        () => null,
-        () => true,
-        280, // fallback width
-      );
+      const getPos = usePopoverPosition({
+        anchor: () => anchorEl,
+        tooltipElement: () => null,
+        active: () => true,
+        fallbackWidth: 280,
+      });
 
       flushSync();
       const pos = getPos();
@@ -194,11 +194,11 @@ describe("usePopoverPosition (reactive hook)", () => {
     const root = $effect.root(() => {
       let isActive = $state(true);
 
-      usePopoverPosition(
-        () => anchorEl,
-        () => null,
-        () => isActive,
-      );
+      usePopoverPosition({
+        anchor: () => anchorEl,
+        tooltipElement: () => null,
+        active: () => isActive,
+      });
 
       flushSync();
       // Deactivate — should trigger cleanup

--- a/sites/status.arolariu.ro/src/lib/hooks/usePopoverPosition.svelte.ts
+++ b/sites/status.arolariu.ro/src/lib/hooks/usePopoverPosition.svelte.ts
@@ -112,7 +112,7 @@ export function usePopoverPosition({
 
   $effect(() => {
     if (!active()) return;
-    // Ensure the reactive deps track both the anchor and tooltipEl getter;
+    // Ensure the reactive deps track both the anchor and tooltipElement getter;
     // Re-running when they change (element switched or re-bound) is part of
     // The hook's contract.
     anchor();

--- a/sites/status.arolariu.ro/src/lib/hooks/usePopoverPosition.svelte.ts
+++ b/sites/status.arolariu.ro/src/lib/hooks/usePopoverPosition.svelte.ts
@@ -37,6 +37,13 @@ export interface ViewportGeometry {
   readonly innerWidth: number;
 }
 
+export interface UsePopoverPositionOptions {
+  readonly anchor: () => HTMLElement | null;
+  readonly tooltipElement: () => HTMLElement | null;
+  readonly active: () => boolean;
+  readonly fallbackWidth?: number;
+}
+
 /**
  * Pure positioning math. Given:
  *  - `anchorRect` — the anchor element's DOMRect
@@ -83,40 +90,41 @@ export function computePopoverPosition(
  * while active; listeners are torn down automatically on scope teardown or
  * when `active()` flips to false (effect re-runs).
  */
-export function usePopoverPosition(
-  anchor: () => HTMLElement | null,
-  tooltipEl: () => HTMLElement | null,
-  active: () => boolean,
+export function usePopoverPosition({
+  anchor,
+  tooltipElement,
+  active,
   fallbackWidth = 280,
-): () => PopoverPosition {
+}: Readonly<UsePopoverPositionOptions>): () => PopoverPosition {
   let position = $state<PopoverPosition>({top: 0, left: 0, flipHoriz: false});
 
-  function recompute() {
-    const el = anchor();
-    if (!el) return;
-    const rect = el.getBoundingClientRect();
-    const tipWidth = tooltipEl()?.offsetWidth ?? fallbackWidth;
-    position = computePopoverPosition(rect, tipWidth, {
-      scrollX: window.scrollX,
-      scrollY: window.scrollY,
-      innerWidth: window.innerWidth,
+  function recompute(): void {
+    const element = anchor();
+    if (!element) return;
+    const rect = element.getBoundingClientRect();
+    const tooltipWidth = tooltipElement()?.offsetWidth ?? fallbackWidth;
+    position = computePopoverPosition(rect, tooltipWidth, {
+      scrollX: globalThis.window.scrollX,
+      scrollY: globalThis.window.scrollY,
+      innerWidth: globalThis.window.innerWidth,
     });
   }
 
   $effect(() => {
     if (!active()) return;
     // Ensure the reactive deps track both the anchor and tooltipEl getter;
-    // re-running when they change (element switched or re-bound) is part of
-    // the hook's contract.
+    // Re-running when they change (element switched or re-bound) is part of
+    // The hook's contract.
     anchor();
-    tooltipEl();
+    tooltipElement();
     recompute();
-    const opts: AddEventListenerOptions = {passive: true};
-    window.addEventListener("scroll", recompute, opts);
-    window.addEventListener("resize", recompute);
+    const options: AddEventListenerOptions = {passive: true};
+    globalThis.window.addEventListener("scroll", recompute, options);
+    globalThis.window.addEventListener("resize", recompute);
+    // eslint-disable-next-line consistent-return -- Svelte effects return cleanup only while active.
     return () => {
-      window.removeEventListener("scroll", recompute);
-      window.removeEventListener("resize", recompute);
+      globalThis.window.removeEventListener("scroll", recompute);
+      globalThis.window.removeEventListener("resize", recompute);
     };
   });
 

--- a/sites/status.arolariu.ro/src/lib/routes/keyboardShortcuts.ts
+++ b/sites/status.arolariu.ro/src/lib/routes/keyboardShortcuts.ts
@@ -18,7 +18,7 @@ import {FILTER_WINDOWS, type FilterWindow} from "../types/status";
  */
 export function shouldIgnoreKeydown(event: KeyboardEvent): boolean {
   if (event.ctrlKey || event.metaKey || event.altKey) return true;
-  const target = event.target;
+  const {target} = event;
   if (!(target instanceof HTMLElement)) return false;
   if (target.matches('input, textarea, select, [contenteditable="true"]')) return true;
   return false;
@@ -31,10 +31,12 @@ export function shouldIgnoreKeydown(event: KeyboardEvent): boolean {
 export interface KeyboardBindings {
   /** Current active filter window — read once per event to compute the next one. */
   readonly getActiveWindow: () => FilterWindow;
-  readonly setActiveWindow: (w: FilterWindow) => void;
+  // eslint-disable-next-line no-unused-vars -- Interface callback names document host binding contracts.
+  readonly setActiveWindow: (windowFilter: FilterWindow) => void;
   /** Whether anything (e.g. a service row) is currently expanded. */
   readonly getExpandedService: () => string | null;
-  readonly setExpandedService: (s: string | null) => void;
+  // eslint-disable-next-line no-unused-vars -- Interface callback names document host binding contracts.
+  readonly setExpandedService: (service: string | null) => void;
   readonly toggleHelp: () => void;
   readonly refresh: () => void;
 }
@@ -46,59 +48,64 @@ export interface KeyboardBindings {
  *  - handles `?` (toggle help), `←/→` (prev/next window), `Escape` (collapse),
  *    `r/R` (refresh), and `1..9` (jump to filter window).
  */
-export function createKeyboardHandler(b: KeyboardBindings): (event: KeyboardEvent) => void {
+// eslint-disable-next-line no-unused-vars -- Return type documents the DOM event handler contract.
+export function createKeyboardHandler(bindings: KeyboardBindings): (event: KeyboardEvent) => void {
   return function handle(event: KeyboardEvent): void {
     if (shouldIgnoreKeydown(event)) return;
     if (event.defaultPrevented) return;
 
     if (event.key === "?") {
       event.preventDefault();
-      b.toggleHelp();
+      bindings.toggleHelp();
       return;
     }
 
-    const active = b.getActiveWindow();
-    const currentIdx = FILTER_WINDOWS.indexOf(active);
+    const active = bindings.getActiveWindow();
+    const currentIndex = FILTER_WINDOWS.indexOf(active);
     const total = FILTER_WINDOWS.length;
 
     switch (event.key) {
       case "ArrowLeft": {
-        const next = FILTER_WINDOWS[(currentIdx - 1 + total) % total];
+        const nextWindow = FILTER_WINDOWS.at((currentIndex - 1 + total) % total);
+        // eslint-disable-next-line capitalized-comments -- v8 ignore directive is case-sensitive.
         /* v8 ignore next */
-        if (next) b.setActiveWindow(next);
+        if (nextWindow) bindings.setActiveWindow(nextWindow);
         event.preventDefault();
         return;
       }
       case "ArrowRight": {
-        const next = FILTER_WINDOWS[(currentIdx + 1) % total];
+        const nextWindow = FILTER_WINDOWS.at((currentIndex + 1) % total);
+        // eslint-disable-next-line capitalized-comments -- v8 ignore directive is case-sensitive.
         /* v8 ignore next */
-        if (next) b.setActiveWindow(next);
+        if (nextWindow) bindings.setActiveWindow(nextWindow);
         event.preventDefault();
         return;
       }
       case "Escape": {
-        if (b.getExpandedService() !== null) {
-          b.setExpandedService(null);
+        if (bindings.getExpandedService() !== null) {
+          bindings.setExpandedService(null);
           event.preventDefault();
         }
         return;
       }
       case "r":
       case "R": {
-        b.refresh();
+        bindings.refresh();
         event.preventDefault();
         return;
       }
-      default:
+      default: {
         break;
+      }
     }
 
     if (event.key >= "1" && event.key <= "9") {
-      const idx = Number(event.key) - 1;
-      const next = FILTER_WINDOWS[idx];
+      const windowIndex = Number(event.key) - 1;
+      const nextWindow = FILTER_WINDOWS.at(windowIndex);
+      // eslint-disable-next-line capitalized-comments -- v8 ignore directive is case-sensitive.
       /* v8 ignore next 3 */
-      if (next) {
-        b.setActiveWindow(next);
+      if (nextWindow) {
+        bindings.setActiveWindow(nextWindow);
         event.preventDefault();
       }
     }

--- a/sites/status.arolariu.ro/src/lib/routes/pageLogic.ts
+++ b/sites/status.arolariu.ro/src/lib/routes/pageLogic.ts
@@ -41,6 +41,7 @@ export function orderedServices(file: AggregateFile | null): readonly ServiceSer
  */
 export function bucketDurationMsFor(bucketSize: BucketSize | undefined): number {
   if (bucketSize === undefined) return BUCKET_SIZE_TO_MS["30m"];
+  // eslint-disable-next-line security/detect-object-injection -- bucketSize is constrained to the BucketSize union.
   return BUCKET_SIZE_TO_MS[bucketSize];
 }
 
@@ -50,5 +51,6 @@ export function bucketDurationMsFor(bucketSize: BucketSize | undefined): number 
  * windows where the 7-day breakdown would just be two samples per bar.
  */
 export function showWeekdayChart(windowFilter: FilterWindow): boolean {
+  // eslint-disable-next-line security/detect-object-injection -- windowFilter is constrained to the FilterWindow union.
   return WINDOW_CONFIGS[windowFilter].showWeekday;
 }

--- a/sites/status.arolariu.ro/src/lib/routes/pageLogic.ts
+++ b/sites/status.arolariu.ro/src/lib/routes/pageLogic.ts
@@ -20,6 +20,11 @@ import {
 /** Display order for service rows on the status page. Drives `orderedServices`. */
 export const SERVICE_DISPLAY_ORDER: readonly ServiceId[] = ["arolariu.ro", "api.arolariu.ro", "exp.arolariu.ro", "cv.arolariu.ro"];
 
+function orderIndex(serviceId: ServiceId): number {
+  const index = SERVICE_DISPLAY_ORDER.indexOf(serviceId);
+  return index === -1 ? SERVICE_DISPLAY_ORDER.length : index;
+}
+
 /**
  * Returns services sorted by the canonical display order. Unknown service
  * ids sort to the end (indexOf returns -1, which `-b.idx` handles naturally —
@@ -27,11 +32,7 @@ export const SERVICE_DISPLAY_ORDER: readonly ServiceId[] = ["arolariu.ro", "api.
  */
 export function orderedServices(file: AggregateFile | null): readonly ServiceSeries[] {
   if (!file) return [];
-  const orderIndex = (id: string): number => {
-    const idx = SERVICE_DISPLAY_ORDER.indexOf(id as ServiceId);
-    return idx === -1 ? SERVICE_DISPLAY_ORDER.length : idx;
-  };
-  return [...file.services].sort((a, b) => orderIndex(a.service) - orderIndex(b.service));
+  return file.services.toSorted((left, right) => orderIndex(left.service) - orderIndex(right.service));
 }
 
 /**

--- a/sites/status.arolariu.ro/src/lib/stores/themeStore.svelte.ts
+++ b/sites/status.arolariu.ro/src/lib/stores/themeStore.svelte.ts
@@ -57,7 +57,8 @@ export function resolveTheme(theme: Theme): ResolvedTheme {
 export function applyTheme(theme: Theme): void {
   const pageDocument = globalThis.document as Document | undefined;
   if (pageDocument === undefined) return;
-  pageDocument.documentElement.dataset.theme = resolveTheme(theme);
+  // eslint-disable-next-line dot-notation -- Svelte's TS config requires index-signature access for DOMStringMap.
+  pageDocument.documentElement.dataset["theme"] = resolveTheme(theme);
 }
 
 /**

--- a/sites/status.arolariu.ro/src/lib/stores/themeStore.svelte.ts
+++ b/sites/status.arolariu.ro/src/lib/stores/themeStore.svelte.ts
@@ -16,15 +16,15 @@ export type Theme = "light" | "dark" | "auto";
 /** Concrete rendered theme after resolving `"auto"` against the OS. */
 export type ResolvedTheme = "light" | "dark";
 
-/** localStorage key for the persisted theme selection. */
+/** LocalStorage key for the persisted theme selection. */
 const STORAGE_KEY = "status-theme";
 
-/** Allowed theme values — used by the runtime guard. */
-const VALID: readonly Theme[] = ["light", "dark", "auto"];
+/** Allowed theme values - used by the runtime guard. */
+const VALID_THEMES: readonly Theme[] = ["light", "dark", "auto"];
 
-/** True when `v` is one of the three valid theme literals. */
-function isValidTheme(v: unknown): v is Theme {
-  return typeof v === "string" && (VALID as readonly string[]).includes(v);
+/** True when `value` is one of the three valid theme literals. */
+function isValidTheme(value: unknown): value is Theme {
+  return typeof value === "string" && (VALID_THEMES as readonly string[]).includes(value);
 }
 
 /**
@@ -32,19 +32,10 @@ function isValidTheme(v: unknown): v is Theme {
  * SSR-safe — returns `"auto"` when `localStorage` is unavailable.
  */
 export function getTheme(): Theme {
-  if (typeof localStorage === "undefined") return "auto";
-  const stored = localStorage.getItem(STORAGE_KEY);
+  const storage = globalThis.localStorage as Storage | undefined;
+  if (storage === undefined) return "auto";
+  const stored = storage.getItem(STORAGE_KEY);
   return isValidTheme(stored) ? stored : "auto";
-}
-
-/**
- * Persist the theme selection and immediately apply it to the document.
- * No-op under SSR.
- */
-export function setTheme(theme: Theme): void {
-  if (typeof localStorage === "undefined") return;
-  localStorage.setItem(STORAGE_KEY, theme);
-  applyTheme(theme);
 }
 
 /**
@@ -54,8 +45,9 @@ export function setTheme(theme: Theme): void {
  */
 export function resolveTheme(theme: Theme): ResolvedTheme {
   if (theme !== "auto") return theme;
-  if (typeof window === "undefined") return "dark";
-  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+  const browserWindow = globalThis.window as Window | undefined;
+  if (browserWindow === undefined) return "dark";
+  return browserWindow.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
 }
 
 /**
@@ -63,6 +55,18 @@ export function resolveTheme(theme: Theme): ResolvedTheme {
  * No-op under SSR. CSS selectors keyed on `[data-theme="dark"]` etc. re-evaluate.
  */
 export function applyTheme(theme: Theme): void {
-  if (typeof document === "undefined") return;
-  document.documentElement.setAttribute("data-theme", resolveTheme(theme));
+  const pageDocument = globalThis.document as Document | undefined;
+  if (pageDocument === undefined) return;
+  pageDocument.documentElement.dataset.theme = resolveTheme(theme);
+}
+
+/**
+ * Persist the theme selection and immediately apply it to the document.
+ * No-op under SSR.
+ */
+export function setTheme(theme: Theme): void {
+  const storage = globalThis.localStorage as Storage | undefined;
+  if (storage === undefined) return;
+  storage.setItem(STORAGE_KEY, theme);
+  applyTheme(theme);
 }

--- a/sites/status.arolariu.ro/src/lib/stores/themeStore.svelte.ts
+++ b/sites/status.arolariu.ro/src/lib/stores/themeStore.svelte.ts
@@ -27,15 +27,27 @@ function isValidTheme(value: unknown): value is Theme {
   return typeof value === "string" && (VALID_THEMES as readonly string[]).includes(value);
 }
 
+function getStorage(): Storage | null {
+  try {
+    return globalThis.localStorage ?? null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Current persisted theme, or `"auto"` when nothing is stored.
  * SSR-safe — returns `"auto"` when `localStorage` is unavailable.
  */
 export function getTheme(): Theme {
-  const storage = globalThis.localStorage as Storage | undefined;
-  if (storage === undefined) return "auto";
-  const stored = storage.getItem(STORAGE_KEY);
-  return isValidTheme(stored) ? stored : "auto";
+  const storage = getStorage();
+  if (storage === null) return "auto";
+  try {
+    const stored = storage.getItem(STORAGE_KEY);
+    return isValidTheme(stored) ? stored : "auto";
+  } catch {
+    return "auto";
+  }
 }
 
 /**
@@ -66,8 +78,13 @@ export function applyTheme(theme: Theme): void {
  * No-op under SSR.
  */
 export function setTheme(theme: Theme): void {
-  const storage = globalThis.localStorage as Storage | undefined;
-  if (storage === undefined) return;
-  storage.setItem(STORAGE_KEY, theme);
+  const storage = getStorage();
+  if (storage !== null) {
+    try {
+      storage.setItem(STORAGE_KEY, theme);
+    } catch {
+      /* Persistence unavailable */
+    }
+  }
   applyTheme(theme);
 }

--- a/sites/status.arolariu.ro/src/lib/stores/themeStore.test.ts
+++ b/sites/status.arolariu.ro/src/lib/stores/themeStore.test.ts
@@ -61,11 +61,36 @@ describe("themeStore", () => {
       vi.unstubAllGlobals();
     });
 
+    it("getTheme returns 'auto' when localStorage access throws", () => {
+      const descriptor = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+      Object.defineProperty(globalThis, "localStorage", {
+        configurable: true,
+        get() {
+          throw new DOMException("Blocked", "SecurityError");
+        },
+      });
+
+      expect(getTheme()).toBe("auto");
+
+      if (descriptor) Object.defineProperty(globalThis, "localStorage", descriptor);
+    });
+
     it("setTheme is a no-op when localStorage is undefined (SSR)", () => {
       vi.stubGlobal("localStorage", undefined);
       // Should not throw; localStorage.setItem is never called
       expect(() => setTheme("dark")).not.toThrow();
       vi.unstubAllGlobals();
+    });
+
+    it("setTheme still applies theme when localStorage persistence throws", () => {
+      const setItem = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+        throw new DOMException("Blocked", "SecurityError");
+      });
+
+      setTheme("dark");
+
+      expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
+      setItem.mockRestore();
     });
 
     it("resolveTheme returns 'dark' when window is undefined (SSR)", () => {

--- a/sites/status.arolariu.ro/src/lib/types/guards.test.ts
+++ b/sites/status.arolariu.ro/src/lib/types/guards.test.ts
@@ -56,6 +56,9 @@ describe("isSubCheck", () => {
   it("rejects negative values inside sampleDurationsMs", () => {
     expect(isSubCheck({name: "mssql", status: "Healthy", durationMs: 12, sampleDurationsMs: [10, -1, 12]})).toBe(false);
   });
+  it("rejects malformed optional sub-check descriptions", () => {
+    expect(isSubCheck({name: "mssql", status: "Healthy", durationMs: 12, description: 42})).toBe(false);
+  });
 });
 
 describe("isProbeResult", () => {
@@ -134,6 +137,9 @@ describe("isServiceSeries", () => {
   it("accepts with subSeries", () => {
     expect(isServiceSeries({service: "api.arolariu.ro", buckets, subSeries: {mssql: buckets}})).toBe(true);
   });
+  it("rejects subSeries entries that are not bucket arrays", () => {
+    expect(isServiceSeries({service: "api.arolariu.ro", buckets, subSeries: {mssql: {not: "an array"}}})).toBe(false);
+  });
 });
 
 describe("isAggregateFile", () => {
@@ -190,6 +196,9 @@ describe("isIncident", () => {
   });
   it("rejects negative probeCount", () => {
     expect(isIncident({...validOpen, probeCount: -1})).toBe(false);
+  });
+  it("rejects incidents with an unsupported status", () => {
+    expect(isIncident({...validOpen, status: "paused"})).toBe(false);
   });
 });
 

--- a/sites/status.arolariu.ro/src/lib/types/guards.ts
+++ b/sites/status.arolariu.ro/src/lib/types/guards.ts
@@ -29,7 +29,6 @@ type SubCheckCandidate = Partial<Record<keyof SubCheck, unknown>>;
 type ProbeResultCandidate = Partial<Record<keyof ProbeResult, unknown>>;
 type BucketCandidate = Partial<Record<keyof Bucket, unknown>>;
 type ServiceSeriesCandidate = Partial<Record<keyof ServiceSeries, unknown>>;
-type IncidentCandidate = Partial<Record<keyof Incident, unknown>>;
 type IncidentsFileCandidate = Partial<Record<keyof IncidentsFile, unknown>>;
 type AggregateFileCandidate = Partial<Record<keyof AggregateFile, unknown>>;
 
@@ -49,6 +48,19 @@ interface WorstSubCheckCandidate {
   readonly name?: unknown;
   readonly status?: unknown;
   readonly description?: unknown;
+}
+
+interface IncidentCandidate {
+  readonly id?: unknown;
+  readonly service?: unknown;
+  readonly subCheck?: unknown;
+  readonly status?: unknown;
+  readonly startedAt?: unknown;
+  readonly severity?: unknown;
+  readonly reason?: unknown;
+  readonly probeCount?: unknown;
+  readonly resolvedAt?: unknown;
+  readonly durationMs?: unknown;
 }
 
 /** True when `value` is a plain object (not an array, not `null`). */

--- a/sites/status.arolariu.ro/src/lib/types/guards.ts
+++ b/sites/status.arolariu.ro/src/lib/types/guards.ts
@@ -25,39 +25,100 @@ import {
   type SubCheck,
 } from "./status";
 
-/** True when `v` is a plain object (not an array, not `null`). */
-function isObject(v: unknown): v is Record<string, unknown> {
-  return typeof v === "object" && v !== null && !Array.isArray(v);
+type SubCheckCandidate = Partial<Record<keyof SubCheck, unknown>>;
+type ProbeResultCandidate = Partial<Record<keyof ProbeResult, unknown>>;
+type BucketCandidate = Partial<Record<keyof Bucket, unknown>>;
+type ServiceSeriesCandidate = Partial<Record<keyof ServiceSeries, unknown>>;
+type IncidentCandidate = Partial<Record<keyof Incident, unknown>>;
+type IncidentsFileCandidate = Partial<Record<keyof IncidentsFile, unknown>>;
+type AggregateFileCandidate = Partial<Record<keyof AggregateFile, unknown>>;
+
+interface ProbeCountsCandidate {
+  readonly healthy?: unknown;
+  readonly total?: unknown;
 }
 
-/** True when `v` is a finite, non-negative number. */
-function isNonNegativeNumber(v: unknown): v is number {
-  return typeof v === "number" && Number.isFinite(v) && v >= 0;
+interface LatencyCandidate {
+  readonly p50?: unknown;
+  readonly p75?: unknown;
+  readonly p95?: unknown;
+  readonly p99?: unknown;
+}
+
+interface WorstSubCheckCandidate {
+  readonly name?: unknown;
+  readonly status?: unknown;
+  readonly description?: unknown;
+}
+
+/** True when `value` is a plain object (not an array, not `null`). */
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** True when `value` is a finite, non-negative number. */
+function isNonNegativeNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+function isOptionalString(value: unknown): boolean {
+  return value === undefined || typeof value === "string";
+}
+
+function isOptionalNumberArray(value: unknown): boolean {
+  return value === undefined || (Array.isArray(value) && value.every(isNonNegativeNumber));
+}
+
+function hasValidProbeCounts(value: unknown): value is ProbeCountsCandidate {
+  if (!isObject(value)) return false;
+  const candidate = value as ProbeCountsCandidate;
+  return (
+    isNonNegativeNumber(candidate.healthy) &&
+    isNonNegativeNumber(candidate.total) &&
+    candidate.healthy <= candidate.total
+  );
+}
+
+function hasValidLatency(value: unknown): value is LatencyCandidate {
+  if (!isObject(value)) return false;
+  const candidate = value as LatencyCandidate;
+  return (
+    isNonNegativeNumber(candidate.p50) &&
+    isNonNegativeNumber(candidate.p99) &&
+    candidate.p50 <= candidate.p99 &&
+    (candidate.p75 === undefined || isNonNegativeNumber(candidate.p75)) &&
+    (candidate.p95 === undefined || isNonNegativeNumber(candidate.p95))
+  );
 }
 
 /** Guard for the `HealthStatus` union. */
-export function isHealthStatus(v: unknown): v is HealthStatus {
-  return v === "Healthy" || v === "Degraded" || v === "Unhealthy";
+export function isHealthStatus(value: unknown): value is HealthStatus {
+  return value === "Healthy" || value === "Degraded" || value === "Unhealthy";
+}
+
+function isWorstSubCheck(value: unknown): value is WorstSubCheckCandidate {
+  if (!isObject(value)) return false;
+  const candidate = value as WorstSubCheckCandidate;
+  return typeof candidate.name === "string" && isHealthStatus(candidate.status) && isOptionalString(candidate.description);
 }
 
 /** Guard for a known `ServiceId`. Strings outside the union are rejected. */
-export function isServiceId(v: unknown): v is ServiceId {
-  return typeof v === "string" && (SERVICE_IDS as readonly string[]).includes(v);
+export function isServiceId(value: unknown): value is ServiceId {
+  return typeof value === "string" && (SERVICE_IDS as readonly string[]).includes(value);
 }
 
 /** Validates a sub-check shape: required name/status/durationMs, optional description/sampleDurationsMs. */
-export function isSubCheck(v: unknown): v is SubCheck {
-  if (!isObject(v)) return false;
-  if (typeof v["name"] !== "string") return false;
-  if (!isHealthStatus(v["status"])) return false;
-  if (!isNonNegativeNumber(v["durationMs"])) return false;
-  if (v["description"] !== undefined && typeof v["description"] !== "string") return false;
-  const sampleDurations = v["sampleDurationsMs"];
-  if (sampleDurations !== undefined) {
-    if (!Array.isArray(sampleDurations)) return false;
-    if (!sampleDurations.every(isNonNegativeNumber)) return false;
-  }
-  return true;
+export function isSubCheck(value: unknown): value is SubCheck {
+  if (!isObject(value)) return false;
+  const candidate = value as SubCheckCandidate;
+  const {name, status, durationMs, description, sampleDurationsMs} = candidate;
+  return (
+    typeof name === "string" &&
+    isHealthStatus(status) &&
+    isNonNegativeNumber(durationMs) &&
+    isOptionalString(description) &&
+    isOptionalNumberArray(sampleDurationsMs)
+  );
 }
 
 /**
@@ -65,28 +126,22 @@ export function isSubCheck(v: unknown): v is SubCheck {
  * current multi-sample shape (`sampleCount >= 1`). `subChecks`, when present,
  * must be an array of valid sub-checks — one bad entry rejects the whole probe.
  */
-export function isProbeResult(v: unknown): v is ProbeResult {
-  if (!isObject(v)) return false;
-  if (!isServiceId(v["service"])) return false;
-  if (typeof v["timestamp"] !== "string") return false;
-  if (!isNonNegativeNumber(v["latencyMs"])) return false;
-  if (!isNonNegativeNumber(v["httpStatus"])) return false;
-  if (!isHealthStatus(v["overall"])) return false;
-  if (v["error"] !== undefined && typeof v["error"] !== "string") return false;
-  const subs = v["subChecks"];
-  if (subs !== undefined) {
-    if (!Array.isArray(subs)) return false;
-    if (!subs.every(isSubCheck)) return false;
-  }
-  if (v["sampleCount"] !== undefined) {
-    if (typeof v["sampleCount"] !== "number" || !Number.isFinite(v["sampleCount"]) || v["sampleCount"] < 1) return false;
-  }
-  const sampleLatencies = v["sampleLatenciesMs"];
-  if (sampleLatencies !== undefined) {
-    if (!Array.isArray(sampleLatencies)) return false;
-    if (!sampleLatencies.every(isNonNegativeNumber)) return false;
-  }
-  return true;
+export function isProbeResult(value: unknown): value is ProbeResult {
+  if (!isObject(value)) return false;
+  const candidate = value as ProbeResultCandidate;
+  const {service, timestamp, latencyMs, httpStatus, overall, error, subChecks, sampleCount, sampleLatenciesMs} = candidate;
+
+  return (
+    isServiceId(service) &&
+    typeof timestamp === "string" &&
+    isNonNegativeNumber(latencyMs) &&
+    isNonNegativeNumber(httpStatus) &&
+    isHealthStatus(overall) &&
+    isOptionalString(error) &&
+    (subChecks === undefined || (Array.isArray(subChecks) && subChecks.every(isSubCheck))) &&
+    (sampleCount === undefined || (typeof sampleCount === "number" && Number.isFinite(sampleCount) && sampleCount >= 1)) &&
+    isOptionalNumberArray(sampleLatenciesMs)
+  );
 }
 
 /**
@@ -97,46 +152,34 @@ export function isProbeResult(v: unknown): v is ProbeResult {
  *    validated as finite non-negative numbers when present.
  *  - Optional `worstSubCheck` shape matches `SubCheckSummary` when carried.
  */
-export function isBucket(v: unknown): v is Bucket {
-  if (!isObject(v)) return false;
-  if (typeof v["t"] !== "string") return false;
-  if (!isHealthStatus(v["status"])) return false;
-  const probes = v["probes"];
-  if (!isObject(probes)) return false;
-  if (!isNonNegativeNumber(probes["healthy"]) || !isNonNegativeNumber(probes["total"])) return false;
-  if (probes["healthy"] > probes["total"]) return false; // invariant
-  const latency = v["latency"];
-  if (!isObject(latency)) return false;
-  if (!isNonNegativeNumber(latency["p50"]) || !isNonNegativeNumber(latency["p99"])) return false;
-  if (latency["p50"] > latency["p99"]) return false; // invariant
-  // p75 / p95 are additive: accept when absent (legacy buckets),
-  // validate as finite non-negative numbers when present.
-  if (latency["p75"] !== undefined && !isNonNegativeNumber(latency["p75"])) return false;
-  if (latency["p95"] !== undefined && !isNonNegativeNumber(latency["p95"])) return false;
-  if (v["httpStatus"] !== undefined && !isNonNegativeNumber(v["httpStatus"])) return false;
-  const worst = v["worstSubCheck"];
-  if (worst !== undefined) {
-    if (!isObject(worst)) return false;
-    if (typeof worst["name"] !== "string") return false;
-    if (!isHealthStatus(worst["status"])) return false;
-    if (worst["description"] !== undefined && typeof worst["description"] !== "string") return false;
-  }
-  return true;
+export function isBucket(value: unknown): value is Bucket {
+  if (!isObject(value)) return false;
+  const candidate = value as BucketCandidate;
+  const {t: timestamp, status, probes, latency, httpStatus, worstSubCheck} = candidate;
+
+  return (
+    typeof timestamp === "string" &&
+    isHealthStatus(status) &&
+    hasValidProbeCounts(probes) &&
+    hasValidLatency(latency) &&
+    (httpStatus === undefined || isNonNegativeNumber(httpStatus)) &&
+    (worstSubCheck === undefined || isWorstSubCheck(worstSubCheck))
+  );
 }
 
 /** Validates a single service's series, including optional sub-series map. */
-export function isServiceSeries(v: unknown): v is ServiceSeries {
-  if (!isObject(v)) return false;
-  if (!isServiceId(v["service"])) return false;
-  if (!Array.isArray(v["buckets"])) return false;
-  if (!v["buckets"].every(isBucket)) return false;
-  const sub = v["subSeries"];
-  if (sub !== undefined) {
-    if (!isObject(sub)) return false;
-    for (const key of Object.keys(sub)) {
-      const series = sub[key];
-      if (!Array.isArray(series) || !series.every(isBucket)) return false;
-    }
+export function isServiceSeries(value: unknown): value is ServiceSeries {
+  if (!isObject(value)) return false;
+  const candidate = value as ServiceSeriesCandidate;
+  const {service, buckets, subSeries} = candidate;
+
+  if (!isServiceId(service)) return false;
+  if (!Array.isArray(buckets) || !buckets.every(isBucket)) return false;
+  if (subSeries === undefined) return true;
+  if (!isObject(subSeries)) return false;
+
+  for (const series of Object.values(subSeries)) {
+    if (!Array.isArray(series) || !series.every(isBucket)) return false;
   }
   return true;
 }
@@ -157,17 +200,18 @@ const VALID_AGGREGATE_PAIRS: ReadonlyMap<string, 14 | 90 | 365> = new Map([
  * is one of the three canonical combinations (reject mismatched pairs) and
  * that every service's series passes `isServiceSeries`.
  */
-export function isAggregateFile(v: unknown): v is AggregateFile {
-  if (!isObject(v)) return false;
-  if (typeof v["generatedAt"] !== "string") return false;
-  const bucketSize = v["bucketSize"];
+export function isAggregateFile(value: unknown): value is AggregateFile {
+  if (!isObject(value)) return false;
+  const candidate = value as AggregateFileCandidate;
+  const {generatedAt, bucketSize, windowDays, services} = candidate;
+  if (typeof generatedAt !== "string") return false;
   if (typeof bucketSize !== "string") return false;
   const expectedWindowDays = VALID_AGGREGATE_PAIRS.get(bucketSize);
-  if (expectedWindowDays === undefined) return false; // unknown bucketSize
-  if (v["windowDays"] !== expectedWindowDays) return false; // mismatched pair
-  if (!Array.isArray(v["services"])) return false;
-  if (!v["services"].every(isServiceSeries)) return false;
-  return true;
+  // Unknown bucketSize.
+  if (expectedWindowDays === undefined) return false;
+  // Mismatched pair.
+  if (windowDays !== expectedWindowDays) return false;
+  return Array.isArray(services) && services.every(isServiceSeries);
 }
 
 /**
@@ -177,36 +221,35 @@ export function isAggregateFile(v: unknown): v is AggregateFile {
  *    `durationMs` as non-negative number).
  *  - Any other `status` value is rejected.
  */
-export function isIncident(v: unknown): v is Incident {
-  if (!isObject(v)) return false;
-  if (typeof v["id"] !== "string") return false;
-  if (!isServiceId(v["service"])) return false;
-  if (v["subCheck"] !== undefined && typeof v["subCheck"] !== "string") return false;
-  if (typeof v["startedAt"] !== "string") return false;
-  if (v["severity"] !== "Degraded" && v["severity"] !== "Unhealthy") return false;
-  if (typeof v["reason"] !== "string") return false;
-  if (!isNonNegativeNumber(v["probeCount"])) return false;
+export function isIncident(value: unknown): value is Incident {
+  if (!isObject(value)) return false;
+  const candidate = value as IncidentCandidate;
+  const {id, service, subCheck, startedAt, severity, reason, probeCount, status, resolvedAt, durationMs} = candidate;
+
+  if (typeof id !== "string") return false;
+  if (!isServiceId(service)) return false;
+  if (subCheck !== undefined && typeof subCheck !== "string") return false;
+  if (typeof startedAt !== "string") return false;
+  if (severity !== "Degraded" && severity !== "Unhealthy") return false;
+  if (typeof reason !== "string") return false;
+  if (!isNonNegativeNumber(probeCount)) return false;
 
   // Discriminated on status: open incidents must NOT carry resolvedAt/durationMs;
-  // resolved incidents MUST carry both.
-  if (v["status"] === "open") {
-    if (v["resolvedAt"] !== undefined) return false;
-    if (v["durationMs"] !== undefined) return false;
-    return true;
+  // Resolved incidents MUST carry both.
+  if (status === "open") {
+    return resolvedAt === undefined && durationMs === undefined;
   }
-  if (v["status"] === "resolved") {
-    if (typeof v["resolvedAt"] !== "string") return false;
-    if (!isNonNegativeNumber(v["durationMs"])) return false;
-    return true;
+
+  if (status === "resolved") {
+    return typeof resolvedAt === "string" && isNonNegativeNumber(durationMs);
   }
+
   return false;
 }
 
 /** Validates the top-level incidents file (generatedAt + array of incidents). */
-export function isIncidentsFile(v: unknown): v is IncidentsFile {
-  if (!isObject(v)) return false;
-  if (typeof v["generatedAt"] !== "string") return false;
-  if (!Array.isArray(v["incidents"])) return false;
-  if (!v["incidents"].every(isIncident)) return false;
-  return true;
+export function isIncidentsFile(value: unknown): value is IncidentsFile {
+  if (!isObject(value)) return false;
+  const candidate = value as IncidentsFileCandidate;
+  return typeof candidate.generatedAt === "string" && Array.isArray(candidate.incidents) && candidate.incidents.every(isIncident);
 }

--- a/sites/status.arolariu.ro/src/routes/+error.svelte
+++ b/sites/status.arolariu.ro/src/routes/+error.svelte
@@ -13,7 +13,7 @@
   import styles from "./ErrorPage.module.scss";
 </script>
 
-<main class={styles.shell}>
-  <h1 class={styles.title}>Error {page.status}</h1>
-  <p class={styles.message}>{page.error?.message ?? "Something went wrong."}</p>
+<main class={styles["shell"]}>
+  <h1 class={styles["title"]}>Error {page.status}</h1>
+  <p class={styles["message"]}>{page.error?.message ?? "Something went wrong."}</p>
 </main>


### PR DESCRIPTION
## Summary
- Cleans up status-site Svelte diagnostics that were blocking the lint pipeline.
- Refactors status aggregation, mock-data, runtime guards, route logic, hooks, and theme utilities to address the focused ESLint findings from `temp/outcome-lint.json`.
- Adds guard characterization coverage before simplifying runtime validation logic.

## Test Plan
- `npm --workspace @arolariu/status run check`
- Focused ESLint over status files from the remediation scope
- `npm run test:status`
- `npm run build:status`

## Reviewer notes
- Work was applied directly to `preview` as requested.
- `npm run lint:status` intermittently hung after printing the lint banner in this environment, so the underlying status `svelte-check` and scoped ESLint commands were run directly.
- Existing local `.vscode/settings.json` changes were left uncommitted.