### PR TITLE
Refactor CI setup into setup-tooling and setup-workspace actions

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "defaultdocumentation.console": {
+      "version": "1.2.4",
+      "commands": ["defaultdocumentation"],
+      "rollForward": false
+    }
+  }
+}

--- a/.github/actions/setup-tooling/action.yml
+++ b/.github/actions/setup-tooling/action.yml
@@ -96,7 +96,16 @@ runs:
         registry-url: ${{ inputs.node-registry-url }}
         # An empty string disables the built-in cache.
         cache: ${{ inputs.cache == 'true' && 'npm' || '' }}
-        cache-dependency-path: package-lock.json
+        # Both lock files, because both feed the same `~/.npm` store:
+        # `setup-workspace` installs the root workspaces AND `.github/scripts`,
+        # which has its own lock file. Keying on the root file alone means a
+        # change to the scripts lock file leaves the key untouched — the stale
+        # cache is restored, `npm ci` re-downloads the new packages, and
+        # because the restore was a hit nothing is written back. Those
+        # downloads would then repeat on every subsequent run.
+        cache-dependency-path: |
+          package-lock.json
+          .github/scripts/package-lock.json
 
     - name: 📦 Setting up .NET v${{ inputs.dotnet-version }}...
       id: dotnet

--- a/.github/actions/setup-tooling/action.yml
+++ b/.github/actions/setup-tooling/action.yml
@@ -1,0 +1,135 @@
+#+#+#+#+############################################################
+# Setup Tooling (Composite Action)
+#
+# Summary:
+# - Installs the language toolchains used across the monorepo:
+#   Node.js, the .NET SDK, and Python.
+#
+# Remarks:
+# - Deliberately repo-agnostic: it installs binaries and nothing else.
+#   Dependency installation, code generation, and browser provisioning
+#   belong to `setup-workspace`, which wraps this action.
+# - Caching is delegated entirely to each `actions/setup-*` action's
+#   built-in mechanism. Those caches are keyed on lock-file hashes and
+#   are NOT scoped per workflow, so every workflow shares one cache per
+#   ecosystem instead of maintaining its own copy.
+# - Every toolchain except Node.js is opt-in. Installing an SDK a job
+#   never uses costs real minutes on every run.
+#+#+#+#+############################################################
+
+name: "Setup Tooling"
+description: "Installs the Node.js, .NET, and Python toolchains with built-in dependency caching."
+author: "arolariu.ro"
+
+inputs:
+  # ── Node.js ──────────────────────────────────────────────────────
+  node:
+    description: "Whether to install Node.js."
+    required: false
+    default: "true"
+
+  # Matches the root `.nvmrc` and `engines.node` in `package.json`.
+  node-version:
+    description: "Node.js version to install."
+    required: false
+    default: "24"
+
+  # Only needed by npm Trusted Publishing (OIDC); leave empty otherwise.
+  node-registry-url:
+    description: "npm registry URL to configure for publishing."
+    required: false
+    default: ""
+
+  # ── .NET ─────────────────────────────────────────────────────────
+  dotnet:
+    description: "Whether to install the .NET SDK."
+    required: false
+    default: "false"
+
+  # Matches <TargetFramework>net10.0</TargetFramework> in
+  # sites/api.arolariu.ro/Directory.Build.props.
+  dotnet-version:
+    description: ".NET SDK version to install."
+    required: false
+    default: "10.0.x"
+
+  # ── Python ───────────────────────────────────────────────────────
+  python:
+    description: "Whether to install Python."
+    required: false
+    default: "false"
+
+  # Matches requires-python in sites/exp.arolariu.ro/pyproject.toml.
+  python-version:
+    description: "Python version to install."
+    required: false
+    default: "3.12"
+
+  # ── Caching ──────────────────────────────────────────────────────
+  cache:
+    description: "Whether to enable each toolchain's built-in dependency cache."
+    required: false
+    default: "true"
+
+outputs:
+  node-cache-hit:
+    description: "Whether actions/setup-node restored the npm cache."
+    value: ${{ steps.node.outputs.cache-hit }}
+
+  dotnet-cache-hit:
+    description: "Whether actions/setup-dotnet restored the NuGet cache."
+    value: ${{ steps.dotnet.outputs.cache-hit }}
+
+  python-cache-hit:
+    description: "Whether actions/setup-python restored the pip cache."
+    value: ${{ steps.python.outputs.cache-hit }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: 📦 Setting up Node.js v${{ inputs.node-version }}...
+      id: node
+      if: inputs.node == 'true'
+      uses: actions/setup-node@v7
+      with:
+        node-version: ${{ inputs.node-version }}
+        registry-url: ${{ inputs.node-registry-url }}
+        # An empty string disables the built-in cache.
+        cache: ${{ inputs.cache == 'true' && 'npm' || '' }}
+        cache-dependency-path: package-lock.json
+
+    - name: 📦 Setting up .NET v${{ inputs.dotnet-version }}...
+      id: dotnet
+      if: inputs.dotnet == 'true'
+      uses: actions/setup-dotnet@v6
+      with:
+        dotnet-version: ${{ inputs.dotnet-version }}
+        # Backed by the six packages.lock.json files under
+        # sites/api.arolariu.ro/{src,tests}. setup-dotnet errors when
+        # caching is on and no lock file exists, so those must stay.
+        cache: ${{ inputs.cache == 'true' }}
+        cache-dependency-path: "**/packages.lock.json"
+
+    - name: 🐍 Setting up Python v${{ inputs.python-version }}...
+      id: python
+      if: inputs.python == 'true'
+      uses: actions/setup-python@v7
+      with:
+        python-version: ${{ inputs.python-version }}
+        cache: ${{ inputs.cache == 'true' && 'pip' || '' }}
+        cache-dependency-path: sites/exp.arolariu.ro/requirements*.txt
+
+    - name: 📋 Toolchain summary
+      shell: bash
+      env:
+        NODE_SUMMARY: ${{ inputs.node == 'true' && inputs.node-version || 'skipped' }}
+        DOTNET_SUMMARY: ${{ inputs.dotnet == 'true' && inputs.dotnet-version || 'skipped' }}
+        PYTHON_SUMMARY: ${{ inputs.python == 'true' && inputs.python-version || 'skipped' }}
+        CACHE_ENABLED: ${{ inputs.cache }}
+      run: |
+        echo "::group::📋 Toolchain"
+        echo "  Node.js: ${NODE_SUMMARY}"
+        echo "  .NET:    ${DOTNET_SUMMARY}"
+        echo "  Python:  ${PYTHON_SUMMARY}"
+        echo "  Cache:   ${CACHE_ENABLED}"
+        echo "::endgroup::"

--- a/.github/actions/setup-tooling/readme.md
+++ b/.github/actions/setup-tooling/readme.md
@@ -64,10 +64,12 @@ Caching is delegated entirely to each `actions/setup-*` action:
 
 | Toolchain | Cached | Keyed on |
 |-----------|--------|----------|
-| Node.js | `~/.npm` | `package-lock.json` |
+| Node.js | `~/.npm` | `package-lock.json` + `.github/scripts/package-lock.json` |
 | .NET | `~/.nuget/packages` | `**/packages.lock.json` (6 files) |
 | Python | pip HTTP cache | `sites/exp.arolariu.ro/requirements*.txt` |
 
 These caches are **not** scoped per workflow. Every workflow shares one cache per ecosystem, rather than each maintaining its own copy against the repository's 10 GB budget.
+
+The Node entry lists both lock files because both feed the same `~/.npm` store — [`setup-workspace`](../setup-workspace/readme.md) installs the root workspaces *and* `.github/scripts`, which is a separate package with its own lock file. Keying on the root file alone would let a scripts-only dependency change go unnoticed: the key would not move, the stale cache would be restored, `npm ci` would re-download the new packages, and because the restore was a hit nothing would be written back — repeating that download on every later run.
 
 > **Do not remove the `packages.lock.json` files.** `actions/setup-dotnet` fails when caching is enabled and no lock file is found.

--- a/.github/actions/setup-tooling/readme.md
+++ b/.github/actions/setup-tooling/readme.md
@@ -1,0 +1,73 @@
+# Setup Tooling Action
+
+Installs the language toolchains used across the arolariu.ro monorepo. This action is deliberately **repo-agnostic** — it installs binaries and nothing else.
+
+For dependency installation, code generation, Playwright browsers, or the component build, use [`setup-workspace`](../setup-workspace/readme.md), which wraps this action.
+
+## When to use which
+
+| Need | Action |
+|------|--------|
+| Just a Node/.NET/Python binary | `setup-tooling` |
+| Binaries **and** `npm ci` / `dotnet restore` / `pip install` / generation | `setup-workspace` |
+
+## Usage
+
+```yaml
+# Node.js only (the default)
+- uses: ./.github/actions/setup-tooling
+
+# .NET only
+- uses: ./.github/actions/setup-tooling
+  with:
+    node: "false"
+    dotnet: "true"
+
+# Python only
+- uses: ./.github/actions/setup-tooling
+  with:
+    node: "false"
+    python: "true"
+
+# Node.js configured for npm Trusted Publishing
+- uses: ./.github/actions/setup-tooling
+  with:
+    node-registry-url: "https://registry.npmjs.org"
+```
+
+## Inputs
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `node` | `true` | Install Node.js |
+| `node-version` | `24` | Matches root `.nvmrc` and `engines.node` |
+| `node-registry-url` | `""` | Sets `registry-url`; required for npm Trusted Publishing |
+| `dotnet` | `false` | Install the .NET SDK |
+| `dotnet-version` | `10.0.x` | Matches `net10.0` in `sites/api.arolariu.ro/Directory.Build.props` |
+| `python` | `false` | Install Python |
+| `python-version` | `3.12` | Matches `requires-python` in `sites/exp.arolariu.ro/pyproject.toml` |
+| `cache` | `true` | Enables built-in caching on every enabled toolchain |
+
+All inputs are strings. `dotnet` and `python` default to `false` because installing an SDK a job never uses costs real minutes on every run.
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `node-cache-hit` | `actions/setup-node` restored the npm cache |
+| `dotnet-cache-hit` | `actions/setup-dotnet` restored the NuGet cache |
+| `python-cache-hit` | `actions/setup-python` restored the pip cache |
+
+## Caching model
+
+Caching is delegated entirely to each `actions/setup-*` action:
+
+| Toolchain | Cached | Keyed on |
+|-----------|--------|----------|
+| Node.js | `~/.npm` | `package-lock.json` |
+| .NET | `~/.nuget/packages` | `**/packages.lock.json` (6 files) |
+| Python | pip HTTP cache | `sites/exp.arolariu.ro/requirements*.txt` |
+
+These caches are **not** scoped per workflow. Every workflow shares one cache per ecosystem, rather than each maintaining its own copy against the repository's 10 GB budget.
+
+> **Do not remove the `packages.lock.json` files.** `actions/setup-dotnet` fails when caching is enabled and no lock file is found.

--- a/.github/actions/setup-workspace/action.yml
+++ b/.github/actions/setup-workspace/action.yml
@@ -173,13 +173,21 @@ runs:
           fi
         }
 
+        # Toolchain prerequisites.
         require "$NODE" node "$INSTALL_NODE_DEPS" install-node-deps
         require "$NODE" node "$INSTALL_SCRIPTS_DEPS" install-scripts-deps
-        require "$NODE" node "$INSTALL_PLAYWRIGHT" install-playwright
-        require "$NODE" node "$RUN_GENERATE" run-generate
-        require "$NODE" node "$RUN_BUILD_COMPONENTS" run-build-components
         require "$DOTNET" dotnet "$INSTALL_DOTNET_DEPS" install-dotnet-deps
         require "$PYTHON" python "$INSTALL_PYTHON_DEPS" install-python-deps
+
+        # These three consume the root `node_modules` tree. `install-node-deps`
+        # gates BOTH the cache restore and `npm ci`, so with it disabled the
+        # tree is absent entirely — `npm run …` would fail outright, and
+        # `npx playwright` would silently fetch a floating version instead of
+        # the one pinned by the lock file. `install-node-deps` in turn
+        # requires `node`, so that prerequisite is covered transitively.
+        require "$INSTALL_NODE_DEPS" install-node-deps "$INSTALL_PLAYWRIGHT" install-playwright
+        require "$INSTALL_NODE_DEPS" install-node-deps "$RUN_GENERATE" run-generate
+        require "$INSTALL_NODE_DEPS" install-node-deps "$RUN_BUILD_COMPONENTS" run-build-components
 
         if [ ${#errors[@]} -gt 0 ]; then
           printf '%s\n' "${errors[@]}"

--- a/.github/actions/setup-workspace/action.yml
+++ b/.github/actions/setup-workspace/action.yml
@@ -10,9 +10,12 @@
 # - Toolchain caching belongs to `setup-tooling` (built-in caches).
 #   This action caches only what it produces itself: `node_modules`
 #   and the Playwright browser bundle.
-# - Both caches are keyed on the lock-file hash ALONE. They are not
-#   scoped per workflow, so all workflows share one entry each rather
-#   than each writing its own multi-hundred-megabyte copy.
+# - Neither cache carries a per-workflow prefix, so all workflows share
+#   one entry each rather than every workflow writing its own
+#   multi-hundred-megabyte copy. The Playwright key is the lock-file
+#   hash alone; the `node_modules` key additionally includes the Node
+#   version, because a cache hit skips `npm ci` and the tree can hold
+#   natively-compiled addons whose ABI is tied to the runtime.
 # - Inputs are never interpolated directly into `run:` blocks; they
 #   are passed through `env:` to avoid script injection.
 #+#+#+#+############################################################

--- a/.github/actions/setup-workspace/action.yml
+++ b/.github/actions/setup-workspace/action.yml
@@ -173,7 +173,11 @@ runs:
           node_modules
           packages/*/node_modules
           sites/*/node_modules
-        key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
+        # The Node major version is part of the key because `node_modules`
+        # can hold natively-compiled addons whose ABI is tied to the runtime
+        # (this tree pulls in `sharp`). On a cache hit `npm ci` is skipped, so
+        # nothing would rebuild them — a Node bump must invalidate the cache.
+        key: ${{ runner.os }}-node-modules-${{ inputs.node-version }}-${{ hashFiles('package-lock.json') }}
 
     - name: 📥 Install npm dependencies
       if: inputs.install-node-deps == 'true' && steps.cache-node-modules.outputs.cache-hit != 'true'

--- a/.github/actions/setup-workspace/action.yml
+++ b/.github/actions/setup-workspace/action.yml
@@ -2,210 +2,262 @@
 # Setup Workspace (Composite Action)
 #
 # Summary:
-# - Bootstraps the monorepo CI environment (Node.js + optional .NET)
-# - Adds dependency caching (npm + NuGet) to speed up workflows
-# - Optionally installs Playwright browsers and generates repo artifacts
+# - Installs toolchains via `setup-tooling`, then bootstraps the
+#   monorepo: dependency installs, Playwright browsers, code
+#   generation, and the shared component build.
 #
 # Remarks:
-# - This action is intentionally “one stop” for workflows so callers can
-#   standardize cache keys, dependency installs, and artifact generation.
-# - Behavior is controlled entirely via inputs; leaving `dotnet-version` empty
-#   skips all .NET setup/restore steps.
-# - All commands run relative to `inputs.working-directory`.
+# - Toolchain caching belongs to `setup-tooling` (built-in caches).
+#   This action caches only what it produces itself: `node_modules`
+#   and the Playwright browser bundle.
+# - Both caches are keyed on the lock-file hash ALONE. They are not
+#   scoped per workflow, so all workflows share one entry each rather
+#   than each writing its own multi-hundred-megabyte copy.
+# - Inputs are never interpolated directly into `run:` blocks; they
+#   are passed through `env:` to avoid script injection.
 #+#+#+#+############################################################
 
 name: "Setup Workspace"
-description: "Sets up Node.js and .NET with optimized caching for the monorepo workspace"
+description: "Installs toolchains via setup-tooling, then bootstraps the arolariu.ro monorepo."
 author: "arolariu.ro"
 
 inputs:
-  # Node.js version to install via actions/setup-node.
+  # ── Toolchain (forwarded verbatim to setup-tooling) ──────────────
+  node:
+    description: "Whether to install Node.js."
+    required: false
+    default: "true"
+
   node-version:
-    description: "Node.js version to use"
+    description: "Node.js version to install."
     required: false
     default: "24"
 
-  # .NET SDK version to install via actions/setup-dotnet.
-  # Set to an empty string to disable .NET steps entirely.
-  dotnet-version:
-    description: ".NET version to use (leave empty to skip .NET setup)"
+  node-registry-url:
+    description: "npm registry URL to configure for publishing."
     required: false
-    default: "10"
+    default: ""
 
-  # When true, runs `npm ci` if the npm cache was not a hit.
-  install-node-dependencies:
-    description: "Whether to install npm dependencies"
-    required: false
-    default: "true"
-
-  # When true (and .NET is enabled), runs `dotnet restore` if the NuGet cache
-  # was not a hit.
-  install-dotnet-dependencies:
-    description: "Whether to install .NET dependencies"
-    required: false
-    default: "true"
-
-  # When true, runs the monorepo generators. Intended for CI workflows that
-  # require generated artifacts to exist before build/test.
-  generate:
-    description: "Whether to run npm run generate command"
+  dotnet:
+    description: "Whether to install the .NET SDK."
     required: false
     default: "false"
 
-  # Workflow-specific prefix for cache keys.
-  # Use this to avoid cross-workflow cache invalidation when necessary.
-  cache-key-prefix:
-    description: "Prefix for cache key to allow per-workflow customization"
+  dotnet-version:
+    description: ".NET SDK version to install."
     required: false
-    default: "default"
+    default: "10.0.x"
 
-  # Relative to repository root; used for both npm and dotnet commands.
-  working-directory:
-    description: "Working directory for npm  and dotnet commands (relative to repository root)"
+  python:
+    description: "Whether to install Python."
     required: false
-    default: "."
+    default: "false"
 
-  # When true, installs Playwright Chromium + OS dependencies.
-  playwright:
-    description: "Whether to install the Playwright browsers and dependencies"
+  python-version:
+    description: "Python version to install."
+    required: false
+    default: "3.12"
+
+  # ── Dependency installation ──────────────────────────────────────
+  install-node-deps:
+    description: "Whether to run `npm ci` at the repository root."
+    required: false
+    default: "true"
+
+  install-scripts-deps:
+    description: "Whether to run `npm ci` inside `.github/scripts`."
+    required: false
+    default: "false"
+
+  install-dotnet-deps:
+    description: "Whether to run `dotnet restore`."
+    required: false
+    default: "false"
+
+  dotnet-deps-path:
+    description: "Solution or project passed to `dotnet restore`."
+    required: false
+    default: "arolariu.slnx"
+
+  install-python-deps:
+    description: "Whether to install Python requirements with pip."
+    required: false
+    default: "false"
+
+  python-deps-path:
+    description: "Requirements file passed to `pip install -r`."
+    required: false
+    default: "sites/exp.arolariu.ro/requirements-dev.txt"
+
+  install-playwright:
+    description: "Whether to install Playwright browsers and OS dependencies."
+    required: false
+    default: "false"
+
+  playwright-browsers:
+    description: "Space-separated Playwright browsers to install."
+    required: false
+    default: "chromium"
+
+  # ── Workspace tasks ──────────────────────────────────────────────
+  run-generate:
+    description: "Whether to run the monorepo generators."
+    required: false
+    default: "false"
+
+  generate-args:
+    description: "Flags passed to `npm run generate`."
+    required: false
+    default: "/e /a /g /i"
+
+  run-build-components:
+    description: "Whether to build the @arolariu/components package."
     required: false
     default: "false"
 
 outputs:
-  # Exposes whether the Node.js cache matched the current lockfile hash.
   node-cache-hit:
-    description: "Whether there was a cache hit for Node.js dependencies"
-    value: ${{ steps.cache-node.outputs.cache-hit }}
+    description: "Whether the npm download cache was restored."
+    value: ${{ steps.tooling.outputs.node-cache-hit }}
 
-  # Exposes whether the NuGet cache matched the current project/sln inputs.
   dotnet-cache-hit:
-    description: "Whether there was a cache hit for .NET packages"
-    value: ${{ steps.cache-dotnet.outputs.cache-hit }}
+    description: "Whether the NuGet package cache was restored."
+    value: ${{ steps.tooling.outputs.dotnet-cache-hit }}
+
+  python-cache-hit:
+    description: "Whether the pip cache was restored."
+    value: ${{ steps.tooling.outputs.python-cache-hit }}
+
+  node-modules-cache-hit:
+    description: "Whether node_modules was restored from cache."
+    value: ${{ steps.cache-node-modules.outputs.cache-hit }}
+
+  playwright-cache-hit:
+    description: "Whether the Playwright browser bundle was restored from cache."
+    value: ${{ steps.cache-playwright.outputs.cache-hit }}
 
 runs:
   using: "composite"
   steps:
-    # ─────────────────────────────────────────────────────────────────
-    # Phase 1: Initialize and record start time
-    # ─────────────────────────────────────────────────────────────────
     - name: 🚀 Initialize workspace setup
       id: init
       shell: bash
-      run: |
-        echo "start_time=$(date +%s)" >> $GITHUB_OUTPUT
-        echo "::group::📋 Setup Configuration"
-        echo "  Node.js:    ${{ inputs.node-version }}"
-        echo "  .NET:       ${{ inputs.dotnet-version || 'disabled' }}"
-        echo "  Playwright: ${{ inputs.playwright }}"
-        echo "  Generate:   ${{ inputs.generate }}"
-        echo "  Cache key:  ${{ inputs.cache-key-prefix }}"
-        echo "::endgroup::"
+      run: echo "start_time=$(date +%s)" >> "$GITHUB_OUTPUT"
 
-    # ─────────────────────────────────────────────────────────────────
-    # Phase 2: SDK Setup (Node.js + .NET)
-    # ─────────────────────────────────────────────────────────────────
-    - name: 📦 Setting up Node.js v${{ inputs.node-version }}...
-      uses: actions/setup-node@v6
+    - name: 🧰 Install toolchains
+      id: tooling
+      uses: ./.github/actions/setup-tooling
       with:
+        node: ${{ inputs.node }}
         node-version: ${{ inputs.node-version }}
+        node-registry-url: ${{ inputs.node-registry-url }}
+        dotnet: ${{ inputs.dotnet }}
+        dotnet-version: ${{ inputs.dotnet-version }}
+        python: ${{ inputs.python }}
+        python-version: ${{ inputs.python-version }}
 
-    - name: 💾 Caching Node.js dependencies...
-      id: cache-node
+    - name: 💾 Restoring node_modules...
+      id: cache-node-modules
+      if: inputs.install-node-deps == 'true'
       uses: actions/cache@v5
       with:
-        # Cache both root and workspace node_modules to support Nx workspaces.
-        # Trade-off: broader paths can increase cache size but reduce CI time.
+        # `~/.npm` is intentionally absent: setup-node already owns it.
         path: |
           node_modules
-          ~/.npm
           **/node_modules
-        key: ${{ runner.os }}-node-${{ inputs.cache-key-prefix }}-${{ hashFiles('**/package-lock.json') }}
-
-    - name: 📦 Setting up .NET v${{ inputs.dotnet-version }}...
-      if: inputs.dotnet-version != ''
-      uses: actions/setup-dotnet@v5
-      with:
-        dotnet-version: ${{ inputs.dotnet-version }}
-
-    - name: 💾 Caching .NET packages...
-      id: cache-dotnet
-      if: inputs.dotnet-version != ''
-      uses: actions/cache@v5
-      with:
-        # Cache NuGet global packages and the dotnet SDK cache locations.
-        path: |
-          ~/.nuget/packages
-          ~/.dotnet
-        key: ${{ runner.os }}-dotnet-${{ inputs.cache-key-prefix }}-${{ hashFiles('**/*.csproj', '**/*.slnx', '**/packages.lock.json') }}
+        key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
 
     - name: 📥 Install npm dependencies
-      if: inputs.install-node-dependencies == 'true'
+      if: inputs.install-node-deps == 'true' && steps.cache-node-modules.outputs.cache-hit != 'true'
       shell: bash
-      working-directory: ${{ inputs.working-directory }}
       run: |
-        if [ "${{ steps.cache-node.outputs.cache-hit }}" != "true" ]; then
-          echo "::group::📦 Installing Node.js dependencies..."
-          npm install --prefer-offline --no-audit
-          echo "::endgroup::"
-          echo "✅ Dependencies installed successfully"
-        else
-          echo "✅ Using cached Node.js dependencies"
-        fi
+        echo "::group::📦 npm ci (root)"
+        npm ci --prefer-offline --no-audit --no-fund
+        echo "::endgroup::"
+
+    - name: 📥 Install .github/scripts dependencies
+      if: inputs.install-scripts-deps == 'true'
+      shell: bash
+      working-directory: .github/scripts
+      run: |
+        echo "::group::📦 npm ci (.github/scripts)"
+        npm ci --prefer-offline --no-audit --no-fund
+        echo "::endgroup::"
 
     - name: 📥 Restore .NET dependencies
-      if: inputs.dotnet-version != '' && inputs.install-dotnet-dependencies == 'true'
+      if: inputs.install-dotnet-deps == 'true'
       shell: bash
-      working-directory: ${{ inputs.working-directory }}
+      env:
+        DOTNET_DEPS_PATH: ${{ inputs.dotnet-deps-path }}
       run: |
-        if [ "${{ steps.cache-dotnet.outputs.cache-hit }}" != "true" ]; then
-          echo "::group::📦 Restoring .NET dependencies..."
-          dotnet restore arolariu.slnx
-          echo "::endgroup::"
-          echo "✅ .NET dependencies restored successfully"
-        else
-          echo "✅ Using cached .NET dependencies"
-        fi
+        echo "::group::📦 dotnet restore"
+        dotnet restore "${DOTNET_DEPS_PATH}"
+        echo "::endgroup::"
+
+    - name: 📥 Install Python dependencies
+      if: inputs.install-python-deps == 'true'
+      shell: bash
+      env:
+        PYTHON_DEPS_PATH: ${{ inputs.python-deps-path }}
+      run: |
+        echo "::group::📦 pip install"
+        python -m pip install --upgrade pip
+        python -m pip install -r "${PYTHON_DEPS_PATH}"
+        echo "::endgroup::"
+
+    - name: 💾 Restoring Playwright browsers...
+      id: cache-playwright
+      if: inputs.install-playwright == 'true'
+      uses: actions/cache@v5
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
 
     - name: 🎭 Install Playwright browsers
-      if: inputs.playwright == 'true'
+      if: inputs.install-playwright == 'true'
       shell: bash
-      working-directory: ${{ inputs.working-directory }}
+      env:
+        PLAYWRIGHT_BROWSERS: ${{ inputs.playwright-browsers }}
+        PLAYWRIGHT_CACHE_HIT: ${{ steps.cache-playwright.outputs.cache-hit }}
       run: |
-        echo "::group::🎭 Installing Playwright browsers..."
-        npx playwright install chromium --with-deps
+        echo "::group::🎭 Playwright"
+        if [ "${PLAYWRIGHT_CACHE_HIT}" = "true" ]; then
+          # Browsers are cached, but OS-level shared libraries are not
+          # part of the cached directory and must be installed anyway.
+          npx playwright install-deps ${PLAYWRIGHT_BROWSERS}
+        else
+          npx playwright install ${PLAYWRIGHT_BROWSERS} --with-deps
+        fi
         echo "::endgroup::"
-        echo "✅ Playwright browsers installed"
 
-    - name: 🔨 Generate artifacts (GraphQL schemas, types, etc.)
-      if: inputs.generate == 'true'
+    - name: 🔨 Generate artifacts (env, acknowledgements, GraphQL, i18n)
+      if: inputs.run-generate == 'true'
       shell: bash
-      working-directory: ${{ inputs.working-directory }}
+      env:
+        GENERATE_ARGS: ${{ inputs.generate-args }}
       run: |
-        echo "::group::🔨 Generating artifacts..."
-        npm run generate /e /a /g /i
+        echo "::group::🔨 npm run generate"
+        npm run generate ${GENERATE_ARGS}
+        echo "::endgroup::"
+
+    - name: 🔨 Build the @arolariu/components package
+      if: inputs.run-build-components == 'true'
+      shell: bash
+      run: |
+        echo "::group::🔨 npm run build:components"
         npm run build:components
         echo "::endgroup::"
-        echo "✅ Artifacts generated successfully"
 
-    # ─────────────────────────────────────────────────────────────────
-    # Phase 7: Summary and Timing
-    # ─────────────────────────────────────────────────────────────────
     - name: ✨ Workspace setup complete
-      id: timing
       shell: bash
+      env:
+        START_TIME: ${{ steps.init.outputs.start_time }}
+        NODE_MODULES_CACHE: ${{ steps.cache-node-modules.outputs.cache-hit == 'true' && 'HIT' || (inputs.install-node-deps != 'true' && 'SKIPPED' || 'MISS') }}
+        PLAYWRIGHT_CACHE: ${{ steps.cache-playwright.outputs.cache-hit == 'true' && 'HIT' || (inputs.install-playwright != 'true' && 'SKIPPED' || 'MISS') }}
       run: |
-        END=$(date +%s)
-        DURATION=$((END - ${{ steps.init.outputs.start_time }}))
-        echo "duration=${DURATION}" >> $GITHUB_OUTPUT
-
-        echo ""
-        echo "┌──────────────────────────────────────────────────────────┐"
-        echo "│  ✅ Workspace Setup Complete                             │"
-        echo "├──────────────────────────────────────────────────────────┤"
-        printf "│  ⏱️  Total time: %3ds                                    │\n" $DURATION
-        echo "├──────────────────────────────────────────────────────────┤"
-        echo "│  Cache Status:                                           │"
-        printf "│    • Node.js:    %-40s│\n" "${{ steps.cache-node.outputs.cache-hit == 'true' && '✅ HIT' || '❌ MISS' }}"
-        printf "│    • .NET:       %-40s│\n" "${{ steps.cache-dotnet.outputs.cache-hit == 'true' && '✅ HIT' || (inputs.dotnet-version == '' && '⏭️  SKIPPED' || '❌ MISS') }}"
-        printf "│    • Playwright: %-40s│\n" "${{ steps.cache-playwright.outputs.cache-hit == 'true' && '✅ HIT' || (inputs.playwright != 'true' && '⏭️  SKIPPED' || '❌ MISS') }}"
-        echo "└──────────────────────────────────────────────────────────┘"
+        DURATION=$(( $(date +%s) - START_TIME ))
+        echo "::group::✨ Workspace setup complete"
+        echo "  Duration:     ${DURATION}s"
+        echo "  node_modules: ${NODE_MODULES_CACHE}"
+        echo "  Playwright:   ${PLAYWRIGHT_CACHE}"
+        echo "::endgroup::"

--- a/.github/actions/setup-workspace/action.yml
+++ b/.github/actions/setup-workspace/action.yml
@@ -162,9 +162,17 @@ runs:
       uses: actions/cache@v5
       with:
         # `~/.npm` is intentionally absent: setup-node already owns it.
+        #
+        # Paths mirror the npm workspaces declared in the root package.json
+        # (`packages/*`, `sites/*`), which are exactly what the root lockfile
+        # governs. A blanket `**/node_modules` would also sweep in
+        # `.github/scripts/node_modules` — a package with its OWN lockfile —
+        # making the cache contents depend on which job happened to populate
+        # it, and restoring a tree the scripts install then deletes anyway.
         path: |
           node_modules
-          **/node_modules
+          packages/*/node_modules
+          sites/*/node_modules
         key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
 
     - name: 📥 Install npm dependencies
@@ -221,12 +229,16 @@ runs:
         PLAYWRIGHT_CACHE_HIT: ${{ steps.cache-playwright.outputs.cache-hit }}
       run: |
         echo "::group::🎭 Playwright"
+        # Split the space-separated browser list into an array rather than
+        # relying on unquoted word-splitting, so the value cannot be glob
+        # expanded against the working directory.
+        read -ra browsers <<< "${PLAYWRIGHT_BROWSERS}"
         if [ "${PLAYWRIGHT_CACHE_HIT}" = "true" ]; then
           # Browsers are cached, but OS-level shared libraries are not
           # part of the cached directory and must be installed anyway.
-          npx playwright install-deps ${PLAYWRIGHT_BROWSERS}
+          npx playwright install-deps "${browsers[@]}"
         else
-          npx playwright install ${PLAYWRIGHT_BROWSERS} --with-deps
+          npx playwright install "${browsers[@]}" --with-deps
         fi
         echo "::endgroup::"
 
@@ -237,7 +249,10 @@ runs:
         GENERATE_ARGS: ${{ inputs.generate-args }}
       run: |
         echo "::group::🔨 npm run generate"
-        npm run generate ${GENERATE_ARGS}
+        # Same reasoning as the Playwright step: split deliberately into an
+        # array instead of letting the shell word-split and glob the value.
+        read -ra generate_args <<< "${GENERATE_ARGS}"
+        npm run generate "${generate_args[@]}"
         echo "::endgroup::"
 
     - name: 🔨 Build the @arolariu/components package

--- a/.github/actions/setup-workspace/action.yml
+++ b/.github/actions/setup-workspace/action.yml
@@ -144,6 +144,51 @@ runs:
       shell: bash
       run: echo "start_time=$(date +%s)" >> "$GITHUB_OUTPUT"
 
+    # Runs BEFORE the toolchains are installed so a contradictory call fails
+    # in seconds rather than after a full SDK provision. Without this guard a
+    # disabled toolchain does not fail loudly: `npm`, `dotnet` and `python`
+    # all exist on the GitHub-hosted images, so the dependent step would
+    # silently run against whatever version the runner happens to ship
+    # instead of the version this action pins.
+    - name: 🔎 Validate input combinations
+      shell: bash
+      env:
+        NODE: ${{ inputs.node }}
+        DOTNET: ${{ inputs.dotnet }}
+        PYTHON: ${{ inputs.python }}
+        INSTALL_NODE_DEPS: ${{ inputs.install-node-deps }}
+        INSTALL_SCRIPTS_DEPS: ${{ inputs.install-scripts-deps }}
+        INSTALL_DOTNET_DEPS: ${{ inputs.install-dotnet-deps }}
+        INSTALL_PYTHON_DEPS: ${{ inputs.install-python-deps }}
+        INSTALL_PLAYWRIGHT: ${{ inputs.install-playwright }}
+        RUN_GENERATE: ${{ inputs.run-generate }}
+        RUN_BUILD_COMPONENTS: ${{ inputs.run-build-components }}
+      run: |
+        errors=()
+
+        # require <toolchain-value> <toolchain-name> <dependent-value> <dependent-name>
+        require() {
+          if [ "$3" = "true" ] && [ "$1" != "true" ]; then
+            errors+=("  - '$4: true' requires '$2: true' (currently '$2: $1')")
+          fi
+        }
+
+        require "$NODE" node "$INSTALL_NODE_DEPS" install-node-deps
+        require "$NODE" node "$INSTALL_SCRIPTS_DEPS" install-scripts-deps
+        require "$NODE" node "$INSTALL_PLAYWRIGHT" install-playwright
+        require "$NODE" node "$RUN_GENERATE" run-generate
+        require "$NODE" node "$RUN_BUILD_COMPONENTS" run-build-components
+        require "$DOTNET" dotnet "$INSTALL_DOTNET_DEPS" install-dotnet-deps
+        require "$PYTHON" python "$INSTALL_PYTHON_DEPS" install-python-deps
+
+        if [ ${#errors[@]} -gt 0 ]; then
+          printf '%s\n' "${errors[@]}"
+          echo "::error::setup-workspace received contradictory inputs (see above). A disabled toolchain still resolves to the runner's preinstalled version, so the dependent step would run against an unpinned toolchain instead of failing."
+          exit 1
+        fi
+
+        echo "✅ Input combination is consistent"
+
     - name: 🧰 Install toolchains
       id: tooling
       uses: ./.github/actions/setup-tooling

--- a/.github/actions/setup-workspace/readme.md
+++ b/.github/actions/setup-workspace/readme.md
@@ -113,8 +113,10 @@ silently fetch a floating version rather than the one the lock file pins.
 | `node_modules`, `packages/*/node_modules`, `sites/*/node_modules` | this action | `<os>-node-modules-<node-version>-<hash(package-lock.json)>` |
 | `~/.cache/ms-playwright` | this action | `<os>-playwright-<hash(package-lock.json)>` |
 
-Both of this action's caches are keyed on the lock-file hash **alone** — there is no per-workflow prefix. One shared entry each, rather than every workflow writing its own multi-hundred-megabyte copy against the repository's 10 GB budget.
+Neither of this action's caches carries a per-workflow prefix — one shared entry each, rather than every workflow writing its own multi-hundred-megabyte copy against the repository's 10 GB budget. Neither uses fallback restore keys.
+
+The two keys are not identical in shape. The Playwright key is the lock-file hash alone, since the cached artifacts are browser binaries and the Playwright version governing them is already pinned by the lock file. The `node_modules` key **also includes the Node version**: a cache hit skips `npm ci`, and the tree can contain natively-compiled addons (this repo pulls in `sharp`) whose ABI is tied to the runtime — so a Node bump must invalidate the cache rather than restore binaries built for the previous version.
 
 The cached `node_modules` paths mirror the npm workspaces declared in the root `package.json` (`packages/*`, `sites/*`) — precisely what the root lock file governs. `.github/scripts` is deliberately excluded: it has its own lock file and its own install step (`install-scripts-deps`), so folding it into a cache keyed on the root lock file would make the cache's contents depend on which job populated it first.
 
-`npm ci` is used rather than `npm install`: it is the correct CI primitive and cannot mutate `package-lock.json`. It is skipped only when the `node_modules` cache hits on an exact lock-file match.
+`npm ci` is used rather than `npm install`: it is the correct CI primitive and cannot mutate `package-lock.json`. It is skipped only when the `node_modules` cache hits — that is, on an exact lock-file match **and** an unchanged Node version.

--- a/.github/actions/setup-workspace/readme.md
+++ b/.github/actions/setup-workspace/readme.md
@@ -1,147 +1,91 @@
 # Setup Workspace Action
 
-A composite GitHub Action that sets up the Node.js and .NET development environment with optimized caching for the arolariu.ro monorepo.
+Installs language toolchains via [`setup-tooling`](../setup-tooling/readme.md), then bootstraps the arolariu.ro monorepo: dependency installs, Playwright browsers, code generation, and the shared component build.
 
-## Features
-
-- ✅ Sets up Node.js with configurable version
-- ✅ Sets up .NET with configurable version (optional)
-- ✅ Intelligent caching for npm and NuGet packages
-- ✅ Automatic dependency installation
-- ✅ Optional Azure setup integration
-- ✅ Optional Playwright browser installation
-- ✅ Customizable cache keys per workflow
+Use [`setup-tooling`](../setup-tooling/readme.md) directly when a job needs only a binary and no repository bootstrap.
 
 ## Usage
 
-### Basic Node.js Setup
-
 ```yaml
-- name: Setup workspace
-  uses: ./.github/actions/setup-workspace
+# Node.js + npm ci (the default)
+- uses: ./.github/actions/setup-workspace
+
+# .NET tests
+- uses: ./.github/actions/setup-workspace
   with:
-    node-version: '24'
-```
+    node: "false"
+    dotnet: "true"
+    install-dotnet-deps: "true"
 
-### With .NET Support
-
-```yaml
-- name: Setup workspace
-  uses: ./.github/actions/setup-workspace
+# Website build: generation, component library, Playwright
+- uses: ./.github/actions/setup-workspace
   with:
-    node-version: '24'
-    dotnet-version: '10.x'
-```
+    install-playwright: "true"
+    run-generate: "true"
+    run-build-components: "true"
 
-### With Azure and Playwright
-
-```yaml
-- name: Setup workspace
-  uses: ./.github/actions/setup-workspace
+# Python checks
+- uses: ./.github/actions/setup-workspace
   with:
-    node-version: '24'
-    playwright: 'true'
-    generate: 'true'
-    cache-key-prefix: 'website-build'
-```
-
-### Custom Working Directory
-
-```yaml
-- name: Setup workspace
-  uses: ./.github/actions/setup-workspace
-  with:
-    node-version: '24'
-    working-directory: './sites/arolariu.ro'
-    cache-key-prefix: 'website'
+    node: "false"
+    install-node-deps: "false"
+    python: "true"
+    install-python-deps: "true"
 ```
 
 ## Inputs
 
-| Input | Description | Required | Default |
-|-------|-------------|----------|---------|
-| `node-version` | Node.js version to use | No | `24` |
-| `dotnet-version` | .NET version to use (leave empty to skip) | No | `10.x` |
-| `install-node-dependencies` | Whether to install npm dependencies | No | `true` |
-| `install-dotnet-dependencies` | Whether to restore .NET dependencies | No | `true` |
-| `cache-key-prefix` | Prefix for cache key customization | No | `default` |
-| `working-directory` | Working directory for npm commands | No | `.` |
-| `playwright` | Whether to install Playwright browsers | No | `false` |
-| `generate` | Whether to run `npm run generate` for GraphQL schemas and artifacts | No | `false` |
+### Toolchain — forwarded to `setup-tooling`
+
+| Input | Default |
+|-------|---------|
+| `node` | `true` |
+| `node-version` | `24` |
+| `node-registry-url` | `""` |
+| `dotnet` | `false` |
+| `dotnet-version` | `10.0.x` |
+| `python` | `false` |
+| `python-version` | `3.12` |
+
+### Dependency installation
+
+| Input | Default | Runs |
+|-------|---------|------|
+| `install-node-deps` | `true` | `npm ci` at the repository root |
+| `install-scripts-deps` | `false` | `npm ci` inside `.github/scripts` |
+| `install-dotnet-deps` | `false` | `dotnet restore <dotnet-deps-path>` |
+| `dotnet-deps-path` | `arolariu.slnx` | — |
+| `install-python-deps` | `false` | `pip install --upgrade pip` then `pip install -r <python-deps-path>` |
+| `python-deps-path` | `sites/exp.arolariu.ro/requirements-dev.txt` | — |
+| `install-playwright` | `false` | `npx playwright install <browsers> --with-deps` |
+| `playwright-browsers` | `chromium` | — |
+
+### Workspace tasks
+
+| Input | Default | Runs |
+|-------|---------|------|
+| `run-generate` | `false` | `npm run generate <generate-args>` |
+| `generate-args` | `/e /a /g /i` | — |
+| `run-build-components` | `false` | `npm run build:components` |
 
 ## Outputs
 
 | Output | Description |
 |--------|-------------|
-| `node-cache-hit` | Whether there was a cache hit for Node.js dependencies |
-| `dotnet-cache-hit` | Whether there was a cache hit for .NET packages |
+| `node-cache-hit` | npm download cache restored |
+| `dotnet-cache-hit` | NuGet package cache restored |
+| `python-cache-hit` | pip cache restored |
+| `node-modules-cache-hit` | `node_modules` restored from cache |
+| `playwright-cache-hit` | Playwright browser bundle restored from cache |
 
-## Cache Strategy
+## Caching model
 
-The action uses hash-based exact matching for cache keys (no fallback keys):
+| Cache | Owner | Key |
+|-------|-------|-----|
+| `~/.npm`, `~/.nuget/packages`, pip | `setup-tooling` (built-in) | lock-file hashes |
+| `node_modules` | this action | `<os>-node-modules-<hash(package-lock.json)>` |
+| `~/.cache/ms-playwright` | this action | `<os>-playwright-<hash(package-lock.json)>` |
 
-### Node.js Cache
-```
-Key: {os}-node-{prefix}-{hash(package-lock.json)}
-```
+Both of this action's caches are keyed on the lock-file hash **alone** — there is no per-workflow prefix. One shared entry each, rather than every workflow writing its own multi-hundred-megabyte copy against the repository's 10 GB budget.
 
-### .NET Cache
-```
-Key: {os}-dotnet-{prefix}-{hash(*.csproj, *.slnx, packages.lock.json)}
-```
-
-**Why no fallback keys?**
-
-Fallback keys can cause cache pollution when lock files are out of sync with package files. The hash-based approach ensures:
-- ✅ Cache hit only when dependencies are exactly the same
-- ✅ Fresh installation when any dependency changes
-- ✅ No risk of using stale cached dependencies
-- ✅ Clear behavior: exact match = cache hit, no match = fresh install
-
-**When does cache invalidate?**
-- a) No version bumps → Lock file unchanged → **Cache HIT**
-- b) Version bump with regenerated lock file → Hash changes → **Cache MISS** → Fresh install ✅
-- c) Only version bumps → Lock file regenerated → **Cache MISS** → Fresh install ✅
-
-**Important**: Cache keys are scoped to workflows via the prefix to prevent cache pollution. When dependencies are updated, the hash-based primary key ensures fresh installations rather than using potentially incompatible caches.
-
-## Examples from Repository Workflows
-
-### Website Build Workflow
-```yaml
-- name: Setup workspace
-  uses: ./.github/actions/setup-workspace
-  with:
-    node-version: '24'
-    playwright: 'true'
-    cache-key-prefix: 'website'
-```
-
-### API Build Workflow
-```yaml
-- name: Setup workspace
-  uses: ./.github/actions/setup-workspace
-  with:
-    node-version: '24'
-    dotnet-version: '10.x'
-    install-node-dependencies: 'false'
-    install-dotnet-dependencies: 'true'
-    cache-key-prefix: 'api'
-```
-
-### Hygiene Check Workflow
-```yaml
-- name: Setup workspace
-  uses: ./.github/actions/setup-workspace
-  with:
-    node-version: '24'
-    cache-key-prefix: 'hygiene'
-```
-
-## Benefits
-
-1. **Consistency**: All workflows use the same setup logic
-2. **Performance**: Intelligent caching reduces build times
-3. **Maintainability**: Single source of truth for setup steps
-4. **Flexibility**: Customizable for different workflow needs
-5. **DRY Principle**: Eliminates code duplication across workflows
+`npm ci` is used rather than `npm install`: it is the correct CI primitive and cannot mutate `package-lock.json`. It is skipped only when the `node_modules` cache hits on an exact lock-file match.

--- a/.github/actions/setup-workspace/readme.md
+++ b/.github/actions/setup-workspace/readme.md
@@ -83,7 +83,7 @@ Use [`setup-tooling`](../setup-tooling/readme.md) directly when a job needs only
 | Cache | Owner | Key |
 |-------|-------|-----|
 | `~/.npm`, `~/.nuget/packages`, pip | `setup-tooling` (built-in) | lock-file hashes |
-| `node_modules`, `packages/*/node_modules`, `sites/*/node_modules` | this action | `<os>-node-modules-<hash(package-lock.json)>` |
+| `node_modules`, `packages/*/node_modules`, `sites/*/node_modules` | this action | `<os>-node-modules-<node-version>-<hash(package-lock.json)>` |
 | `~/.cache/ms-playwright` | this action | `<os>-playwright-<hash(package-lock.json)>` |
 
 Both of this action's caches are keyed on the lock-file hash **alone** — there is no per-workflow prefix. One shared entry each, rather than every workflow writing its own multi-hundred-megabyte copy against the repository's 10 GB budget.

--- a/.github/actions/setup-workspace/readme.md
+++ b/.github/actions/setup-workspace/readme.md
@@ -75,15 +75,25 @@ requested while its toolchain is disabled:
 
 | Requires | Dependent inputs |
 |----------|------------------|
-| `node: 'true'` | `install-node-deps`, `install-scripts-deps`, `install-playwright`, `run-generate`, `run-build-components` |
+| `node: 'true'` | `install-node-deps`, `install-scripts-deps` |
+| `install-node-deps: 'true'` | `install-playwright`, `run-generate`, `run-build-components` |
 | `dotnet: 'true'` | `install-dotnet-deps` |
 | `python: 'true'` | `install-python-deps` |
 
-This exists because a disabled toolchain does **not** produce an obvious
-failure on its own. `npm`, `dotnet`, and `python` are all preinstalled on
-GitHub-hosted runners, so without the guard the dependent step would quietly
-run against whatever version the image happens to ship instead of the version
-this action pins — and you would only notice via a confusing downstream error.
+Two reasons this exists.
+
+A **disabled toolchain** does not produce an obvious failure on its own.
+`npm`, `dotnet`, and `python` are all preinstalled on GitHub-hosted runners,
+so without the guard the dependent step would quietly run against whatever
+version the image happens to ship instead of the version this action pins —
+and you would only notice via a confusing downstream error.
+
+**`install-node-deps` gates both the cache restore and `npm ci`,** so with it
+disabled the root `node_modules` tree is absent entirely. `npm run generate`
+and `npm run build:components` would fail outright, and `npx playwright` would
+silently fetch a floating version rather than the one the lock file pins.
+`install-scripts-deps` is deliberately *not* in that group: it installs
+`.github/scripts` independently and does not need the root tree.
 
 ## Outputs
 

--- a/.github/actions/setup-workspace/readme.md
+++ b/.github/actions/setup-workspace/readme.md
@@ -68,6 +68,23 @@ Use [`setup-tooling`](../setup-tooling/readme.md) directly when a job needs only
 | `generate-args` | `/e /a /g /i` | — |
 | `run-build-components` | `false` | `npm run build:components` |
 
+### Input validation
+
+The action fails fast, before installing anything, when a dependent task is
+requested while its toolchain is disabled:
+
+| Requires | Dependent inputs |
+|----------|------------------|
+| `node: 'true'` | `install-node-deps`, `install-scripts-deps`, `install-playwright`, `run-generate`, `run-build-components` |
+| `dotnet: 'true'` | `install-dotnet-deps` |
+| `python: 'true'` | `install-python-deps` |
+
+This exists because a disabled toolchain does **not** produce an obvious
+failure on its own. `npm`, `dotnet`, and `python` are all preinstalled on
+GitHub-hosted runners, so without the guard the dependent step would quietly
+run against whatever version the image happens to ship instead of the version
+this action pins — and you would only notice via a confusing downstream error.
+
 ## Outputs
 
 | Output | Description |

--- a/.github/actions/setup-workspace/readme.md
+++ b/.github/actions/setup-workspace/readme.md
@@ -83,9 +83,11 @@ Use [`setup-tooling`](../setup-tooling/readme.md) directly when a job needs only
 | Cache | Owner | Key |
 |-------|-------|-----|
 | `~/.npm`, `~/.nuget/packages`, pip | `setup-tooling` (built-in) | lock-file hashes |
-| `node_modules` | this action | `<os>-node-modules-<hash(package-lock.json)>` |
+| `node_modules`, `packages/*/node_modules`, `sites/*/node_modules` | this action | `<os>-node-modules-<hash(package-lock.json)>` |
 | `~/.cache/ms-playwright` | this action | `<os>-playwright-<hash(package-lock.json)>` |
 
 Both of this action's caches are keyed on the lock-file hash **alone** — there is no per-workflow prefix. One shared entry each, rather than every workflow writing its own multi-hundred-megabyte copy against the repository's 10 GB budget.
+
+The cached `node_modules` paths mirror the npm workspaces declared in the root `package.json` (`packages/*`, `sites/*`) — precisely what the root lock file governs. `.github/scripts` is deliberately excluded: it has its own lock file and its own install step (`install-scripts-deps`), so folding it into a cache keyed on the root lock file would make the cache's contents depend on which job populated it first.
 
 `npm ci` is used rather than `npm install`: it is the correct CI primitive and cannot mutate `package-lock.json`. It is skipped only when the `node_modules` cache hits on an exact lock-file match.

--- a/.github/instructions/workflows.instructions.md
+++ b/.github/instructions/workflows.instructions.md
@@ -932,8 +932,10 @@ Use emoji prefix + descriptive action:
 ### Internal Documentation
 
 - **RFC 0001**: `docs/rfc/0001-github-actions-workflows.md` - Architecture decisions
-- **Composite Action**: `.github/actions/setup-workspace/action.yml` - Implementation
-- **Composite Action README**: `.github/actions/setup-workspace/README.md` - Usage guide
+- **Composite Action (setup-tooling)**: `.github/actions/setup-tooling/action.yml` - Toolchain installation
+- **Composite Action README (setup-tooling)**: `.github/actions/setup-tooling/readme.md` - Usage guide
+- **Composite Action (setup-workspace)**: `.github/actions/setup-workspace/action.yml` - Repository bootstrap
+- **Composite Action README (setup-workspace)**: `.github/actions/setup-workspace/readme.md` - Usage guide
 
 ### External Resources
 

--- a/.github/instructions/workflows.instructions.md
+++ b/.github/instructions/workflows.instructions.md
@@ -58,7 +58,7 @@ This document provides guidelines for developing and maintaining GitHub Actions 
 | `official-components-publish.yml` | Publish npm package | Tag push, Manual | Publish |
 
 **Key Patterns:**
-- Use `setup-workspace` composite action for all workspace setup
+- Use `setup-tooling` for binaries, `setup-workspace` for full workspace setup
 - OIDC for Azure authentication - NO long-lived secrets
 - Hash-based caching only - NO fallback keys (intentional)
 - Progress emojis: 📥 🔐 🚀 🏗️ 🧪 ✅ ⚠️
@@ -120,135 +120,69 @@ official-api-trigger.yml
 
 ---
 
-## Composite Action: setup-workspace
+## Composite Actions
 
-**Location:** `.github/actions/setup-workspace/action.yml`
+Two composite actions live under `.github/actions/`. All workflows MUST use them; hand-rolled `actions/setup-node`, `actions/setup-dotnet`, and `actions/setup-python` steps are prohibited.
 
-All workflows MUST use this composite action for workspace setup. It ensures consistency across all CI/CD pipelines.
+| Action | Responsibility |
+|--------|----------------|
+| `setup-tooling` | Installs Node.js / .NET / Python. Repo-agnostic. Caching is delegated to each `setup-*` action's built-in mechanism |
+| `setup-workspace` | Invokes `setup-tooling`, then bootstraps the repo: `npm ci`, `dotnet restore`, `pip install`, Playwright, `npm run generate`, `npm run build:components` |
 
-### Inputs
+Use `setup-tooling` when a job needs only a binary. Use `setup-workspace` for everything else.
 
-```yaml
-inputs:
-  node-version:
-    description: 'Node.js version'
-    required: false
-    default: '24'
-  dotnet-version:
-    description: '.NET SDK version'
-    required: false
-    default: '10.0.x'
-  cache-key-prefix:
-    description: 'Prefix for cache keys (workflow scope)'
-    required: false
-    default: 'default'
-  setup-azure:
-    description: 'Configure Azure CLI'
-    required: false
-    default: 'false'
-  playwright:
-    description: 'Install Playwright browsers'
-    required: false
-    default: 'false'
-  generate:
-    description: 'Run npm run generate (GraphQL, i18n, env)'
-    required: false
-    default: 'false'
-```
+### Input naming scheme
 
-### Outputs
+| Group | Pattern | Examples |
+|-------|---------|----------|
+| Toolchain | bare tool noun, `<tool>-version` | `node`, `dotnet`, `python-version` |
+| Dependency install | `install-<target>-deps`, `<target>-deps-path` | `install-node-deps`, `dotnet-deps-path` |
+| Tool install | `install-<tool>`, `<tool>-<qualifier>` | `install-playwright`, `playwright-browsers` |
+| Workspace task | `run-<task>`, `<task>-args` | `run-generate`, `generate-args` |
+| Outputs | `<tool>-cache-hit` | `node-cache-hit`, `playwright-cache-hit` |
+
+All inputs are strings. `dotnet` and `python` default to `false` — opt in explicitly. Never gate a toolchain by passing an empty version string.
+
+### Usage examples
 
 ```yaml
-outputs:
-  node-cache-hit:
-    description: 'Whether Node.js dependencies were restored from cache'
-  dotnet-cache-hit:
-    description: 'Whether .NET packages were restored from cache'
-```
+# Node.js + npm ci (the default)
+- name: 📦 Setup workspace
+  uses: ./.github/actions/setup-workspace
 
-### Usage Examples
-
-**Website workflow (full setup):**
-```yaml
-- name: 🚀 Setup workspace
+# .NET tests
+- name: 📦 Setup workspace
   uses: ./.github/actions/setup-workspace
   with:
-    node-version: '24'
-    cache-key-prefix: 'website'
-    setup-azure: 'true'
-    playwright: 'true'
-    generate: 'true'
-```
+    node: 'false'
+    install-node-deps: 'false'
+    dotnet: 'true'
+    install-dotnet-deps: 'true'
 
-**API workflow (.NET only):**
-```yaml
-- name: 🚀 Setup workspace
+# Website build
+- name: 📦 Setup workspace
   uses: ./.github/actions/setup-workspace
   with:
-    node-version: ''  # Skip Node.js
-    dotnet-version: '10.0.x'
-    cache-key-prefix: 'api'
-    setup-azure: 'true'
+    install-playwright: 'true'
+    run-generate: 'true'
+    run-build-components: 'true'
+
+# Binary only — no repository bootstrap
+- name: 🧰 Setup tooling
+  uses: ./.github/actions/setup-tooling
 ```
 
-**Hygiene workflow (Node.js only):**
-```yaml
-- name: 🚀 Setup workspace
-  uses: ./.github/actions/setup-workspace
-  with:
-    node-version: '24'
-    dotnet-version: ''  # Skip .NET
-    cache-key-prefix: 'hygiene'
-```
+Full input tables: [`setup-tooling`](../actions/setup-tooling/readme.md), [`setup-workspace`](../actions/setup-workspace/readme.md).
 
----
+### Caching
 
-## Caching Strategy
+| Cache | Owner | Key |
+|-------|-------|-----|
+| `~/.npm`, `~/.nuget/packages`, pip | `setup-tooling` (built-in) | lock-file hashes |
+| `node_modules` | `setup-workspace` | `<os>-node-modules-<hash(package-lock.json)>` |
+| `~/.cache/ms-playwright` | `setup-workspace` | `<os>-playwright-<hash(package-lock.json)>` |
 
-### Philosophy: Hash-Based Only, NO Fallback Keys
-
-**This is intentional and documented in RFC 0001.**
-
-```yaml
-# ✅ CORRECT: Hash-based exact match only
-key: ${{ runner.os }}-node-${{ inputs.cache-key-prefix }}-${{ hashFiles('**/package-lock.json') }}
-# NO restore-keys!
-
-# ❌ WRONG: Fallback keys enable stale cache issues
-restore-keys: |
-  ${{ runner.os }}-node-${{ inputs.cache-key-prefix }}-
-  ${{ runner.os }}-node-
-```
-
-### Why No Fallback Keys?
-
-From RFC 0001:
-> "The 'restore-keys' approach that most projects use can cause stale dependency issues. When a developer adds a new package but the workflow uses a fallback cache from before that package was added, the build might fail or behave unexpectedly."
-
-**Cache Invalidation Scenarios:**
-| Scenario | Lock File | Cache Result | Outcome |
-|----------|-----------|--------------|---------|
-| No dependency changes | Unchanged | HIT ✅ | Fast build |
-| New package added | Changed | MISS → Fresh install | Correct deps |
-| Package version bump | Changed | MISS → Fresh install | Correct deps |
-| Only code changes | Unchanged | HIT ✅ | Fast build |
-
-### Cache Key Structure
-
-```yaml
-# Node.js cache key
-${{ runner.os }}-node-${{ inputs.cache-key-prefix }}-${{ hashFiles('**/package-lock.json') }}
-# Example: linux-node-website-7f3e9a2c1b5d4...
-
-# .NET cache key  
-${{ runner.os }}-dotnet-${{ inputs.cache-key-prefix }}-${{ hashFiles('**/*.csproj') }}
-# Example: linux-dotnet-api-a1b2c3d4e5f6...
-```
-
-**Key Components:**
-- `runner.os`: OS isolation (linux, windows, macos)
-- `cache-key-prefix`: Workflow isolation (website, api, hygiene)
-- `hashFiles()`: Content-based invalidation
+There is **no** per-workflow cache prefix and there are **no** fallback restore keys. Every workflow shares one entry per cache.
 
 ---
 
@@ -497,7 +431,6 @@ jobs:
         uses: ./.github/actions/setup-workspace
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache-key-prefix: 'workflow-name'
 
       - name: 🏗️ Build
         run: npm run build
@@ -908,7 +841,7 @@ env:
 ```yaml
 - name: 🔍 Debug cache
   run: |
-    echo "Cache key: ${{ runner.os }}-node-${{ inputs.cache-key-prefix }}-${{ hashFiles('**/package-lock.json') }}"
+    echo "Cache key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}"
     echo "Lock file hash: $(sha256sum package-lock.json)"
 ```
 

--- a/.github/instructions/workflows.instructions.md
+++ b/.github/instructions/workflows.instructions.md
@@ -179,7 +179,7 @@ Full input tables: [`setup-tooling`](../actions/setup-tooling/readme.md), [`setu
 | Cache | Owner | Key |
 |-------|-------|-----|
 | `~/.npm`, `~/.nuget/packages`, pip | `setup-tooling` (built-in) | lock-file hashes |
-| `node_modules` | `setup-workspace` | `<os>-node-modules-<hash(package-lock.json)>` |
+| `node_modules` | `setup-workspace` | `<os>-node-modules-<node-version>-<hash(package-lock.json)>` |
 | `~/.cache/ms-playwright` | `setup-workspace` | `<os>-playwright-<hash(package-lock.json)>` |
 
 There is **no** per-workflow cache prefix and there are **no** fallback restore keys. Every workflow shares one entry per cache.
@@ -841,7 +841,7 @@ env:
 ```yaml
 - name: 🔍 Debug cache
   run: |
-    echo "Cache key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}"
+    echo "Cache key: ${{ runner.os }}-node-modules-${{ inputs.node-version }}-${{ hashFiles('package-lock.json') }}"
     echo "Lock file hash: $(sha256sum package-lock.json)"
 ```
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -33,6 +33,4 @@ jobs:
       - name: 🚀 Setup workspace
         uses: ./.github/actions/setup-workspace
         with:
-          node-version: "24"
-          dotnet-version: "10.0.x"
-          cache-key-prefix: "copilot-agent"
+          dotnet: "true"

--- a/.github/workflows/official-api-trigger.yml
+++ b/.github/workflows/official-api-trigger.yml
@@ -109,10 +109,10 @@ jobs:
       - name: 📦 Setup workspace
         uses: ./.github/actions/setup-workspace
         with:
-          dotnet-version: '10'
-          install-node-dependencies: 'false'
-          install-dotnet-dependencies: 'true'
-          cache-key-prefix: 'api'
+          node: 'false'
+          install-node-deps: 'false'
+          dotnet: 'true'
+          install-dotnet-deps: 'true'
 
       - name: 🧪 Running unit tests...
         working-directory: .
@@ -184,14 +184,6 @@ jobs:
           echo "│ 📅 Timestamp:     $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
           echo "└────────────────────────────────────────────────────────────┘"
           echo "::endgroup::"
-
-      - name: 📦 Setup workspace
-        uses: ./.github/actions/setup-workspace
-        with:
-          dotnet-version: '10.x'
-          install-node-dependencies: 'false'
-          install-dotnet-dependencies: 'false'
-          cache-key-prefix: 'api'
 
       - name: 🔒 Performing auth against Azure Public Cloud...
         uses: Azure/login@v3

--- a/.github/workflows/official-components-publish.yml
+++ b/.github/workflows/official-components-publish.yml
@@ -107,8 +107,6 @@ jobs:
         uses: ./.github/actions/setup-workspace
         with:
           node-version: ${{ env.NODE_VERSION }}
-          dotnet-version: ""
-          cache-key-prefix: "components"
 
       - name: 📋 Extract package information
         id: package-info
@@ -208,19 +206,16 @@ jobs:
           echo "└────────────────────────────────────────────────────────────┘"
           echo "::endgroup::"
 
-      - name: 📦 Setup Node.js with npm registry
-        uses: actions/setup-node@v7
+      - name: 📦 Setup workspace
+        uses: ./.github/actions/setup-workspace
         with:
           node-version: ${{ env.NODE_VERSION }}
-          registry-url: "https://registry.npmjs.org"
+          node-registry-url: "https://registry.npmjs.org"
 
-      # Ensure npm CLI is new enough for trusted publishing (11.5.1+)
+      # Ensure npm CLI is new enough for trusted publishing (11.5.1+).
+      # Kept in the workflow: this is publish-specific, not workspace bootstrap.
       - name: 🔄 Update npm to latest
         run: npm install -g npm@latest
-
-      - name: 📥 Install dependencies
-        run: npm ci
-        working-directory: .
 
       - name: 🏗️ Build package
         run: npm run build

--- a/.github/workflows/official-cv-trigger.yml
+++ b/.github/workflows/official-cv-trigger.yml
@@ -96,9 +96,6 @@ jobs:
 
       - name: 📦 Setup workspace
         uses: ./.github/actions/setup-workspace
-        with:
-          node-version: '24'
-          cache-key-prefix: 'cv'
 
       - name: 🧪 Running unit tests...
         working-directory: './sites/cv.arolariu.ro'
@@ -143,9 +140,6 @@ jobs:
 
       - name: 📦 Setup workspace
         uses: ./.github/actions/setup-workspace
-        with:
-          node-version: '24'
-          cache-key-prefix: 'cv'
 
       - name: 📦 Prepare and build...
         working-directory: './sites/cv.arolariu.ro'

--- a/.github/workflows/official-docs-trigger.yml
+++ b/.github/workflows/official-docs-trigger.yml
@@ -121,8 +121,7 @@ jobs:
           echo "Restoring the API graph root and installing DefaultDocumentation.Console + pydoc-markdown..."
           START_TIME=$(date +%s)
           dotnet restore sites/api.arolariu.ro/src/Core/arolariu.Backend.Core.csproj
-          dotnet tool install --global DefaultDocumentation.Console --version 1.2.4 || dotnet tool update --global DefaultDocumentation.Console --version 1.2.4
-          echo "${HOME}/.dotnet/tools" >> $GITHUB_PATH
+          dotnet tool restore
           python -m pip install --upgrade pip
           python -m pip install -r sites/exp.arolariu.ro/requirements-dev.txt
           END_TIME=$(date +%s)

--- a/.github/workflows/official-docs-trigger.yml
+++ b/.github/workflows/official-docs-trigger.yml
@@ -104,26 +104,17 @@ jobs:
       - name: 📦 Setup workspace
         uses: ./.github/actions/setup-workspace
         with:
-          dotnet-version: '10.0.x'
-          install-node-dependencies: 'true'
-          install-dotnet-dependencies: 'false'
-          cache-key-prefix: 'docs'
-
-      - name: 🐍 Setting up Python 3.12 for pydoc-markdown...
-        uses: actions/setup-python@v7
-        with:
-          python-version: '3.12'
-          cache: 'pip'
+          dotnet: 'true'
+          python: 'true'
+          install-python-deps: 'true'
 
       - name: "[DOCS::1/4] 🏗️ Installing documentation extractor dependencies..."
         run: |
           echo "::group::📦 Documentation Extractor Dependencies"
-          echo "Restoring the API graph root and installing DefaultDocumentation.Console + pydoc-markdown..."
+          echo "Restoring the API graph root and the DefaultDocumentation local tool..."
           START_TIME=$(date +%s)
           dotnet restore sites/api.arolariu.ro/src/Core/arolariu.Backend.Core.csproj
           dotnet tool restore
-          python -m pip install --upgrade pip
-          python -m pip install -r sites/exp.arolariu.ro/requirements-dev.txt
           END_TIME=$(date +%s)
           DURATION=$((END_TIME - START_TIME))
           echo "::notice::✅ Documentation extractor dependencies installed in ${DURATION}s"

--- a/.github/workflows/official-e2e-action.yml
+++ b/.github/workflows/official-e2e-action.yml
@@ -55,12 +55,8 @@ jobs:
       - name: 📥 Checkout repository
         uses: actions/checkout@v7
 
-      - name: 🚀 Setup workspace
-        uses: ./.github/actions/setup-workspace
-        with:
-          cache-key-prefix: "e2e"
-          dotnet-version: ""
-          node-version: "24"
+      - name: 🧰 Setup tooling
+        uses: ./.github/actions/setup-tooling
 
       - name: 🔍 Resolve run inputs
         id: resolve
@@ -120,10 +116,6 @@ jobs:
 
       - name: 🚀 Setup workspace
         uses: ./.github/actions/setup-workspace
-        with:
-          cache-key-prefix: "e2e"
-          dotnet-version: ""
-          node-version: "24"
 
       - name: 🌡️ Backend health check
         if: matrix.target == 'backend'
@@ -240,13 +232,8 @@ jobs:
       - name: 📥 Checkout repository
         uses: actions/checkout@v7
 
-      - name: 🚀 Setup workspace
-        uses: ./.github/actions/setup-workspace
-        with:
-          cache-key-prefix: "e2e"
-          dotnet-version: ""
-          install-node-dependencies: "false"
-          node-version: "24"
+      - name: 🧰 Setup tooling
+        uses: ./.github/actions/setup-tooling
 
       - name: 📥 Download E2E artifacts
         uses: actions/download-artifact@v8

--- a/.github/workflows/official-exp-trigger.yml
+++ b/.github/workflows/official-exp-trigger.yml
@@ -99,20 +99,13 @@ jobs:
           echo "└────────────────────────────────────────────────────────────┘"
           echo "::endgroup::"
 
-      # Note: .github/actions/setup-workspace is Node.js + .NET only.
-      # Python setup uses actions/setup-python directly with pip caching.
-      - name: 🐍 Setup Python
-        uses: actions/setup-python@v7
+      - name: 📦 Setup workspace
+        uses: ./.github/actions/setup-workspace
         with:
-          python-version: '3.12'
-          cache: 'pip'
-          cache-dependency-path: 'sites/exp.arolariu.ro/requirements.txt'
-
-      - name: 📦 Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install pytest pytest-cov ruff bandit
+          node: 'false'
+          install-node-deps: 'false'
+          python: 'true'
+          install-python-deps: 'true'
 
       - name: 🔍 Running lint checks...
         run: python -m ruff check .

--- a/.github/workflows/official-hygiene-check-v2.yml
+++ b/.github/workflows/official-hygiene-check-v2.yml
@@ -108,20 +108,18 @@ jobs:
           fetch-depth: 0
           ref: ${{ env.HEAD_REF }}
 
+      # Toolchains, dependency installs, and the component build are all
+      # driven from the matrix. `needs-dotnet` / `needs-python` are YAML
+      # booleans; interpolation renders them as the strings 'true'/'false',
+      # which is exactly what the composite action compares against.
       - name: 📦 Setup workspace
         uses: ./.github/actions/setup-workspace
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache-key-prefix: 'hygiene-${{ matrix.provider.id }}-${{ github.event.pull_request.number || github.run_id }}'
-          install-node-dependencies: 'true'
-
-      - name: 📦 Install scripts deps
-        working-directory: .github/scripts
-        run: npm ci
-
-      - name: 🔨 Build components package
-        if: matrix.provider.id == 'lint' || matrix.provider.id == 'test-typescript'
-        run: npm run build:components
+          install-scripts-deps: 'true'
+          run-build-components: ${{ matrix.provider.id == 'lint' || matrix.provider.id == 'test-typescript' }}
+          dotnet: ${{ matrix.provider.needs-dotnet }}
+          python: ${{ matrix.provider.needs-python }}
 
       - name: 🔧 SvelteKit sync (generates .svelte-kit/tsconfig.json required by eslint-plugin-n)
         if: matrix.provider.id == 'lint'
@@ -129,29 +127,17 @@ jobs:
         run: npx svelte-kit sync
         continue-on-error: true
 
-      - name: 📦 Setup .NET
-        if: matrix.provider.needs-dotnet
-        uses: actions/setup-dotnet@v6
-        with:
-          dotnet-version: '10.0.x'
-
-      - name: 📦 Restore .NET projects
+      # Kept out of setup-workspace on purpose: both installs are
+      # best-effort here. A transient restore failure must not fail the
+      # hygiene provider — the provider itself reports the real result.
+      - name: 📦 Restore .NET projects (best-effort)
         if: matrix.provider.needs-dotnet
         run: dotnet restore arolariu.slnx
         continue-on-error: true
 
-      - name: 📦 Setup Python
+      - name: 📦 Install Python dev deps (best-effort)
         if: matrix.provider.needs-python
-        uses: actions/setup-python@v7
-        with:
-          python-version: '3.x'
-          cache: 'pip'
-          cache-dependency-path: sites/exp.arolariu.ro/requirements-dev.txt
-
-      - name: 📦 Install Python dev deps
-        if: matrix.provider.needs-python
-        working-directory: sites/exp.arolariu.ro
-        run: python -m pip install -q -r requirements-dev.txt
+        run: python -m pip install -q -r sites/exp.arolariu.ro/requirements-dev.txt
         continue-on-error: true
 
       - name: 🚀 Run provider (${{ matrix.provider.id }})
@@ -189,12 +175,8 @@ jobs:
         uses: ./.github/actions/setup-workspace
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache-key-prefix: 'hygiene-gate-${{ github.event.pull_request.number || github.run_id }}'
-          install-node-dependencies: 'false'
-
-      - name: 📦 Install scripts deps
-        working-directory: .github/scripts
-        run: npm ci
+          install-node-deps: 'false'
+          install-scripts-deps: 'true'
 
       - name: 📥 Download all outcome artifacts
         uses: actions/download-artifact@v6

--- a/.github/workflows/official-status-probe.yml
+++ b/.github/workflows/official-status-probe.yml
@@ -49,9 +49,6 @@ jobs:
 
       - name: 📦 Setup workspace
         uses: ./.github/actions/setup-workspace
-        with:
-          node-version: '24'
-          cache-key-prefix: 'status-probe'
 
       - name: 🌲 Prepare status-data worktree (fetch or bootstrap orphan branch)
         run: |

--- a/.github/workflows/official-status-trigger.yml
+++ b/.github/workflows/official-status-trigger.yml
@@ -95,9 +95,6 @@ jobs:
 
       - name: 📦 Setup workspace
         uses: ./.github/actions/setup-workspace
-        with:
-          node-version: '24'
-          cache-key-prefix: 'status'
 
       - name: 🧪 Running unit tests...
         working-directory: './sites/status.arolariu.ro'
@@ -142,9 +139,6 @@ jobs:
 
       - name: 📦 Setup workspace
         uses: ./.github/actions/setup-workspace
-        with:
-          node-version: '24'
-          cache-key-prefix: 'status'
 
       - name: 📦 Prepare and build...
         working-directory: './sites/status.arolariu.ro'

--- a/.github/workflows/official-website-build.yml
+++ b/.github/workflows/official-website-build.yml
@@ -147,10 +147,9 @@ jobs:
       - name: 📦 Setup workspace
         uses: ./.github/actions/setup-workspace
         with:
-          node-version: '24'
-          playwright: 'true'
-          generate: 'true'
-          cache-key-prefix: 'website'
+          install-playwright: 'true'
+          run-generate: 'true'
+          run-build-components: 'true'
 
       - name: 🧬 TypeScript type-check (tsgo)
         working-directory: './sites/arolariu.ro'
@@ -306,9 +305,8 @@ jobs:
       - name: 📦 Setup workspace
         uses: ./.github/actions/setup-workspace
         with:
-          node-version: '24'
-          generate: 'true'
-          cache-key-prefix: 'website'
+          run-generate: 'true'
+          run-build-components: 'true'
 
       - name: 🔒 Performing auth against private Azure Container Registry...
         working-directory: '.'

--- a/docs/rfc/0001-github-actions-workflows.md
+++ b/docs/rfc/0001-github-actions-workflows.md
@@ -130,7 +130,7 @@ Toolchain caches (`~/.npm`, `~/.nuget/packages`, pip) are delegated entirely to 
 
 | Toolchain | Action | `cache-dependency-path` |
 |-----------|--------|------------------------|
-| Node.js (npm download cache) | `actions/setup-node@v7` | `package-lock.json` |
+| Node.js (npm download cache) | `actions/setup-node@v7` | `package-lock.json`, `.github/scripts/package-lock.json` |
 | .NET (NuGet) | `actions/setup-dotnet@v6` | `**/packages.lock.json` |
 | Python (pip) | `actions/setup-python@v7` | `sites/exp.arolariu.ro/requirements*.txt` |
 

--- a/docs/rfc/0001-github-actions-workflows.md
+++ b/docs/rfc/0001-github-actions-workflows.md
@@ -3,13 +3,13 @@
 - **Status**: Implemented
 - **Date**: 2025-10-22
 - **Authors**: arolariu
-- **Related Components**: `.github/workflows/`, `.github/actions/setup-workspace`
+- **Related Components**: `.github/workflows/`, `.github/actions/setup-tooling`, `.github/actions/setup-workspace`
 
 ---
 
 ## Abstract
 
-This RFC documents the comprehensive DevOps architecture for the arolariu.ro monorepo using GitHub Actions. The system implements a structured approach to CI/CD with distinct workflow patterns: **build-release workflows** for staged deployments with validation gates, and **trigger workflows** for direct build-and-deploy operations. All workflows leverage a centralized composite action (`setup-workspace`) for consistent environment setup, intelligent caching, and enhanced developer experience.
+This RFC documents the comprehensive DevOps architecture for the arolariu.ro monorepo using GitHub Actions. The system implements a structured approach to CI/CD with distinct workflow patterns: **build-release workflows** for staged deployments with validation gates, and **trigger workflows** for direct build-and-deploy operations. All workflows leverage two centralized composite actions — `setup-tooling` for language toolchains and `setup-workspace` for repository bootstrap — giving consistent environment setup, shared un-prefixed caching, and a single place to change a toolchain version.
 
 ---
 
@@ -101,39 +101,24 @@ Trigger (push/PR) → Lint → Format → Test → Report
 
 ## 3. Technical Design
 
-### 3.1 Composite Action: `setup-workspace`
+### 3.1 Composite Actions: setup-tooling and setup-workspace
 
 **Purpose:** Centralized environment setup for all workflows
 
-**Location:** `.github/actions/setup-workspace/`
+**Location:** `.github/actions/setup-tooling/`, `.github/actions/setup-workspace/`
 
-**Features:**
-- Node.js setup with version control
-- .NET setup with version control
-- Intelligent dependency caching (hash-based, no fallback)
-- Playwright browser installation
-- GraphQL artifact generation
-- Progress indicators with emojis
+| Action | Responsibility |
+|--------|----------------|
+| `setup-tooling` | Installs Node.js / .NET / Python. Repo-agnostic. Caching is delegated to each `setup-*` action's built-in mechanism |
+| `setup-workspace` | Invokes `setup-tooling`, then bootstraps the repo: `npm ci`, `dotnet restore`, `pip install`, Playwright, `npm run generate`, `npm run build:components` |
 
-**Inputs:**
-```yaml
-inputs:
-  node-version:                    # Node.js version (default: '24')
-  dotnet-version:                  # .NET version (default: '10.x')
-  install-node-dependencies:       # Toggle npm install (default: 'true')
-  install-dotnet-dependencies:     # Toggle dotnet restore (default: 'true')
-  cache-key-prefix:                # Workflow-specific cache key (e.g., 'website', 'api')
-  working-directory:               # Custom directory for npm commands (default: '.')
-  playwright:                      # Install Playwright browsers (default: 'false')
-  generate:                        # Run npm run generate (default: 'false')
-```
+Use `setup-tooling` when a job needs only a binary. Use `setup-workspace` for everything else.
 
-**Outputs:**
-```yaml
-outputs:
-  node-cache-hit:      # Whether Node.js cache was hit (true/false)
-  dotnet-cache-hit:    # Whether .NET cache was hit (true/false)
-```
+| Cache | Owner | Key |
+|-------|-------|-----|
+| `~/.npm`, `~/.nuget/packages`, pip | `setup-tooling` (built-in) | lock-file hashes |
+| `node_modules` | `setup-workspace` | `<os>-node-modules-<hash(package-lock.json)>` |
+| `~/.cache/ms-playwright` | `setup-workspace` | `<os>-playwright-<hash(package-lock.json)>` |
 
 ### 3.2 Caching Strategy
 
@@ -240,7 +225,6 @@ jobs:
         uses: ./.github/actions/setup-workspace
         with:
           node-version: '24'
-          cache-key-prefix: 'workflow-name'
           # ... other inputs
       
       - name: 🏗️ Build
@@ -386,21 +370,18 @@ Trigger: PR
 
 ### 6.1 Cache Key Generation
 
-**Node.js:**
+**Node.js (node_modules):**
 ```yaml
-key: ${{ runner.os }}-node-${{ inputs.cache-key-prefix }}-${{ hashFiles('**/package-lock.json') }}
+key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
 ```
 
 **Components:**
 - `${{ runner.os }}`: OS-specific (linux, windows, macos)
-- `${{ inputs.cache-key-prefix }}`: Workflow identifier (website, api, hygiene, etc.)
-- `${{ hashFiles('**/package-lock.json') }}`: SHA-256 hash of all package-lock.json files
+- `${{ hashFiles('package-lock.json') }}`: SHA-256 hash of the root `package-lock.json`
 
 **Example:**
 ```
-linux-node-website-7f3e9a2c1b5d4...
-linux-node-api-a1b2c3d4e5f6...
-linux-node-hygiene-9e8d7c6b5a4...
+linux-node-modules-7f3e9a2c1b5d4...
 ```
 
 ### 6.2 Progress Indicators
@@ -440,9 +421,7 @@ The composite action provides clear visual feedback:
 - name: 🚀 Setup workspace
   uses: ./.github/actions/setup-workspace
   with:
-    node-version: '24'
-    generate: 'true'  # Generates GraphQL types, schemas, etc.
-    cache-key-prefix: 'website'
+    run-generate: 'true'  # Generates GraphQL types, schemas, etc.
 
 - name: 🏗️ Build website
   run: npm run build  # Can now use generated GraphQL types
@@ -535,7 +514,8 @@ The composite action provides clear visual feedback:
 ## 10. Related Documentation
 
 ### 10.1 Internal Documentation
-- `.github/actions/setup-workspace/README.md` - Composite action usage guide
+- `.github/actions/setup-tooling/readme.md` - setup-tooling usage guide
+- `.github/actions/setup-workspace/readme.md` - setup-workspace usage guide
 - `.github/instructions/workflows.instructions.md` - Workflow development guidelines
 
 ### 10.2 External References

--- a/docs/rfc/0001-github-actions-workflows.md
+++ b/docs/rfc/0001-github-actions-workflows.md
@@ -117,7 +117,7 @@ Use `setup-tooling` when a job needs only a binary. Use `setup-workspace` for ev
 | Cache | Owner | Key |
 |-------|-------|-----|
 | `~/.npm`, `~/.nuget/packages`, pip | `setup-tooling` (built-in) | lock-file hashes |
-| `node_modules` | `setup-workspace` | `<os>-node-modules-<hash(package-lock.json)>` |
+| `node_modules` | `setup-workspace` | `<os>-node-modules-<node-version>-<hash(package-lock.json)>` |
 | `~/.cache/ms-playwright` | `setup-workspace` | `<os>-playwright-<hash(package-lock.json)>` |
 
 ### 3.2 Caching Strategy
@@ -142,9 +142,14 @@ Workspace caches use explicit `actions/cache@v5` steps. The keys below are copie
 
 **node_modules:**
 ```yaml
-key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
+key: ${{ runner.os }}-node-modules-${{ inputs.node-version }}-${{ hashFiles('package-lock.json') }}
 ```
-Example: `linux-node-modules-a3f9b2c1d4e5...`
+Example: `linux-node-modules-24-a3f9b2c1d4e5...`
+
+The Node version is part of the key because `node_modules` can contain
+natively-compiled addons whose ABI is tied to the runtime. A cache hit skips
+`npm ci`, so nothing would rebuild them — bumping Node must invalidate the
+cache rather than restore binaries built for the previous runtime.
 
 **Playwright browser bundle (`~/.cache/ms-playwright`):**
 ```yaml
@@ -152,8 +157,12 @@ key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
 ```
 Example: `linux-playwright-b7e4c9a2f1d8...`
 
+The Playwright key omits the Node version deliberately: the cached artifacts
+are browser binaries, not Node addons, and the Playwright version that governs
+them is already pinned by the lock file.
+
 **Behavior (both caches):**
-- **Cache hit**: When `package-lock.json` hasn't changed
+- **Cache hit**: When `package-lock.json` hasn't changed (and, for `node_modules`, the Node version is unchanged)
 - **Cache miss**: When `package-lock.json` changes (due to package updates)
 - **No fallback**: Ensures fresh installation when dependencies change
 
@@ -161,25 +170,28 @@ Example: `linux-playwright-b7e4c9a2f1d8...`
 
 **Problem with fallback keys:**
 ```yaml
-# DANGEROUS (old approach)
-key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
+# DANGEROUS (what we deliberately do NOT do)
+key: ${{ runner.os }}-node-modules-${{ inputs.node-version }}-${{ hashFiles('package-lock.json') }}
 restore-keys: |
+  linux-node-modules-24-
   linux-node-modules-
-  linux-node-
 ```
 
+Note the key itself is the current one — the hazard below comes entirely from
+the `restore-keys` stanza, not from the key format.
+
 **Scenario that fails:**
-1. Dev pushes feature → Cache created: `linux-node-modules-hash123`
+1. Dev pushes feature → Cache created: `linux-node-modules-24-hash123`
 2. 3 days later, dev updates `package.json` (version bump)
 3. BUT doesn't regenerate `package-lock.json` (edge case)
 4. Workflow runs → Primary key misses
-5. Fallback `linux-node-modules-` hits old cache! ❌
+5. Fallback `linux-node-modules-24-` hits old cache! ❌
 6. Build fails with incompatible dependencies ❌
 
 **Solution (current approach):**
 ```yaml
 # SAFE (current approach)
-key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
+key: ${{ runner.os }}-node-modules-${{ inputs.node-version }}-${{ hashFiles('package-lock.json') }}
 # NO restore-keys
 ```
 
@@ -383,16 +395,17 @@ Trigger: PR
 
 **Node.js (node_modules):**
 ```yaml
-key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
+key: ${{ runner.os }}-node-modules-${{ inputs.node-version }}-${{ hashFiles('package-lock.json') }}
 ```
 
 **Components:**
 - `${{ runner.os }}`: OS-specific (linux, windows, macos)
+- `${{ inputs.node-version }}`: guards against restoring native addons built for a different Node ABI
 - `${{ hashFiles('package-lock.json') }}`: SHA-256 hash of the root `package-lock.json`
 
 **Example:**
 ```
-linux-node-modules-7f3e9a2c1b5d4...
+linux-node-modules-24-7f3e9a2c1b5d4...
 ```
 
 ### 6.2 Progress Indicators

--- a/docs/rfc/0001-github-actions-workflows.md
+++ b/docs/rfc/0001-github-actions-workflows.md
@@ -163,7 +163,7 @@ them is already pinned by the lock file.
 
 **Behavior (both caches):**
 - **Cache hit**: When `package-lock.json` hasn't changed (and, for `node_modules`, the Node version is unchanged)
-- **Cache miss**: When `package-lock.json` changes (due to package updates)
+- **Cache miss**: When `package-lock.json` changes (due to package updates), or — for `node_modules` — when the Node version is bumped
 - **No fallback**: Ensures fresh installation when dependencies change
 
 #### **Why No Fallback Keys?**

--- a/docs/rfc/0001-github-actions-workflows.md
+++ b/docs/rfc/0001-github-actions-workflows.md
@@ -124,58 +124,69 @@ Use `setup-tooling` when a job needs only a binary. Use `setup-workspace` for ev
 
 **Philosophy:** Hash-based exact matching, no fallback keys
 
-#### **Node.js Caching**
-```yaml
-Cache Key: {os}-node-{workflow}-{hash(package-lock.json)}
-Example: linux-node-website-a3f9b2c1d4e5...
-```
+#### **Toolchain Caches (setup-tooling)**
 
-**Behavior:**
+Toolchain caches (`~/.npm`, `~/.nuget/packages`, pip) are delegated entirely to each `actions/setup-*` action's built-in mechanism. The `setup-tooling` action configures each with a `cache-dependency-path` pointing at the relevant lock file:
+
+| Toolchain | Action | `cache-dependency-path` |
+|-----------|--------|------------------------|
+| Node.js (npm download cache) | `actions/setup-node@v7` | `package-lock.json` |
+| .NET (NuGet) | `actions/setup-dotnet@v6` | `**/packages.lock.json` |
+| Python (pip) | `actions/setup-python@v7` | `sites/exp.arolariu.ro/requirements*.txt` |
+
+The exact key strings are generated internally by each `setup-*` action; no per-workflow segment is added.
+
+#### **Workspace Caches (setup-workspace)**
+
+Workspace caches use explicit `actions/cache@v5` steps. The keys below are copied verbatim from `setup-workspace/action.yml`:
+
+**node_modules:**
+```yaml
+key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
+```
+Example: `linux-node-modules-a3f9b2c1d4e5...`
+
+**Playwright browser bundle (`~/.cache/ms-playwright`):**
+```yaml
+key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+```
+Example: `linux-playwright-b7e4c9a2f1d8...`
+
+**Behavior (both caches):**
 - **Cache hit**: When `package-lock.json` hasn't changed
 - **Cache miss**: When `package-lock.json` changes (due to package updates)
 - **No fallback**: Ensures fresh installation when dependencies change
-
-#### **.NET Caching**
-```yaml
-Cache Key: {os}-dotnet-{workflow}-{hash(*.csproj, *.slnx, packages.lock.json)}
-Example: linux-dotnet-api-b7e4c9a2f1d8...
-```
-
-**Behavior:**
-- **Cache hit**: When project files and lock files haven't changed
-- **Cache miss**: When any .csproj, .slnx, or packages.lock.json changes
-- **No fallback**: Ensures fresh restoration when dependencies change
 
 #### **Why No Fallback Keys?**
 
 **Problem with fallback keys:**
 ```yaml
 # DANGEROUS (old approach)
-key: linux-node-website-{hash}
+key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
 restore-keys: |
-  linux-node-website-
+  linux-node-modules-
   linux-node-
 ```
 
 **Scenario that fails:**
-1. Dev pushes feature → Cache created: `linux-node-website-hash123`
+1. Dev pushes feature → Cache created: `linux-node-modules-hash123`
 2. 3 days later, dev updates `package.json` (version bump)
 3. BUT doesn't regenerate `package-lock.json` (edge case)
 4. Workflow runs → Primary key misses
-5. Fallback `linux-node-website-` hits old cache! ❌
+5. Fallback `linux-node-modules-` hits old cache! ❌
 6. Build fails with incompatible dependencies ❌
 
 **Solution (current approach):**
 ```yaml
 # SAFE (current approach)
-key: linux-node-website-{hash}
+key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
 # NO restore-keys
 ```
 
 **Benefits:**
 - ✅ No stale cache reuse when lock files are out of sync
 - ✅ Forces fresh installation when dependencies change
-- ✅ Prevents cache pollution between workflows
+- ✅ All workflows share one cache entry per lock-file state (no per-workflow copies)
 - ✅ Clear: cache hit = exact match, cache miss = fresh install
 
 **Trade-off:**
@@ -467,7 +478,7 @@ The composite action provides clear visual feedback:
 **Current Approach:**
 - Hash-based keys prevent cache poisoning
 - No cross-workflow cache sharing via fallback keys
-- Workflow-scoped prefixes for isolation
+- Shared un-prefixed keys — all workflows use one cache entry per lock-file state; no fallback restore keys prevent stale-dependency propagation
 
 **Benefits:**
 - Malicious cached dependencies cannot spread between workflows

--- a/scripts/docs-assemble.test.ts
+++ b/scripts/docs-assemble.test.ts
@@ -10,6 +10,7 @@ import {
   findDotnetBuildRoots,
   assertExpectedDocumentationTiers,
   getDefaultDocumentationArgs,
+  getDefaultDocumentationCommand,
 } from './docs-assemble';
 
 describe('syncProse', () => {
@@ -254,5 +255,22 @@ describe('DefaultDocumentation arguments', () => {
       'Internal',
       'Private',
     ]);
+  });
+});
+
+describe('DefaultDocumentation invocation', () => {
+  it('invokes the tool through the dotnet driver, not a bare PATH executable', () => {
+    const {command, args} = getDefaultDocumentationCommand('api.dll', 'out');
+
+    // Local tools declared in .config/dotnet-tools.json are resolved by the
+    // dotnet driver and are never placed on PATH.
+    expect(command).toBe('dotnet');
+    expect(args[0]).toBe('defaultdocumentation');
+  });
+
+  it('forwards the full generator argument list after the tool name', () => {
+    const {args} = getDefaultDocumentationCommand('api.dll', 'out');
+
+    expect(args.slice(1)).toEqual(getDefaultDocumentationArgs('api.dll', 'out'));
   });
 });

--- a/scripts/docs-assemble.ts
+++ b/scripts/docs-assemble.ts
@@ -42,9 +42,10 @@ const DOTNET_TFM = 'net10.0';
  * Commands that, on Windows, ship as `.cmd` shims rather than real
  * `.exe` binaries. `spawn` can't locate those without either the
  * explicit `.cmd` extension or `shell: true`, so we reserve
- * `shell: true` exclusively for this set. Everything else (dotnet,
- * python, DefaultDocumentation) is a real executable on PATH and
- * runs faster + safer without cmd.exe in between.
+ * `shell: true` exclusively for this set. Everything else (`dotnet`,
+ * `python`) is a real executable on PATH and runs faster + safer
+ * without cmd.exe in between. DefaultDocumentation is no longer
+ * spawned directly — it is a local tool invoked through `dotnet`.
  */
 const NPM_FAMILY_COMMANDS = new Set(['npm', 'npx', 'node']);
 
@@ -337,6 +338,29 @@ export function getDefaultDocumentationArgs(dll: string, outDir: string): readon
 }
 
 /**
+ * Build the full command + arguments for invoking DefaultDocumentation.
+ *
+ * @remarks
+ * `DefaultDocumentation.Console` is declared as a **local** tool in
+ * `.config/dotnet-tools.json` and restored with `dotnet tool restore`.
+ * Local tools are resolved by the dotnet driver and are never placed on
+ * `PATH`, so they must be invoked as `dotnet <command>`. The command name
+ * is LOWERCASE (`defaultdocumentation`) — NuGet registers tool commands in
+ * lower case regardless of the package name's casing, and Linux file
+ * systems enforce that strictly.
+ *
+ * @param dll - Absolute path to the compiled assembly.
+ * @param outDir - Absolute output directory for generated markdown.
+ * @returns The command and arguments to spawn.
+ */
+export function getDefaultDocumentationCommand(
+  dll: string,
+  outDir: string,
+): {readonly command: string; readonly args: readonly string[]} {
+  return {command: 'dotnet', args: ['defaultdocumentation', ...getDefaultDocumentationArgs(dll, outDir)]};
+}
+
+/**
  * Discover every `.csproj` under `api.arolariu.ro/src/`, build the
  * minimum set of graph roots with one `dotnet build` call each (so
  * MSBuild covers the whole graph via ProjectReference transitivity),
@@ -355,20 +379,10 @@ async function runDotnetInternals(): Promise<string> {
     const outDir = join(DOTNET_INTERNALS_DIR, proj.assemblyName);
     mkdirSync(outDir, {recursive: true});
     const dll = join(API_ROOT, proj.binRelative, `${proj.assemblyName}.dll`);
-    // DefaultDocumentation.Console is installed globally (via `dotnet tool
-    // install --global`) — see sites/docs.arolariu.ro/README.md for the
-    // one-time local setup command. The invocable name is LOWERCASE
-    // (`defaultdocumentation`) — NuGet registers tool commands in lower
-    // case regardless of the package name's casing, and Linux file
-    // systems enforce that strictly. Windows' case-insensitive file
-    // system masks a PascalCase call here, so a mixed-case spelling
-    // silently works locally and only breaks on Linux CI.
-    log += await runCommand(
-      'defaultdocumentation',
-      getDefaultDocumentationArgs(dll, outDir),
-      API_ROOT,
-      {buffered: true},
-    );
+    // DefaultDocumentation.Console is declared as a **local** tool in
+    // `.config/dotnet-tools.json` and restored with `dotnet tool restore`.
+    const {command, args} = getDefaultDocumentationCommand(dll, outDir);
+    log += await runCommand(command, args, API_ROOT, {buffered: true});
   }
   assertNonEmpty(DOTNET_INTERNALS_DIR, 'defaultdocumentation');
   return log;

--- a/sites/docs.arolariu.ro/README.md
+++ b/sites/docs.arolariu.ro/README.md
@@ -82,17 +82,15 @@ so MSBuild compiles the full assembly set in one pass.
 npm install                                                        # from repo root
 dotnet restore sites/api.arolariu.ro/src/Core/arolariu.Backend.Core.csproj
 python -m pip install -r sites/exp.arolariu.ro/requirements-dev.txt
-dotnet tool update --global DefaultDocumentation.Console --version 1.2.4
+dotnet tool restore                                                # from repo root
 ```
 
-After the global install, verify `defaultdocumentation` (lowercase —
-that's the invocable command NuGet registers regardless of the
-`DefaultDocumentation.Console` package casing) is on your `PATH`. The
-dotnet CLI places global tools at `~/.dotnet/tools` on Unix and
-`%USERPROFILE%\.dotnet\tools` on Windows — add that directory to PATH
-if it isn't already. The orchestrator spawns the lowercase name
-because Linux file systems are case-sensitive; a PascalCase spelling
-silently works on Windows and then breaks in CI.
+`DefaultDocumentation.Console` is declared as a **local** tool in
+`.config/dotnet-tools.json`, so `dotnet tool restore` is all that is
+needed — there is no global install and nothing to add to `PATH`. The
+orchestrator invokes it as `dotnet defaultdocumentation` (lowercase;
+NuGet registers tool commands in lower case regardless of the package
+name's casing, and Linux file systems enforce that strictly).
 
 **Everyday commands** (from the repo root):
 

--- a/sites/exp.arolariu.ro/AGENTS.md
+++ b/sites/exp.arolariu.ro/AGENTS.md
@@ -9,11 +9,17 @@ Configuration proxy and feature flag service for the arolariu.ro platform.
 ## Commands
 
 ```bash
-python -m ruff check .      # Lint (Ruff)
+python -m ruff check .       # Lint (Ruff)
 python -m pytest -q          # Run tests
-pip install -r requirements-dev.txt   # Install deps (dev: adds pytest, pytest-cov, ruff, bandit, pydoc-markdown)
-pip install -r requirements.txt       # Install runtime deps only
 uvicorn main:app --reload    # Dev server
+```
+
+Installing dependencies — pick **one**, not both. `requirements-dev.txt`
+starts with `-r requirements.txt`, so it is a superset:
+
+```bash
+pip install -r requirements-dev.txt   # Development: runtime + pytest, pytest-cov, ruff, bandit, pydoc-markdown
+pip install -r requirements.txt       # Runtime only (what the Docker image installs)
 ```
 
 ## API Endpoints

--- a/sites/exp.arolariu.ro/AGENTS.md
+++ b/sites/exp.arolariu.ro/AGENTS.md
@@ -11,7 +11,8 @@ Configuration proxy and feature flag service for the arolariu.ro platform.
 ```bash
 python -m ruff check .      # Lint (Ruff)
 python -m pytest -q          # Run tests
-pip install -r requirements.txt  # Install deps
+pip install -r requirements-dev.txt   # Install deps (dev: adds pytest, pytest-cov, ruff, bandit, pydoc-markdown)
+pip install -r requirements.txt       # Install runtime deps only
 uvicorn main:app --reload    # Dev server
 ```
 

--- a/sites/exp.arolariu.ro/requirements-dev.txt
+++ b/sites/exp.arolariu.ro/requirements-dev.txt
@@ -2,5 +2,7 @@
 # Install locally: pip install -r requirements-dev.txt
 -r requirements.txt
 pytest==9.1.1
+pytest-cov==7.1.0
 ruff==0.16.0
+bandit==1.9.4
 pydoc-markdown==4.8.2


### PR DESCRIPTION
This pull request introduces a new reusable GitHub Action, `setup-tooling`, for setting up language toolchains (Node.js, .NET, Python) in the monorepo. The action is designed to be repo-agnostic, focusing solely on installing binaries and leveraging built-in dependency caching. The PR also provides comprehensive documentation and configuration for the action.

The most important changes are:

**New GitHub Action: Toolchain Setup**
- Added `.github/actions/setup-tooling/action.yml`, a composite action that installs Node.js, .NET SDK, and Python toolchains with optional built-in dependency caching and flexible configuration for each toolchain.
- Outputs cache hit status for each toolchain, allowing downstream jobs to react to cache restores.

**Documentation**
- Added `.github/actions/setup-tooling/readme.md` with detailed usage instructions, input/output descriptions, and caching model explanations, making it easy for team members to adopt the action correctly.

**.NET Tooling Support**
- Introduced `.config/dotnet-tools.json` to track and configure .NET CLI tools, specifically registering `defaultdocumentation.console` for documentation generation.