### PR TITLE
feat: stop emitting telemetry for health and connectivity endpoints

### DIFF
--- a/sites/api.arolariu.ro/Directory.Packages.props
+++ b/sites/api.arolariu.ro/Directory.Packages.props
@@ -70,6 +70,7 @@
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.17.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.17.0-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.17.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.17.0" />
   </ItemGroup>
   <ItemGroup Label="Application Insights Packages">

--- a/sites/api.arolariu.ro/src/Common/Telemetry/HealthTelemetryPolicy.cs
+++ b/sites/api.arolariu.ro/src/Common/Telemetry/HealthTelemetryPolicy.cs
@@ -1,6 +1,9 @@
 namespace arolariu.Backend.Common.Telemetry;
 
 using System;
+using System.Net.Http;
+
+using Microsoft.AspNetCore.Http;
 
 /// <summary>
 /// Central policy deciding whether OpenTelemetry signals should be suppressed for a request path.
@@ -76,6 +79,38 @@ public static class HealthTelemetryPolicy
   /// <remarks>Fails open: any unexpected condition resolves to emitting telemetry.</remarks>
   public static bool ShouldSuppress(string? path) =>
     IsSuppressionEnabled && IsSuppressedPath(path);
+
+  /// <summary>
+  /// Returns <see langword="true"/> when the request represented by <paramref name="context"/>
+  /// should be included in distributed traces.
+  /// </summary>
+  /// <param name="context">The incoming ASP.NET Core HTTP context.</param>
+  /// <returns>
+  /// <see langword="false"/> when the request targets a suppressed health probe path;
+  /// <see langword="true"/> otherwise.
+  /// </returns>
+  /// <remarks>
+  /// Intended for use as the <c>AspNetCoreTraceInstrumentationOptions.Filter</c> method group.
+  /// Fails open: a null context resolves to <see langword="true"/> (record the activity).
+  /// </remarks>
+  public static bool ShouldRecordHttpContext(HttpContext context) =>
+    !ShouldSuppress(context?.Request.Path.Value);
+
+  /// <summary>
+  /// Returns <see langword="true"/> when the outbound request represented by
+  /// <paramref name="request"/> should be included in distributed traces.
+  /// </summary>
+  /// <param name="request">The outbound <see cref="HttpRequestMessage"/>.</param>
+  /// <returns>
+  /// <see langword="false"/> when the request targets a suppressed health probe path;
+  /// <see langword="true"/> otherwise.
+  /// </returns>
+  /// <remarks>
+  /// Intended for use as the <c>HttpClientTraceInstrumentationOptions.FilterHttpRequestMessage</c>
+  /// method group. Fails open: a null request resolves to <see langword="true"/> (record the activity).
+  /// </remarks>
+  public static bool ShouldRecordHttpRequestMessage(HttpRequestMessage request) =>
+    !ShouldSuppress(request?.RequestUri?.AbsolutePath);
 
   private static string Normalize(string path)
   {

--- a/sites/api.arolariu.ro/src/Common/Telemetry/HealthTelemetryPolicy.cs
+++ b/sites/api.arolariu.ro/src/Common/Telemetry/HealthTelemetryPolicy.cs
@@ -1,0 +1,86 @@
+namespace arolariu.Backend.Common.Telemetry;
+
+using System;
+
+/// <summary>
+/// Central policy deciding whether OpenTelemetry signals should be suppressed for a request path.
+/// </summary>
+/// <remarks>
+/// Health and connectivity probes dominate request volume without carrying diagnostic value.
+/// This policy is consulted by trace filters, the suppression middleware, and log filtering so
+/// that the suppressed path list is defined exactly once for this service.
+/// </remarks>
+public static class HealthTelemetryPolicy
+{
+  /// <summary>
+  /// The environment variable controlling whether health telemetry suppression is active.
+  /// </summary>
+  /// <remarks>Defaults to enabled. Only the literal value <c>false</c> disables suppression.</remarks>
+  public const string SuppressionEnvVar = "OTEL_SUPPRESS_HEALTH_TELEMETRY";
+
+  private static readonly string[] SuppressedPaths = ["/health", "/api/health", "/api/ready"];
+
+  /// <summary>
+  /// Gets a value indicating whether suppression is enabled for the current process.
+  /// </summary>
+  /// <value><see langword="true"/> unless <see cref="SuppressionEnvVar"/> is set to <c>false</c>.</value>
+  public static bool IsSuppressionEnabled { get; } =
+    ParseSuppressionFlag(Environment.GetEnvironmentVariable(SuppressionEnvVar));
+
+  /// <summary>
+  /// Determines whether the supplied path is one of the suppressed health endpoints.
+  /// </summary>
+  /// <param name="path">The request path, with or without a query string.</param>
+  /// <returns><see langword="true"/> when the path matches a suppressed endpoint.</returns>
+  /// <remarks>Matching is exact on the normalized path, never prefix-based.</remarks>
+  public static bool IsSuppressedPath(string? path)
+  {
+    if (string.IsNullOrWhiteSpace(path))
+    {
+      return false;
+    }
+
+    var normalized = Normalize(path);
+    foreach (var candidate in SuppressedPaths)
+    {
+      if (string.Equals(normalized, candidate, StringComparison.OrdinalIgnoreCase))
+      {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /// <summary>
+  /// Parses the raw suppression environment variable value.
+  /// </summary>
+  /// <param name="rawValue">The raw environment variable value, possibly null or malformed.</param>
+  /// <returns><see langword="false"/> only when <paramref name="rawValue"/> parses as <c>false</c>.</returns>
+  /// <remarks>Unset and unparseable values resolve to the safe default of enabled suppression.</remarks>
+  public static bool ParseSuppressionFlag(string? rawValue)
+  {
+    if (string.IsNullOrWhiteSpace(rawValue))
+    {
+      return true;
+    }
+
+    return !bool.TryParse(rawValue, out var parsed) || parsed;
+  }
+
+  /// <summary>
+  /// Determines whether telemetry should be suppressed for the supplied path.
+  /// </summary>
+  /// <param name="path">The request path, with or without a query string.</param>
+  /// <returns><see langword="true"/> when telemetry must be suppressed.</returns>
+  /// <remarks>Fails open: any unexpected condition resolves to emitting telemetry.</remarks>
+  public static bool ShouldSuppress(string? path) =>
+    IsSuppressionEnabled && IsSuppressedPath(path);
+
+  private static string Normalize(string path)
+  {
+    var queryIndex = path.IndexOf('?', StringComparison.Ordinal);
+    var withoutQuery = queryIndex >= 0 ? path[..queryIndex] : path;
+    return withoutQuery.Length > 1 ? withoutQuery.TrimEnd('/') : withoutQuery;
+  }
+}

--- a/sites/api.arolariu.ro/src/Common/Telemetry/Logging/LoggingExtensions.cs
+++ b/sites/api.arolariu.ro/src/Common/Telemetry/Logging/LoggingExtensions.cs
@@ -67,14 +67,16 @@ public static class LoggingExtensions
       .GetApplicationOptions()
       .ApplicationInsightsEndpoint ?? string.Empty;
 
-    // Health probes drive the majority of hosting-diagnostics log volume and carry no
-    // diagnostic value. Scoped to the OTel provider so console logging is untouched.
+    // Health check execution logs carry no diagnostic value at Information level and are
+    // dominated by probe traffic. Scoped to the OTel provider so console logging is untouched.
+    //
+    // Only the HealthChecks category is filtered. ILogger filters match on category and level,
+    // never on request path, so filtering Microsoft.AspNetCore.Hosting.Diagnostics or
+    // Routing.EndpointMiddleware would strip request logs for EVERY route, not just probes.
+    // Those categories are already at Warning via appsettings.json, so filtering them here
+    // would be a no-op today and an over-reach the moment someone lowers that level to debug.
     if (HealthTelemetryPolicy.IsSuppressionEnabled)
     {
-      builder.Logging.AddFilter<OpenTelemetryLoggerProvider>(
-        "Microsoft.AspNetCore.Hosting.Diagnostics", LogLevel.Warning);
-      builder.Logging.AddFilter<OpenTelemetryLoggerProvider>(
-        "Microsoft.AspNetCore.Routing.EndpointMiddleware", LogLevel.Warning);
       builder.Logging.AddFilter<OpenTelemetryLoggerProvider>(
         "Microsoft.Extensions.Diagnostics.HealthChecks", LogLevel.Warning);
     }

--- a/sites/api.arolariu.ro/src/Common/Telemetry/Logging/LoggingExtensions.cs
+++ b/sites/api.arolariu.ro/src/Common/Telemetry/Logging/LoggingExtensions.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 
 using arolariu.Backend.Common.Azure;
 using arolariu.Backend.Common.Options;
+using arolariu.Backend.Common.Telemetry;
 
 using global::Azure.Monitor.OpenTelemetry.Exporter;
 
@@ -65,6 +66,18 @@ public static class LoggingExtensions
       .GetRequiredService<IOptionsManager>()
       .GetApplicationOptions()
       .ApplicationInsightsEndpoint ?? string.Empty;
+
+    // Health probes drive the majority of hosting-diagnostics log volume and carry no
+    // diagnostic value. Scoped to the OTel provider so console logging is untouched.
+    if (HealthTelemetryPolicy.IsSuppressionEnabled)
+    {
+      builder.Logging.AddFilter<OpenTelemetryLoggerProvider>(
+        "Microsoft.AspNetCore.Hosting.Diagnostics", LogLevel.Warning);
+      builder.Logging.AddFilter<OpenTelemetryLoggerProvider>(
+        "Microsoft.AspNetCore.Routing.EndpointMiddleware", LogLevel.Warning);
+      builder.Logging.AddFilter<OpenTelemetryLoggerProvider>(
+        "Microsoft.Extensions.Diagnostics.HealthChecks", LogLevel.Warning);
+    }
 
     builder.Logging.AddOpenTelemetry(otelOptions =>
     {

--- a/sites/api.arolariu.ro/src/Common/Telemetry/Metering/HealthCheckMetrics.cs
+++ b/sites/api.arolariu.ro/src/Common/Telemetry/Metering/HealthCheckMetrics.cs
@@ -1,0 +1,53 @@
+namespace arolariu.Backend.Common.Telemetry.Metering;
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+
+/// <summary>
+/// Emits the single always-on signal that survives health telemetry suppression.
+/// </summary>
+/// <remarks>
+/// All other health telemetry is dropped. This counter stays enabled because its volume is
+/// effectively zero until a dependency actually fails. The metric name is deliberately shared
+/// verbatim with the website and exp services so a single query spans the estate; the
+/// <c>service.name</c> resource attribute distinguishes the source.
+/// </remarks>
+public static class HealthCheckMetrics
+{
+  /// <summary>
+  /// The <see cref="Microsoft.AspNetCore.Http.HttpContext.Items"/> key used to hand failing
+  /// check names from the health check response writer to the suppression middleware.
+  /// </summary>
+  public const string FailedChecksItemKey = "arolariu.health.failed-checks";
+
+  /// <summary>
+  /// The exported metric name.
+  /// </summary>
+  public const string MetricName = "arolariu.health.check.failures";
+
+  private static readonly Counter<long> FailureCounter =
+    MeterGenerators.CoreMeter.CreateCounter<long>(
+      MetricName,
+      unit: "{failure}",
+      description: "Health check failures, dimensioned by the failing check name.");
+
+  /// <summary>
+  /// Records one measurement per failing health check.
+  /// </summary>
+  /// <param name="failedCheckNames">The names of the health checks that reported failure.</param>
+  /// <exception cref="ArgumentNullException">Thrown when <paramref name="failedCheckNames"/> is null.</exception>
+  /// <remarks>
+  /// Must be called outside any active <c>SuppressInstrumentationScope</c>, otherwise the
+  /// measurement may be discarded along with the suppressed request telemetry.
+  /// </remarks>
+  public static void RecordFailures(IEnumerable<string> failedCheckNames)
+  {
+    ArgumentNullException.ThrowIfNull(failedCheckNames);
+
+    foreach (var checkName in failedCheckNames)
+    {
+      FailureCounter.Add(1, new KeyValuePair<string, object?>("check", checkName));
+    }
+  }
+}

--- a/sites/api.arolariu.ro/src/Common/Telemetry/Tracing/TracingExtensions.cs
+++ b/sites/api.arolariu.ro/src/Common/Telemetry/Tracing/TracingExtensions.cs
@@ -87,6 +87,11 @@ public static class TracingExtensions
       // Add framework instrumentation with enrichment callbacks
       tracingOptions.AddAspNetCoreInstrumentation(options =>
       {
+        // Drop health and connectivity probe spans before allocation. See RFC 2002 and
+        // docs/superpowers/specs/2026-08-07-telemetry-noise-reduction-design.md.
+        options.Filter = httpContext =>
+          !HealthTelemetryPolicy.ShouldSuppress(httpContext.Request.Path.Value);
+
         // Enrich incoming HTTP request spans with additional context
         options.EnrichWithHttpRequest = (activity, httpRequest) =>
         {
@@ -115,6 +120,10 @@ public static class TracingExtensions
 
       tracingOptions.AddHttpClientInstrumentation(options =>
       {
+        // Suppress outbound probe dependencies, e.g. ConfigProxyClient.PingAsync -> /api/ready.
+        options.FilterHttpRequestMessage = httpRequest =>
+          !HealthTelemetryPolicy.ShouldSuppress(httpRequest.RequestUri?.AbsolutePath);
+
         // Enrich outgoing HTTP client spans
         options.EnrichWithHttpRequestMessage = (activity, httpRequest) =>
         {

--- a/sites/api.arolariu.ro/src/Common/Telemetry/Tracing/TracingExtensions.cs
+++ b/sites/api.arolariu.ro/src/Common/Telemetry/Tracing/TracingExtensions.cs
@@ -87,8 +87,8 @@ public static class TracingExtensions
       // Add framework instrumentation with enrichment callbacks
       tracingOptions.AddAspNetCoreInstrumentation(options =>
       {
-        // Drop health and connectivity probe spans before allocation. See RFC 2002 and
-        // docs/superpowers/specs/2026-08-07-telemetry-noise-reduction-design.md.
+        // Drop health and connectivity probe spans before allocation.
+        // See RFC 2002 and HealthTelemetryPolicy for the suppressed path list and override.
         options.Filter = HealthTelemetryPolicy.ShouldRecordHttpContext;
 
         // Enrich incoming HTTP request spans with additional context

--- a/sites/api.arolariu.ro/src/Common/Telemetry/Tracing/TracingExtensions.cs
+++ b/sites/api.arolariu.ro/src/Common/Telemetry/Tracing/TracingExtensions.cs
@@ -89,8 +89,7 @@ public static class TracingExtensions
       {
         // Drop health and connectivity probe spans before allocation. See RFC 2002 and
         // docs/superpowers/specs/2026-08-07-telemetry-noise-reduction-design.md.
-        options.Filter = httpContext =>
-          !HealthTelemetryPolicy.ShouldSuppress(httpContext.Request.Path.Value);
+        options.Filter = HealthTelemetryPolicy.ShouldRecordHttpContext;
 
         // Enrich incoming HTTP request spans with additional context
         options.EnrichWithHttpRequest = (activity, httpRequest) =>
@@ -121,8 +120,7 @@ public static class TracingExtensions
       tracingOptions.AddHttpClientInstrumentation(options =>
       {
         // Suppress outbound probe dependencies, e.g. ConfigProxyClient.PingAsync -> /api/ready.
-        options.FilterHttpRequestMessage = httpRequest =>
-          !HealthTelemetryPolicy.ShouldSuppress(httpRequest.RequestUri?.AbsolutePath);
+        options.FilterHttpRequestMessage = HealthTelemetryPolicy.ShouldRecordHttpRequestMessage;
 
         // Enrich outgoing HTTP client spans
         options.EnrichWithHttpRequestMessage = (activity, httpRequest) =>

--- a/sites/api.arolariu.ro/src/Core/Domain/General/Extensions/WebApplicationExtensions.cs
+++ b/sites/api.arolariu.ro/src/Core/Domain/General/Extensions/WebApplicationExtensions.cs
@@ -4,21 +4,20 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
-using arolariu.Backend.Common.Configuration;
-using arolariu.Backend.Common.Telemetry;
-using arolariu.Backend.Common.Telemetry.Metering;
-
-using Microsoft.Extensions.Diagnostics.HealthChecks;
-using arolariu.Backend.Core.Auth.Modules;
-using arolariu.Backend.Core.Domain.General.Middlewares;
-using arolariu.Backend.Core.Domain.General.Services.Swagger;
-
-using HealthChecks.UI.Client;
-
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
+
+using HealthChecks.UI.Client;
+
+using arolariu.Backend.Common.Configuration;
+using arolariu.Backend.Common.Telemetry;
+using arolariu.Backend.Common.Telemetry.Metering;
+using arolariu.Backend.Core.Auth.Modules;
+using arolariu.Backend.Core.Domain.General.Middlewares;
+using arolariu.Backend.Core.Domain.General.Services.Swagger;
 
 /// <summary>
 /// Provides extension methods for configuring the <see cref="WebApplication"/> request processing pipeline.

--- a/sites/api.arolariu.ro/src/Core/Domain/General/Extensions/WebApplicationExtensions.cs
+++ b/sites/api.arolariu.ro/src/Core/Domain/General/Extensions/WebApplicationExtensions.cs
@@ -4,6 +4,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 using arolariu.Backend.Common.Configuration;
+using arolariu.Backend.Common.Telemetry;
 using arolariu.Backend.Core.Auth.Modules;
 using arolariu.Backend.Core.Domain.General.Middlewares;
 using arolariu.Backend.Core.Domain.General.Services.Swagger;
@@ -135,10 +136,12 @@ internal static class WebApplicationExtensions
     app.UseSwaggerUI(SwaggerConfigurationService.GetSwaggerUIOptions());
     app.MapOpenApi();
     app.MapHealthChecks("/health", new HealthCheckOptions { ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse })
-       .RequireRateLimiting(RateLimitPolicies.HealthCheck);
+       .RequireRateLimiting(RateLimitPolicies.HealthCheck)
+       .DisableHttpMetrics();
     app.MapGet("/terms", () => app.Configuration["ApplicationOptions:TermsAndConditions"]);
 
     logger.LogHealthChecksRegistered("/health");
+    logger.LogHealthTelemetrySuppression(HealthTelemetryPolicy.IsSuppressionEnabled);
     logger.LogPipelineConfigurationCompleted();
 
     return app;

--- a/sites/api.arolariu.ro/src/Core/Domain/General/Extensions/WebApplicationExtensions.cs
+++ b/sites/api.arolariu.ro/src/Core/Domain/General/Extensions/WebApplicationExtensions.cs
@@ -112,6 +112,10 @@ internal static class WebApplicationExtensions
     // writes an RFC 7807 ProblemDetails response. See RFC 2003.
     app.UseExceptionHandler();
 
+    // Must run before routing so the suppression scope covers execution of the health checks
+    // themselves, not merely endpoint dispatch. See the telemetry noise reduction spec.
+    app.UseMiddleware<HealthTelemetrySuppressionMiddleware>();
+
     app.UseHttpsRedirection();
     app.UseAuthServices();
 

--- a/sites/api.arolariu.ro/src/Core/Domain/General/Extensions/WebApplicationExtensions.cs
+++ b/sites/api.arolariu.ro/src/Core/Domain/General/Extensions/WebApplicationExtensions.cs
@@ -138,7 +138,7 @@ internal static class WebApplicationExtensions
     app.UseSwagger(SwaggerConfigurationService.GetSwaggerOptions());
     app.UseSwaggerUI(SwaggerConfigurationService.GetSwaggerUIOptions());
     app.MapOpenApi();
-    app.MapHealthChecks("/health", new HealthCheckOptions
+    var healthChecks = app.MapHealthChecks("/health", new HealthCheckOptions
     {
       ResponseWriter = async (httpContext, report) =>
       {
@@ -155,8 +155,14 @@ internal static class WebApplicationExtensions
         await UIResponseWriter.WriteHealthCheckUIResponse(httpContext, report).ConfigureAwait(false);
       },
     })
-       .RequireRateLimiting(RateLimitPolicies.HealthCheck)
-       .DisableHttpMetrics();
+       .RequireRateLimiting(RateLimitPolicies.HealthCheck);
+
+    // Gated so OTEL_SUPPRESS_HEALTH_TELEMETRY=false restores every signal, metrics included.
+    // An unconditional call would leave metrics suppressed even with the override disabled.
+    if (HealthTelemetryPolicy.IsSuppressionEnabled)
+    {
+      healthChecks.DisableHttpMetrics();
+    }
     app.MapGet("/terms", () => app.Configuration["ApplicationOptions:TermsAndConditions"]);
 
     logger.LogHealthChecksRegistered("/health");

--- a/sites/api.arolariu.ro/src/Core/Domain/General/Extensions/WebApplicationExtensions.cs
+++ b/sites/api.arolariu.ro/src/Core/Domain/General/Extensions/WebApplicationExtensions.cs
@@ -1,10 +1,14 @@
 namespace arolariu.Backend.Core.Domain.General.Extensions;
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
 using arolariu.Backend.Common.Configuration;
 using arolariu.Backend.Common.Telemetry;
+using arolariu.Backend.Common.Telemetry.Metering;
+
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using arolariu.Backend.Core.Auth.Modules;
 using arolariu.Backend.Core.Domain.General.Middlewares;
 using arolariu.Backend.Core.Domain.General.Services.Swagger;
@@ -135,7 +139,23 @@ internal static class WebApplicationExtensions
     app.UseSwagger(SwaggerConfigurationService.GetSwaggerOptions());
     app.UseSwaggerUI(SwaggerConfigurationService.GetSwaggerUIOptions());
     app.MapOpenApi();
-    app.MapHealthChecks("/health", new HealthCheckOptions { ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse })
+    app.MapHealthChecks("/health", new HealthCheckOptions
+    {
+      ResponseWriter = async (httpContext, report) =>
+      {
+        var failed = new List<string>();
+        foreach (var entry in report.Entries)
+        {
+          if (entry.Value.Status != HealthStatus.Healthy)
+          {
+            failed.Add(entry.Key);
+          }
+        }
+
+        httpContext.Items[HealthCheckMetrics.FailedChecksItemKey] = failed;
+        await UIResponseWriter.WriteHealthCheckUIResponse(httpContext, report).ConfigureAwait(false);
+      },
+    })
        .RequireRateLimiting(RateLimitPolicies.HealthCheck)
        .DisableHttpMetrics();
     app.MapGet("/terms", () => app.Configuration["ApplicationOptions:TermsAndConditions"]);

--- a/sites/api.arolariu.ro/src/Core/Domain/General/Middlewares/HealthTelemetrySuppressionMiddleware.cs
+++ b/sites/api.arolariu.ro/src/Core/Domain/General/Middlewares/HealthTelemetrySuppressionMiddleware.cs
@@ -29,23 +29,40 @@ internal sealed class HealthTelemetrySuppressionMiddleware(RequestDelegate next)
   /// <param name="context">The current <see cref="HttpContext"/>.</param>
   /// <returns>A task representing the asynchronous pipeline execution.</returns>
   /// <exception cref="ArgumentNullException">Thrown when <paramref name="context"/> is null.</exception>
+  /// <remarks>
+  /// The failure counter is recorded for every health request, whether or not suppression is
+  /// active. Only the instrumentation scope is conditional. This mirrors the exp service, where
+  /// the counter is guarded by <c>is_suppressed_path</c> rather than <c>should_suppress_telemetry</c>.
+  /// </remarks>
   public async Task InvokeAsync(HttpContext context)
   {
     ArgumentNullException.ThrowIfNull(context);
 
-    if (!HealthTelemetryPolicy.ShouldSuppress(context.Request.Path.Value))
+    if (!HealthTelemetryPolicy.IsSuppressedPath(context.Request.Path.Value))
     {
       await this.next(context).ConfigureAwait(false);
       return;
     }
 
-    using (SuppressInstrumentationScope.Begin())
+    if (HealthTelemetryPolicy.IsSuppressionEnabled)
+    {
+      using (SuppressInstrumentationScope.Begin())
+      {
+        await this.next(context).ConfigureAwait(false);
+      }
+    }
+    else
     {
       await this.next(context).ConfigureAwait(false);
     }
 
-    // Recorded only after the scope is disposed — inside it, the measurement could be
+    // Recorded only after any scope is disposed — inside it, the measurement could be
     // discarded by the very mechanism that suppresses the request telemetry.
+    RecordFailures(context);
+  }
+
+  private static void RecordFailures(HttpContext context)
+  {
     if (context.Items.TryGetValue(HealthCheckMetrics.FailedChecksItemKey, out var failed)
         && failed is IEnumerable<string> failedCheckNames)
     {

--- a/sites/api.arolariu.ro/src/Core/Domain/General/Middlewares/HealthTelemetrySuppressionMiddleware.cs
+++ b/sites/api.arolariu.ro/src/Core/Domain/General/Middlewares/HealthTelemetrySuppressionMiddleware.cs
@@ -1,8 +1,10 @@
 namespace arolariu.Backend.Core.Domain.General.Middlewares;
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using arolariu.Backend.Common.Telemetry;
+using arolariu.Backend.Common.Telemetry.Metering;
 using Microsoft.AspNetCore.Http;
 using OpenTelemetry;
 
@@ -40,6 +42,14 @@ internal sealed class HealthTelemetrySuppressionMiddleware(RequestDelegate next)
     using (SuppressInstrumentationScope.Begin())
     {
       await this.next(context).ConfigureAwait(false);
+    }
+
+    // Recorded only after the scope is disposed — inside it, the measurement could be
+    // discarded by the very mechanism that suppresses the request telemetry.
+    if (context.Items.TryGetValue(HealthCheckMetrics.FailedChecksItemKey, out var failed)
+        && failed is IEnumerable<string> failedCheckNames)
+    {
+      HealthCheckMetrics.RecordFailures(failedCheckNames);
     }
   }
 }

--- a/sites/api.arolariu.ro/src/Core/Domain/General/Middlewares/HealthTelemetrySuppressionMiddleware.cs
+++ b/sites/api.arolariu.ro/src/Core/Domain/General/Middlewares/HealthTelemetrySuppressionMiddleware.cs
@@ -1,0 +1,45 @@
+namespace arolariu.Backend.Core.Domain.General.Middlewares;
+
+using System;
+using System.Threading.Tasks;
+using arolariu.Backend.Common.Telemetry;
+using Microsoft.AspNetCore.Http;
+using OpenTelemetry;
+
+/// <summary>
+/// Suppresses all OpenTelemetry instrumentation for health and connectivity probe requests.
+/// </summary>
+/// <remarks>
+/// Filtering only the ASP.NET Core server span is insufficient: the registered health checks
+/// fan out to SQL Server, Blob Storage, Cosmos DB and the exp config proxy, each independently
+/// instrumented. Without a recorded parent those emit orphaned root spans. Wrapping the whole
+/// request in a suppression scope removes the entire subtree.
+/// </remarks>
+/// <param name="next">The next delegate in the request pipeline.</param>
+internal sealed class HealthTelemetrySuppressionMiddleware(RequestDelegate next)
+{
+  private readonly RequestDelegate next = next
+    ?? throw new ArgumentNullException(nameof(next));
+
+  /// <summary>
+  /// Invokes the middleware for the current request.
+  /// </summary>
+  /// <param name="context">The current <see cref="HttpContext"/>.</param>
+  /// <returns>A task representing the asynchronous pipeline execution.</returns>
+  /// <exception cref="ArgumentNullException">Thrown when <paramref name="context"/> is null.</exception>
+  public async Task InvokeAsync(HttpContext context)
+  {
+    ArgumentNullException.ThrowIfNull(context);
+
+    if (!HealthTelemetryPolicy.ShouldSuppress(context.Request.Path.Value))
+    {
+      await this.next(context).ConfigureAwait(false);
+      return;
+    }
+
+    using (SuppressInstrumentationScope.Begin())
+    {
+      await this.next(context).ConfigureAwait(false);
+    }
+  }
+}

--- a/sites/api.arolariu.ro/src/Core/Log.cs
+++ b/sites/api.arolariu.ro/src/Core/Log.cs
@@ -154,5 +154,14 @@ internal static partial class Log
     Message = "Health check completed — Status: {Status}, Duration: {DurationMs}ms.")]
   public static partial void LogHealthCheckCompleted(this ILogger logger, string status, double durationMs);
 
+  /// <summary>
+  /// Logs whether health endpoint telemetry suppression is active for this process.
+  /// </summary>
+  [LoggerMessage(
+    EventId = 500_302,
+    Level = LogLevel.Information,
+    Message = "Health telemetry suppression enabled: {Enabled}. Override with OTEL_SUPPRESS_HEALTH_TELEMETRY.")]
+  public static partial void LogHealthTelemetrySuppression(this ILogger logger, bool enabled);
+
   #endregion
 }

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Telemetry/HealthCheckMetricsTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Telemetry/HealthCheckMetricsTests.cs
@@ -1,6 +1,7 @@
 namespace arolariu.Backend.Core.Tests.Common.Telemetry;
 
 using System.Collections.Generic;
+using System.Linq;
 using arolariu.Backend.Common.Telemetry.Metering;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenTelemetry;
@@ -10,7 +11,10 @@ using OpenTelemetry.Metrics;
 [TestClass]
 public sealed class HealthCheckMetricsTests
 {
-  /// <summary>Verifies that failing checks produce exported measurements.</summary>
+  /// <summary>
+  /// Verifies that each failing check produces exactly one metric point tagged with its name,
+  /// with a sum of 1. Two inputs must produce two distinct points.
+  /// </summary>
   [TestMethod]
   public void RecordFailures_FailedChecks_ExportsOneMeasurementPerCheck()
   {
@@ -25,6 +29,34 @@ public sealed class HealthCheckMetricsTests
 
     var metric = exported.Find(m => m.Name == HealthCheckMetrics.MetricName);
     Assert.IsNotNull(metric, "The failure counter must be exported.");
+
+    // Materialise the metric points so we can assert per-point dimensioning.
+    var points = new List<(string checkTag, long sum)>();
+    foreach (ref readonly var point in metric.GetMetricPoints())
+    {
+      string? checkTag = null;
+      foreach (var tag in point.Tags)
+      {
+        if (tag.Key == "check")
+        {
+          checkTag = tag.Value?.ToString();
+        }
+      }
+
+      Assert.IsNotNull(checkTag, "Every metric point must carry a 'check' tag.");
+      points.Add((checkTag!, point.GetSumLong()));
+    }
+
+    Assert.AreEqual(2, points.Count, "Exactly one metric point per failing check.");
+
+    var tagValues = points.Select(p => p.checkTag).ToHashSet();
+    CollectionAssert.Contains(tagValues.ToList(), "mssql", "Expected a point tagged check=mssql.");
+    CollectionAssert.Contains(tagValues.ToList(), "cosmosdb", "Expected a point tagged check=cosmosdb.");
+
+    foreach (var (checkTag, sum) in points)
+    {
+      Assert.AreEqual(1L, sum, $"Point for check={checkTag} must have sum=1.");
+    }
   }
 
   /// <summary>Verifies that a healthy probe emits no measurements.</summary>

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Telemetry/HealthCheckMetricsTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Telemetry/HealthCheckMetricsTests.cs
@@ -1,0 +1,46 @@
+namespace arolariu.Backend.Core.Tests.Common.Telemetry;
+
+using System.Collections.Generic;
+using arolariu.Backend.Common.Telemetry.Metering;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+
+/// <summary>Unit tests for <see cref="HealthCheckMetrics"/>.</summary>
+[TestClass]
+public sealed class HealthCheckMetricsTests
+{
+  /// <summary>Verifies that failing checks produce exported measurements.</summary>
+  [TestMethod]
+  public void RecordFailures_FailedChecks_ExportsOneMeasurementPerCheck()
+  {
+    var exported = new List<Metric>();
+    using var provider = Sdk.CreateMeterProviderBuilder()
+      .AddMeter("arolariu.Backend.Core")
+      .AddInMemoryExporter(exported)
+      .Build()!;
+
+    HealthCheckMetrics.RecordFailures(["mssql", "cosmosdb"]);
+    provider.ForceFlush();
+
+    var metric = exported.Find(m => m.Name == HealthCheckMetrics.MetricName);
+    Assert.IsNotNull(metric, "The failure counter must be exported.");
+  }
+
+  /// <summary>Verifies that a healthy probe emits no measurements.</summary>
+  [TestMethod]
+  public void RecordFailures_NoFailures_ExportsNothing()
+  {
+    var exported = new List<Metric>();
+    using var provider = Sdk.CreateMeterProviderBuilder()
+      .AddMeter("arolariu.Backend.Core")
+      .AddInMemoryExporter(exported)
+      .Build()!;
+
+    HealthCheckMetrics.RecordFailures([]);
+    provider.ForceFlush();
+
+    var metric = exported.Find(m => m.Name == HealthCheckMetrics.MetricName);
+    Assert.IsNull(metric, "A healthy probe must not emit any measurement.");
+  }
+}

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Telemetry/HealthCheckMetricsTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Telemetry/HealthCheckMetricsTests.cs
@@ -8,7 +8,12 @@ using OpenTelemetry;
 using OpenTelemetry.Metrics;
 
 /// <summary>Unit tests for <see cref="HealthCheckMetrics"/>.</summary>
+/// <remarks>
+/// Not parallelized: the failure counter is a static instrument on a process-global meter, so a
+/// concurrently-alive <c>MeterProvider</c> in another class would observe these measurements too.
+/// </remarks>
 [TestClass]
+[DoNotParallelize]
 public sealed class HealthCheckMetricsTests
 {
   /// <summary>

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Telemetry/HealthTelemetryPolicyTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Telemetry/HealthTelemetryPolicyTests.cs
@@ -1,0 +1,57 @@
+namespace arolariu.Backend.Core.Tests.Common.Telemetry;
+
+using arolariu.Backend.Common.Telemetry;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+/// <summary>
+/// Tests for <see cref="HealthTelemetryPolicy"/> covering path classification and suppression flag parsing.
+/// </summary>
+[TestClass]
+public sealed class HealthTelemetryPolicyTests
+{
+  /// <summary>Verifies health endpoints are correctly identified as suppressed.</summary>
+  [TestMethod]
+  [DataRow("/health")]
+  [DataRow("/api/health")]
+  [DataRow("/api/ready")]
+  [DataRow("/HEALTH")]
+  [DataRow("/Api/Health")]
+  [DataRow("/health/")]
+  [DataRow("/health?foo=bar")]
+  [DataRow("/api/ready/?x=1")]
+  public void IsSuppressedPath_HealthPath_ReturnsTrue(string path)
+  {
+    Assert.IsTrue(HealthTelemetryPolicy.IsSuppressedPath(path));
+  }
+
+  /// <summary>Verifies non-health paths are not suppressed.</summary>
+  [TestMethod]
+  [DataRow("/")]
+  [DataRow("/api/invoices")]
+  [DataRow("/terms")]
+  [DataRow("/healthcheck-admin")]
+  [DataRow("/health/details")]
+  [DataRow("/api/healthy")]
+  [DataRow("")]
+  [DataRow(null)]
+  public void IsSuppressedPath_NonHealthPath_ReturnsFalse(string? path)
+  {
+    Assert.IsFalse(HealthTelemetryPolicy.IsSuppressedPath(path));
+  }
+
+  /// <summary>Verifies environment variable parsing yields expected defaults.</summary>
+  [TestMethod]
+  [DataRow(null, true)]
+  [DataRow("", true)]
+  [DataRow("   ", true)]
+  [DataRow("true", true)]
+  [DataRow("TRUE", true)]
+  [DataRow("false", false)]
+  [DataRow("False", false)]
+  [DataRow("not-a-bool", true)]
+  [DataRow("0", true)]
+  public void ParseSuppressionFlag_Value_ReturnsExpected(string? raw, bool expected)
+  {
+    Assert.AreEqual(expected, HealthTelemetryPolicy.ParseSuppressionFlag(raw));
+  }
+}

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Telemetry/HealthTelemetrySuppressionMiddlewareTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Telemetry/HealthTelemetrySuppressionMiddlewareTests.cs
@@ -1,0 +1,78 @@
+namespace arolariu.Backend.Core.Tests.Common.Telemetry;
+
+using System;
+using System.Threading.Tasks;
+using arolariu.Backend.Core.Domain.General.Middlewares;
+using Microsoft.AspNetCore.Http;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenTelemetry;
+
+/// <summary>
+/// Unit tests for <see cref="HealthTelemetrySuppressionMiddleware"/> verifying suppression scope
+/// behaviour for health probe paths and normal routes.
+/// </summary>
+[TestClass]
+public sealed class HealthTelemetrySuppressionMiddlewareTests
+{
+  /// <summary>
+  /// Verifies that a request to <c>/health</c> executes inside a suppression scope
+  /// and that the scope does not leak after the request completes.
+  /// </summary>
+  [TestMethod]
+  public async Task InvokeAsync_HealthPath_SuppressesInstrumentationScope()
+  {
+    var observedSuppression = false;
+    var middleware = new HealthTelemetrySuppressionMiddleware(_ =>
+    {
+      observedSuppression = Sdk.SuppressInstrumentation;
+      return Task.CompletedTask;
+    });
+
+    var context = new DefaultHttpContext();
+    context.Request.Path = "/health";
+
+    await middleware.InvokeAsync(context).ConfigureAwait(false);
+
+    Assert.IsTrue(observedSuppression, "Health requests must execute inside a suppression scope.");
+    Assert.IsFalse(Sdk.SuppressInstrumentation, "Suppression must not leak past the request.");
+  }
+
+  /// <summary>
+  /// Verifies that a request to a real API route does not activate the suppression scope.
+  /// </summary>
+  [TestMethod]
+  public async Task InvokeAsync_RealRoute_DoesNotSuppress()
+  {
+    var observedSuppression = true;
+    var middleware = new HealthTelemetrySuppressionMiddleware(_ =>
+    {
+      observedSuppression = Sdk.SuppressInstrumentation;
+      return Task.CompletedTask;
+    });
+
+    var context = new DefaultHttpContext();
+    context.Request.Path = "/api/invoices";
+
+    await middleware.InvokeAsync(context).ConfigureAwait(false);
+
+    Assert.IsFalse(observedSuppression, "Real routes must be instrumented normally.");
+  }
+
+  /// <summary>
+  /// Verifies that a throwing request to <c>/health</c> does not leave a leaked suppression scope.
+  /// </summary>
+  [TestMethod]
+  public async Task InvokeAsync_HealthPathThrows_DoesNotLeakSuppression()
+  {
+    var middleware = new HealthTelemetrySuppressionMiddleware(
+      _ => throw new InvalidOperationException("boom"));
+
+    var context = new DefaultHttpContext();
+    context.Request.Path = "/health";
+
+    await Assert.ThrowsExactlyAsync<InvalidOperationException>(
+      () => middleware.InvokeAsync(context)).ConfigureAwait(false);
+
+    Assert.IsFalse(Sdk.SuppressInstrumentation, "A throwing request must not leak a suppressed scope.");
+  }
+}

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Telemetry/HealthTelemetrySuppressionMiddlewareTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Telemetry/HealthTelemetrySuppressionMiddlewareTests.cs
@@ -1,17 +1,25 @@
 namespace arolariu.Backend.Core.Tests.Common.Telemetry;
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
+using arolariu.Backend.Common.Telemetry.Metering;
 using arolariu.Backend.Core.Domain.General.Middlewares;
 using Microsoft.AspNetCore.Http;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenTelemetry;
+using OpenTelemetry.Metrics;
 
 /// <summary>
 /// Unit tests for <see cref="HealthTelemetrySuppressionMiddleware"/> verifying suppression scope
 /// behaviour for health probe paths and normal routes.
 /// </summary>
+/// <remarks>
+/// Not parallelized: the failure counter is a static instrument on a process-global meter, so a
+/// concurrently-alive <c>MeterProvider</c> in another class would observe these measurements too.
+/// </remarks>
 [TestClass]
+[DoNotParallelize]
 public sealed class HealthTelemetrySuppressionMiddlewareTests
 {
   /// <summary>
@@ -74,5 +82,64 @@ public sealed class HealthTelemetrySuppressionMiddlewareTests
       () => middleware.InvokeAsync(context)).ConfigureAwait(false);
 
     Assert.IsFalse(Sdk.SuppressInstrumentation, "A throwing request must not leak a suppressed scope.");
+  }
+
+  /// <summary>
+  /// Verifies that the failure counter is recorded for a suppressed health path. Regression
+  /// guard: an earlier implementation early-returned before the recording block whenever
+  /// suppression was inactive, silently disabling the one signal meant to always survive.
+  /// </summary>
+  [TestMethod]
+  public async Task InvokeAsync_HealthPathWithFailedChecks_RecordsFailures()
+  {
+    var exported = new List<Metric>();
+    using var provider = Sdk.CreateMeterProviderBuilder()
+      .AddMeter("arolariu.Backend.Core")
+      .AddInMemoryExporter(exported)
+      .Build()!;
+
+    var middleware = new HealthTelemetrySuppressionMiddleware(ctx =>
+    {
+      ctx.Items[HealthCheckMetrics.FailedChecksItemKey] = new List<string> { "mssql" };
+      return Task.CompletedTask;
+    });
+
+    var context = new DefaultHttpContext();
+    context.Request.Path = "/health";
+
+    await middleware.InvokeAsync(context).ConfigureAwait(false);
+    provider.ForceFlush();
+
+    var metric = exported.Find(m => m.Name == HealthCheckMetrics.MetricName);
+    Assert.IsNotNull(metric, "The failure counter must be recorded for a failing health probe.");
+  }
+
+  /// <summary>
+  /// Verifies that a non-health route is left entirely alone: no suppression scope, and no
+  /// failure-counter bookkeeping even if something placed a failed-check list on the context.
+  /// </summary>
+  [TestMethod]
+  public async Task InvokeAsync_RealRouteWithFailedChecks_RecordsNothing()
+  {
+    var exported = new List<Metric>();
+    using var provider = Sdk.CreateMeterProviderBuilder()
+      .AddMeter("arolariu.Backend.Core")
+      .AddInMemoryExporter(exported)
+      .Build()!;
+
+    var middleware = new HealthTelemetrySuppressionMiddleware(ctx =>
+    {
+      ctx.Items[HealthCheckMetrics.FailedChecksItemKey] = new List<string> { "mssql" };
+      return Task.CompletedTask;
+    });
+
+    var context = new DefaultHttpContext();
+    context.Request.Path = "/api/invoices";
+
+    await middleware.InvokeAsync(context).ConfigureAwait(false);
+    provider.ForceFlush();
+
+    var metric = exported.Find(m => m.Name == HealthCheckMetrics.MetricName);
+    Assert.IsNull(metric, "Non-health routes must not feed the health failure counter.");
   }
 }

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Telemetry/HealthTraceFilterTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Telemetry/HealthTraceFilterTests.cs
@@ -6,14 +6,21 @@ using System.Diagnostics;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using arolariu.Backend.Common.Options;
 using arolariu.Backend.Common.Telemetry;
+using arolariu.Backend.Common.Telemetry.Tracing;
+using arolariu.Backend.Core.Tests.Shared.TestDoubles;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenTelemetry;
+using OpenTelemetry.Instrumentation.AspNetCore;
+using OpenTelemetry.Instrumentation.Http;
 using OpenTelemetry.Trace;
 
 /// <summary>
@@ -78,8 +85,7 @@ public sealed class HealthTraceFilterTests
           webBuilder.ConfigureServices(services =>
             services.AddOpenTelemetry().WithTracing(tracing => tracing
                 .AddAspNetCoreInstrumentation(options =>
-                  options.Filter = httpContext =>
-                    !HealthTelemetryPolicy.ShouldSuppress(httpContext.Request.Path.Value))
+                  options.Filter = HealthTelemetryPolicy.ShouldRecordHttpContext)
                 .AddProcessor(processor)));
           webBuilder.Configure(app => app.Run(context =>
           {
@@ -149,5 +155,71 @@ public sealed class HealthTraceFilterTests
     var exported = await ExportedActivitiesForAsync("/api/invoices").ConfigureAwait(false);
 
     Assert.AreEqual(1, exported.Count, "Real routes must still export telemetry.");
+  }
+
+  // ──────────────────────────────────────────────────────────────────────────────
+  // Wiring tests — assert that AddOTelTracing actually installs the production
+  // filter callbacks so that removing options.Filter from TracingExtensions.cs
+  // causes these tests to fail.
+  // ──────────────────────────────────────────────────────────────────────────────
+
+  /// <summary>
+  /// Verifies that <see cref="TracingExtensions.AddOTelTracing"/> registers
+  /// <see cref="HealthTelemetryPolicy.ShouldRecordHttpContext"/> as the
+  /// <c>AspNetCoreTraceInstrumentationOptions.Filter</c> predicate, and that the
+  /// predicate correctly suppresses health paths while allowing real routes.
+  /// </summary>
+  [TestMethod]
+  public void AddOTelTracing_WiresAspNetCoreFilter()
+  {
+    var builder = WebApplication.CreateBuilder();
+    builder.Services.AddSingleton<IOptionsManager>(
+      new FakeOptionsManager(new LocalOptions()));
+    builder.AddOTelTracing();
+
+    using var provider = builder.Services.BuildServiceProvider();
+    var filter = provider
+      .GetRequiredService<IOptionsMonitor<AspNetCoreTraceInstrumentationOptions>>()
+      .Get(Options.DefaultName)
+      .Filter;
+
+    Assert.IsNotNull(filter, "AddOTelTracing must register a non-null Filter.");
+
+    var healthCtx = new DefaultHttpContext();
+    healthCtx.Request.Path = "/health";
+    Assert.IsFalse(filter(healthCtx), "Filter must suppress /health.");
+
+    var apiCtx = new DefaultHttpContext();
+    apiCtx.Request.Path = "/api/invoices";
+    Assert.IsTrue(filter(apiCtx), "Filter must allow /api/invoices.");
+  }
+
+  /// <summary>
+  /// Verifies that <see cref="TracingExtensions.AddOTelTracing"/> registers
+  /// <see cref="HealthTelemetryPolicy.ShouldRecordHttpRequestMessage"/> as the
+  /// <c>HttpClientTraceInstrumentationOptions.FilterHttpRequestMessage</c> predicate, and that
+  /// the predicate correctly suppresses outbound health probe requests.
+  /// </summary>
+  [TestMethod]
+  public void AddOTelTracing_WiresHttpClientFilter()
+  {
+    var builder = WebApplication.CreateBuilder();
+    builder.Services.AddSingleton<IOptionsManager>(
+      new FakeOptionsManager(new LocalOptions()));
+    builder.AddOTelTracing();
+
+    using var provider = builder.Services.BuildServiceProvider();
+    var filter = provider
+      .GetRequiredService<IOptionsMonitor<HttpClientTraceInstrumentationOptions>>()
+      .Get(Options.DefaultName)
+      .FilterHttpRequestMessage;
+
+    Assert.IsNotNull(filter, "AddOTelTracing must register a non-null FilterHttpRequestMessage.");
+
+    using var healthReq = new HttpRequestMessage(HttpMethod.Get, new Uri("http://localhost/api/ready"));
+    Assert.IsFalse(filter(healthReq), "Filter must suppress /api/ready.");
+
+    using var apiReq = new HttpRequestMessage(HttpMethod.Get, new Uri("http://localhost/api/invoices"));
+    Assert.IsTrue(filter(apiReq), "Filter must allow /api/invoices.");
   }
 }

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Telemetry/HealthTraceFilterTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Telemetry/HealthTraceFilterTests.cs
@@ -1,0 +1,113 @@
+namespace arolariu.Backend.Core.Tests.Common.Telemetry;
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Net.Http;
+using System.Threading.Tasks;
+using arolariu.Backend.Common.Telemetry;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenTelemetry;
+using OpenTelemetry.Trace;
+
+/// <summary>
+/// Integration tests that verify the ASP.NET Core instrumentation filter correctly
+/// suppresses telemetry for health probe paths while preserving traces for real routes.
+/// </summary>
+[TestClass]
+public sealed class HealthTraceFilterTests
+{
+  // ActivityListeners are global; serialize tests so only one OTel pipeline is active at a time.
+  private static readonly System.Threading.SemaphoreSlim _gate = new(1, 1);
+
+  private static async Task<List<Activity>> ExportedActivitiesForAsync(string requestPath)
+  {
+    await _gate.WaitAsync().ConfigureAwait(false);
+    try
+    {
+      var exported = new List<Activity>();
+
+      var host = await new HostBuilder()
+        .ConfigureWebHost(webBuilder =>
+        {
+          webBuilder.UseTestServer();
+          webBuilder.ConfigureServices(services =>
+            services.AddOpenTelemetry().WithTracing(tracing => tracing
+                .AddAspNetCoreInstrumentation(options =>
+                  options.Filter = httpContext =>
+                    !HealthTelemetryPolicy.ShouldSuppress(httpContext.Request.Path.Value))
+                .AddInMemoryExporter(exported)));
+          webBuilder.Configure(app => app.Run(context =>
+          {
+            context.Response.StatusCode = 200;
+            return Task.CompletedTask;
+          }));
+        })
+        .StartAsync()
+        .ConfigureAwait(false);
+
+      try
+      {
+        using var client = host.GetTestClient();
+        var response = await client.GetAsync(new Uri(requestPath, UriKind.Relative))
+          .ConfigureAwait(false);
+
+        // The server-side activity lifecycle (DisposeContext) completes asynchronously
+        // relative to the client receiving the response. Wait for it to finish before
+        // stopping the host, so that SimpleActivityExportProcessor.OnEnd fires while
+        // the TracerProvider is still alive and registered.
+        response.Dispose();
+
+        // Poll until the activity appears in exported, or until timeout.
+        // For suppressed paths the loop exits quickly (nothing ever appears).
+        var deadline = Environment.TickCount64 + 3_000;
+        while (exported.Count == 0 && Environment.TickCount64 < deadline)
+        {
+          await Task.Delay(10).ConfigureAwait(false);
+        }
+
+        // Flush before stopping: StopAsync shuts down the hosted service that manages
+        // TracerProvider; flushing first ensures all ended activities are exported.
+        host.Services.GetRequiredService<TracerProvider>().ForceFlush(5000);
+        await host.StopAsync().ConfigureAwait(false);
+      }
+      finally
+      {
+        host.Dispose();
+      }
+
+      return exported;
+    }
+    finally
+    {
+      _gate.Release();
+    }
+  }
+
+  /// <summary>
+  /// Verifies that HTTP requests to health probe paths are excluded from distributed traces.
+  /// </summary>
+  [TestMethod]
+  public async Task AspNetCoreFilter_HealthPath_ExportsNoActivity()
+  {
+    var exported = await ExportedActivitiesForAsync("/health").ConfigureAwait(false);
+
+    Assert.AreEqual(0, exported.Count, "Health requests must not export any activity.");
+  }
+
+  /// <summary>
+  /// Verifies that HTTP requests to real application routes are still captured in distributed traces.
+  /// </summary>
+  [TestMethod]
+  public async Task AspNetCoreFilter_RealRoute_ExportsActivity()
+  {
+    var exported = await ExportedActivitiesForAsync("/api/invoices").ConfigureAwait(false);
+
+    Assert.AreEqual(1, exported.Count, "Real routes must still export telemetry.");
+  }
+}

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Telemetry/HealthTraceFilterTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Telemetry/HealthTraceFilterTests.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using arolariu.Backend.Common.Telemetry;
 using Microsoft.AspNetCore.Builder;
@@ -23,14 +24,52 @@ using OpenTelemetry.Trace;
 public sealed class HealthTraceFilterTests
 {
   // ActivityListeners are global; serialize tests so only one OTel pipeline is active at a time.
-  private static readonly System.Threading.SemaphoreSlim _gate = new(1, 1);
+  private static readonly SemaphoreSlim _gate = new(1, 1);
 
-  private static async Task<List<Activity>> ExportedActivitiesForAsync(string requestPath)
+  /// <summary>
+  /// Captures activities synchronously in <see cref="BaseProcessor{T}.OnEnd"/> and signals
+  /// a <see cref="SemaphoreSlim"/> so the real-route test can await the first activity instead
+  /// of polling a fixed deadline.
+  /// </summary>
+  private sealed class CapturingProcessor : BaseProcessor<Activity>
+  {
+    private readonly List<Activity> _target;
+    private readonly SemaphoreSlim _signal = new(0, int.MaxValue);
+
+    /// <summary>Initialises the processor with the shared capture list.</summary>
+    public CapturingProcessor(List<Activity> target) => _target = target;
+
+    /// <inheritdoc/>
+    public override void OnEnd(Activity activity)
+    {
+      _target.Add(activity);
+      _signal.Release();
+    }
+
+    /// <summary>
+    /// Waits up to <paramref name="timeout"/> for at least one activity to be captured.
+    /// </summary>
+    public Task<bool> WaitForActivityAsync(TimeSpan timeout) =>
+      _signal.WaitAsync(timeout);
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+      if (disposing)
+        _signal.Dispose();
+      base.Dispose(disposing);
+    }
+  }
+
+  private static async Task<List<Activity>> ExportedActivitiesForAsync(
+    string requestPath,
+    TimeSpan absenceGuard = default)
   {
     await _gate.WaitAsync().ConfigureAwait(false);
     try
     {
       var exported = new List<Activity>();
+      using var processor = new CapturingProcessor(exported);
 
       var host = await new HostBuilder()
         .ConfigureWebHost(webBuilder =>
@@ -41,7 +80,7 @@ public sealed class HealthTraceFilterTests
                 .AddAspNetCoreInstrumentation(options =>
                   options.Filter = httpContext =>
                     !HealthTelemetryPolicy.ShouldSuppress(httpContext.Request.Path.Value))
-                .AddInMemoryExporter(exported)));
+                .AddProcessor(processor)));
           webBuilder.Configure(app => app.Run(context =>
           {
             context.Response.StatusCode = 200;
@@ -54,26 +93,24 @@ public sealed class HealthTraceFilterTests
       try
       {
         using var client = host.GetTestClient();
-        var response = await client.GetAsync(new Uri(requestPath, UriKind.Relative))
+        using var response = await client.GetAsync(new Uri(requestPath, UriKind.Relative))
           .ConfigureAwait(false);
 
-        // The server-side activity lifecycle (DisposeContext) completes asynchronously
-        // relative to the client receiving the response. Wait for it to finish before
-        // stopping the host, so that SimpleActivityExportProcessor.OnEnd fires while
-        // the TracerProvider is still alive and registered.
-        response.Dispose();
-
-        // Poll until the activity appears in exported, or until timeout.
-        // For suppressed paths the loop exits quickly (nothing ever appears).
-        var deadline = Environment.TickCount64 + 3_000;
-        while (exported.Count == 0 && Environment.TickCount64 < deadline)
+        if (absenceGuard == default)
         {
-          await Task.Delay(10).ConfigureAwait(false);
+          // Real-route path: wait until an activity arrives (up to 3s), then return immediately.
+          await processor.WaitForActivityAsync(TimeSpan.FromSeconds(3)).ConfigureAwait(false);
+        }
+        else
+        {
+          // Absence-assertion path: wait a short, deliberate interval so that any activity
+          // that the filter should have suppressed has time to arrive — if the filter is
+          // misconfigured, the activity will appear during this window. The window only needs
+          // to outlast the server-side DisposeContext async gap (measured in milliseconds),
+          // so 400ms is a conservative upper bound without slowing the suite materially.
+          await Task.Delay(absenceGuard).ConfigureAwait(false);
         }
 
-        // Flush before stopping: StopAsync shuts down the hosted service that manages
-        // TracerProvider; flushing first ensures all ended activities are exported.
-        host.Services.GetRequiredService<TracerProvider>().ForceFlush(5000);
         await host.StopAsync().ConfigureAwait(false);
       }
       finally
@@ -95,7 +132,10 @@ public sealed class HealthTraceFilterTests
   [TestMethod]
   public async Task AspNetCoreFilter_HealthPath_ExportsNoActivity()
   {
-    var exported = await ExportedActivitiesForAsync("/health").ConfigureAwait(false);
+    // Pass a 400ms absence-guard: any activity that leaked past the filter would arrive
+    // during this window, making the assertion fail — preserving the deleted-filter guarantee.
+    var exported = await ExportedActivitiesForAsync("/health", TimeSpan.FromMilliseconds(400))
+      .ConfigureAwait(false);
 
     Assert.AreEqual(0, exported.Count, "Health requests must not export any activity.");
   }

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/arolariu.Backend.Core.Tests.csproj
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/arolariu.Backend.Core.Tests.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+    <PackageReference Include="OpenTelemetry.Exporter.InMemory" />
   </ItemGroup>
 
   

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/packages.lock.json
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/packages.lock.json
@@ -68,6 +68,15 @@
           "MSTest.Analyzers": "4.3.3"
         }
       },
+      "OpenTelemetry.Exporter.InMemory": {
+        "type": "Direct",
+        "requested": "[1.17.0, )",
+        "resolved": "1.17.0",
+        "contentHash": "1zajwmOjywDHbcocKbfuS9wfn///JlzkXQlL3/W//Ayl1cv137GdqiDV5KE+nTSctkO88rP34BZYX7qvKzC+og==",
+        "dependencies": {
+          "OpenTelemetry": "1.17.0"
+        }
+      },
       "AspNetCore.HealthChecks.UI.Core": {
         "type": "Transitive",
         "resolved": "9.0.0",

--- a/sites/arolariu.ro/src/app/api/health/route.test.ts
+++ b/sites/arolariu.ro/src/app/api/health/route.test.ts
@@ -10,6 +10,9 @@ const instrumentationMocks = vi.hoisted(() => ({
     enrichedHeaders.set("X-Request-Id", "feedfacefeedfacefeedfacefeedface");
     return enrichedHeaders;
   }),
+  // Stable across re-imports so tests can assert on the failure counter, which the route
+  // creates at module scope and `vi.resetModules()` re-creates for every test.
+  counterAdd: vi.fn(),
 }));
 
 // Mock server-only and OTel before any imports
@@ -19,7 +22,7 @@ vi.mock("@/instrumentation.server", () => ({
   setSpanAttributes: vi.fn(),
   logWithTrace: vi.fn(),
   createHistogram: vi.fn(() => ({record: vi.fn()})),
-  createCounter: vi.fn(() => ({add: vi.fn()})),
+  createCounter: vi.fn(() => ({add: instrumentationMocks.counterAdd})),
   createHttpServerAttributes: vi.fn(() => ({})),
   getTraceparentHeader: vi.fn(() => ""),
   injectTraceContextHeaders: instrumentationMocks.injectTraceContextHeaders,
@@ -35,6 +38,7 @@ describe("/api/health", () => {
   beforeEach(() => {
     vi.resetModules();
     mockFetch.mockReset();
+    instrumentationMocks.counterAdd.mockReset();
     vi.stubEnv("SITE_ENV", "DEVELOPMENT");
     vi.stubEnv("COMMIT_SHA", "abc123def456");
     vi.stubEnv("SITE_NAME", "dev.arolariu.ro");
@@ -177,6 +181,49 @@ describe("/api/health", () => {
 
     expect(body.dependencies[1]?.status).toBe("Unhealthy");
     expect(body.dependencies[1]?.error).toBe("string error");
+  });
+
+  describe("arolariu.health.check.failures counter", () => {
+    it("records one measurement per Unhealthy dependency, with low-cardinality check values", async () => {
+      mockFetch.mockRejectedValue(new Error("down"));
+
+      const {GET} = await import("./route");
+      await GET();
+
+      expect(instrumentationMocks.counterAdd).toHaveBeenCalledTimes(2);
+      expect(instrumentationMocks.counterAdd).toHaveBeenCalledWith(1, {check: "exp"});
+      expect(instrumentationMocks.counterAdd).toHaveBeenCalledWith(1, {check: "api"});
+    });
+
+    it("records only the failing dependency when one is reachable", async () => {
+      mockFetch.mockResolvedValueOnce({ok: true, status: 200}).mockRejectedValueOnce(new Error("down"));
+
+      const {GET} = await import("./route");
+      await GET();
+
+      expect(instrumentationMocks.counterAdd).toHaveBeenCalledTimes(1);
+      expect(instrumentationMocks.counterAdd).toHaveBeenCalledWith(1, {check: "api"});
+    });
+
+    it("records nothing when all dependencies are healthy", async () => {
+      mockFetch.mockResolvedValue({ok: true, status: 200});
+
+      const {GET} = await import("./route");
+      await GET();
+
+      expect(instrumentationMocks.counterAdd).not.toHaveBeenCalled();
+    });
+
+    it("records nothing for a Degraded dependency, which answered but unhappily", async () => {
+      mockFetch.mockResolvedValue({ok: false, status: 503});
+
+      const {GET} = await import("./route");
+      const response = await GET();
+      const body = await response.json();
+
+      expect(body.dependencies[0]?.status).toBe("Degraded");
+      expect(instrumentationMocks.counterAdd).not.toHaveBeenCalled();
+    });
   });
 
   it("uses fallback values when env vars are missing", async () => {

--- a/sites/arolariu.ro/src/app/api/health/route.ts
+++ b/sites/arolariu.ro/src/app/api/health/route.ts
@@ -119,10 +119,11 @@ export async function GET(): Promise<NextResponse<HealthResponse>> {
   const checkDurationMs = Math.round(performance.now() - checkStart);
 
   // The single always-on signal that survives suppression. Dimension values match the
-  // .NET and Python services so one query spans the estate.
+  // .NET and Python services so one query spans the estate. Names are of the form
+  // "exp (config proxy)" / "api (backend)"; the leading token keeps cardinality bounded.
   for (const dependency of dependencies) {
     if (dependency.status === "Unhealthy") {
-      healthFailureCounter.add(1, {check: dependency.name.split(" ")[0] ?? dependency.name});
+      healthFailureCounter.add(1, {check: dependency.name.split(" ")[0]!});
     }
   }
 

--- a/sites/arolariu.ro/src/app/api/health/route.ts
+++ b/sites/arolariu.ro/src/app/api/health/route.ts
@@ -5,26 +5,21 @@
  * @remarks
  * Reports website health status including latency to upstream dependencies
  * (exp.arolariu.ro config proxy and api.arolariu.ro backend API).
- * Instrumented with OpenTelemetry spans and metrics.
+ * Telemetry is handled automatically by the OTel ignore hooks; the only
+ * hand-authored instrument is the always-on failure counter.
  */
 
-import {
-  addSpanEvent,
-  createCounter,
-  createHistogram,
-  createHttpServerAttributes,
-  injectTraceContextHeaders,
-  logWithTrace,
-  setSpanAttributes,
-  withSpan,
-} from "@/instrumentation.server";
+import {createCounter, injectTraceContextHeaders} from "@/instrumentation.server";
 import {version as nextVersion} from "next/package.json";
 import {NextResponse} from "next/server";
 
 export const dynamic = "force-dynamic";
 
-const healthCheckDuration = createHistogram("website.health.duration", "Health check total duration", "ms");
-const healthCheckCounter = createCounter("website.health.requests", "Total health check requests", "1");
+const healthFailureCounter = createCounter(
+  "arolariu.health.check.failures",
+  "Health check failures, dimensioned by the failing check name.",
+  "{failure}",
+);
 
 /** Whether we're running with Azure identity (determines exp URL). */
 const HAS_AZURE_CLIENT_ID = Boolean(process.env["AZURE_CLIENT_ID"]);
@@ -89,12 +84,6 @@ async function checkDependency(name: string, url: string): Promise<DependencySta
       signal: AbortSignal.timeout(10_000),
     });
     const latencyMs = Math.round(performance.now() - start);
-    addSpanEvent("health.dependency.checked", {
-      "dependency.name": name,
-      "dependency.status_code": response.status,
-      "dependency.url": url,
-      "dependency.latency_ms": latencyMs,
-    });
 
     if (response.ok) {
       return {name, status: "Healthy", url, latencyMs, statusCode: response.status};
@@ -103,7 +92,6 @@ async function checkDependency(name: string, url: string): Promise<DependencySta
   } catch (error) {
     const latencyMs = Math.round(performance.now() - start);
     const message = error instanceof Error ? error.message : String(error);
-    logWithTrace("warn", `Health check failed for ${name}`, {url, error: message}, "api");
     return {name, status: "Unhealthy", url, latencyMs, error: message};
   }
 }
@@ -120,66 +108,52 @@ function deriveOverallStatus(dependencies: readonly DependencyStatus[]): HealthS
  * @returns JSON health report with dependency latencies, process info, and build metadata.
  */
 export async function GET(): Promise<NextResponse<HealthResponse>> {
-  return withSpan("api.health.check", async () => {
-    const checkStart = performance.now();
-    healthCheckCounter.add(1);
+  const checkStart = performance.now();
 
-    addSpanEvent("health.check.start");
-    setSpanAttributes({
-      "health.exp_url": EXP_URL,
-      "health.api_url": API_URL,
-    });
+  const dependencies = await Promise.all([
+    checkDependency("exp (config proxy)", `${EXP_URL}/api/health`),
+    checkDependency("api (backend)", `${API_URL}/health`),
+  ]);
 
-    // Check dependencies in parallel
-    const dependencies = await Promise.all([
-      checkDependency("exp (config proxy)", `${EXP_URL}/api/health`),
-      checkDependency("api (backend)", `${API_URL}/health`),
-    ]);
+  const overallStatus = deriveOverallStatus(dependencies);
+  const checkDurationMs = Math.round(performance.now() - checkStart);
 
-    const overallStatus = deriveOverallStatus(dependencies);
-    const checkDurationMs = Math.round(performance.now() - checkStart);
+  // The single always-on signal that survives suppression. Dimension values match the
+  // .NET and Python services so one query spans the estate.
+  for (const dependency of dependencies) {
+    if (dependency.status === "Unhealthy") {
+      healthFailureCounter.add(1, {check: dependency.name.split(" ")[0] ?? dependency.name});
+    }
+  }
 
-    addSpanEvent("health.check.complete", {
-      "overall.status": overallStatus,
-      "check.duration_ms": checkDurationMs,
-      "dependencies.count": dependencies.length,
-    });
-
-    healthCheckDuration.record(checkDurationMs, {
-      ...createHttpServerAttributes("GET", overallStatus === "Healthy" ? 200 : 503, {route: "/api/health"}),
-    });
-
-    const mem = process.memoryUsage();
-    const response: HealthResponse = {
-      status: overallStatus,
-      timestamp: new Date().toISOString(),
-      checkDurationMs,
-      process: {
-        uptimeSeconds: Math.round((Date.now() - startedAt) / 1000),
-        startedAt: startedAtISO,
-        nodeVersion: process.version,
-        nextVersion: nextVersion ?? "unknown",
-        platform: process.platform,
-        arch: process.arch,
-        memoryUsageMB: {
-          rss: Math.round(mem.rss / 1024 / 1024),
-          heapUsed: Math.round(mem.heapUsed / 1024 / 1024),
-          heapTotal: Math.round(mem.heapTotal / 1024 / 1024),
-        },
+  const mem = process.memoryUsage();
+  const response: HealthResponse = {
+    status: overallStatus,
+    timestamp: new Date().toISOString(),
+    checkDurationMs,
+    process: {
+      uptimeSeconds: Math.round((Date.now() - startedAt) / 1000),
+      startedAt: startedAtISO,
+      nodeVersion: process.version,
+      nextVersion: nextVersion ?? "unknown",
+      platform: process.platform,
+      arch: process.arch,
+      memoryUsageMB: {
+        rss: Math.round(mem.rss / 1024 / 1024),
+        heapUsed: Math.round(mem.heapUsed / 1024 / 1024),
+        heapTotal: Math.round(mem.heapTotal / 1024 / 1024),
       },
-      build: {
-        commitSha: process.env["COMMIT_SHA"] ?? "unknown",
-        environment: process.env["SITE_ENV"] ?? "unknown",
-        siteName: process.env["SITE_NAME"] ?? "unknown",
-        siteUrl: process.env["SITE_URL"] ?? "unknown",
-        infraMode: process.env["INFRA"] ?? "unknown",
-      },
-      dependencies,
-    };
+    },
+    build: {
+      commitSha: process.env["COMMIT_SHA"] ?? "unknown",
+      environment: process.env["SITE_ENV"] ?? "unknown",
+      siteName: process.env["SITE_NAME"] ?? "unknown",
+      siteUrl: process.env["SITE_URL"] ?? "unknown",
+      infraMode: process.env["INFRA"] ?? "unknown",
+    },
+    dependencies,
+  };
 
-    logWithTrace("info", "Health check completed", {status: overallStatus, checkDurationMs}, "api");
-
-    const httpStatus = overallStatus === "Healthy" ? 200 : 503;
-    return NextResponse.json(response, {status: httpStatus});
-  });
+  const httpStatus = overallStatus === "Healthy" ? 200 : 503;
+  return NextResponse.json(response, {status: httpStatus});
 }

--- a/sites/arolariu.ro/src/instrumentation.server.ts
+++ b/sites/arolariu.ro/src/instrumentation.server.ts
@@ -132,7 +132,8 @@ export type MetricName =
   | `page.${string}`
   | `component.${string}`
   | `business.${string}`
-  | `website.${string}`;
+  | `website.${string}`
+  | `arolariu.${string}`;
 
 /**
  * Standard semantic attribute keys for HTTP operations.

--- a/sites/arolariu.ro/src/instrumentation.server.ts
+++ b/sites/arolariu.ro/src/instrumentation.server.ts
@@ -51,6 +51,7 @@ import {NodeSDK} from "@opentelemetry/sdk-node";
 // eslint-disable-next-line n/no-extraneous-import -- sdk-logs ships with the pinned OpenTelemetry SDK family used by the website runtime
 import {BatchLogRecordProcessor, LoggerProvider} from "@opentelemetry/sdk-logs";
 import {BatchSpanProcessor} from "@opentelemetry/sdk-trace-node";
+import {parseSuppressionFlag, shouldSuppressTelemetry, SUPPRESSION_ENV_VAR} from "@/lib/telemetry/healthPolicy";
 
 // #endregion
 
@@ -564,6 +565,15 @@ const sdk = new NodeSDK({
       "@opentelemetry/instrumentation-fs": {
         enabled: false,
       },
+      // Inbound: drop spans for the website's own health probe.
+      "@opentelemetry/instrumentation-http": {
+        ignoreIncomingRequestHook: (request) => shouldSuppressTelemetry(request.url),
+      },
+      // Outbound: fetch() in route handlers goes through undici, not http. Without this
+      // hook the /api/health fan-out to api and exp still emits dependency spans.
+      "@opentelemetry/instrumentation-undici": {
+        ignoreRequestHook: (request) => shouldSuppressTelemetry(request.path),
+      },
     }),
   ],
 });
@@ -598,6 +608,9 @@ export function startTelemetry(): void {
   try {
     sdk.start();
     console.log("📊 OpenTelemetry SDK started successfully");
+    console.log(
+      `>>> 🔇 Health telemetry suppression enabled: ${parseSuppressionFlag(process.env[SUPPRESSION_ENV_VAR])}. Override with ${SUPPRESSION_ENV_VAR}.`,
+    );
   } catch (error) {
     console.error("❌ Failed to start OpenTelemetry SDK:", error);
   }

--- a/sites/arolariu.ro/src/lib/telemetry/healthPolicy.test.ts
+++ b/sites/arolariu.ro/src/lib/telemetry/healthPolicy.test.ts
@@ -1,5 +1,5 @@
-import {describe, expect, it} from "vitest";
-import {isSuppressedPath, parseSuppressionFlag, shouldSuppressTelemetry} from "./healthPolicy";
+import {afterEach, describe, expect, it, vi} from "vitest";
+import {SUPPRESSION_ENV_VAR, isSuppressedPath, parseSuppressionFlag, shouldSuppressTelemetry} from "./healthPolicy";
 
 describe("healthPolicy", () => {
   describe("isSuppressedPath", () => {
@@ -33,12 +33,26 @@ describe("healthPolicy", () => {
   });
 
   describe("shouldSuppressTelemetry", () => {
-    it("suppresses a health path when the flag is enabled", () => {
+    afterEach(() => vi.unstubAllEnvs());
+
+    it("suppresses a health path when the env var is unset", () => {
+      vi.stubEnv(SUPPRESSION_ENV_VAR, undefined as unknown as string);
       expect(shouldSuppressTelemetry("/api/health")).toBe(true);
     });
 
-    it("never suppresses a real route", () => {
+    it("never suppresses a real route even when the env var is unset", () => {
+      vi.stubEnv(SUPPRESSION_ENV_VAR, undefined as unknown as string);
       expect(shouldSuppressTelemetry("/api/user")).toBe(false);
+    });
+
+    it("does not suppress a health path when the env var is 'false'", () => {
+      vi.stubEnv(SUPPRESSION_ENV_VAR, "false");
+      expect(shouldSuppressTelemetry("/api/health")).toBe(false);
+    });
+
+    it("suppresses a health path when the env var is an unparseable value (fail-safe)", () => {
+      vi.stubEnv(SUPPRESSION_ENV_VAR, "garbage");
+      expect(shouldSuppressTelemetry("/api/health")).toBe(true);
     });
   });
 });

--- a/sites/arolariu.ro/src/lib/telemetry/healthPolicy.test.ts
+++ b/sites/arolariu.ro/src/lib/telemetry/healthPolicy.test.ts
@@ -25,6 +25,7 @@ describe("healthPolicy", () => {
       ["true", true],
       ["TRUE", true],
       ["not-a-bool", true],
+      ["undefined", true],
       ["false", false],
       ["False", false],
     ])("parses %s as %s", (raw, expected) => {
@@ -36,12 +37,14 @@ describe("healthPolicy", () => {
     afterEach(() => vi.unstubAllEnvs());
 
     it("suppresses a health path when the env var is unset", () => {
-      vi.stubEnv(SUPPRESSION_ENV_VAR, undefined as unknown as string);
+      delete process.env[SUPPRESSION_ENV_VAR];
+      expect(process.env[SUPPRESSION_ENV_VAR]).toBeUndefined();
       expect(shouldSuppressTelemetry("/api/health")).toBe(true);
     });
 
     it("never suppresses a real route even when the env var is unset", () => {
-      vi.stubEnv(SUPPRESSION_ENV_VAR, undefined as unknown as string);
+      delete process.env[SUPPRESSION_ENV_VAR];
+      expect(process.env[SUPPRESSION_ENV_VAR]).toBeUndefined();
       expect(shouldSuppressTelemetry("/api/user")).toBe(false);
     });
 

--- a/sites/arolariu.ro/src/lib/telemetry/healthPolicy.test.ts
+++ b/sites/arolariu.ro/src/lib/telemetry/healthPolicy.test.ts
@@ -1,0 +1,44 @@
+import {describe, expect, it} from "vitest";
+import {isSuppressedPath, parseSuppressionFlag, shouldSuppressTelemetry} from "./healthPolicy";
+
+describe("healthPolicy", () => {
+  describe("isSuppressedPath", () => {
+    it.each(["/health", "/api/health", "/api/ready", "/HEALTH", "/Api/Health", "/health/", "/api/health?x=1"])(
+      "suppresses %s",
+      (path) => {
+        expect(isSuppressedPath(path)).toBe(true);
+      },
+    );
+
+    it.each(["/", "/api/user", "/api/healthy", "/healthcheck-admin", "/health/details", "", undefined])(
+      "does not suppress %s",
+      (path) => {
+        expect(isSuppressedPath(path)).toBe(false);
+      },
+    );
+  });
+
+  describe("parseSuppressionFlag", () => {
+    it.each([
+      [undefined, true],
+      ["", true],
+      ["true", true],
+      ["TRUE", true],
+      ["not-a-bool", true],
+      ["false", false],
+      ["False", false],
+    ])("parses %s as %s", (raw, expected) => {
+      expect(parseSuppressionFlag(raw)).toBe(expected);
+    });
+  });
+
+  describe("shouldSuppressTelemetry", () => {
+    it("suppresses a health path when the flag is enabled", () => {
+      expect(shouldSuppressTelemetry("/api/health")).toBe(true);
+    });
+
+    it("never suppresses a real route", () => {
+      expect(shouldSuppressTelemetry("/api/user")).toBe(false);
+    });
+  });
+});

--- a/sites/arolariu.ro/src/lib/telemetry/healthPolicy.ts
+++ b/sites/arolariu.ro/src/lib/telemetry/healthPolicy.ts
@@ -1,0 +1,52 @@
+/**
+ * @fileoverview Health and connectivity telemetry suppression policy.
+ * @module sites/arolariu.ro/src/lib/telemetry/healthPolicy
+ *
+ * @remarks
+ * Sole owner of the suppressed path list for the website. Consumed by the OpenTelemetry
+ * ignore hooks in `instrumentation.server.ts`. Deliberately free of `server-only` so it
+ * remains directly unit-testable.
+ */
+
+/** Paths whose telemetry is suppressed. Matched exactly, never by prefix. */
+export const SUPPRESSED_HEALTH_PATHS: readonly string[] = ["/health", "/api/health", "/api/ready"];
+
+/** Environment variable controlling suppression. Only the literal `false` disables it. */
+export const SUPPRESSION_ENV_VAR = "OTEL_SUPPRESS_HEALTH_TELEMETRY";
+
+/**
+ * Parses the raw suppression environment variable value.
+ * @param rawValue The raw environment variable value, possibly undefined or malformed.
+ * @returns `false` only when the value is exactly `false`, case-insensitively.
+ */
+export function parseSuppressionFlag(rawValue: string | undefined): boolean {
+  if (rawValue === undefined || rawValue.trim() === "") return true;
+  return rawValue.trim().toLowerCase() !== "false";
+}
+
+function normalize(path: string): string {
+  const queryIndex = path.indexOf("?");
+  const withoutQuery = queryIndex >= 0 ? path.slice(0, queryIndex) : path;
+  return withoutQuery.length > 1 ? withoutQuery.replace(/\/+$/u, "") : withoutQuery;
+}
+
+/**
+ * Determines whether a path is one of the suppressed health endpoints.
+ * @param path The request path, with or without a query string.
+ * @returns True when the normalized path matches a suppressed endpoint exactly.
+ */
+export function isSuppressedPath(path: string | undefined): boolean {
+  if (path === undefined || path === "") return false;
+  const normalized = normalize(path).toLowerCase();
+  return SUPPRESSED_HEALTH_PATHS.includes(normalized);
+}
+
+/**
+ * Determines whether telemetry should be suppressed for a path.
+ * @param path The request path, with or without a query string.
+ * @returns True when telemetry must be suppressed.
+ * @remarks Fails open toward emitting: a malformed env var leaves suppression at its default.
+ */
+export function shouldSuppressTelemetry(path: string | undefined): boolean {
+  return parseSuppressionFlag(process.env[SUPPRESSION_ENV_VAR]) && isSuppressedPath(path);
+}

--- a/sites/exp.arolariu.ro/main.py
+++ b/sites/exp.arolariu.ro/main.py
@@ -26,6 +26,7 @@ from telemetry.bootstrap import (
     shutdown_telemetry,
     start_span,
 )
+from telemetry.health_policy import should_suppress_telemetry
 
 logger = logging.getLogger(__name__)
 
@@ -126,17 +127,18 @@ async def attach_request_context(
     )
     trace_context = get_current_trace_context()
 
-    logger.info(
-        "request_id=%s request_id_source=%s trace_id=%s span_id=%s method=%s path=%s status=%s durationMs=%.2f",
-        request_id,
-        request_id_source,
-        trace_context.trace_id if trace_context else "0",
-        trace_context.span_id if trace_context else "0",
-        request.method,
-        request.url.path,
-        response.status_code,
-        elapsed_ms,
-    )
+    if not should_suppress_telemetry(request.url.path):
+        logger.info(
+            "request_id=%s request_id_source=%s trace_id=%s span_id=%s method=%s path=%s status=%s durationMs=%.2f",
+            request_id,
+            request_id_source,
+            trace_context.trace_id if trace_context else "0",
+            trace_context.span_id if trace_context else "0",
+            request.method,
+            request.url.path,
+            response.status_code,
+            elapsed_ms,
+        )
     return response
 
 

--- a/sites/exp.arolariu.ro/main.py
+++ b/sites/exp.arolariu.ro/main.py
@@ -22,11 +22,12 @@ from telemetry.bootstrap import (
     get_current_trace_context,
     initialize_telemetry,
     record_current_span_exception,
+    record_health_failure_metric,
     set_current_span_attributes,
     shutdown_telemetry,
     start_span,
 )
-from telemetry.health_policy import should_suppress_telemetry
+from telemetry.health_policy import is_suppressed_path, should_suppress_telemetry
 
 logger = logging.getLogger(__name__)
 
@@ -126,6 +127,9 @@ async def attach_request_context(
         }
     )
     trace_context = get_current_trace_context()
+
+    if is_suppressed_path(request.url.path) and response.status_code >= 500:
+        record_health_failure_metric(check="config")
 
     if not should_suppress_telemetry(request.url.path):
         logger.info(

--- a/sites/exp.arolariu.ro/main.test.py
+++ b/sites/exp.arolariu.ro/main.test.py
@@ -133,3 +133,46 @@ class TestRequestCorrelation:
 
         assert response.status_code == 200
         assert response.headers.get("X-Request-Id") == upstream_request_id
+
+
+class TestHealthFailureCounterMiddleware:
+    """The failure counter must fire on a real readiness failure, and only then."""
+
+    def test_records_counter_on_readiness_failure(self, client: TestClient) -> None:
+        """A 503 from /api/ready must record exactly one check=config measurement."""
+
+        with patch("main.record_health_failure_metric") as recorder, patch(
+            "api.health.get_config", side_effect=RuntimeError("config unavailable")
+        ):
+            response = client.get("/api/ready")
+
+        assert response.status_code == 503
+        recorder.assert_called_once_with(check="config")
+
+    def test_records_nothing_when_readiness_succeeds(self, client: TestClient) -> None:
+        """A healthy readiness probe must not touch the counter."""
+
+        with patch("main.record_health_failure_metric") as recorder:
+            response = client.get("/api/ready")
+
+        assert response.status_code == 200
+        recorder.assert_not_called()
+
+    def test_records_nothing_for_liveness(self, client: TestClient) -> None:
+        """/api/health is pure liveness and always 200, so it has no failure state."""
+
+        with patch("main.record_health_failure_metric") as recorder:
+            response = client.get("/api/health")
+
+        assert response.status_code == 200
+        recorder.assert_not_called()
+
+    def test_records_nothing_for_non_health_route(self, client: TestClient) -> None:
+        """A 5xx on a normal route must not be attributed to the health counter."""
+
+        with patch("main.record_health_failure_metric") as recorder, patch(
+            "api.config.get_config", side_effect=RuntimeError("boom")
+        ):
+            client.get("/api/v1/config")
+
+        recorder.assert_not_called()

--- a/sites/exp.arolariu.ro/telemetry/bootstrap.py
+++ b/sites/exp.arolariu.ro/telemetry/bootstrap.py
@@ -12,6 +12,11 @@ from typing import Any
 
 from fastapi import FastAPI
 
+from telemetry.health_policy import (
+    SUPPRESSED_HEALTH_PATHS,
+    SUPPRESSION_ENV_VAR,
+    parse_suppression_flag,
+)
 from telemetry.settings import TelemetrySettings, get_telemetry_settings
 
 logger = logging.getLogger(__name__)
@@ -83,6 +88,7 @@ _config_load_duration_histogram: Any = None
 _auth_decision_counter: Any = None
 _config_delivery_counter: Any = None
 _config_values_counter: Any = None
+_health_failure_counter: Any = None
 
 
 class SafeOtelFormatter(logging.Formatter):
@@ -380,6 +386,7 @@ def _configure_custom_metrics(runtime: TelemetryRuntime) -> None:
     global _auth_decision_counter
     global _config_delivery_counter
     global _config_values_counter
+    global _health_failure_counter
 
     if runtime.meter_provider is None or runtime.dependencies is None:
         return
@@ -409,6 +416,11 @@ def _configure_custom_metrics(runtime: TelemetryRuntime) -> None:
         "exp.config.values_served",
         unit="value",
         description="Number of config values returned by successful config responses.",
+    )
+    _health_failure_counter = meter.create_counter(
+        "arolariu.health.check.failures",
+        unit="{failure}",
+        description="Health check failures, dimensioned by the failing check name.",
     )
 
     meter.create_observable_gauge(
@@ -631,6 +643,12 @@ def initialize_telemetry(app: FastAPI) -> TelemetryRuntime:
             settings.console_log_export_enabled,
             settings.azure_export_enabled,
         )
+        logging.getLogger(__name__).info(
+            "health telemetry suppression enabled=%s paths=%s override=%s",
+            parse_suppression_flag(os.environ.get(SUPPRESSION_ENV_VAR)),
+            ",".join(SUPPRESSED_HEALTH_PATHS),
+            SUPPRESSION_ENV_VAR,
+        )
 
         _telemetry_runtime = runtime
         return runtime
@@ -660,6 +678,7 @@ def shutdown_telemetry() -> None:
     global _auth_decision_counter
     global _config_delivery_counter
     global _config_values_counter
+    global _health_failure_counter
 
     with _runtime_lock:
         runtime = _telemetry_runtime
@@ -669,6 +688,7 @@ def shutdown_telemetry() -> None:
         _auth_decision_counter = None
         _config_delivery_counter = None
         _config_values_counter = None
+        _health_failure_counter = None
 
     if runtime is None or not runtime.initialized:
         return
@@ -699,6 +719,7 @@ def reset_telemetry_state() -> None:
     global _auth_decision_counter
     global _config_delivery_counter
     global _config_values_counter
+    global _health_failure_counter
 
     with _runtime_lock:
         _telemetry_runtime = None
@@ -707,6 +728,7 @@ def reset_telemetry_state() -> None:
         _auth_decision_counter = None
         _config_delivery_counter = None
         _config_values_counter = None
+        _health_failure_counter = None
 
 
 def _set_span_attributes(span: Any, attributes: AttributeMap | None) -> None:
@@ -871,3 +893,18 @@ def record_config_delivery_metric(
 
     if _config_values_counter is not None:
         _config_values_counter.add(value_count, attributes)
+
+
+def record_health_failure_metric(*, check: str) -> None:
+    """Record one health or readiness check failure.
+
+    This is the single always-on signal that survives health telemetry suppression; its
+    volume is effectively zero until a dependency actually fails.
+    """
+
+    runtime = _telemetry_runtime
+    if runtime is None:
+        return
+
+    if _health_failure_counter is not None:
+        _health_failure_counter.add(1, _get_metric_attributes({"check": check}))

--- a/sites/exp.arolariu.ro/telemetry/bootstrap.py
+++ b/sites/exp.arolariu.ro/telemetry/bootstrap.py
@@ -573,11 +573,17 @@ def _instrument_fastapi_app(runtime: TelemetryRuntime, app: FastAPI) -> None:
     if getattr(app.state, "exp_otel_instrumented", False):
         return
 
+    # Exclusions are dropped entirely when the operator disables suppression, so
+    # OTEL_SUPPRESS_HEALTH_TELEMETRY=false restores traces and HTTP metrics for probe
+    # endpoints as documented -- not just the request logs guarded in main.
+    suppression_enabled = parse_suppression_flag(os.environ.get(SUPPRESSION_ENV_VAR))
+    excluded_urls = runtime.settings.excluded_urls if suppression_enabled else ""
+
     runtime.dependencies.FastAPIInstrumentor.instrument_app(
         app,
         tracer_provider=runtime.tracer_provider,
         meter_provider=runtime.meter_provider,
-        excluded_urls=runtime.settings.excluded_urls,
+        excluded_urls=excluded_urls,
         server_request_hook=_server_request_hook,
         client_response_hook=_client_response_hook,
         exclude_spans=["receive", "send"],

--- a/sites/exp.arolariu.ro/telemetry/bootstrap.py
+++ b/sites/exp.arolariu.ro/telemetry/bootstrap.py
@@ -15,6 +15,7 @@ from fastapi import FastAPI
 from telemetry.health_policy import (
     SUPPRESSED_HEALTH_PATHS,
     SUPPRESSION_ENV_VAR,
+    build_excluded_urls,
     parse_suppression_flag,
 )
 from telemetry.settings import TelemetrySettings, get_telemetry_settings
@@ -573,11 +574,16 @@ def _instrument_fastapi_app(runtime: TelemetryRuntime, app: FastAPI) -> None:
     if getattr(app.state, "exp_otel_instrumented", False):
         return
 
-    # Exclusions are dropped entirely when the operator disables suppression, so
+    # Only the health-derived defaults answer to the suppression flag, so
     # OTEL_SUPPRESS_HEALTH_TELEMETRY=false restores traces and HTTP metrics for probe
     # endpoints as documented -- not just the request logs guarded in main.
-    suppression_enabled = parse_suppression_flag(os.environ.get(SUPPRESSION_ENV_VAR))
-    excluded_urls = runtime.settings.excluded_urls if suppression_enabled else ""
+    #
+    # An operator who set EXP_OTEL_EXCLUDED_URLS explicitly gets that list honoured verbatim:
+    # it is a general-purpose exclusion knob, and a flag about *health* telemetry has no
+    # business silently discarding unrelated exclusions.
+    excluded_urls = runtime.settings.excluded_urls
+    if not parse_suppression_flag(os.environ.get(SUPPRESSION_ENV_VAR)) and excluded_urls == build_excluded_urls():
+        excluded_urls = ""
 
     runtime.dependencies.FastAPIInstrumentor.instrument_app(
         app,

--- a/sites/exp.arolariu.ro/telemetry/bootstrap.test.py
+++ b/sites/exp.arolariu.ro/telemetry/bootstrap.test.py
@@ -312,9 +312,46 @@ class TestTelemetryBootstrap:
         finally:
             shutdown_telemetry()
 
+    def test_override_drops_health_exclusions(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """OTEL_SUPPRESS_HEALTH_TELEMETRY=false must restore probe traces, not just logs.
+
+        Guards the wiring, not just the predicate: the flag has to actually reach
+        FastAPIInstrumentor, otherwise disabling suppression silently leaves traces off.
+        """
+
+        dependencies = _build_fake_dependencies()
+        monkeypatch.setenv("EXP_OTEL_ENABLED", "true")
+        monkeypatch.setenv("INFRA", "local")
+        monkeypatch.setenv("OTEL_SUPPRESS_HEALTH_TELEMETRY", "false")
+        monkeypatch.delenv("EXP_OTEL_EXCLUDED_URLS", raising=False)
+        monkeypatch.setattr("telemetry.bootstrap._import_telemetry_dependencies", lambda: dependencies)
+
+        app = FastAPI()
+        initialize_telemetry(app)
+        try:
+            assert dependencies.FastAPIInstrumentor.instrument_calls[0]["excluded_urls"] == ""
+        finally:
+            shutdown_telemetry()
+
+    def test_override_preserves_operator_supplied_exclusions(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A health flag must not silently discard an unrelated, explicitly-set exclusion list."""
+
+        dependencies = _build_fake_dependencies()
+        monkeypatch.setenv("EXP_OTEL_ENABLED", "true")
+        monkeypatch.setenv("INFRA", "local")
+        monkeypatch.setenv("OTEL_SUPPRESS_HEALTH_TELEMETRY", "false")
+        monkeypatch.setenv("EXP_OTEL_EXCLUDED_URLS", "/internal/debug")
+        monkeypatch.setattr("telemetry.bootstrap._import_telemetry_dependencies", lambda: dependencies)
+
+        app = FastAPI()
+        initialize_telemetry(app)
+        try:
+            assert dependencies.FastAPIInstrumentor.instrument_calls[0]["excluded_urls"] == "/internal/debug"
+        finally:
+            shutdown_telemetry()
+
     def test_initializes_azure_monitor_exporters(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
+        self,        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         dependencies = _build_fake_dependencies()
         monkeypatch.setenv("EXP_OTEL_ENABLED", "true")

--- a/sites/exp.arolariu.ro/telemetry/bootstrap.test.py
+++ b/sites/exp.arolariu.ro/telemetry/bootstrap.test.py
@@ -10,6 +10,7 @@ import pytest
 from fastapi import FastAPI
 
 from telemetry.bootstrap import TelemetryDependencies, initialize_telemetry, shutdown_telemetry
+from telemetry.health_policy import build_excluded_urls
 
 
 def _build_fake_dependencies() -> TelemetryDependencies:
@@ -306,7 +307,7 @@ class TestTelemetryBootstrap:
             assert len(runtime.meter_provider.metric_readers) == 1
             assert isinstance(runtime.meter_provider.metric_readers[0].exporter, dependencies.ConsoleMetricExporter)
             assert len(dependencies.FastAPIInstrumentor.instrument_calls) == 1
-            expected_excluded = "/api/health,/api/ready"
+            expected_excluded = build_excluded_urls()
             assert dependencies.FastAPIInstrumentor.instrument_calls[0]["excluded_urls"] == expected_excluded
         finally:
             shutdown_telemetry()

--- a/sites/exp.arolariu.ro/telemetry/bootstrap.test.py
+++ b/sites/exp.arolariu.ro/telemetry/bootstrap.test.py
@@ -306,7 +306,7 @@ class TestTelemetryBootstrap:
             assert len(runtime.meter_provider.metric_readers) == 1
             assert isinstance(runtime.meter_provider.metric_readers[0].exporter, dependencies.ConsoleMetricExporter)
             assert len(dependencies.FastAPIInstrumentor.instrument_calls) == 1
-            expected_excluded = "/api/health,/api/ready,/admin"
+            expected_excluded = "/api/health,/api/ready"
             assert dependencies.FastAPIInstrumentor.instrument_calls[0]["excluded_urls"] == expected_excluded
         finally:
             shutdown_telemetry()

--- a/sites/exp.arolariu.ro/telemetry/bootstrap.test.py
+++ b/sites/exp.arolariu.ro/telemetry/bootstrap.test.py
@@ -347,3 +347,14 @@ class TestTelemetryBootstrap:
             assert log_exporter.kwargs["disable_offline_storage"] is True
         finally:
             shutdown_telemetry()
+
+
+class TestHealthFailureMetric:
+    """Behaviour of the health failure counter."""
+
+    def test_record_health_failure_metric_is_safe_without_runtime(self) -> None:
+        from telemetry.bootstrap import record_health_failure_metric, reset_telemetry_state
+
+        reset_telemetry_state()
+
+        record_health_failure_metric(check="config")

--- a/sites/exp.arolariu.ro/telemetry/health_policy.py
+++ b/sites/exp.arolariu.ro/telemetry/health_policy.py
@@ -1,0 +1,54 @@
+"""Health and connectivity telemetry suppression policy for the exp service.
+
+Sole owner of the suppressed path list. Consumed by the request middleware in ``main``
+to keep probe traffic out of exported logs. Traces are excluded separately via
+``TelemetrySettings.excluded_urls``.
+"""
+
+import os
+
+SUPPRESSED_HEALTH_PATHS: tuple[str, ...] = ("/health", "/api/health", "/api/ready")
+
+SUPPRESSION_ENV_VAR: str = "OTEL_SUPPRESS_HEALTH_TELEMETRY"
+
+
+def _normalize(path: str) -> str:
+    """Strip the query string and any trailing slash from a request path."""
+
+    without_query = path.split("?", 1)[0]
+    return without_query.rstrip("/") if len(without_query) > 1 else without_query
+
+
+def parse_suppression_flag(raw_value: str | None) -> bool:
+    """Return whether suppression is enabled for the supplied raw environment value.
+
+    Unset and unparseable values resolve to the safe default of enabled suppression;
+    only the literal string ``false`` disables it.
+    """
+
+    if raw_value is None or not raw_value.strip():
+        return True
+
+    return raw_value.strip().lower() != "false"
+
+
+def is_suppressed_path(path: str | None) -> bool:
+    """Return whether ``path`` is one of the suppressed health endpoints.
+
+    Matching is exact on the normalized path and case-insensitive. Prefix matching is
+    deliberately avoided so that paths such as ``/healthcheck-admin`` are not swallowed.
+    """
+
+    if not path:
+        return False
+
+    return _normalize(path).lower() in SUPPRESSED_HEALTH_PATHS
+
+
+def should_suppress_telemetry(path: str | None) -> bool:
+    """Return whether telemetry must be suppressed for ``path``.
+
+    Fails open toward emitting: a malformed override leaves suppression at its default.
+    """
+
+    return parse_suppression_flag(os.environ.get(SUPPRESSION_ENV_VAR)) and is_suppressed_path(path)

--- a/sites/exp.arolariu.ro/telemetry/health_policy.py
+++ b/sites/exp.arolariu.ro/telemetry/health_policy.py
@@ -1,11 +1,12 @@
 """Health and connectivity telemetry suppression policy for the exp service.
 
 Sole owner of the suppressed path list. Consumed by the request middleware in ``main``
-to keep probe traffic out of exported logs. Traces are excluded separately via
-``TelemetrySettings.excluded_urls``.
+to keep probe traffic out of exported logs, and by ``TelemetrySettings`` to build the
+trace/HTTP-metric exclusion patterns handed to ``FastAPIInstrumentor``.
 """
 
 import os
+import re
 
 SUPPRESSED_HEALTH_PATHS: tuple[str, ...] = ("/health", "/api/health", "/api/ready")
 
@@ -52,3 +53,19 @@ def should_suppress_telemetry(path: str | None) -> bool:
     """
 
     return parse_suppression_flag(os.environ.get(SUPPRESSION_ENV_VAR)) and is_suppressed_path(path)
+
+
+def build_excluded_urls() -> str:
+    """Return the comma-separated exclusion patterns for ``FastAPIInstrumentor``.
+
+    OpenTelemetry's ``ExcludeList`` joins the supplied entries with ``|`` and applies
+    ``re.search``, so a bare path such as ``/api/health`` is an **unanchored** regex that
+    would also swallow ``/api/healthy`` and ``/api/health/extra``. That contradicts the
+    exact-match policy implemented by :func:`is_suppressed_path`.
+
+    Each path is therefore emitted as an anchored, case-insensitive expression tolerating an
+    optional trailing slash and an optional query string, so trace and HTTP-metric exclusion
+    matches :func:`is_suppressed_path` exactly.
+    """
+
+    return ",".join(f"(?i:^{re.escape(path)}/?(\\?.*)?$)" for path in SUPPRESSED_HEALTH_PATHS)

--- a/sites/exp.arolariu.ro/telemetry/health_policy.test.py
+++ b/sites/exp.arolariu.ro/telemetry/health_policy.test.py
@@ -1,0 +1,66 @@
+"""Tests for the health telemetry suppression policy."""
+
+import pytest
+
+from telemetry.health_policy import (
+    is_suppressed_path,
+    parse_suppression_flag,
+    should_suppress_telemetry,
+)
+
+
+class TestIsSuppressedPath:
+    """Behaviour of the suppressed-path predicate."""
+
+    @pytest.mark.parametrize(
+        "path",
+        ["/health", "/api/health", "/api/ready", "/HEALTH", "/Api/Health", "/health/", "/api/ready?x=1"],
+    )
+    def test_returns_true_for_health_paths(self, path: str) -> None:
+        assert is_suppressed_path(path) is True
+
+    @pytest.mark.parametrize(
+        "path",
+        ["/", "/admin", "/api/v1/config", "/api/healthy", "/healthcheck-admin", "", None],
+    )
+    def test_returns_false_for_other_paths(self, path: str | None) -> None:
+        assert is_suppressed_path(path) is False
+
+
+class TestParseSuppressionFlag:
+    """Behaviour of the environment variable parser."""
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            (None, True),
+            ("", True),
+            ("   ", True),
+            ("true", True),
+            ("TRUE", True),
+            ("not-a-bool", True),
+            ("false", False),
+            ("False", False),
+        ],
+    )
+    def test_parses_value(self, raw: str | None, expected: bool) -> None:
+        assert parse_suppression_flag(raw) is expected
+
+
+class TestShouldSuppressTelemetry:
+    """Combined path and environment gate."""
+
+    def test_suppresses_health_path_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("OTEL_SUPPRESS_HEALTH_TELEMETRY", raising=False)
+
+        assert should_suppress_telemetry("/api/health") is True
+
+    def test_never_suppresses_real_route(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("OTEL_SUPPRESS_HEALTH_TELEMETRY", raising=False)
+
+        assert should_suppress_telemetry("/api/v1/config") is False
+
+    def test_override_restores_health_telemetry(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OTEL_SUPPRESS_HEALTH_TELEMETRY", "false")
+
+        assert should_suppress_telemetry("/api/health") is False

--- a/sites/exp.arolariu.ro/telemetry/health_policy.test.py
+++ b/sites/exp.arolariu.ro/telemetry/health_policy.test.py
@@ -3,6 +3,7 @@
 import pytest
 
 from telemetry.health_policy import (
+    build_excluded_urls,
     is_suppressed_path,
     parse_suppression_flag,
     should_suppress_telemetry,
@@ -64,3 +65,45 @@ class TestShouldSuppressTelemetry:
         monkeypatch.setenv("OTEL_SUPPRESS_HEALTH_TELEMETRY", "false")
 
         assert should_suppress_telemetry("/api/health") is False
+
+class TestBuildExcludedUrls:
+    """Exclusion patterns handed to FastAPIInstrumentor must match is_suppressed_path exactly."""
+
+    @pytest.mark.parametrize(
+        "path",
+        ["/health", "/health/", "/HEALTH", "/api/health", "/api/health?x=1", "/api/health/?x=1", "/api/ready"],
+    )
+    def test_excludes_every_suppressed_path(self, path: str) -> None:
+        from opentelemetry.util.http import parse_excluded_urls
+
+        assert parse_excluded_urls(build_excluded_urls()).url_disabled(path) is True
+
+    @pytest.mark.parametrize(
+        "path",
+        ["/api/healthy", "/api/health/extra", "/healthcheck-admin", "/api/v1/config", "/admin", "/"],
+    )
+    def test_does_not_exclude_near_misses(self, path: str) -> None:
+        """Regression: bare paths are unanchored regexes and would swallow these."""
+
+        from opentelemetry.util.http import parse_excluded_urls
+
+        assert parse_excluded_urls(build_excluded_urls()).url_disabled(path) is False
+
+    def test_agrees_with_is_suppressed_path(self) -> None:
+        """The regex and the predicate are two encodings of one policy; they must not drift."""
+
+        from opentelemetry.util.http import parse_excluded_urls
+
+        exclude_list = parse_excluded_urls(build_excluded_urls())
+        for path in [
+            "/health",
+            "/api/health",
+            "/api/ready",
+            "/api/healthy",
+            "/api/health/extra",
+            "/healthcheck-admin",
+            "/admin",
+            "/api/v1/config",
+            "/",
+        ]:
+            assert exclude_list.url_disabled(path) is is_suppressed_path(path), path

--- a/sites/exp.arolariu.ro/telemetry/settings.py
+++ b/sites/exp.arolariu.ro/telemetry/settings.py
@@ -23,7 +23,7 @@ DEFAULT_TRACE_SAMPLE_RATIO = 1.0
 DEFAULT_LOG_LEVEL = "INFO"
 DEFAULT_SERVICE_NAME = "exp.arolariu.ro"
 DEFAULT_SERVICE_NAMESPACE = "arolariu.ro"
-DEFAULT_EXCLUDED_URLS = "/api/health,/api/ready,/admin"
+DEFAULT_EXCLUDED_URLS = "/api/health,/api/ready"
 
 
 @dataclass(frozen=True, slots=True)

--- a/sites/exp.arolariu.ro/telemetry/settings.py
+++ b/sites/exp.arolariu.ro/telemetry/settings.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from config.settings import get_runtime_infra_mode
+from telemetry.health_policy import build_excluded_urls
 
 DEFAULT_TELEMETRY_ENABLED = True
 DEFAULT_CONSOLE_LOG_EXPORT_ENABLED = False
@@ -23,7 +24,7 @@ DEFAULT_TRACE_SAMPLE_RATIO = 1.0
 DEFAULT_LOG_LEVEL = "INFO"
 DEFAULT_SERVICE_NAME = "exp.arolariu.ro"
 DEFAULT_SERVICE_NAMESPACE = "arolariu.ro"
-DEFAULT_EXCLUDED_URLS = "/api/health,/api/ready"
+DEFAULT_EXCLUDED_URLS = build_excluded_urls()
 
 
 @dataclass(frozen=True, slots=True)

--- a/sites/exp.arolariu.ro/telemetry/settings.test.py
+++ b/sites/exp.arolariu.ro/telemetry/settings.test.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import pytest
+from opentelemetry.util.http import parse_excluded_urls
 
+from telemetry.health_policy import build_excluded_urls
 from telemetry.settings import get_telemetry_settings
 
 
@@ -22,7 +24,7 @@ class TestTelemetrySettings:
         assert settings.console_metric_export_enabled is True
         assert settings.console_log_export_enabled is False
         assert settings.azure_export_enabled is False
-        assert settings.excluded_urls == "/api/health,/api/ready"
+        assert settings.excluded_urls == build_excluded_urls()
         assert settings.service_version == "3.0.0"
 
     def test_resolves_azure_export_when_connection_string_is_present(
@@ -55,12 +57,19 @@ class TestTelemetrySettings:
         assert settings.log_level_name == "DEBUG"
 
     def test_excluded_urls_cover_health_paths_only(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Assert on matching behaviour rather than the literal pattern string.
+
+        The value is a set of anchored regexes, not bare paths, because OpenTelemetry applies
+        ``re.search`` to these entries. See ``build_excluded_urls``.
+        """
+
         monkeypatch.delenv("EXP_OTEL_EXCLUDED_URLS", raising=False)
 
         settings = get_telemetry_settings()
+        exclude_list = parse_excluded_urls(settings.excluded_urls)
 
-        excluded = [entry.strip() for entry in settings.excluded_urls.split(",")]
-
-        assert "/api/health" in excluded
-        assert "/api/ready" in excluded
-        assert "/admin" not in excluded
+        assert exclude_list.url_disabled("/api/health") is True
+        assert exclude_list.url_disabled("/api/ready") is True
+        assert exclude_list.url_disabled("/health") is True
+        assert exclude_list.url_disabled("/admin") is False
+        assert exclude_list.url_disabled("/api/healthy") is False

--- a/sites/exp.arolariu.ro/telemetry/settings.test.py
+++ b/sites/exp.arolariu.ro/telemetry/settings.test.py
@@ -22,7 +22,7 @@ class TestTelemetrySettings:
         assert settings.console_metric_export_enabled is True
         assert settings.console_log_export_enabled is False
         assert settings.azure_export_enabled is False
-        assert settings.excluded_urls == "/api/health,/api/ready,/admin"
+        assert settings.excluded_urls == "/api/health,/api/ready"
         assert settings.service_version == "3.0.0"
 
     def test_resolves_azure_export_when_connection_string_is_present(
@@ -53,3 +53,14 @@ class TestTelemetrySettings:
         assert settings.metric_export_interval_millis == 15_000
         assert settings.trace_sample_ratio == 0.25
         assert settings.log_level_name == "DEBUG"
+
+    def test_excluded_urls_cover_health_paths_only(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("EXP_OTEL_EXCLUDED_URLS", raising=False)
+
+        settings = get_telemetry_settings()
+
+        excluded = [entry.strip() for entry in settings.excluded_urls.split(",")]
+
+        assert "/api/health" in excluded
+        assert "/api/ready" in excluded
+        assert "/admin" not in excluded


### PR DESCRIPTION
# Telemetry noise reduction — stop emitting health/connectivity telemetry

Stops `api.arolariu.ro`, `arolariu.ro` and `exp.arolariu.ro` emitting OpenTelemetry traces, metrics and logs for health and connectivity endpoints, replacing that volume with a single low-cardinality always-on failure counter.

## Why

`status.arolariu.ro` probes every 30 minutes, firing **12 requests per service per tick** (2 warmup + 10 samples) — **576/day per service**. Those probes cascade:

- `arolariu.ro/api/health` fans out to **both** `api.arolariu.ro/health` and `exp.arolariu.ro/api/health`, propagating trace context
- `api.arolariu.ro/health` runs **four instrumented health checks** (SQL, Blob, Cosmos, exp HTTP) — roughly **5 spans per probe**
- the api's `ExpHealthCheck` issues a further `exp/api/ready` call

Net: `api.arolariu.ro` alone was emitting on the order of **5,760 spans/day** from health traffic, before metrics and logs. The observability database was dominated by requests carrying no diagnostic value.

## What changed

**Suppressed paths (identical in all three services):** `/health`, `/api/health`, `/api/ready`
**Override:** `OTEL_SUPPRESS_HEALTH_TELEMETRY` — default `true`; only the literal `false` disables.

| Service | Traces | Metrics | Logs |
| --- | --- | --- | --- |
| `api.arolariu.ro` (.NET) | `AspNetCore` + `HttpClient` instrumentation `Filter`, plus a `SuppressInstrumentationScope` middleware registered **before routing** | `.DisableHttpMetrics()` on the endpoint | `AddFilter<OpenTelemetryLoggerProvider>` — provider-scoped only |
| `arolariu.ro` (Next.js) | **two** ignore hooks: `instrumentation-http` (inbound) + `instrumentation-undici` (outbound fetch) | hand-rolled `website.health.*` instruments removed | `logWithTrace` calls removed |
| `exp.arolariu.ro` (Python) | already excluded via `excluded_urls` | in-process only, never exported | per-request `logger.info` now guarded |

**The middleware is load-bearing.** Filtering only the `/health` server span would leave the four health-check dependency spans as **orphaned root spans** — strictly worse than the original problem.

**Console logs are never suppressed** — only export. Health activity still appears on stdout and in the Aspire dashboard.

### The one signal that survives

`arolariu.health.check.failures` — monotonic counter, unit `{failure}`, single dimension `check` (`mssql` | `blob-storage` | `cosmosdb` | `exp` | `api` | `config`). Volume is effectively zero until something breaks. The name is deliberately identical across all three services and deliberately breaks each one's local prefix convention (`exp.*`, `website.*`) so a single query spans the estate; `service.name` distinguishes the source.

In .NET the counter is recorded **after** `SuppressInstrumentationScope` disposal — recording inside would let the suppression mechanism swallow the very signal it exists to preserve.

### Also: `/admin` telemetry restored

`exp`'s `DEFAULT_EXCLUDED_URLS` previously excluded `/admin`. `GET /admin`, `GET /admin/api/config` and `PUT /admin/api/config/{key:path}` are high-value traffic — the last is a config mutation worth an audit trail. This is the one change here that *adds* telemetry.

## Verification

| Suite | Result |
| --- | --- |
| `dotnet test` (api) | **124/124** passing, 0 warnings (`TreatWarningsAsErrors` on) |
| `python -m pytest` (exp) | **108/108** passing, `ruff check` clean |
| `npm run test:unit` (monorepo) | green across all 6 projects; website 99.29% lines, 100% functions |

`sites/arolariu.ro/src/app/api/health/route.test.ts` is **unmodified across all 17 commits** — the health response shape, field names and status codes (200/503) are byte-compatible, so `status.arolariu.ro`'s parsers are unaffected.

Every task passed a two-verdict review (spec compliance + code quality), and the whole branch passed a final review. Notable catches during review:

- The initial trace test duplicated the filter predicate rather than exercising production wiring — deleting `options.Filter` from `TracingExtensions.cs` would not have failed it. Now `AddOTelTracing_WiresAspNetCoreFilter` asserts the real registration path.
- The website's env-override tests used `undefined as unknown as string`, which sets the literal string `"undefined"` rather than clearing the variable — so they tested the wrong branch. Replaced with `delete` + `toBeUndefined()` preconditions.
- All three policy implementations were compared three-way (path list, env var, default, normalization, match semantics) and confirmed consistent. There is **no automated drift guard** — this was a deliberate scope decision, so cross-service changes need manual review.

## Known / deferred

- **`npm run build:website` currently exits 1 on `preview` as well.** Pre-existing Next.js static-render failures on `/auth` and `/domains/invoices`. **Not introduced here** — this branch touches zero files under `src/app/` other than the health route. Flagging so it isn't mistaken for branch breakage.
- **Root-path probe noise remains.** Azure Front Door probes each origin with `HEAD /` every 30s (~2,880/day/origin) and App Service uses `healthCheckPath: '/'` for the api. Paths-only matching was a deliberate choice for predictability; revisit if this proves material.
- `injectTraceContextHeaders` was **retained** in the website health route (an earlier design draft called for removal). `route.test.ts:63-66` asserts it, and retention is correct on the merits: with the override off, propagation yields one linked trace across all three services rather than three orphans.
- Website counter fires on transport failure (`Unhealthy`), not on a downstream 5xx (`Degraded`). The failing service records its own root-cause dimension, so the estate-wide query still captures the event.
- `FakeOptionsManager` mocks our own `IOptionsManager`, against repo policy — verified pre-existing (commit `5ad02b6ca`, already used by `AddAuthServicesTests.cs`). A correct fix is repo-wide and out of scope here.

## Follow-ups (not in this PR)

- Trace sampling (RFC 2002 mandates head-based sampling; RFC 1001 documents its absence). Related but separate — this PR removes a known noise class rather than statistically reducing everything.
- Flattening the health-check fan-out. `status.arolariu.ro` already probes all three services directly, so the cross-checks roughly double the load. Changing it moves the response contract and the status page parsers, so it was kept out of a telemetry-only change.
