### PR TITLE
Health telemetry suppression + xUnit to MSTest consolidation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -205,10 +205,6 @@ dotnet_naming_style.begins_with_i.capitalization = pascal_case
 dotnet_naming_style.pascal_case.capitalization = pascal_case
 
 # Suppress or configure specific analyzer diagnostics
-dotnet_diagnostic.xUnit2025.severity = warning
-dotnet_diagnostic.xUnit2024.severity = warning
-dotnet_diagnostic.xUnit2023.severity = warning
-dotnet_diagnostic.xUnit2022.severity = warning
 dotnet_diagnostic.IDE0160.severity = warning
 dotnet_diagnostic.IDE0051.severity = suggestion
 dotnet_diagnostic.IDE0052.severity = warning

--- a/.github/agents/backend-expert.agent.md
+++ b/.github/agents/backend-expert.agent.md
@@ -22,6 +22,30 @@ You are a senior-principal-level backend engineer for the arolariu.ro monorepo.
 
 Design, implement, test, and document backend services using .NET, Domain-Driven Design, and The Standard architecture—ensuring production-grade, secure, observable, and testable code. Runtime version is defined in [AGENTS.md > Versions](../../AGENTS.md#versions).
 
+## Agent Contract
+
+### Scope
+Backend work in `sites/api.arolariu.ro/` — services, brokers, endpoints, telemetry, and their MSTest coverage across the Core, Core.Auth, Invoices, and Common bounded contexts. Does not cover frontend code, infrastructure/Bicep, or CI workflows; hand those to the relevant specialist agent.
+
+### Required Inputs
+- The bounded context and layer being changed, plus the sibling files it must match.
+- `.github/instructions/backend.instructions.md` and `.github/instructions/csharp.instructions.md`.
+- RFC 2001 (DDD), RFC 2002 (OpenTelemetry), RFC 2003 (The Standard), RFC 2004 (XML docs) when the change is architecture-sensitive.
+- `AGENTS.md > Versions` for the authoritative runtime versions.
+
+### Execution Constraints
+See [Safety Rules](#safety-rules) for the full non-negotiable list. In summary: respect the layer hierarchy with no sideways calls, keep Brokers logic-free, obey the Florance Pattern, XML-document every public API, use `.ConfigureAwait(false)` with no sync-over-async, and never silence a diagnostic to make a build pass — `TreatWarningsAsErrors` is enabled.
+
+### Validation
+```bash
+dotnet build sites/api.arolariu.ro/src/Core
+dotnet test sites/api.arolariu.ro/tests
+```
+Report the actual command output as evidence; do not claim success without it.
+
+### Escalation Conditions
+Stop and ask the user before proceeding when the work involves a database schema change, authentication or authorization logic, a new bounded context, a new NuGet dependency, or any infrastructure or CI/CD change. Disclose assumptions, risk flags, and confidence per the [Self-Audit and Uncertainty Protocol](#self-audit-and-uncertainty-protocol-mandatory).
+
 ## Persona
 
 - You specialize in .NET, C#, Domain-Driven Design, and The Standard architecture (versions in AGENTS.md > Versions)

--- a/.github/agents/backend-expert.agent.md
+++ b/.github/agents/backend-expert.agent.md
@@ -59,7 +59,7 @@ npm run dev:api              # Dev server via Nx
 4. **Implement with TryCatch pattern:** Wrap operations in exception handling
 5. **Add observability:** OpenTelemetry activity spans for tracing
 6. **Document:** XML documentation on all public APIs
-7. **Test:** xUnit tests with 85%+ coverage target
+7. **Test:** MSTest tests with 85%+ coverage target
 8. **Validate:** `dotnet build` with no warnings (TreatWarningsAsErrors enabled)
 
 ## Project Knowledge
@@ -85,7 +85,7 @@ npm run dev:api              # Dev server via Nx
 | Orchestration Services | `[Domain]/Services/Orchestration/` | Service coordination |
 | Processing Services | `[Domain]/Services/Processing/` | Complex transformations |
 | Endpoints | `[Domain]/Endpoints/` | Minimal API routes |
-| Tests | `sites/api.arolariu.ro/tests/` | xUnit/MSTest tests |
+| Tests | `sites/api.arolariu.ro/tests/` | MSTest tests |
 
 ## The Standard - Layer Hierarchy
 
@@ -213,13 +213,13 @@ public async Task ProcessInvoice(Invoice invoice) { } // No XML docs!
 
 ## Testing Standards
 
-- **Framework:** xUnit (domain tests), MSTest (core tests), Moq (mocking)
+- **Framework:** MSTest, Moq (mocking)
 - **Coverage target:** 85%+
 - **Naming convention:** `MethodName_Condition_ExpectedResult`
 - **Test builders:** Use `InvoiceBuilder.CreateRandomInvoice()` from test utilities
 
 ```csharp
-[Fact]
+[TestMethod]
 public async Task AnalyzeInvoiceWithOptions_ValidInput_ExecutesCompleteWorkflow()
 {
     // Arrange

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -63,7 +63,7 @@ If rules conflict, resolve in this order:
 
 ## Local Dev Loop & Verification
 
-- **Routine verification is cheap by design.** For typical edits, verify with `npm run test:unit` (Vitest unit + xUnit only) and `npm run build:website`. Run these freely.
+- **Routine verification is cheap by design.** For typical edits, verify with `npm run test:unit` (Vitest unit + MSTest only) and `npm run build:website`. Run these freely.
 - **`npm run lint` and `npm run test:website` are expensive — don't run them for routine edits.** `lint` runs ESLint with 20+ plugins; `test:website` runs the **full** website suite (`test:unit && test:e2e` Playwright **&&** `test:storybook`), not unit-only. Reserve both for a final pass before a PR, or when the user explicitly asks.
 - **Tests are colocated.** Put `*.test.ts` next to the file it covers (e.g. `utils.generic.test.ts` beside `utils.generic.ts`); shared test builders live in `sites/arolariu.ro/tests/helpers/builders/`.
 - **Minimize test doubles.** Prefer real implementations and never mock our own modules — mock only true external boundaries (network, Azure SDK, Clerk, etc.). Excess mocks/stubs/fakes are a smell in this codebase.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -346,7 +346,7 @@ updates:
   # ===========================================================================
   # BACKEND - .NET 10 API
   # ===========================================================================
-  # Modular monolith API: Microsoft, Azure SDK, OpenTelemetry, xUnit
+  # Modular monolith API: Microsoft, Azure SDK, OpenTelemetry, MSTest
   - package-ecosystem: "nuget"
     directory: "/sites/api.arolariu.ro"
     target-branch: "preview"
@@ -393,10 +393,10 @@ updates:
         update-types:
           - "minor"
           - "major"
-      # Testing: xUnit, Moq, Coverlet
+      # Testing: MSTest, Moq, Coverlet
       testing:
         patterns:
-          - "xunit*"
+          - "MSTest*"
           - "Moq*"
           - "coverlet*"
         update-types:

--- a/.github/docs/ai-customization-guide.md
+++ b/.github/docs/ai-customization-guide.md
@@ -63,7 +63,7 @@ Invoke with `@workspace /prompt` in VS Code or use directly in Copilot CLI:
 |--------|---------|
 | `api-endpoint` | Scaffold a new API endpoint (The Standard layers) |
 | `new-page` | Scaffold a Next.js page (Island pattern) |
-| `unit-test` | Generate unit tests (Vitest or xUnit) |
+| `unit-test` | Generate unit tests (Vitest or MSTest) |
 | `comment-standard` | Add JSDoc/XML documentation to code |
 | `fix-bug` | Systematic debugging workflow |
 | `extend-store` | Add state/actions to a Zustand store |

--- a/.github/instructions/backend.instructions.md
+++ b/.github/instructions/backend.instructions.md
@@ -72,7 +72,7 @@ You are an AI assistant specialized in Domain-Driven Design (DDD), The Standard 
 | **Authentication** | ASP.NET Identity + JWT Bearer | - |
 | **Observability** | OpenTelemetry | pinned in `Directory.Packages.props` |
 | **AI Services** | Azure OpenAI, Document Intelligence | - |
-| **Testing** | xUnit, MSTest, Moq | - |
+| **Testing** | MSTest, Moq | - |
 
 ---
 
@@ -550,18 +550,18 @@ tests/
 Pattern: `MethodName_Condition_ExpectedResult`
 
 ```csharp
-[Fact]
+[TestMethod]
 public void Constructor_NullAnalysisService_ThrowsArgumentNullException()
 {
     // Arrange
     IInvoiceAnalysisOrchestrationService? nullService = null;
     
     // Act & Assert
-    Assert.Throws<ArgumentNullException>(() => 
+    Assert.ThrowsExactly<ArgumentNullException>(() => 
         new InvoiceProcessingService(nullService!));
 }
 
-[Fact]
+[TestMethod]
 public async Task AnalyzeInvoiceWithOptions_ValidInput_ExecutesCompleteWorkflow()
 {
     // Arrange
@@ -596,8 +596,8 @@ public static class InvoiceBuilder
 
 | Package | Purpose |
 |---------|---------|
-| `xunit` | Primary test framework |
-| `MSTest` | Alternative framework |
+| `MSTest.TestFramework` | Primary test framework |
+| `MSTest.TestAdapter` | Test discovery and VSTest execution adapter |
 | `Moq` | Mocking |
 | `coverlet.collector` | Code coverage |
 | `Microsoft.EntityFrameworkCore.InMemory` | In-memory database testing |

--- a/.github/instructions/csharp.instructions.md
+++ b/.github/instructions/csharp.instructions.md
@@ -628,18 +628,20 @@ namespace arolariu.Backend.Domain.Tests.Invoices.Services.Orchestration;
 using System;
 using System.Threading.Tasks;
 
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using Xunit;
 
 using arolariu.Backend.Domain.Invoices.Services.Orchestration;
 
-public class InvoiceOrchestrationServiceTests
+[TestClass]
+public sealed class InvoiceOrchestrationServiceTests
 {
-    private readonly Mock<IInvoiceStorageFoundationService> _mockFoundationService;
-    private readonly Mock<IInvoiceAnalysisFoundationService> _mockAnalysisService;
-    private readonly InvoiceOrchestrationService _sut;
+    private Mock<IInvoiceStorageFoundationService> _mockFoundationService = null!;
+    private Mock<IInvoiceAnalysisFoundationService> _mockAnalysisService = null!;
+    private InvoiceOrchestrationService _sut = null!;
 
-    public InvoiceOrchestrationServiceTests()
+    [TestInitialize]
+    public void TestInitialize()
     {
         _mockFoundationService = new Mock<IInvoiceStorageFoundationService>();
         _mockAnalysisService = new Mock<IInvoiceAnalysisFoundationService>();
@@ -648,15 +650,15 @@ public class InvoiceOrchestrationServiceTests
             _mockAnalysisService.Object);
     }
 
-    [Fact]
+    [TestMethod]
     public void Constructor_NullFoundationService_ThrowsArgumentNullException()
     {
         // Arrange & Act & Assert
-        Assert.Throws<ArgumentNullException>(() =>
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
             new InvoiceOrchestrationService(null!, _mockAnalysisService.Object));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CreateInvoiceObject_ValidInvoice_CallsFoundationService()
     {
         // Arrange

--- a/.github/instructions/workflows.instructions.md
+++ b/.github/instructions/workflows.instructions.md
@@ -104,7 +104,7 @@ official-api-trigger.yml
 │ Trigger: Push main      │
 │                         │
 │ Job: test               │
-│  └─ Run xUnit tests     │
+│  └─ Run MSTest tests    │
 │                         │
 │ Job: build-and-deploy   │
 │  └─ Build .NET app      │
@@ -625,7 +625,7 @@ paths-ignore:
     path: playwright-report/
 ```
 
-### .NET Tests (xUnit)
+### .NET Tests (MSTest)
 
 ```yaml
 - name: 🧪 Run tests

--- a/.github/memory/memory.json
+++ b/.github/memory/memory.json
@@ -38,7 +38,7 @@
         "Brokers are thin wrappers ONLY — no business logic",
         "No sideways calls: Foundation↔Foundation forbidden, use Orchestration",
         "XML docs required on all public APIs, TreatWarningsAsErrors enabled",
-        "85%+ test coverage target, xUnit + MSTest"
+        "85%+ test coverage target, MSTest"
       ]
     },
     {

--- a/.github/prompts/api-endpoint.prompt.md
+++ b/.github/prompts/api-endpoint.prompt.md
@@ -15,6 +15,35 @@ Generate a complete API endpoint following The Standard architecture pattern, in
 
 ---
 
+## Agent Contract
+
+### Scope
+Scaffolding a new HTTP endpoint in `sites/api.arolariu.ro/`, spanning Broker, Foundation Service, Orchestration/Processing, and Endpoint layers plus their MSTest coverage. Does not cover frontend consumers, database schema changes, or auth policy changes.
+
+### Required Inputs
+- The target bounded context under `sites/api.arolariu.ro/src/**` (Core, Core.Auth, Invoices, or Common).
+- `.github/instructions/backend.instructions.md` and `.github/instructions/csharp.instructions.md`.
+- RFC 2001 (DDD), RFC 2003 (The Standard), RFC 2004 (XML docs).
+- The existing endpoint and service files the new endpoint will sit beside.
+
+### Execution Constraints
+- Respect The Standard layer hierarchy; never make Foundation→Foundation calls.
+- Keep Brokers free of business logic and obey the Florance Pattern (max 2-3 dependencies per service).
+- XML docs on every public API; `.ConfigureAwait(false)` in library code; no sync-over-async.
+- `TreatWarningsAsErrors` is enabled — never silence a diagnostic with `NoWarn` or `#pragma` to make a build pass.
+- Do not create or delete files outside the scope above without user confirmation.
+
+### Validation
+```bash
+dotnet build sites/api.arolariu.ro/src/Core
+dotnet test sites/api.arolariu.ro/tests
+```
+
+### Escalation Conditions
+Stop and ask the user before proceeding when the work involves a new bounded context, a database schema change, authentication or authorization logic, a new NuGet dependency, or any change to CI/CD or infrastructure. See **Ask-User Criteria** under [Execution Contract](#execution-contract) for the full rule.
+
+---
+
 ## What Gets Generated
 
 For a new endpoint, create the following artifacts in order:

--- a/.github/prompts/api-endpoint.prompt.md
+++ b/.github/prompts/api-endpoint.prompt.md
@@ -1,6 +1,6 @@
 ---
 name: "api-endpoint"
-description: 'Scaffolds a complete API endpoint following The Standard architecture with Broker, Foundation Service, Endpoint, and xUnit tests.'
+description: 'Scaffolds a complete API endpoint following The Standard architecture with Broker, Foundation Service, Endpoint, and MSTest tests.'
 agent: 'agent'
 model: 'Claude Sonnet 4.5'
 tools: ['codebase', 'search', 'editFiles', 'terminalLastCommand']
@@ -97,18 +97,19 @@ public static IServiceCollection Add[Domain]Services(this IServiceCollection ser
 
 ```csharp
 // tests/[Domain]/Services/Foundation/[Entity]StorageFoundationServiceTests.cs
+[TestClass]
 public class [Entity]StorageFoundationServiceTests
 {
-    [Fact]
+    [TestMethod]
     public async Task Create[Entity]Object_ValidInput_CreatesSuccessfully() { }
 
-    [Fact]
+    [TestMethod]
     public async Task Create[Entity]Object_NullInput_ThrowsValidationException() { }
 
-    [Fact]
+    [TestMethod]
     public async Task Retrieve[Entity]Object_ExistingId_ReturnsEntity() { }
 
-    [Fact]
+    [TestMethod]
     public async Task Retrieve[Entity]Object_NonExistentId_ReturnsNull() { }
 }
 ```
@@ -125,7 +126,7 @@ public class [Entity]StorageFoundationServiceTests
 - [ ] `.ConfigureAwait(false)` on all async calls
 - [ ] Endpoint mapped with proper HTTP verbs and authorization
 - [ ] DI registration in Extensions class
-- [ ] xUnit tests with 85%+ coverage
+- [ ] MSTest tests with 85%+ coverage
 - [ ] `dotnet build` passes with no warnings
 
 ## RFC Grounding Checklist (Mandatory)

--- a/.github/prompts/fix-bug.prompt.md
+++ b/.github/prompts/fix-bug.prompt.md
@@ -35,7 +35,7 @@ lastReviewed: 2026-05-08
 - Write a test named `MethodOrComponent_BugCondition_ExpectedBehavior`
 - The test MUST fail without the fix and pass with it
 - Frontend: Vitest + Testing Library
-- Backend: xUnit with AAA pattern
+- Backend: MSTest with AAA pattern
 
 ### 5. Verify
 ```bash

--- a/.github/prompts/fix-bug.prompt.md
+++ b/.github/prompts/fix-bug.prompt.md
@@ -6,6 +6,39 @@ lastReviewed: 2026-05-08
 
 # Bug Fix Workflow
 
+## Agent Contract
+
+### Scope
+Reproducing, diagnosing, and fixing a specific defect anywhere in the monorepo, plus the regression test that proves it. Does not cover feature work, opportunistic refactoring, or dependency upgrades.
+
+### Required Inputs
+- The bug report or failing behavior, with enough detail to reproduce it.
+- The affected source file(s) and their colocated tests.
+- Recent history for those files (`git log --oneline -10 -- <file>`).
+- The relevant RFC when the fix touches architecture — see `.github/agent-governance/rfc-grounding-protocol.md`.
+
+### Execution Constraints
+- Reproduce before fixing. A fix without a reproduction is a guess.
+- Fix the root cause, not the symptom; keep the change minimal and surgical.
+- Do not refactor while fixing — unrelated cleanup belongs in its own change.
+- The regression test must fail without the fix and pass with it. Verify both directions.
+- Never weaken, skip, or delete an existing assertion to make a suite green.
+
+### Validation
+```bash
+# Frontend — routine, cheap
+npm run test:unit
+npm run build:website
+
+# Backend
+dotnet test sites/api.arolariu.ro/tests
+dotnet build sites/api.arolariu.ro/src/Core
+```
+Reserve `npm run lint` and `npm run test:website` for a final pre-PR pass; both are expensive and are not routine verification.
+
+### Escalation Conditions
+Stop and ask the user before proceeding when the root cause sits in authentication/authorization, infrastructure, or a database schema; when the correct fix would change public behavior or an API contract; or when the bug turns out to be intended behavior that someone relies on.
+
 ## Execution Contract
 
 1. **Reproduce** — Confirm the bug exists with evidence (test, command output, or behavior observation)
@@ -39,9 +72,9 @@ lastReviewed: 2026-05-08
 
 ### 5. Verify
 ```bash
-# Frontend
-npm run test:website
-npm run lint
+# Frontend — routine, cheap
+npm run test:unit
+npm run build:website
 
 # Backend
 dotnet test sites/api.arolariu.ro/tests

--- a/.github/prompts/unit-test.prompt.md
+++ b/.github/prompts/unit-test.prompt.md
@@ -1,6 +1,6 @@
 ---
 name: "unit-test-generator"
-description: 'Generates comprehensive unit tests for TypeScript/React (Vitest) and C# (xUnit/MSTest) following established codebase patterns and achieving 90%+ coverage.'
+description: 'Generates comprehensive unit tests for TypeScript/React (Vitest) and C# (MSTest) following established codebase patterns and achieving 90%+ coverage.'
 agent: 'agent'
 model: 'Claude Sonnet 4.5'
 tools: ['codebase', 'search', 'editFiles', 'terminalLastCommand']
@@ -11,11 +11,11 @@ lastReviewed: 2026-05-08
 
 ## Purpose
 
-This prompt analyzes source code and generates comprehensive, idiomatic unit tests following the arolariu.ro testing standards and patterns. It supports both frontend (TypeScript/React with Vitest) and backend (C# with xUnit/MSTest) test generation.
+This prompt analyzes source code and generates comprehensive, idiomatic unit tests following the arolariu.ro testing standards and patterns. It supports both frontend (TypeScript/React with Vitest) and backend (C# with MSTest) test generation.
 
 **Testing Frameworks:**
 - **Frontend**: Vitest + @testing-library/react
-- **Backend**: xUnit (domain tests) + MSTest (core tests)
+- **Backend**: MSTest
 
 **Coverage Target**: 90%+ per `vitest.config.ts` thresholds
 
@@ -566,7 +566,7 @@ const invoices = new InvoiceBuilder()
 
 ---
 
-# Part 2: Backend Testing (C# with xUnit/MSTest)
+# Part 2: Backend Testing (C# with MSTest)
 
 ## Test Project Structure
 
@@ -580,31 +580,33 @@ tests/
 │       ├── Models/
 │       ├── Services/
 │       └── Data/
-└── arolariu.Backend.Domain.Tests/    # xUnit for domain logic
+└── arolariu.Backend.Domain.Tests/    # MSTest for domain logic
     └── Invoices/
         ├── Brokers/
         └── Services/
             └── Orchestration/
 ```
 
-## xUnit Test Pattern
+## MSTest Test Pattern — Service (with mocks)
 
 ```csharp
 /// <summary>
 /// Comprehensive unit tests for <see cref="InvoiceOrchestrationService"/>.
 /// Method naming follows MethodName_Condition_ExpectedResult pattern.
 /// </summary>
+[TestClass]
 public sealed class InvoiceOrchestrationServiceTests
 {
-    private readonly Mock<IInvoiceAnalysisFoundationService> mockAnalysisService;
-    private readonly Mock<IInvoiceStorageFoundationService> mockStorageService;
-    private readonly Mock<ILoggerFactory> mockLoggerFactory;
-    private readonly InvoiceOrchestrationService orchestrationService;
+    private Mock<IInvoiceAnalysisFoundationService> mockAnalysisService = null!;
+    private Mock<IInvoiceStorageFoundationService> mockStorageService = null!;
+    private Mock<ILoggerFactory> mockLoggerFactory = null!;
+    private InvoiceOrchestrationService orchestrationService = null!;
 
     /// <summary>
     /// Initializes test fixtures with mocked dependencies.
     /// </summary>
-    public InvoiceOrchestrationServiceTests()
+    [TestInitialize]
+    public void TestInitialize()
     {
         mockAnalysisService = new Mock<IInvoiceAnalysisFoundationService>();
         mockStorageService = new Mock<IInvoiceStorageFoundationService>();
@@ -622,12 +624,12 @@ public sealed class InvoiceOrchestrationServiceTests
 
     #region Constructor Tests
 
-    [Fact]
+    [TestMethod]
     public void Constructor_NullAnalysisService_ThrowsArgumentNullException() =>
-        Assert.Throws<ArgumentNullException>(() =>
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
             new InvoiceOrchestrationService(null!, mockStorageService.Object, mockLoggerFactory.Object));
 
-    [Fact]
+    [TestMethod]
     public void Constructor_ValidDependencies_CreatesInstance()
     {
         var service = new InvoiceOrchestrationService(
@@ -635,14 +637,14 @@ public sealed class InvoiceOrchestrationServiceTests
             mockStorageService.Object,
             mockLoggerFactory.Object);
 
-        Assert.NotNull(service);
+        Assert.IsNotNull(service);
     }
 
     #endregion
 
     #region Method Tests
 
-    [Fact]
+    [TestMethod]
     public async Task AnalyzeInvoice_ValidInput_ExecutesCompleteWorkflow()
     {
         // Arrange
@@ -669,7 +671,7 @@ public sealed class InvoiceOrchestrationServiceTests
             AnalysisOptions.CompleteAnalysis, originalInvoice), Times.Once);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task AnalyzeInvoice_StorageThrows_PropagatesException()
     {
         // Arrange
@@ -679,7 +681,7 @@ public sealed class InvoiceOrchestrationServiceTests
             .ThrowsAsync(new InvoiceNotFoundException());
 
         // Act & Assert
-        await Assert.ThrowsAsync<InvoiceNotFoundException>(() =>
+        await Assert.ThrowsExactlyAsync<InvoiceNotFoundException>(() =>
             orchestrationService.AnalyzeInvoiceWithOptions(
                 AnalysisOptions.InvoiceOnly, invoiceId, null));
     }
@@ -688,7 +690,7 @@ public sealed class InvoiceOrchestrationServiceTests
 }
 ```
 
-## MSTest Test Pattern
+## MSTest Test Pattern — Entity
 
 ```csharp
 /// <summary>
@@ -799,13 +801,13 @@ describe("ComponentName", () => {
 ### C# (MethodName_Condition_ExpectedResult)
 
 ```csharp
-[Fact]
+[TestMethod]
 public void CreateInvoice_ValidInput_ReturnsCreatedInvoice() { }
 
-[Fact]
+[TestMethod]
 public void CreateInvoice_NullInput_ThrowsArgumentNullException() { }
 
-[Fact]
+[TestMethod]
 public async Task GetInvoice_NotFound_ReturnsNull() { }
 ```
 

--- a/.github/prompts/unit-test.prompt.md
+++ b/.github/prompts/unit-test.prompt.md
@@ -21,6 +21,36 @@ This prompt analyzes source code and generates comprehensive, idiomatic unit tes
 
 ---
 
+## Agent Contract
+
+### Scope
+Generating and extending unit tests for frontend (Vitest + Testing Library) and backend (MSTest) code in this monorepo. Covers test files, mock builders, and fixtures. Does not cover E2E/Playwright specs, Storybook stories, or changes to the production code under test.
+
+### Required Inputs
+- The source file(s) under test and their existing colocated `*.test.ts`/`*.cs` neighbours.
+- `.github/instructions/typescript.instructions.md` or `.github/instructions/csharp.instructions.md`, per stack.
+- Existing shared builders in `sites/arolariu.ro/tests/helpers/builders/` and `tests/**/Builders/`.
+- RFC 1002 (JSDoc) for frontend, RFC 2004 (XML docs) for backend.
+
+### Execution Constraints
+- Tests are colocated: put `*.test.ts` beside the file it covers.
+- Mock only true external boundaries (network, Azure SDK, Clerk). Never mock our own modules; excess test doubles are a smell here.
+- Do not modify production code to make a test pass — report the defect instead.
+- Backend: MSTest only. `[TestClass]` on every test class, and prefer `Assert.ThrowsExactly`/`ThrowsExactlyAsync` for exact-type expectations, since MSTest's bare `Assert.Throws` matches derived types too.
+- Never weaken or delete an existing assertion to turn a suite green.
+
+### Validation
+```bash
+npm run test:unit                     # Vitest + MSTest (routine check)
+dotnet test sites/api.arolariu.ro/tests
+```
+Avoid `npm run test:website` for routine work — it runs the full Playwright and Storybook suites.
+
+### Escalation Conditions
+Stop and ask the user before proceeding when a test cannot be written without changing production behavior, when the required coverage would demand a new dependency, or when an existing test appears deliberately wrong rather than merely outdated. See **Ask-User Criteria** under [Execution Contract](#execution-contract) for the full rule.
+
+---
+
 ## Core Instructions
 
 When invoked with source code:

--- a/.github/scripts/src/hygiene/providers/testDotnetProvider.ts
+++ b/.github/scripts/src/hygiene/providers/testDotnetProvider.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview .NET unit tests provider (@arolariu/api xUnit suite via TRX).
+ * @fileoverview .NET unit tests provider (@arolariu/api MSTest suite via TRX).
  * @module github/scripts/src/hygiene/providers/testDotnetProvider
  *
  * @remarks

--- a/.github/skills/ddd-service/SKILL.md
+++ b/.github/skills/ddd-service/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ddd-service
-description: 'Scaffolds a complete DDD service following The Standard architecture with Broker, Foundation Service, Processing/Orchestration layers, partial class separation, TryCatch pattern, OpenTelemetry tracing, and xUnit tests for the arolariu.ro backend.'
+description: 'Scaffolds a complete DDD service following The Standard architecture with Broker, Foundation Service, Processing/Orchestration layers, partial class separation, TryCatch pattern, OpenTelemetry tracing, and MSTest tests for the arolariu.ro backend.'
 lastReviewed: 2026-05-08
 ---
 
@@ -136,6 +136,7 @@ public static IServiceCollection Add[Domain]Services(this IServiceCollection ser
 
 **`tests/[Domain]/Services/Foundation/[Entity]StorageFoundationServiceTests.cs`**:
 ```csharp
+[TestClass]
 public class [Entity]StorageFoundationServiceTests
 {
     private readonly Mock<I[Entity]NoSqlBroker> _mockBroker = new();
@@ -148,7 +149,7 @@ public class [Entity]StorageFoundationServiceTests
             new NullLoggerFactory());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Create[Entity]Object_ValidInput_CreatesSuccessfully()
     {
         // Arrange
@@ -159,11 +160,11 @@ public class [Entity]StorageFoundationServiceTests
         _mockBroker.Verify(b => b.Create[Entity]Async(entity), Times.Once);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Create[Entity]Object_NullInput_ThrowsValidationException()
     {
         // Act & Assert
-        await Assert.ThrowsAsync<[Entity]ValidationException>(
+        await Assert.ThrowsExactlyAsync<[Entity]ValidationException>(
             () => _service.Create[Entity]Object(null!));
     }
 }
@@ -179,7 +180,7 @@ public class [Entity]StorageFoundationServiceTests
 - [ ] OpenTelemetry activity spans on all methods
 - [ ] XML documentation on all public APIs
 - [ ] DI registration in Extensions class
-- [ ] xUnit tests with 85%+ coverage
+- [ ] MSTest tests with 85%+ coverage
 - [ ] `dotnet build` passes with no warnings
 - [ ] Max 2-3 dependencies (Florance Pattern)
 

--- a/.github/skills/ddd-service/SKILL.md
+++ b/.github/skills/ddd-service/SKILL.md
@@ -8,6 +8,34 @@ lastReviewed: 2026-05-08
 
 Generates a complete service following The Standard architecture for the arolariu.ro backend API.
 
+## Agent Contract
+
+### Scope
+Scaffolding a DDD service in `sites/api.arolariu.ro/` — Broker, Foundation, Processing/Orchestration layers with partial-class separation, the TryCatch pattern, OpenTelemetry tracing, and MSTest coverage. Does not cover endpoint routing, frontend consumers, or persistence schema design.
+
+### Required Inputs
+- The target bounded context under `sites/api.arolariu.ro/src/**` and the aggregate or entity being served.
+- `.github/instructions/backend.instructions.md` and `.github/instructions/csharp.instructions.md`.
+- RFC 2001 (DDD), RFC 2002 (OpenTelemetry), RFC 2003 (The Standard), RFC 2004 (XML docs).
+- An existing sibling service to match for structure and naming.
+
+### Execution Constraints
+- Respect the layer hierarchy: Endpoints → Processing → Orchestration → Foundation → Brokers. No Foundation→Foundation sideways calls.
+- Brokers are thin wrappers with no business logic; obey the Florance Pattern (max 2-3 dependencies per service).
+- Wrap service methods in the TryCatch pattern with an OpenTelemetry `Activity`.
+- XML docs on every public API; `.ConfigureAwait(false)` throughout; no sync-over-async.
+- `TreatWarningsAsErrors` is enabled — fix diagnostics at the source, never with `NoWarn` or `#pragma`.
+- Generated tests use MSTest: `[TestClass]` on every test class, and `Assert.ThrowsExactly`/`ThrowsExactlyAsync` for exact-type exception expectations (MSTest's bare `Assert.Throws` also matches derived types).
+
+### Validation
+```bash
+dotnet build sites/api.arolariu.ro/src/Core
+dotnet test sites/api.arolariu.ro/tests
+```
+
+### Escalation Conditions
+Stop and ask the user before proceeding when the work creates a new bounded context, changes a Cosmos or SQL schema, touches authentication or authorization, or adds a NuGet dependency. See **Ask-User Criteria** under [Execution Contract](#execution-contract) for the full rule.
+
 ## When to Use
 
 - Creating a new CRUD service for a domain entity

--- a/.github/workflows/official-api-trigger.yml
+++ b/.github/workflows/official-api-trigger.yml
@@ -120,7 +120,7 @@ jobs:
           echo "::group::🧪 Running .NET Unit Tests"
           echo "📍 Solution: arolariu.slnx"
           echo "📍 Configuration: Release"
-          echo "📍 Test framework: xUnit"
+          echo "📍 Test framework: MSTest"
           echo ""
           START_TIME=$(date +%s)
           dotnet test --configuration Release --logger trx --results-directory ./sites/api.arolariu.ro/TestResults --collect:"XPlat Code Coverage" ./arolariu.slnx

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ npm run build:components   # Build component library
 
 # Testing
 npm run test               # Run all tests
-npm run test:unit          # Unit tests (Vitest + xUnit)
+npm run test:unit          # Unit tests (Vitest + MSTest)
 npm run test:e2e           # E2E tests (Playwright + Newman)
 npm run test:website       # Website FULL suite: Vitest + Playwright E2E + Storybook (expensive)
 npm run test:api           # API tests only
@@ -167,7 +167,7 @@ sites/
     src/Core.Auth/         #   Authentication bounded context
     src/Invoices/          #   Invoice management bounded context
     src/Common/            #   Shared DDD base classes, telemetry
-    tests/                 #   xUnit + MSTest tests
+    tests/                 #   MSTest tests
   cv.arolariu.ro/          # SvelteKit CV site (standalone)
   docs.arolariu.ro/        # DocFX documentation site
   exp.arolariu.ro/         # Python FastAPI experimental service
@@ -286,7 +286,7 @@ sites/cv.arolariu.ro (SvelteKit — standalone)
 |--------|-----------|----------------|---------|
 | Frontend unit | Vitest + Testing Library | 90%+ | `npm run test:unit` |
 | Frontend E2E | Playwright | Critical paths | `npm run test:e2e:frontend` |
-| Backend unit | xUnit + MSTest | 85%+ | `dotnet test sites/api.arolariu.ro/tests` |
+| Backend unit | MSTest | 85%+ | `dotnet test sites/api.arolariu.ro/tests` |
 | Backend E2E | Newman/Postman | API contracts | `npm run test:e2e:backend` |
 
 **Test patterns**: AAA (Arrange, Act, Assert), mock builders (`InvoiceBuilder`, `ProductBuilder`), proper cleanup in `afterEach`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Make sure you're familiar with the project structure and how to run tests:
 ```bash
 npm run test             # all tests
 npm run test:website     # frontend unit tests (Vitest)
-npm run test:api         # backend tests (xUnit)
+npm run test:api         # backend tests (MSTest)
 npm run test:e2e         # end-to-end tests (Playwright + Newman)
 ```
 
@@ -76,7 +76,7 @@ npm run doctor           # check workspace health
 - [ ] Max 2-3 dependencies per service (Florance Pattern)
 - [ ] XML documentation on all public APIs
 - [ ] `.ConfigureAwait(false)` in library code
-- [ ] Tests written with xUnit
+- [ ] Tests written with MSTest
 - [ ] No business logic in Brokers
 
 **All changes:**

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -251,7 +251,7 @@ npm run dev:cv           # SvelteKit CV site standalone
 ```bash
 npm run test             # All tests
 npm run test:website     # Website unit tests (Vitest)
-npm run test:api         # API tests (xUnit)
+npm run test:api         # API tests (MSTest)
 npm run test:exp         # exp tests (pytest)
 npm run test:unit        # All unit tests
 npm run test:e2e         # All E2E tests (Playwright + Newman)

--- a/README.md
+++ b/README.md
@@ -495,7 +495,7 @@ arolariu.ro/
 │   │   │   ├── Core.Auth/          #    Authentication bounded context
 │   │   │   ├── Invoices/           #    Invoice management bounded context
 │   │   │   └── Common/             #    Shared DDD base classes, telemetry
-│   │   └── tests/                  #    xUnit + MSTest tests
+│   │   └── tests/                  #    MSTest tests
 │   │
 │   ├── cv.arolariu.ro/             # 📄 SvelteKit 2 CV/Resume (standalone)
 │   └── docs.arolariu.ro/           # 📚 DocFX documentation site
@@ -508,7 +508,7 @@ arolariu.ro/
 ├── 📜 scripts/                     # Build & utility scripts
 ├── 🛠️  tooling/                    # Dev tooling
 │   ├── AppHost/                    #    .NET Aspire 13.x AppHost (orchestrator)
-│   └── AppHost.Tests/              #    xUnit tests for AppHost helpers
+│   └── AppHost.Tests/              #    MSTest tests for AppHost helpers
 ├── 📖 docs/                        # Architecture documentation & RFCs
 │   └── rfc/                        #    13 Architecture Decision Records
 │
@@ -844,7 +844,7 @@ This repository is fully configured with **GitHub Copilot** context-aware AI ass
 | Prompt | Purpose |
 |:------:|:--------|
 | `comment-standard` | Consistent JSDoc/XML documentation |
-| `unit-test` | Test scaffolding (Vitest/xUnit) |
+| `unit-test` | Test scaffolding (Vitest/MSTest) |
 | `refactor` | Safe refactoring with patterns |
 | `api-endpoint` | New .NET endpoint scaffold |
 | `new-page` | Next.js page with i18n + metadata |

--- a/docs/backend/README.md
+++ b/docs/backend/README.md
@@ -11,7 +11,7 @@ The backend is built using:
 - **Architecture**: Modular Monolith
 - **Design Patterns**: Domain-Driven Design (DDD) + SOLID principles
 - **API Style**: ASP.NET Core Minimal APIs
-- **Testing**: xUnit
+- **Testing**: MSTest
 
 ## Architecture
 
@@ -105,7 +105,7 @@ Practical, concise guides for rapid development:
 
 ### Testing
 
-- Unit testing with xUnit
+- Unit testing with MSTest
 - Integration testing patterns
 - Test naming conventions: `MethodName_Condition_ExpectedResult()`
 - Test coverage standards (85%+)

--- a/docs/backend/configureawait-best-practices.md
+++ b/docs/backend/configureawait-best-practices.md
@@ -80,7 +80,7 @@ public async Task<ProcessedData> ProcessAsync(InputData data)
 
 ```csharp
 // ✅ CORRECT - No ConfigureAwait in tests
-[Fact]
+[TestMethod]
 public async Task GetInvoice_ValidId_ReturnsInvoice()
 {
     // Arrange
@@ -92,18 +92,18 @@ public async Task GetInvoice_ValidId_ReturnsInvoice()
     var result = await _service.GetInvoiceAsync(Guid.NewGuid());
 
     // Assert
-    Assert.NotNull(result);
-    Assert.Equal(expectedInvoice.id, result.id);
+    Assert.IsNotNull(result);
+    Assert.AreEqual(expectedInvoice.id, result.id);
 }
 ```
 
 ```csharp
 // ❌ INCORRECT - ConfigureAwait in test bypasses parallelization
-[Fact]
+[TestMethod]
 public async Task GetInvoice_ValidId_ReturnsInvoice()
 {
     var result = await _service.GetInvoiceAsync(Guid.NewGuid()).ConfigureAwait(false);
-    Assert.NotNull(result);
+    Assert.IsNotNull(result);
 }
 ```
 
@@ -182,7 +182,7 @@ private async Task<Invoice> TryCatchAsync(ReturningInvoiceFunction function)
 
 ```csharp
 // ✅ CORRECT - Integration tests can omit ConfigureAwait
-[Fact]
+[TestMethod]
 public async Task EndToEnd_CreateAndRetrieveInvoice_Success()
 {
     // Arrange
@@ -279,7 +279,7 @@ await orchestrationService.CreateInvoiceObject(invoice, null);
 - [ConfigureAwait FAQ](https://devblogs.microsoft.com/dotnet/configureawait-faq/)
 - [CA2007: Do not directly await a Task](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2007)
 - [Async/Await Best Practices](https://learn.microsoft.com/en-us/archive/msdn-magazine/2013/march/async-await-best-practices-in-asynchronous-programming)
-- [Test Parallelization in xUnit](https://xunit.net/docs/running-tests-in-parallel)
+- [MSTest Parallel Test Execution](https://learn.microsoft.com/dotnet/core/testing/unit-testing-parallel-execution)
 
 ---
 

--- a/docs/backend/the-standard-guide.md
+++ b/docs/backend/the-standard-guide.md
@@ -701,7 +701,7 @@ public class InvoiceProcessingService
 ### Foundation Service Tests
 
 ```csharp
-[Fact]
+[TestMethod]
 public async Task ShouldAddInvoiceAsync()
 {
     // given
@@ -729,7 +729,7 @@ public async Task ShouldAddInvoiceAsync()
 ### Exception Classification Tests
 
 ```csharp
-[Fact]
+[TestMethod]
 public async Task ShouldThrowValidationExceptionOnAddIfInvoiceIsNullAndLogItAsync()
 {
     // given
@@ -745,7 +745,7 @@ public async Task ShouldThrowValidationExceptionOnAddIfInvoiceIsNullAndLogItAsyn
         this.invoiceStorageFoundationService.AddInvoiceAsync(nullInvoice);
     
     // then
-    await Assert.ThrowsAsync<InvoiceStorageFoundationServiceValidationException>(
+    await Assert.ThrowsExactlyAsync<InvoiceStorageFoundationServiceValidationException>(
         () => addInvoiceTask.AsTask());
 }
 ```

--- a/docs/rfc/2001-domain-driven-design-architecture.md
+++ b/docs/rfc/2001-domain-driven-design-architecture.md
@@ -356,7 +356,7 @@ public static void MapInvoiceEndpoints(this WebApplication app)
 All tests follow: `MethodName_Condition_ExpectedResult()`
 
 ```csharp
-[Fact(DisplayName = "Invoice creation succeeds with valid data")]
+[TestMethod]
 public void CreateInvoice_WithValidData_ReturnsSuccessResult()
 {
     // Arrange
@@ -367,12 +367,12 @@ public void CreateInvoice_WithValidData_ReturnsSuccessResult()
     var invoice = Invoice.Create(merchant.Id, products);
     
     // Assert
-    Assert.NotNull(invoice);
-    Assert.Equal(merchant.Id, invoice.MerchantId);
-    Assert.Equal(products.Count, invoice.Products.Count);
+    Assert.IsNotNull(invoice);
+    Assert.AreEqual(merchant.Id, invoice.MerchantId);
+    Assert.AreEqual(products.Count, invoice.Products.Count);
 }
 
-[Fact(DisplayName = "Invoice creation fails with empty products")]
+[TestMethod]
 public void CreateInvoice_WithEmptyProducts_ThrowsArgumentException()
 {
     // Arrange
@@ -380,7 +380,7 @@ public void CreateInvoice_WithEmptyProducts_ThrowsArgumentException()
     var emptyProducts = new List<Product>();
     
     // Act & Assert
-    Assert.Throws<ArgumentException>(() => 
+    Assert.ThrowsExactly<ArgumentException>(() => 
         Invoice.Create(merchantId, emptyProducts));
 }
 ```
@@ -420,7 +420,7 @@ public void CreateInvoice_WithEmptyProducts_ThrowsArgumentException()
 
 - [.NET 10.0 Documentation](https://docs.microsoft.com/en-us/dotnet/)
 - [ASP.NET Core Minimal APIs](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/minimal-apis)
-- [xUnit Testing](https://xunit.net/)
+- [MSTest Documentation](https://learn.microsoft.com/dotnet/core/testing/unit-testing-mstest-intro)
 
 ---
 

--- a/docs/rfc/2002-opentelemetry-backend-observability.md
+++ b/docs/rfc/2002-opentelemetry-backend-observability.md
@@ -491,7 +491,7 @@ public async Task CreateInvoice_ShouldCreateActivitySpan()
   await invoiceProcessingService.CreateInvoice(testInvoice);
 
   // Assert
-  Assert.Contains(activities, a => a.DisplayName == nameof(CreateInvoice));
+  Assert.Contains(a => a.DisplayName == nameof(CreateInvoice), activities);
 }
 ```
 

--- a/docs/rfc/2002-opentelemetry-backend-observability.md
+++ b/docs/rfc/2002-opentelemetry-backend-observability.md
@@ -453,7 +453,7 @@ public class InvoiceController : ControllerBase
 **Approach**: Test telemetry configuration without actual export
 
 ```csharp
-[Fact]
+[TestMethod]
 public void AddOTelTracing_ShouldRegisterActivitySources()
 {
   // Arrange
@@ -465,7 +465,7 @@ public void AddOTelTracing_ShouldRegisterActivitySources()
   // Assert
   var serviceProvider = builder.Services.BuildServiceProvider();
   var tracerProvider = serviceProvider.GetService<TracerProvider>();
-  Assert.NotNull(tracerProvider);
+  Assert.IsNotNull(tracerProvider);
 }
 ```
 
@@ -474,7 +474,7 @@ public void AddOTelTracing_ShouldRegisterActivitySources()
 **Approach**: Verify telemetry end-to-end with in-memory exporter
 
 ```csharp
-[Fact]
+[TestMethod]
 public async Task CreateInvoice_ShouldCreateActivitySpan()
 {
   // Arrange

--- a/docs/rfc/2003-the-standard-implementation.md
+++ b/docs/rfc/2003-the-standard-implementation.md
@@ -960,6 +960,7 @@ The Standard emphasizes **unit testing at every layer** with:
 ### Example: Foundation Service Unit Test
 
 ```csharp
+[TestClass]
 public class InvoiceStorageFoundationServiceTests
 {
   private readonly Mock<IInvoiceNoSqlBroker> brokerMock;
@@ -972,7 +973,7 @@ public class InvoiceStorageFoundationServiceTests
     service = new InvoiceStorageFoundationService(brokerMock.Object, loggerFactory.Object);
   }
 
-  [Fact]
+  [TestMethod]
   public async Task Should_CreateInvoice_When_ValidInvoiceProvided()
   {
     // Arrange
@@ -986,14 +987,14 @@ public class InvoiceStorageFoundationServiceTests
     brokerMock.Verify(b => b.CreateInvoiceAsync(invoice), Times.Once);
   }
 
-  [Fact]
+  [TestMethod]
   public async Task Should_ThrowValidationException_When_IdentifierNotSet()
   {
     // Arrange
     Guid? invalidId = null;
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceIdNotSetException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceIdNotSetException>(() =>
       service.ReadInvoiceObject(invalidId.Value));
   }
 }

--- a/sites/api.arolariu.ro/Directory.Packages.props
+++ b/sites/api.arolariu.ro/Directory.Packages.props
@@ -70,6 +70,7 @@
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.17.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.17.0-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.17.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.17.0" />
   </ItemGroup>
   <ItemGroup Label="Application Insights Packages">

--- a/sites/api.arolariu.ro/Directory.Packages.props
+++ b/sites/api.arolariu.ro/Directory.Packages.props
@@ -93,7 +93,6 @@
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="MSTest.TestAdapter" Version="4.3.3" />
     <PackageVersion Include="MSTest.TestFramework" Version="4.3.3" />
-    <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+
   </ItemGroup>
 </Project>

--- a/sites/api.arolariu.ro/README.md
+++ b/sites/api.arolariu.ro/README.md
@@ -49,7 +49,7 @@ The codebase adheres to SOLID design patterns:
 - **API Pattern**: ASP.NET Core Minimal APIs
 - **Dependency Injection**: Built-in DI container
 - **Documentation**: OpenAPI/Swagger with Swashbuckle
-- **Testing**: xUnit with comprehensive unit and integration tests
+- **Testing**: MSTest with comprehensive unit and integration tests
 - **Logging**: Microsoft.Extensions.Logging with structured logging
 - **Telemetry**: OpenTelemetry for observability
 - **Health Checks**: Built-in health check middleware
@@ -158,7 +158,7 @@ dotnet test --collect:"XPlat Code Coverage"
 
 Example:
 ```csharp
-[Fact(DisplayName = "Invoice creation succeeds with valid data")]
+[TestMethod]
 public void CreateInvoice_WithValidData_ReturnsSuccessResult()
 {
     // Arrange
@@ -168,8 +168,8 @@ public void CreateInvoice_WithValidData_ReturnsSuccessResult()
     var result = _invoiceService.Create(invoice);
     
     // Assert
-    Assert.NotNull(result);
-    Assert.True(result.IsSuccess);
+    Assert.IsNotNull(result);
+    Assert.IsTrue(result.IsSuccess);
 }
 ```
 
@@ -424,7 +424,7 @@ Required environment variables:
 - [Domain-Driven Design](https://martinfowler.com/tags/domain%20driven%20design.html)
 - [SOLID Principles](https://en.wikipedia.org/wiki/SOLID)
 - [ASP.NET Core](https://docs.microsoft.com/en-us/aspnet/core/)
-- [xUnit Testing](https://xunit.net/)
+- [MSTest Documentation](https://learn.microsoft.com/dotnet/core/testing/unit-testing-mstest-intro)
 
 ---
 

--- a/sites/api.arolariu.ro/src/Common/Telemetry/HealthTelemetryPolicy.cs
+++ b/sites/api.arolariu.ro/src/Common/Telemetry/HealthTelemetryPolicy.cs
@@ -1,6 +1,9 @@
 namespace arolariu.Backend.Common.Telemetry;
 
 using System;
+using System.Net.Http;
+
+using Microsoft.AspNetCore.Http;
 
 /// <summary>
 /// Central policy deciding whether OpenTelemetry signals should be suppressed for a request path.
@@ -76,6 +79,38 @@ public static class HealthTelemetryPolicy
   /// <remarks>Fails open: any unexpected condition resolves to emitting telemetry.</remarks>
   public static bool ShouldSuppress(string? path) =>
     IsSuppressionEnabled && IsSuppressedPath(path);
+
+  /// <summary>
+  /// Returns <see langword="true"/> when the request represented by <paramref name="context"/>
+  /// should be included in distributed traces.
+  /// </summary>
+  /// <param name="context">The incoming ASP.NET Core HTTP context.</param>
+  /// <returns>
+  /// <see langword="false"/> when the request targets a suppressed health probe path;
+  /// <see langword="true"/> otherwise.
+  /// </returns>
+  /// <remarks>
+  /// Intended for use as the <c>AspNetCoreTraceInstrumentationOptions.Filter</c> method group.
+  /// Fails open: a null context resolves to <see langword="true"/> (record the activity).
+  /// </remarks>
+  public static bool ShouldRecordHttpContext(HttpContext context) =>
+    !ShouldSuppress(context?.Request.Path.Value);
+
+  /// <summary>
+  /// Returns <see langword="true"/> when the outbound request represented by
+  /// <paramref name="request"/> should be included in distributed traces.
+  /// </summary>
+  /// <param name="request">The outbound <see cref="HttpRequestMessage"/>.</param>
+  /// <returns>
+  /// <see langword="false"/> when the request targets a suppressed health probe path;
+  /// <see langword="true"/> otherwise.
+  /// </returns>
+  /// <remarks>
+  /// Intended for use as the <c>HttpClientTraceInstrumentationOptions.FilterHttpRequestMessage</c>
+  /// method group. Fails open: a null request resolves to <see langword="true"/> (record the activity).
+  /// </remarks>
+  public static bool ShouldRecordHttpRequestMessage(HttpRequestMessage request) =>
+    !ShouldSuppress(request?.RequestUri?.AbsolutePath);
 
   private static string Normalize(string path)
   {

--- a/sites/api.arolariu.ro/src/Common/Telemetry/HealthTelemetryPolicy.cs
+++ b/sites/api.arolariu.ro/src/Common/Telemetry/HealthTelemetryPolicy.cs
@@ -76,7 +76,11 @@ public static class HealthTelemetryPolicy
   /// </summary>
   /// <param name="path">The request path, with or without a query string.</param>
   /// <returns><see langword="true"/> when telemetry must be suppressed.</returns>
-  /// <remarks>Fails open: any unexpected condition resolves to emitting telemetry.</remarks>
+  /// <remarks>
+  /// Fails safe toward suppression: an unset or unparseable <see cref="SuppressionEnvVar"/>
+  /// leaves suppression enabled, so cost control holds even when the environment is
+  /// misconfigured. Only the literal value <c>false</c> re-enables health telemetry.
+  /// </remarks>
   public static bool ShouldSuppress(string? path) =>
     IsSuppressionEnabled && IsSuppressedPath(path);
 

--- a/sites/api.arolariu.ro/src/Common/Telemetry/HealthTelemetryPolicy.cs
+++ b/sites/api.arolariu.ro/src/Common/Telemetry/HealthTelemetryPolicy.cs
@@ -1,0 +1,86 @@
+namespace arolariu.Backend.Common.Telemetry;
+
+using System;
+
+/// <summary>
+/// Central policy deciding whether OpenTelemetry signals should be suppressed for a request path.
+/// </summary>
+/// <remarks>
+/// Health and connectivity probes dominate request volume without carrying diagnostic value.
+/// This policy is consulted by trace filters, the suppression middleware, and log filtering so
+/// that the suppressed path list is defined exactly once for this service.
+/// </remarks>
+public static class HealthTelemetryPolicy
+{
+  /// <summary>
+  /// The environment variable controlling whether health telemetry suppression is active.
+  /// </summary>
+  /// <remarks>Defaults to enabled. Only the literal value <c>false</c> disables suppression.</remarks>
+  public const string SuppressionEnvVar = "OTEL_SUPPRESS_HEALTH_TELEMETRY";
+
+  private static readonly string[] SuppressedPaths = ["/health", "/api/health", "/api/ready"];
+
+  /// <summary>
+  /// Gets a value indicating whether suppression is enabled for the current process.
+  /// </summary>
+  /// <value><see langword="true"/> unless <see cref="SuppressionEnvVar"/> is set to <c>false</c>.</value>
+  public static bool IsSuppressionEnabled { get; } =
+    ParseSuppressionFlag(Environment.GetEnvironmentVariable(SuppressionEnvVar));
+
+  /// <summary>
+  /// Determines whether the supplied path is one of the suppressed health endpoints.
+  /// </summary>
+  /// <param name="path">The request path, with or without a query string.</param>
+  /// <returns><see langword="true"/> when the path matches a suppressed endpoint.</returns>
+  /// <remarks>Matching is exact on the normalized path, never prefix-based.</remarks>
+  public static bool IsSuppressedPath(string? path)
+  {
+    if (string.IsNullOrWhiteSpace(path))
+    {
+      return false;
+    }
+
+    var normalized = Normalize(path);
+    foreach (var candidate in SuppressedPaths)
+    {
+      if (string.Equals(normalized, candidate, StringComparison.OrdinalIgnoreCase))
+      {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /// <summary>
+  /// Parses the raw suppression environment variable value.
+  /// </summary>
+  /// <param name="rawValue">The raw environment variable value, possibly null or malformed.</param>
+  /// <returns><see langword="false"/> only when <paramref name="rawValue"/> parses as <c>false</c>.</returns>
+  /// <remarks>Unset and unparseable values resolve to the safe default of enabled suppression.</remarks>
+  public static bool ParseSuppressionFlag(string? rawValue)
+  {
+    if (string.IsNullOrWhiteSpace(rawValue))
+    {
+      return true;
+    }
+
+    return !bool.TryParse(rawValue, out var parsed) || parsed;
+  }
+
+  /// <summary>
+  /// Determines whether telemetry should be suppressed for the supplied path.
+  /// </summary>
+  /// <param name="path">The request path, with or without a query string.</param>
+  /// <returns><see langword="true"/> when telemetry must be suppressed.</returns>
+  /// <remarks>Fails open: any unexpected condition resolves to emitting telemetry.</remarks>
+  public static bool ShouldSuppress(string? path) =>
+    IsSuppressionEnabled && IsSuppressedPath(path);
+
+  private static string Normalize(string path)
+  {
+    var queryIndex = path.IndexOf('?', StringComparison.Ordinal);
+    var withoutQuery = queryIndex >= 0 ? path[..queryIndex] : path;
+    return withoutQuery.Length > 1 ? withoutQuery.TrimEnd('/') : withoutQuery;
+  }
+}

--- a/sites/api.arolariu.ro/src/Common/Telemetry/Logging/LoggingExtensions.cs
+++ b/sites/api.arolariu.ro/src/Common/Telemetry/Logging/LoggingExtensions.cs
@@ -67,14 +67,16 @@ public static class LoggingExtensions
       .GetApplicationOptions()
       .ApplicationInsightsEndpoint ?? string.Empty;
 
-    // Health probes drive the majority of hosting-diagnostics log volume and carry no
-    // diagnostic value. Scoped to the OTel provider so console logging is untouched.
+    // Health check execution logs carry no diagnostic value at Information level and are
+    // dominated by probe traffic. Scoped to the OTel provider so console logging is untouched.
+    //
+    // Only the HealthChecks category is filtered. ILogger filters match on category and level,
+    // never on request path, so filtering Microsoft.AspNetCore.Hosting.Diagnostics or
+    // Routing.EndpointMiddleware would strip request logs for EVERY route, not just probes.
+    // Those categories are already at Warning via appsettings.json, so filtering them here
+    // would be a no-op today and an over-reach the moment someone lowers that level to debug.
     if (HealthTelemetryPolicy.IsSuppressionEnabled)
     {
-      builder.Logging.AddFilter<OpenTelemetryLoggerProvider>(
-        "Microsoft.AspNetCore.Hosting.Diagnostics", LogLevel.Warning);
-      builder.Logging.AddFilter<OpenTelemetryLoggerProvider>(
-        "Microsoft.AspNetCore.Routing.EndpointMiddleware", LogLevel.Warning);
       builder.Logging.AddFilter<OpenTelemetryLoggerProvider>(
         "Microsoft.Extensions.Diagnostics.HealthChecks", LogLevel.Warning);
     }

--- a/sites/api.arolariu.ro/src/Common/Telemetry/Logging/LoggingExtensions.cs
+++ b/sites/api.arolariu.ro/src/Common/Telemetry/Logging/LoggingExtensions.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 
 using arolariu.Backend.Common.Azure;
 using arolariu.Backend.Common.Options;
+using arolariu.Backend.Common.Telemetry;
 
 using global::Azure.Monitor.OpenTelemetry.Exporter;
 
@@ -65,6 +66,18 @@ public static class LoggingExtensions
       .GetRequiredService<IOptionsManager>()
       .GetApplicationOptions()
       .ApplicationInsightsEndpoint ?? string.Empty;
+
+    // Health probes drive the majority of hosting-diagnostics log volume and carry no
+    // diagnostic value. Scoped to the OTel provider so console logging is untouched.
+    if (HealthTelemetryPolicy.IsSuppressionEnabled)
+    {
+      builder.Logging.AddFilter<OpenTelemetryLoggerProvider>(
+        "Microsoft.AspNetCore.Hosting.Diagnostics", LogLevel.Warning);
+      builder.Logging.AddFilter<OpenTelemetryLoggerProvider>(
+        "Microsoft.AspNetCore.Routing.EndpointMiddleware", LogLevel.Warning);
+      builder.Logging.AddFilter<OpenTelemetryLoggerProvider>(
+        "Microsoft.Extensions.Diagnostics.HealthChecks", LogLevel.Warning);
+    }
 
     builder.Logging.AddOpenTelemetry(otelOptions =>
     {

--- a/sites/api.arolariu.ro/src/Common/Telemetry/Metering/HealthCheckMetrics.cs
+++ b/sites/api.arolariu.ro/src/Common/Telemetry/Metering/HealthCheckMetrics.cs
@@ -1,0 +1,53 @@
+namespace arolariu.Backend.Common.Telemetry.Metering;
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+
+/// <summary>
+/// Emits the single always-on signal that survives health telemetry suppression.
+/// </summary>
+/// <remarks>
+/// All other health telemetry is dropped. This counter stays enabled because its volume is
+/// effectively zero until a dependency actually fails. The metric name is deliberately shared
+/// verbatim with the website and exp services so a single query spans the estate; the
+/// <c>service.name</c> resource attribute distinguishes the source.
+/// </remarks>
+public static class HealthCheckMetrics
+{
+  /// <summary>
+  /// The <see cref="Microsoft.AspNetCore.Http.HttpContext.Items"/> key used to hand failing
+  /// check names from the health check response writer to the suppression middleware.
+  /// </summary>
+  public const string FailedChecksItemKey = "arolariu.health.failed-checks";
+
+  /// <summary>
+  /// The exported metric name.
+  /// </summary>
+  public const string MetricName = "arolariu.health.check.failures";
+
+  private static readonly Counter<long> FailureCounter =
+    MeterGenerators.CoreMeter.CreateCounter<long>(
+      MetricName,
+      unit: "{failure}",
+      description: "Health check failures, dimensioned by the failing check name.");
+
+  /// <summary>
+  /// Records one measurement per failing health check.
+  /// </summary>
+  /// <param name="failedCheckNames">The names of the health checks that reported failure.</param>
+  /// <exception cref="ArgumentNullException">Thrown when <paramref name="failedCheckNames"/> is null.</exception>
+  /// <remarks>
+  /// Must be called outside any active <c>SuppressInstrumentationScope</c>, otherwise the
+  /// measurement may be discarded along with the suppressed request telemetry.
+  /// </remarks>
+  public static void RecordFailures(IEnumerable<string> failedCheckNames)
+  {
+    ArgumentNullException.ThrowIfNull(failedCheckNames);
+
+    foreach (var checkName in failedCheckNames)
+    {
+      FailureCounter.Add(1, new KeyValuePair<string, object?>("check", checkName));
+    }
+  }
+}

--- a/sites/api.arolariu.ro/src/Common/Telemetry/Tracing/TracingExtensions.cs
+++ b/sites/api.arolariu.ro/src/Common/Telemetry/Tracing/TracingExtensions.cs
@@ -87,6 +87,11 @@ public static class TracingExtensions
       // Add framework instrumentation with enrichment callbacks
       tracingOptions.AddAspNetCoreInstrumentation(options =>
       {
+        // Drop health and connectivity probe spans before allocation. See RFC 2002 and
+        // docs/superpowers/specs/2026-08-07-telemetry-noise-reduction-design.md.
+        options.Filter = httpContext =>
+          !HealthTelemetryPolicy.ShouldSuppress(httpContext.Request.Path.Value);
+
         // Enrich incoming HTTP request spans with additional context
         options.EnrichWithHttpRequest = (activity, httpRequest) =>
         {
@@ -115,6 +120,10 @@ public static class TracingExtensions
 
       tracingOptions.AddHttpClientInstrumentation(options =>
       {
+        // Suppress outbound probe dependencies, e.g. ConfigProxyClient.PingAsync -> /api/ready.
+        options.FilterHttpRequestMessage = httpRequest =>
+          !HealthTelemetryPolicy.ShouldSuppress(httpRequest.RequestUri?.AbsolutePath);
+
         // Enrich outgoing HTTP client spans
         options.EnrichWithHttpRequestMessage = (activity, httpRequest) =>
         {

--- a/sites/api.arolariu.ro/src/Common/Telemetry/Tracing/TracingExtensions.cs
+++ b/sites/api.arolariu.ro/src/Common/Telemetry/Tracing/TracingExtensions.cs
@@ -87,8 +87,8 @@ public static class TracingExtensions
       // Add framework instrumentation with enrichment callbacks
       tracingOptions.AddAspNetCoreInstrumentation(options =>
       {
-        // Drop health and connectivity probe spans before allocation. See RFC 2002 and
-        // docs/superpowers/specs/2026-08-07-telemetry-noise-reduction-design.md.
+        // Drop health and connectivity probe spans before allocation.
+        // See RFC 2002 and HealthTelemetryPolicy for the suppressed path list and override.
         options.Filter = HealthTelemetryPolicy.ShouldRecordHttpContext;
 
         // Enrich incoming HTTP request spans with additional context

--- a/sites/api.arolariu.ro/src/Common/Telemetry/Tracing/TracingExtensions.cs
+++ b/sites/api.arolariu.ro/src/Common/Telemetry/Tracing/TracingExtensions.cs
@@ -89,8 +89,7 @@ public static class TracingExtensions
       {
         // Drop health and connectivity probe spans before allocation. See RFC 2002 and
         // docs/superpowers/specs/2026-08-07-telemetry-noise-reduction-design.md.
-        options.Filter = httpContext =>
-          !HealthTelemetryPolicy.ShouldSuppress(httpContext.Request.Path.Value);
+        options.Filter = HealthTelemetryPolicy.ShouldRecordHttpContext;
 
         // Enrich incoming HTTP request spans with additional context
         options.EnrichWithHttpRequest = (activity, httpRequest) =>
@@ -121,8 +120,7 @@ public static class TracingExtensions
       tracingOptions.AddHttpClientInstrumentation(options =>
       {
         // Suppress outbound probe dependencies, e.g. ConfigProxyClient.PingAsync -> /api/ready.
-        options.FilterHttpRequestMessage = httpRequest =>
-          !HealthTelemetryPolicy.ShouldSuppress(httpRequest.RequestUri?.AbsolutePath);
+        options.FilterHttpRequestMessage = HealthTelemetryPolicy.ShouldRecordHttpRequestMessage;
 
         // Enrich outgoing HTTP client spans
         options.EnrichWithHttpRequestMessage = (activity, httpRequest) =>

--- a/sites/api.arolariu.ro/src/Core/Domain/General/Extensions/WebApplicationExtensions.cs
+++ b/sites/api.arolariu.ro/src/Core/Domain/General/Extensions/WebApplicationExtensions.cs
@@ -4,21 +4,20 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
-using arolariu.Backend.Common.Configuration;
-using arolariu.Backend.Common.Telemetry;
-using arolariu.Backend.Common.Telemetry.Metering;
-
-using Microsoft.Extensions.Diagnostics.HealthChecks;
-using arolariu.Backend.Core.Auth.Modules;
-using arolariu.Backend.Core.Domain.General.Middlewares;
-using arolariu.Backend.Core.Domain.General.Services.Swagger;
-
-using HealthChecks.UI.Client;
-
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
+
+using HealthChecks.UI.Client;
+
+using arolariu.Backend.Common.Configuration;
+using arolariu.Backend.Common.Telemetry;
+using arolariu.Backend.Common.Telemetry.Metering;
+using arolariu.Backend.Core.Auth.Modules;
+using arolariu.Backend.Core.Domain.General.Middlewares;
+using arolariu.Backend.Core.Domain.General.Services.Swagger;
 
 /// <summary>
 /// Provides extension methods for configuring the <see cref="WebApplication"/> request processing pipeline.

--- a/sites/api.arolariu.ro/src/Core/Domain/General/Extensions/WebApplicationExtensions.cs
+++ b/sites/api.arolariu.ro/src/Core/Domain/General/Extensions/WebApplicationExtensions.cs
@@ -4,6 +4,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 using arolariu.Backend.Common.Configuration;
+using arolariu.Backend.Common.Telemetry;
 using arolariu.Backend.Core.Auth.Modules;
 using arolariu.Backend.Core.Domain.General.Middlewares;
 using arolariu.Backend.Core.Domain.General.Services.Swagger;
@@ -135,10 +136,12 @@ internal static class WebApplicationExtensions
     app.UseSwaggerUI(SwaggerConfigurationService.GetSwaggerUIOptions());
     app.MapOpenApi();
     app.MapHealthChecks("/health", new HealthCheckOptions { ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse })
-       .RequireRateLimiting(RateLimitPolicies.HealthCheck);
+       .RequireRateLimiting(RateLimitPolicies.HealthCheck)
+       .DisableHttpMetrics();
     app.MapGet("/terms", () => app.Configuration["ApplicationOptions:TermsAndConditions"]);
 
     logger.LogHealthChecksRegistered("/health");
+    logger.LogHealthTelemetrySuppression(HealthTelemetryPolicy.IsSuppressionEnabled);
     logger.LogPipelineConfigurationCompleted();
 
     return app;

--- a/sites/api.arolariu.ro/src/Core/Domain/General/Extensions/WebApplicationExtensions.cs
+++ b/sites/api.arolariu.ro/src/Core/Domain/General/Extensions/WebApplicationExtensions.cs
@@ -112,6 +112,10 @@ internal static class WebApplicationExtensions
     // writes an RFC 7807 ProblemDetails response. See RFC 2003.
     app.UseExceptionHandler();
 
+    // Must run before routing so the suppression scope covers execution of the health checks
+    // themselves, not merely endpoint dispatch. See the telemetry noise reduction spec.
+    app.UseMiddleware<HealthTelemetrySuppressionMiddleware>();
+
     app.UseHttpsRedirection();
     app.UseAuthServices();
 

--- a/sites/api.arolariu.ro/src/Core/Domain/General/Extensions/WebApplicationExtensions.cs
+++ b/sites/api.arolariu.ro/src/Core/Domain/General/Extensions/WebApplicationExtensions.cs
@@ -138,7 +138,7 @@ internal static class WebApplicationExtensions
     app.UseSwagger(SwaggerConfigurationService.GetSwaggerOptions());
     app.UseSwaggerUI(SwaggerConfigurationService.GetSwaggerUIOptions());
     app.MapOpenApi();
-    app.MapHealthChecks("/health", new HealthCheckOptions
+    var healthChecks = app.MapHealthChecks("/health", new HealthCheckOptions
     {
       ResponseWriter = async (httpContext, report) =>
       {
@@ -155,8 +155,14 @@ internal static class WebApplicationExtensions
         await UIResponseWriter.WriteHealthCheckUIResponse(httpContext, report).ConfigureAwait(false);
       },
     })
-       .RequireRateLimiting(RateLimitPolicies.HealthCheck)
-       .DisableHttpMetrics();
+       .RequireRateLimiting(RateLimitPolicies.HealthCheck);
+
+    // Gated so OTEL_SUPPRESS_HEALTH_TELEMETRY=false restores every signal, metrics included.
+    // An unconditional call would leave metrics suppressed even with the override disabled.
+    if (HealthTelemetryPolicy.IsSuppressionEnabled)
+    {
+      healthChecks.DisableHttpMetrics();
+    }
     app.MapGet("/terms", () => app.Configuration["ApplicationOptions:TermsAndConditions"]);
 
     logger.LogHealthChecksRegistered("/health");

--- a/sites/api.arolariu.ro/src/Core/Domain/General/Extensions/WebApplicationExtensions.cs
+++ b/sites/api.arolariu.ro/src/Core/Domain/General/Extensions/WebApplicationExtensions.cs
@@ -1,10 +1,14 @@
 namespace arolariu.Backend.Core.Domain.General.Extensions;
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
 using arolariu.Backend.Common.Configuration;
 using arolariu.Backend.Common.Telemetry;
+using arolariu.Backend.Common.Telemetry.Metering;
+
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using arolariu.Backend.Core.Auth.Modules;
 using arolariu.Backend.Core.Domain.General.Middlewares;
 using arolariu.Backend.Core.Domain.General.Services.Swagger;
@@ -135,7 +139,23 @@ internal static class WebApplicationExtensions
     app.UseSwagger(SwaggerConfigurationService.GetSwaggerOptions());
     app.UseSwaggerUI(SwaggerConfigurationService.GetSwaggerUIOptions());
     app.MapOpenApi();
-    app.MapHealthChecks("/health", new HealthCheckOptions { ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse })
+    app.MapHealthChecks("/health", new HealthCheckOptions
+    {
+      ResponseWriter = async (httpContext, report) =>
+      {
+        var failed = new List<string>();
+        foreach (var entry in report.Entries)
+        {
+          if (entry.Value.Status != HealthStatus.Healthy)
+          {
+            failed.Add(entry.Key);
+          }
+        }
+
+        httpContext.Items[HealthCheckMetrics.FailedChecksItemKey] = failed;
+        await UIResponseWriter.WriteHealthCheckUIResponse(httpContext, report).ConfigureAwait(false);
+      },
+    })
        .RequireRateLimiting(RateLimitPolicies.HealthCheck)
        .DisableHttpMetrics();
     app.MapGet("/terms", () => app.Configuration["ApplicationOptions:TermsAndConditions"]);

--- a/sites/api.arolariu.ro/src/Core/Domain/General/Middlewares/HealthTelemetrySuppressionMiddleware.cs
+++ b/sites/api.arolariu.ro/src/Core/Domain/General/Middlewares/HealthTelemetrySuppressionMiddleware.cs
@@ -29,23 +29,40 @@ internal sealed class HealthTelemetrySuppressionMiddleware(RequestDelegate next)
   /// <param name="context">The current <see cref="HttpContext"/>.</param>
   /// <returns>A task representing the asynchronous pipeline execution.</returns>
   /// <exception cref="ArgumentNullException">Thrown when <paramref name="context"/> is null.</exception>
+  /// <remarks>
+  /// The failure counter is recorded for every health request, whether or not suppression is
+  /// active. Only the instrumentation scope is conditional. This mirrors the exp service, where
+  /// the counter is guarded by <c>is_suppressed_path</c> rather than <c>should_suppress_telemetry</c>.
+  /// </remarks>
   public async Task InvokeAsync(HttpContext context)
   {
     ArgumentNullException.ThrowIfNull(context);
 
-    if (!HealthTelemetryPolicy.ShouldSuppress(context.Request.Path.Value))
+    if (!HealthTelemetryPolicy.IsSuppressedPath(context.Request.Path.Value))
     {
       await this.next(context).ConfigureAwait(false);
       return;
     }
 
-    using (SuppressInstrumentationScope.Begin())
+    if (HealthTelemetryPolicy.IsSuppressionEnabled)
+    {
+      using (SuppressInstrumentationScope.Begin())
+      {
+        await this.next(context).ConfigureAwait(false);
+      }
+    }
+    else
     {
       await this.next(context).ConfigureAwait(false);
     }
 
-    // Recorded only after the scope is disposed — inside it, the measurement could be
+    // Recorded only after any scope is disposed — inside it, the measurement could be
     // discarded by the very mechanism that suppresses the request telemetry.
+    RecordFailures(context);
+  }
+
+  private static void RecordFailures(HttpContext context)
+  {
     if (context.Items.TryGetValue(HealthCheckMetrics.FailedChecksItemKey, out var failed)
         && failed is IEnumerable<string> failedCheckNames)
     {

--- a/sites/api.arolariu.ro/src/Core/Domain/General/Middlewares/HealthTelemetrySuppressionMiddleware.cs
+++ b/sites/api.arolariu.ro/src/Core/Domain/General/Middlewares/HealthTelemetrySuppressionMiddleware.cs
@@ -1,8 +1,10 @@
 namespace arolariu.Backend.Core.Domain.General.Middlewares;
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using arolariu.Backend.Common.Telemetry;
+using arolariu.Backend.Common.Telemetry.Metering;
 using Microsoft.AspNetCore.Http;
 using OpenTelemetry;
 
@@ -40,6 +42,14 @@ internal sealed class HealthTelemetrySuppressionMiddleware(RequestDelegate next)
     using (SuppressInstrumentationScope.Begin())
     {
       await this.next(context).ConfigureAwait(false);
+    }
+
+    // Recorded only after the scope is disposed — inside it, the measurement could be
+    // discarded by the very mechanism that suppresses the request telemetry.
+    if (context.Items.TryGetValue(HealthCheckMetrics.FailedChecksItemKey, out var failed)
+        && failed is IEnumerable<string> failedCheckNames)
+    {
+      HealthCheckMetrics.RecordFailures(failedCheckNames);
     }
   }
 }

--- a/sites/api.arolariu.ro/src/Core/Domain/General/Middlewares/HealthTelemetrySuppressionMiddleware.cs
+++ b/sites/api.arolariu.ro/src/Core/Domain/General/Middlewares/HealthTelemetrySuppressionMiddleware.cs
@@ -1,0 +1,45 @@
+namespace arolariu.Backend.Core.Domain.General.Middlewares;
+
+using System;
+using System.Threading.Tasks;
+using arolariu.Backend.Common.Telemetry;
+using Microsoft.AspNetCore.Http;
+using OpenTelemetry;
+
+/// <summary>
+/// Suppresses all OpenTelemetry instrumentation for health and connectivity probe requests.
+/// </summary>
+/// <remarks>
+/// Filtering only the ASP.NET Core server span is insufficient: the registered health checks
+/// fan out to SQL Server, Blob Storage, Cosmos DB and the exp config proxy, each independently
+/// instrumented. Without a recorded parent those emit orphaned root spans. Wrapping the whole
+/// request in a suppression scope removes the entire subtree.
+/// </remarks>
+/// <param name="next">The next delegate in the request pipeline.</param>
+internal sealed class HealthTelemetrySuppressionMiddleware(RequestDelegate next)
+{
+  private readonly RequestDelegate next = next
+    ?? throw new ArgumentNullException(nameof(next));
+
+  /// <summary>
+  /// Invokes the middleware for the current request.
+  /// </summary>
+  /// <param name="context">The current <see cref="HttpContext"/>.</param>
+  /// <returns>A task representing the asynchronous pipeline execution.</returns>
+  /// <exception cref="ArgumentNullException">Thrown when <paramref name="context"/> is null.</exception>
+  public async Task InvokeAsync(HttpContext context)
+  {
+    ArgumentNullException.ThrowIfNull(context);
+
+    if (!HealthTelemetryPolicy.ShouldSuppress(context.Request.Path.Value))
+    {
+      await this.next(context).ConfigureAwait(false);
+      return;
+    }
+
+    using (SuppressInstrumentationScope.Begin())
+    {
+      await this.next(context).ConfigureAwait(false);
+    }
+  }
+}

--- a/sites/api.arolariu.ro/src/Core/Log.cs
+++ b/sites/api.arolariu.ro/src/Core/Log.cs
@@ -154,5 +154,14 @@ internal static partial class Log
     Message = "Health check completed — Status: {Status}, Duration: {DurationMs}ms.")]
   public static partial void LogHealthCheckCompleted(this ILogger logger, string status, double durationMs);
 
+  /// <summary>
+  /// Logs whether health endpoint telemetry suppression is active for this process.
+  /// </summary>
+  [LoggerMessage(
+    EventId = 500_302,
+    Level = LogLevel.Information,
+    Message = "Health telemetry suppression enabled: {Enabled}. Override with OTEL_SUPPRESS_HEALTH_TELEMETRY.")]
+  public static partial void LogHealthTelemetrySuppression(this ILogger logger, bool enabled);
+
   #endregion
 }

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Telemetry/HealthCheckMetricsTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Telemetry/HealthCheckMetricsTests.cs
@@ -1,6 +1,7 @@
 namespace arolariu.Backend.Core.Tests.Common.Telemetry;
 
 using System.Collections.Generic;
+using System.Linq;
 using arolariu.Backend.Common.Telemetry.Metering;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenTelemetry;
@@ -10,7 +11,10 @@ using OpenTelemetry.Metrics;
 [TestClass]
 public sealed class HealthCheckMetricsTests
 {
-  /// <summary>Verifies that failing checks produce exported measurements.</summary>
+  /// <summary>
+  /// Verifies that each failing check produces exactly one metric point tagged with its name,
+  /// with a sum of 1. Two inputs must produce two distinct points.
+  /// </summary>
   [TestMethod]
   public void RecordFailures_FailedChecks_ExportsOneMeasurementPerCheck()
   {
@@ -25,6 +29,34 @@ public sealed class HealthCheckMetricsTests
 
     var metric = exported.Find(m => m.Name == HealthCheckMetrics.MetricName);
     Assert.IsNotNull(metric, "The failure counter must be exported.");
+
+    // Materialise the metric points so we can assert per-point dimensioning.
+    var points = new List<(string checkTag, long sum)>();
+    foreach (ref readonly var point in metric.GetMetricPoints())
+    {
+      string? checkTag = null;
+      foreach (var tag in point.Tags)
+      {
+        if (tag.Key == "check")
+        {
+          checkTag = tag.Value?.ToString();
+        }
+      }
+
+      Assert.IsNotNull(checkTag, "Every metric point must carry a 'check' tag.");
+      points.Add((checkTag!, point.GetSumLong()));
+    }
+
+    Assert.AreEqual(2, points.Count, "Exactly one metric point per failing check.");
+
+    var tagValues = points.Select(p => p.checkTag).ToHashSet();
+    CollectionAssert.Contains(tagValues.ToList(), "mssql", "Expected a point tagged check=mssql.");
+    CollectionAssert.Contains(tagValues.ToList(), "cosmosdb", "Expected a point tagged check=cosmosdb.");
+
+    foreach (var (checkTag, sum) in points)
+    {
+      Assert.AreEqual(1L, sum, $"Point for check={checkTag} must have sum=1.");
+    }
   }
 
   /// <summary>Verifies that a healthy probe emits no measurements.</summary>

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Telemetry/HealthCheckMetricsTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Telemetry/HealthCheckMetricsTests.cs
@@ -1,0 +1,46 @@
+namespace arolariu.Backend.Core.Tests.Common.Telemetry;
+
+using System.Collections.Generic;
+using arolariu.Backend.Common.Telemetry.Metering;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+
+/// <summary>Unit tests for <see cref="HealthCheckMetrics"/>.</summary>
+[TestClass]
+public sealed class HealthCheckMetricsTests
+{
+  /// <summary>Verifies that failing checks produce exported measurements.</summary>
+  [TestMethod]
+  public void RecordFailures_FailedChecks_ExportsOneMeasurementPerCheck()
+  {
+    var exported = new List<Metric>();
+    using var provider = Sdk.CreateMeterProviderBuilder()
+      .AddMeter("arolariu.Backend.Core")
+      .AddInMemoryExporter(exported)
+      .Build()!;
+
+    HealthCheckMetrics.RecordFailures(["mssql", "cosmosdb"]);
+    provider.ForceFlush();
+
+    var metric = exported.Find(m => m.Name == HealthCheckMetrics.MetricName);
+    Assert.IsNotNull(metric, "The failure counter must be exported.");
+  }
+
+  /// <summary>Verifies that a healthy probe emits no measurements.</summary>
+  [TestMethod]
+  public void RecordFailures_NoFailures_ExportsNothing()
+  {
+    var exported = new List<Metric>();
+    using var provider = Sdk.CreateMeterProviderBuilder()
+      .AddMeter("arolariu.Backend.Core")
+      .AddInMemoryExporter(exported)
+      .Build()!;
+
+    HealthCheckMetrics.RecordFailures([]);
+    provider.ForceFlush();
+
+    var metric = exported.Find(m => m.Name == HealthCheckMetrics.MetricName);
+    Assert.IsNull(metric, "A healthy probe must not emit any measurement.");
+  }
+}

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Telemetry/HealthCheckMetricsTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Telemetry/HealthCheckMetricsTests.cs
@@ -8,7 +8,12 @@ using OpenTelemetry;
 using OpenTelemetry.Metrics;
 
 /// <summary>Unit tests for <see cref="HealthCheckMetrics"/>.</summary>
+/// <remarks>
+/// Not parallelized: the failure counter is a static instrument on a process-global meter, so a
+/// concurrently-alive <c>MeterProvider</c> in another class would observe these measurements too.
+/// </remarks>
 [TestClass]
+[DoNotParallelize]
 public sealed class HealthCheckMetricsTests
 {
   /// <summary>

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Telemetry/HealthTelemetryPolicyTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Telemetry/HealthTelemetryPolicyTests.cs
@@ -1,0 +1,57 @@
+namespace arolariu.Backend.Core.Tests.Common.Telemetry;
+
+using arolariu.Backend.Common.Telemetry;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+/// <summary>
+/// Tests for <see cref="HealthTelemetryPolicy"/> covering path classification and suppression flag parsing.
+/// </summary>
+[TestClass]
+public sealed class HealthTelemetryPolicyTests
+{
+  /// <summary>Verifies health endpoints are correctly identified as suppressed.</summary>
+  [TestMethod]
+  [DataRow("/health")]
+  [DataRow("/api/health")]
+  [DataRow("/api/ready")]
+  [DataRow("/HEALTH")]
+  [DataRow("/Api/Health")]
+  [DataRow("/health/")]
+  [DataRow("/health?foo=bar")]
+  [DataRow("/api/ready/?x=1")]
+  public void IsSuppressedPath_HealthPath_ReturnsTrue(string path)
+  {
+    Assert.IsTrue(HealthTelemetryPolicy.IsSuppressedPath(path));
+  }
+
+  /// <summary>Verifies non-health paths are not suppressed.</summary>
+  [TestMethod]
+  [DataRow("/")]
+  [DataRow("/api/invoices")]
+  [DataRow("/terms")]
+  [DataRow("/healthcheck-admin")]
+  [DataRow("/health/details")]
+  [DataRow("/api/healthy")]
+  [DataRow("")]
+  [DataRow(null)]
+  public void IsSuppressedPath_NonHealthPath_ReturnsFalse(string? path)
+  {
+    Assert.IsFalse(HealthTelemetryPolicy.IsSuppressedPath(path));
+  }
+
+  /// <summary>Verifies environment variable parsing yields expected defaults.</summary>
+  [TestMethod]
+  [DataRow(null, true)]
+  [DataRow("", true)]
+  [DataRow("   ", true)]
+  [DataRow("true", true)]
+  [DataRow("TRUE", true)]
+  [DataRow("false", false)]
+  [DataRow("False", false)]
+  [DataRow("not-a-bool", true)]
+  [DataRow("0", true)]
+  public void ParseSuppressionFlag_Value_ReturnsExpected(string? raw, bool expected)
+  {
+    Assert.AreEqual(expected, HealthTelemetryPolicy.ParseSuppressionFlag(raw));
+  }
+}

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Telemetry/HealthTelemetrySuppressionMiddlewareTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Telemetry/HealthTelemetrySuppressionMiddlewareTests.cs
@@ -1,0 +1,78 @@
+namespace arolariu.Backend.Core.Tests.Common.Telemetry;
+
+using System;
+using System.Threading.Tasks;
+using arolariu.Backend.Core.Domain.General.Middlewares;
+using Microsoft.AspNetCore.Http;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenTelemetry;
+
+/// <summary>
+/// Unit tests for <see cref="HealthTelemetrySuppressionMiddleware"/> verifying suppression scope
+/// behaviour for health probe paths and normal routes.
+/// </summary>
+[TestClass]
+public sealed class HealthTelemetrySuppressionMiddlewareTests
+{
+  /// <summary>
+  /// Verifies that a request to <c>/health</c> executes inside a suppression scope
+  /// and that the scope does not leak after the request completes.
+  /// </summary>
+  [TestMethod]
+  public async Task InvokeAsync_HealthPath_SuppressesInstrumentationScope()
+  {
+    var observedSuppression = false;
+    var middleware = new HealthTelemetrySuppressionMiddleware(_ =>
+    {
+      observedSuppression = Sdk.SuppressInstrumentation;
+      return Task.CompletedTask;
+    });
+
+    var context = new DefaultHttpContext();
+    context.Request.Path = "/health";
+
+    await middleware.InvokeAsync(context).ConfigureAwait(false);
+
+    Assert.IsTrue(observedSuppression, "Health requests must execute inside a suppression scope.");
+    Assert.IsFalse(Sdk.SuppressInstrumentation, "Suppression must not leak past the request.");
+  }
+
+  /// <summary>
+  /// Verifies that a request to a real API route does not activate the suppression scope.
+  /// </summary>
+  [TestMethod]
+  public async Task InvokeAsync_RealRoute_DoesNotSuppress()
+  {
+    var observedSuppression = true;
+    var middleware = new HealthTelemetrySuppressionMiddleware(_ =>
+    {
+      observedSuppression = Sdk.SuppressInstrumentation;
+      return Task.CompletedTask;
+    });
+
+    var context = new DefaultHttpContext();
+    context.Request.Path = "/api/invoices";
+
+    await middleware.InvokeAsync(context).ConfigureAwait(false);
+
+    Assert.IsFalse(observedSuppression, "Real routes must be instrumented normally.");
+  }
+
+  /// <summary>
+  /// Verifies that a throwing request to <c>/health</c> does not leave a leaked suppression scope.
+  /// </summary>
+  [TestMethod]
+  public async Task InvokeAsync_HealthPathThrows_DoesNotLeakSuppression()
+  {
+    var middleware = new HealthTelemetrySuppressionMiddleware(
+      _ => throw new InvalidOperationException("boom"));
+
+    var context = new DefaultHttpContext();
+    context.Request.Path = "/health";
+
+    await Assert.ThrowsExactlyAsync<InvalidOperationException>(
+      () => middleware.InvokeAsync(context)).ConfigureAwait(false);
+
+    Assert.IsFalse(Sdk.SuppressInstrumentation, "A throwing request must not leak a suppressed scope.");
+  }
+}

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Telemetry/HealthTelemetrySuppressionMiddlewareTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Telemetry/HealthTelemetrySuppressionMiddlewareTests.cs
@@ -1,17 +1,25 @@
 namespace arolariu.Backend.Core.Tests.Common.Telemetry;
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
+using arolariu.Backend.Common.Telemetry.Metering;
 using arolariu.Backend.Core.Domain.General.Middlewares;
 using Microsoft.AspNetCore.Http;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenTelemetry;
+using OpenTelemetry.Metrics;
 
 /// <summary>
 /// Unit tests for <see cref="HealthTelemetrySuppressionMiddleware"/> verifying suppression scope
 /// behaviour for health probe paths and normal routes.
 /// </summary>
+/// <remarks>
+/// Not parallelized: the failure counter is a static instrument on a process-global meter, so a
+/// concurrently-alive <c>MeterProvider</c> in another class would observe these measurements too.
+/// </remarks>
 [TestClass]
+[DoNotParallelize]
 public sealed class HealthTelemetrySuppressionMiddlewareTests
 {
   /// <summary>
@@ -74,5 +82,64 @@ public sealed class HealthTelemetrySuppressionMiddlewareTests
       () => middleware.InvokeAsync(context)).ConfigureAwait(false);
 
     Assert.IsFalse(Sdk.SuppressInstrumentation, "A throwing request must not leak a suppressed scope.");
+  }
+
+  /// <summary>
+  /// Verifies that the failure counter is recorded for a suppressed health path. Regression
+  /// guard: an earlier implementation early-returned before the recording block whenever
+  /// suppression was inactive, silently disabling the one signal meant to always survive.
+  /// </summary>
+  [TestMethod]
+  public async Task InvokeAsync_HealthPathWithFailedChecks_RecordsFailures()
+  {
+    var exported = new List<Metric>();
+    using var provider = Sdk.CreateMeterProviderBuilder()
+      .AddMeter("arolariu.Backend.Core")
+      .AddInMemoryExporter(exported)
+      .Build()!;
+
+    var middleware = new HealthTelemetrySuppressionMiddleware(ctx =>
+    {
+      ctx.Items[HealthCheckMetrics.FailedChecksItemKey] = new List<string> { "mssql" };
+      return Task.CompletedTask;
+    });
+
+    var context = new DefaultHttpContext();
+    context.Request.Path = "/health";
+
+    await middleware.InvokeAsync(context).ConfigureAwait(false);
+    provider.ForceFlush();
+
+    var metric = exported.Find(m => m.Name == HealthCheckMetrics.MetricName);
+    Assert.IsNotNull(metric, "The failure counter must be recorded for a failing health probe.");
+  }
+
+  /// <summary>
+  /// Verifies that a non-health route is left entirely alone: no suppression scope, and no
+  /// failure-counter bookkeeping even if something placed a failed-check list on the context.
+  /// </summary>
+  [TestMethod]
+  public async Task InvokeAsync_RealRouteWithFailedChecks_RecordsNothing()
+  {
+    var exported = new List<Metric>();
+    using var provider = Sdk.CreateMeterProviderBuilder()
+      .AddMeter("arolariu.Backend.Core")
+      .AddInMemoryExporter(exported)
+      .Build()!;
+
+    var middleware = new HealthTelemetrySuppressionMiddleware(ctx =>
+    {
+      ctx.Items[HealthCheckMetrics.FailedChecksItemKey] = new List<string> { "mssql" };
+      return Task.CompletedTask;
+    });
+
+    var context = new DefaultHttpContext();
+    context.Request.Path = "/api/invoices";
+
+    await middleware.InvokeAsync(context).ConfigureAwait(false);
+    provider.ForceFlush();
+
+    var metric = exported.Find(m => m.Name == HealthCheckMetrics.MetricName);
+    Assert.IsNull(metric, "Non-health routes must not feed the health failure counter.");
   }
 }

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Telemetry/HealthTraceFilterTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Telemetry/HealthTraceFilterTests.cs
@@ -6,14 +6,21 @@ using System.Diagnostics;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using arolariu.Backend.Common.Options;
 using arolariu.Backend.Common.Telemetry;
+using arolariu.Backend.Common.Telemetry.Tracing;
+using arolariu.Backend.Core.Tests.Shared.TestDoubles;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenTelemetry;
+using OpenTelemetry.Instrumentation.AspNetCore;
+using OpenTelemetry.Instrumentation.Http;
 using OpenTelemetry.Trace;
 
 /// <summary>
@@ -78,8 +85,7 @@ public sealed class HealthTraceFilterTests
           webBuilder.ConfigureServices(services =>
             services.AddOpenTelemetry().WithTracing(tracing => tracing
                 .AddAspNetCoreInstrumentation(options =>
-                  options.Filter = httpContext =>
-                    !HealthTelemetryPolicy.ShouldSuppress(httpContext.Request.Path.Value))
+                  options.Filter = HealthTelemetryPolicy.ShouldRecordHttpContext)
                 .AddProcessor(processor)));
           webBuilder.Configure(app => app.Run(context =>
           {
@@ -149,5 +155,71 @@ public sealed class HealthTraceFilterTests
     var exported = await ExportedActivitiesForAsync("/api/invoices").ConfigureAwait(false);
 
     Assert.AreEqual(1, exported.Count, "Real routes must still export telemetry.");
+  }
+
+  // ──────────────────────────────────────────────────────────────────────────────
+  // Wiring tests — assert that AddOTelTracing actually installs the production
+  // filter callbacks so that removing options.Filter from TracingExtensions.cs
+  // causes these tests to fail.
+  // ──────────────────────────────────────────────────────────────────────────────
+
+  /// <summary>
+  /// Verifies that <see cref="TracingExtensions.AddOTelTracing"/> registers
+  /// <see cref="HealthTelemetryPolicy.ShouldRecordHttpContext"/> as the
+  /// <c>AspNetCoreTraceInstrumentationOptions.Filter</c> predicate, and that the
+  /// predicate correctly suppresses health paths while allowing real routes.
+  /// </summary>
+  [TestMethod]
+  public void AddOTelTracing_WiresAspNetCoreFilter()
+  {
+    var builder = WebApplication.CreateBuilder();
+    builder.Services.AddSingleton<IOptionsManager>(
+      new FakeOptionsManager(new LocalOptions()));
+    builder.AddOTelTracing();
+
+    using var provider = builder.Services.BuildServiceProvider();
+    var filter = provider
+      .GetRequiredService<IOptionsMonitor<AspNetCoreTraceInstrumentationOptions>>()
+      .Get(Options.DefaultName)
+      .Filter;
+
+    Assert.IsNotNull(filter, "AddOTelTracing must register a non-null Filter.");
+
+    var healthCtx = new DefaultHttpContext();
+    healthCtx.Request.Path = "/health";
+    Assert.IsFalse(filter(healthCtx), "Filter must suppress /health.");
+
+    var apiCtx = new DefaultHttpContext();
+    apiCtx.Request.Path = "/api/invoices";
+    Assert.IsTrue(filter(apiCtx), "Filter must allow /api/invoices.");
+  }
+
+  /// <summary>
+  /// Verifies that <see cref="TracingExtensions.AddOTelTracing"/> registers
+  /// <see cref="HealthTelemetryPolicy.ShouldRecordHttpRequestMessage"/> as the
+  /// <c>HttpClientTraceInstrumentationOptions.FilterHttpRequestMessage</c> predicate, and that
+  /// the predicate correctly suppresses outbound health probe requests.
+  /// </summary>
+  [TestMethod]
+  public void AddOTelTracing_WiresHttpClientFilter()
+  {
+    var builder = WebApplication.CreateBuilder();
+    builder.Services.AddSingleton<IOptionsManager>(
+      new FakeOptionsManager(new LocalOptions()));
+    builder.AddOTelTracing();
+
+    using var provider = builder.Services.BuildServiceProvider();
+    var filter = provider
+      .GetRequiredService<IOptionsMonitor<HttpClientTraceInstrumentationOptions>>()
+      .Get(Options.DefaultName)
+      .FilterHttpRequestMessage;
+
+    Assert.IsNotNull(filter, "AddOTelTracing must register a non-null FilterHttpRequestMessage.");
+
+    using var healthReq = new HttpRequestMessage(HttpMethod.Get, new Uri("http://localhost/api/ready"));
+    Assert.IsFalse(filter(healthReq), "Filter must suppress /api/ready.");
+
+    using var apiReq = new HttpRequestMessage(HttpMethod.Get, new Uri("http://localhost/api/invoices"));
+    Assert.IsTrue(filter(apiReq), "Filter must allow /api/invoices.");
   }
 }

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Telemetry/HealthTraceFilterTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Telemetry/HealthTraceFilterTests.cs
@@ -1,0 +1,113 @@
+namespace arolariu.Backend.Core.Tests.Common.Telemetry;
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Net.Http;
+using System.Threading.Tasks;
+using arolariu.Backend.Common.Telemetry;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenTelemetry;
+using OpenTelemetry.Trace;
+
+/// <summary>
+/// Integration tests that verify the ASP.NET Core instrumentation filter correctly
+/// suppresses telemetry for health probe paths while preserving traces for real routes.
+/// </summary>
+[TestClass]
+public sealed class HealthTraceFilterTests
+{
+  // ActivityListeners are global; serialize tests so only one OTel pipeline is active at a time.
+  private static readonly System.Threading.SemaphoreSlim _gate = new(1, 1);
+
+  private static async Task<List<Activity>> ExportedActivitiesForAsync(string requestPath)
+  {
+    await _gate.WaitAsync().ConfigureAwait(false);
+    try
+    {
+      var exported = new List<Activity>();
+
+      var host = await new HostBuilder()
+        .ConfigureWebHost(webBuilder =>
+        {
+          webBuilder.UseTestServer();
+          webBuilder.ConfigureServices(services =>
+            services.AddOpenTelemetry().WithTracing(tracing => tracing
+                .AddAspNetCoreInstrumentation(options =>
+                  options.Filter = httpContext =>
+                    !HealthTelemetryPolicy.ShouldSuppress(httpContext.Request.Path.Value))
+                .AddInMemoryExporter(exported)));
+          webBuilder.Configure(app => app.Run(context =>
+          {
+            context.Response.StatusCode = 200;
+            return Task.CompletedTask;
+          }));
+        })
+        .StartAsync()
+        .ConfigureAwait(false);
+
+      try
+      {
+        using var client = host.GetTestClient();
+        var response = await client.GetAsync(new Uri(requestPath, UriKind.Relative))
+          .ConfigureAwait(false);
+
+        // The server-side activity lifecycle (DisposeContext) completes asynchronously
+        // relative to the client receiving the response. Wait for it to finish before
+        // stopping the host, so that SimpleActivityExportProcessor.OnEnd fires while
+        // the TracerProvider is still alive and registered.
+        response.Dispose();
+
+        // Poll until the activity appears in exported, or until timeout.
+        // For suppressed paths the loop exits quickly (nothing ever appears).
+        var deadline = Environment.TickCount64 + 3_000;
+        while (exported.Count == 0 && Environment.TickCount64 < deadline)
+        {
+          await Task.Delay(10).ConfigureAwait(false);
+        }
+
+        // Flush before stopping: StopAsync shuts down the hosted service that manages
+        // TracerProvider; flushing first ensures all ended activities are exported.
+        host.Services.GetRequiredService<TracerProvider>().ForceFlush(5000);
+        await host.StopAsync().ConfigureAwait(false);
+      }
+      finally
+      {
+        host.Dispose();
+      }
+
+      return exported;
+    }
+    finally
+    {
+      _gate.Release();
+    }
+  }
+
+  /// <summary>
+  /// Verifies that HTTP requests to health probe paths are excluded from distributed traces.
+  /// </summary>
+  [TestMethod]
+  public async Task AspNetCoreFilter_HealthPath_ExportsNoActivity()
+  {
+    var exported = await ExportedActivitiesForAsync("/health").ConfigureAwait(false);
+
+    Assert.AreEqual(0, exported.Count, "Health requests must not export any activity.");
+  }
+
+  /// <summary>
+  /// Verifies that HTTP requests to real application routes are still captured in distributed traces.
+  /// </summary>
+  [TestMethod]
+  public async Task AspNetCoreFilter_RealRoute_ExportsActivity()
+  {
+    var exported = await ExportedActivitiesForAsync("/api/invoices").ConfigureAwait(false);
+
+    Assert.AreEqual(1, exported.Count, "Real routes must still export telemetry.");
+  }
+}

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Telemetry/HealthTraceFilterTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/Telemetry/HealthTraceFilterTests.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using arolariu.Backend.Common.Telemetry;
 using Microsoft.AspNetCore.Builder;
@@ -23,14 +24,52 @@ using OpenTelemetry.Trace;
 public sealed class HealthTraceFilterTests
 {
   // ActivityListeners are global; serialize tests so only one OTel pipeline is active at a time.
-  private static readonly System.Threading.SemaphoreSlim _gate = new(1, 1);
+  private static readonly SemaphoreSlim _gate = new(1, 1);
 
-  private static async Task<List<Activity>> ExportedActivitiesForAsync(string requestPath)
+  /// <summary>
+  /// Captures activities synchronously in <see cref="BaseProcessor{T}.OnEnd"/> and signals
+  /// a <see cref="SemaphoreSlim"/> so the real-route test can await the first activity instead
+  /// of polling a fixed deadline.
+  /// </summary>
+  private sealed class CapturingProcessor : BaseProcessor<Activity>
+  {
+    private readonly List<Activity> _target;
+    private readonly SemaphoreSlim _signal = new(0, int.MaxValue);
+
+    /// <summary>Initialises the processor with the shared capture list.</summary>
+    public CapturingProcessor(List<Activity> target) => _target = target;
+
+    /// <inheritdoc/>
+    public override void OnEnd(Activity activity)
+    {
+      _target.Add(activity);
+      _signal.Release();
+    }
+
+    /// <summary>
+    /// Waits up to <paramref name="timeout"/> for at least one activity to be captured.
+    /// </summary>
+    public Task<bool> WaitForActivityAsync(TimeSpan timeout) =>
+      _signal.WaitAsync(timeout);
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+      if (disposing)
+        _signal.Dispose();
+      base.Dispose(disposing);
+    }
+  }
+
+  private static async Task<List<Activity>> ExportedActivitiesForAsync(
+    string requestPath,
+    TimeSpan absenceGuard = default)
   {
     await _gate.WaitAsync().ConfigureAwait(false);
     try
     {
       var exported = new List<Activity>();
+      using var processor = new CapturingProcessor(exported);
 
       var host = await new HostBuilder()
         .ConfigureWebHost(webBuilder =>
@@ -41,7 +80,7 @@ public sealed class HealthTraceFilterTests
                 .AddAspNetCoreInstrumentation(options =>
                   options.Filter = httpContext =>
                     !HealthTelemetryPolicy.ShouldSuppress(httpContext.Request.Path.Value))
-                .AddInMemoryExporter(exported)));
+                .AddProcessor(processor)));
           webBuilder.Configure(app => app.Run(context =>
           {
             context.Response.StatusCode = 200;
@@ -54,26 +93,24 @@ public sealed class HealthTraceFilterTests
       try
       {
         using var client = host.GetTestClient();
-        var response = await client.GetAsync(new Uri(requestPath, UriKind.Relative))
+        using var response = await client.GetAsync(new Uri(requestPath, UriKind.Relative))
           .ConfigureAwait(false);
 
-        // The server-side activity lifecycle (DisposeContext) completes asynchronously
-        // relative to the client receiving the response. Wait for it to finish before
-        // stopping the host, so that SimpleActivityExportProcessor.OnEnd fires while
-        // the TracerProvider is still alive and registered.
-        response.Dispose();
-
-        // Poll until the activity appears in exported, or until timeout.
-        // For suppressed paths the loop exits quickly (nothing ever appears).
-        var deadline = Environment.TickCount64 + 3_000;
-        while (exported.Count == 0 && Environment.TickCount64 < deadline)
+        if (absenceGuard == default)
         {
-          await Task.Delay(10).ConfigureAwait(false);
+          // Real-route path: wait until an activity arrives (up to 3s), then return immediately.
+          await processor.WaitForActivityAsync(TimeSpan.FromSeconds(3)).ConfigureAwait(false);
+        }
+        else
+        {
+          // Absence-assertion path: wait a short, deliberate interval so that any activity
+          // that the filter should have suppressed has time to arrive — if the filter is
+          // misconfigured, the activity will appear during this window. The window only needs
+          // to outlast the server-side DisposeContext async gap (measured in milliseconds),
+          // so 400ms is a conservative upper bound without slowing the suite materially.
+          await Task.Delay(absenceGuard).ConfigureAwait(false);
         }
 
-        // Flush before stopping: StopAsync shuts down the hosted service that manages
-        // TracerProvider; flushing first ensures all ended activities are exported.
-        host.Services.GetRequiredService<TracerProvider>().ForceFlush(5000);
         await host.StopAsync().ConfigureAwait(false);
       }
       finally
@@ -95,7 +132,10 @@ public sealed class HealthTraceFilterTests
   [TestMethod]
   public async Task AspNetCoreFilter_HealthPath_ExportsNoActivity()
   {
-    var exported = await ExportedActivitiesForAsync("/health").ConfigureAwait(false);
+    // Pass a 400ms absence-guard: any activity that leaked past the filter would arrive
+    // during this window, making the assertion fail — preserving the deleted-filter guarantee.
+    var exported = await ExportedActivitiesForAsync("/health", TimeSpan.FromMilliseconds(400))
+      .ConfigureAwait(false);
 
     Assert.AreEqual(0, exported.Count, "Health requests must not export any activity.");
   }

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/arolariu.Backend.Core.Tests.csproj
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/arolariu.Backend.Core.Tests.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+    <PackageReference Include="OpenTelemetry.Exporter.InMemory" />
   </ItemGroup>
 
   

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/packages.lock.json
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/packages.lock.json
@@ -68,6 +68,15 @@
           "MSTest.Analyzers": "4.3.3"
         }
       },
+      "OpenTelemetry.Exporter.InMemory": {
+        "type": "Direct",
+        "requested": "[1.17.0, )",
+        "resolved": "1.17.0",
+        "contentHash": "1zajwmOjywDHbcocKbfuS9wfn///JlzkXQlL3/W//Ayl1cv137GdqiDV5KE+nTSctkO88rP34BZYX7qvKzC+og==",
+        "dependencies": {
+          "OpenTelemetry": "1.17.0"
+        }
+      },
       "AspNetCore.HealthChecks.UI.Core": {
         "type": "Transitive",
         "resolved": "9.0.0",

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/AssemblyInfo.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[assembly: Parallelize(Workers = 4, Scope = ExecutionScope.ClassLevel)]

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Builders/InvoiceBuilder.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Builders/InvoiceBuilder.cs
@@ -9,7 +9,6 @@ using arolariu.Backend.Domain.Invoices.DDD.AggregatorRoots.Invoices;
 using arolariu.Backend.Domain.Invoices.DDD.ValueObjects;
 using arolariu.Backend.Domain.Invoices.DDD.ValueObjects.Products;
 
-using Xunit;
 
 /// <summary>
 /// Test data builder for <see cref="Invoice"/> entities following test naming and data generation patterns.
@@ -68,12 +67,12 @@ internal static class InvoiceBuilder
     };
   }
 
-  public static TheoryData<Invoice> GetInvoiceTheoryData() => new()
-  {
-    CreateRandomInvoice(),
-    CreateRandomInvoice(),
-    CreateRandomInvoice()
-  };
+  public static IEnumerable<object[]> GetInvoiceTheoryData() =>
+  [
+    [CreateRandomInvoice()],
+    [CreateRandomInvoice()],
+    [CreateRandomInvoice()]
+  ];
 
   public static List<Invoice> CreateMultipleRandomInvoices(int count = 3)
   {

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Builders/MerchantBuilder.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Builders/MerchantBuilder.cs
@@ -7,7 +7,6 @@ using System.Diagnostics.CodeAnalysis;
 using arolariu.Backend.Common.DDD.ValueObjects;
 using arolariu.Backend.Domain.Invoices.DDD.Entities.Merchants;
 
-using Xunit;
 
 /// <summary>
 /// Test data builder for <see cref="Merchant"/> aggregates used across domain test cases.
@@ -61,12 +60,12 @@ public static class MerchantTestDataBuilder
   }
 
   /// <summary>Provides theory data containing several randomized merchants.</summary>
-  public static TheoryData<Merchant> GetMerchantTheoryData() => new()
-  {
-    CreateRandomMerchant(),
-    CreateRandomMerchant(),
-    CreateRandomMerchant()
-  };
+  public static IEnumerable<object[]> GetMerchantTheoryData() =>
+  [
+    [CreateRandomMerchant()],
+    [CreateRandomMerchant()],
+    [CreateRandomMerchant()]
+  ];
 
   /// <summary>Creates multiple randomly generated merchants.</summary>
   public static List<Merchant> CreateMultipleRandomMerchants(int count = 3)

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Integration/EndpointCancellationTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Integration/EndpointCancellationTests.cs
@@ -17,12 +17,13 @@ using Microsoft.Extensions.Hosting;
 
 using Moq;
 
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 /// <summary>
 /// Asserts that a cancelled request produces the correct HTTP outcome at the endpoint boundary:
 /// a client disconnect is not a server fault, and only a genuine timeout yields 504.
 /// </summary>
+[TestClass]
 public sealed class EndpointCancellationTests
 {
   // ---------------------------------------------------------------------------
@@ -108,7 +109,7 @@ public sealed class EndpointCancellationTests
   /// write tier exists: a write must not be reported as a client abort when the server is the one
   /// that gave up on it.
   /// </remarks>
-  [Fact]
+  [TestMethod]
   public async Task DeleteInvoicesAsync_WhenWriteScopeCancelled_Returns504NotClientClosed()
   {
     var processing = new Mock<IInvoiceProcessingService>();
@@ -133,8 +134,8 @@ public sealed class EndpointCancellationTests
       .DeleteInvoicesAsync(processing.Object, accessor)
       .ConfigureAwait(true);
 
-    var statusResult = Assert.IsAssignableFrom<IStatusCodeHttpResult>(result);
-    Assert.Equal(StatusCodes.Status504GatewayTimeout, statusResult.StatusCode);
+    var statusResult = Assert.IsInstanceOfType<IStatusCodeHttpResult>(result);
+    Assert.AreEqual(StatusCodes.Status504GatewayTimeout, statusResult.StatusCode);
   }
 
   /// <summary>
@@ -142,7 +143,7 @@ public sealed class EndpointCancellationTests
   /// and no <c>IHttpRequestTimeoutFeature</c> is present (i.e. the client disconnected),
   /// the endpoint returns 499 and not a 5xx error.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task RetrieveAllInvoicesAsync_WhenClientDisconnects_DoesNotReturnServerError()
   {
     var processing = new Mock<IInvoiceProcessingService>();
@@ -158,8 +159,8 @@ public sealed class EndpointCancellationTests
       .ConfigureAwait(true);
 
     // No IHttpRequestTimeoutFeature is present, so this is a client abort — never 500/503.
-    var statusResult = Assert.IsAssignableFrom<IStatusCodeHttpResult>(result);
-    Assert.Equal(StatusCodes.Status499ClientClosedRequest, statusResult.StatusCode);
+    var statusResult = Assert.IsInstanceOfType<IStatusCodeHttpResult>(result);
+    Assert.AreEqual(StatusCodes.Status499ClientClosedRequest, statusResult.StatusCode);
   }
 
   /// <summary>
@@ -168,7 +169,7 @@ public sealed class EndpointCancellationTests
   /// <see cref="InvoiceEndpoints.RetrieveAllInvoicesAsync"/> returns 504 Gateway Timeout —
   /// not 499 or any 5xx server fault.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task RetrieveAllInvoicesAsync_WhenRequestTimesOut_Returns504()
   {
     var processing = new Mock<IInvoiceProcessingService>();
@@ -186,8 +187,8 @@ public sealed class EndpointCancellationTests
       .ConfigureAwait(true);
 
     // IHttpRequestTimeoutFeature is present with a cancelled token → this is a server timeout.
-    var statusResult = Assert.IsAssignableFrom<IStatusCodeHttpResult>(result);
-    Assert.Equal(StatusCodes.Status504GatewayTimeout, statusResult.StatusCode);
+    var statusResult = Assert.IsInstanceOfType<IStatusCodeHttpResult>(result);
+    Assert.AreEqual(StatusCodes.Status504GatewayTimeout, statusResult.StatusCode);
   }
 
   /// <summary>
@@ -196,7 +197,7 @@ public sealed class EndpointCancellationTests
   /// <see cref="InvoiceEndpoints.RetrieveSpecificInvoiceAsync"/> returns 499 (client disconnect)
   /// rather than a 5xx server fault.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task RetrieveSpecificInvoiceAsync_WhenClientDisconnects_Returns499()
   {
     var processing = new Mock<IInvoiceProcessingService>();
@@ -211,8 +212,8 @@ public sealed class EndpointCancellationTests
       .RetrieveSpecificInvoiceAsync(processing.Object, accessor, Guid.NewGuid(), CancellationToken.None)
       .ConfigureAwait(true);
 
-    var statusResult = Assert.IsAssignableFrom<IStatusCodeHttpResult>(result);
-    Assert.Equal(StatusCodes.Status499ClientClosedRequest, statusResult.StatusCode);
+    var statusResult = Assert.IsInstanceOfType<IStatusCodeHttpResult>(result);
+    Assert.AreEqual(StatusCodes.Status499ClientClosedRequest, statusResult.StatusCode);
   }
 
   /// <summary>
@@ -220,7 +221,7 @@ public sealed class EndpointCancellationTests
   /// and no <c>IHttpRequestTimeoutFeature</c> is present (client disconnected),
   /// <see cref="InvoiceEndpoints.CreateNewInvoiceAsync"/> returns 499.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateNewInvoiceAsync_WhenClientDisconnects_Returns499()
   {
     var processing = new Mock<IInvoiceProcessingService>();
@@ -246,8 +247,8 @@ public sealed class EndpointCancellationTests
       .CreateNewInvoiceAsync(processing.Object, accessor, invoiceDto)
       .ConfigureAwait(true);
 
-    var statusResult = Assert.IsAssignableFrom<IStatusCodeHttpResult>(result);
-    Assert.Equal(StatusCodes.Status499ClientClosedRequest, statusResult.StatusCode);
+    var statusResult = Assert.IsInstanceOfType<IStatusCodeHttpResult>(result);
+    Assert.AreEqual(StatusCodes.Status499ClientClosedRequest, statusResult.StatusCode);
   }
 
   /// <summary>
@@ -255,7 +256,7 @@ public sealed class EndpointCancellationTests
   /// and a cancelled <c>IHttpRequestTimeoutFeature</c> is installed,
   /// <see cref="InvoiceEndpoints.CreateNewInvoiceAsync"/> returns 504 Gateway Timeout.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateNewInvoiceAsync_WhenRequestTimesOut_Returns504()
   {
     var processing = new Mock<IInvoiceProcessingService>();
@@ -285,7 +286,7 @@ public sealed class EndpointCancellationTests
       .ConfigureAwait(true);
 
     // IHttpRequestTimeoutFeature present with cancelled token → server timeout.
-    var statusResult = Assert.IsAssignableFrom<IStatusCodeHttpResult>(result);
-    Assert.Equal(StatusCodes.Status504GatewayTimeout, statusResult.StatusCode);
+    var statusResult = Assert.IsInstanceOfType<IStatusCodeHttpResult>(result);
+    Assert.AreEqual(StatusCodes.Status504GatewayTimeout, statusResult.StatusCode);
   }
 }

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Integration/ExceptionHandlerPipelineTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Integration/ExceptionHandlerPipelineTests.cs
@@ -14,7 +14,7 @@ using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 /// <summary>
 /// Integration-style tests asserting that the ASP.NET Core pipeline wiring of
@@ -40,6 +40,7 @@ using Xunit;
 /// standardised ProblemDetails contract.
 /// </para>
 /// </remarks>
+[TestClass]
 public sealed class ExceptionHandlerPipelineTests
 {
   /// <summary>
@@ -109,7 +110,7 @@ public sealed class ExceptionHandlerPipelineTests
   /// pipeline wiring exists to guarantee — endpoint try/catch blocks cannot see these
   /// faults because they occur before the handler runs.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task MalformedJsonBody_ReturnsProblemDetails_NotPlainText()
   {
     // Arrange
@@ -138,7 +139,7 @@ public sealed class ExceptionHandlerPipelineTests
       // IProblemDetailsService does not emit.
       Assert.Contains("api.arolariu.ro/problems", body, StringComparison.Ordinal);
 
-      Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+      Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
     }
   }
 }

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Integration/InvoiceEndpointsStatusCodeTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Integration/InvoiceEndpointsStatusCodeTests.cs
@@ -20,7 +20,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 using Moq;
 
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 /// <summary>
 /// Integration-style tests asserting that invoice REST endpoints emit the correct
@@ -48,6 +48,7 @@ using Xunit;
 /// matches the implementation.
 /// </para>
 /// </remarks>
+[TestClass]
 public sealed class InvoiceEndpointsStatusCodeTests
 {
   #region Local test exceptions implementing the Common marker interfaces.
@@ -203,7 +204,7 @@ public sealed class InvoiceEndpointsStatusCodeTests
 
   private static ProblemDetails GetProblemDetails(IResult result)
   {
-    var problem = Assert.IsType<ProblemHttpResult>(result);
+    var problem = Assert.IsExactInstanceOfType<ProblemHttpResult>(result);
     return problem.ProblemDetails;
   }
   #endregion
@@ -213,7 +214,7 @@ public sealed class InvoiceEndpointsStatusCodeTests
   /// Verifies that an <see cref="INotFoundException"/> thrown by the processing service
   /// is mapped to a 404 Not Found <see cref="ProblemDetails"/> response by the endpoint.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task RetrieveSpecificInvoiceAsync_WhenServiceThrowsNotFound_Returns404()
   {
     // Arrange
@@ -226,16 +227,16 @@ public sealed class InvoiceEndpointsStatusCodeTests
 ;
 
     // Assert
-    Assert.Equal(StatusCodes.Status404NotFound, GetStatusCode(result));
+    Assert.AreEqual(StatusCodes.Status404NotFound, GetStatusCode(result));
     var problem = GetProblemDetails(result);
-    Assert.Equal(ProblemTypeUris.NotFound, problem.Type);
+    Assert.AreEqual(ProblemTypeUris.NotFound, problem.Type);
   }
 
   /// <summary>
   /// Verifies that an <see cref="IAlreadyExistsException"/> thrown by the processing service
   /// is mapped to a 409 Conflict <see cref="ProblemDetails"/> response by the endpoint.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task RetrieveSpecificInvoiceAsync_WhenServiceThrowsConflict_Returns409()
   {
     var mockService = CreateServiceMockThatThrowsOnRead(new TestConflictException("already exists"));
@@ -245,15 +246,15 @@ public sealed class InvoiceEndpointsStatusCodeTests
       .RetrieveSpecificInvoiceAsync(mockService.Object, accessor, Guid.NewGuid(), CancellationToken.None)
 ;
 
-    Assert.Equal(StatusCodes.Status409Conflict, GetStatusCode(result));
-    Assert.Equal(ProblemTypeUris.Conflict, GetProblemDetails(result).Type);
+    Assert.AreEqual(StatusCodes.Status409Conflict, GetStatusCode(result));
+    Assert.AreEqual(ProblemTypeUris.Conflict, GetProblemDetails(result).Type);
   }
 
   /// <summary>
   /// Verifies that an <see cref="ILockedException"/> thrown by the processing service
   /// is mapped to a 423 Locked <see cref="ProblemDetails"/> response by the endpoint.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task RetrieveSpecificInvoiceAsync_WhenServiceThrowsLocked_Returns423()
   {
     var mockService = CreateServiceMockThatThrowsOnRead(new TestLockedException("resource locked"));
@@ -263,8 +264,8 @@ public sealed class InvoiceEndpointsStatusCodeTests
       .RetrieveSpecificInvoiceAsync(mockService.Object, accessor, Guid.NewGuid(), CancellationToken.None)
 ;
 
-    Assert.Equal(StatusCodes.Status423Locked, GetStatusCode(result));
-    Assert.Equal(ProblemTypeUris.Locked, GetProblemDetails(result).Type);
+    Assert.AreEqual(StatusCodes.Status423Locked, GetStatusCode(result));
+    Assert.AreEqual(ProblemTypeUris.Locked, GetProblemDetails(result).Type);
   }
 
   /// <summary>
@@ -272,7 +273,7 @@ public sealed class InvoiceEndpointsStatusCodeTests
   /// is mapped to a 429 Too Many Requests <see cref="ProblemDetails"/> response carrying
   /// the retry hint on the <c>retryAfterSeconds</c> extension member.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task RetrieveSpecificInvoiceAsync_WhenServiceThrowsRateLimit_Returns429WithRetryAfterSecondsExtension()
   {
     // Arrange - include a non-trivial RetryAfter so the mapper surfaces a positive hint.
@@ -287,23 +288,23 @@ public sealed class InvoiceEndpointsStatusCodeTests
 ;
 
     // Assert
-    Assert.Equal(StatusCodes.Status429TooManyRequests, GetStatusCode(result));
+    Assert.AreEqual(StatusCodes.Status429TooManyRequests, GetStatusCode(result));
     var problem = GetProblemDetails(result);
-    Assert.Equal(ProblemTypeUris.RateLimited, problem.Type);
+    Assert.AreEqual(ProblemTypeUris.RateLimited, problem.Type);
 
     // The mapper surfaces the retry hint as a ProblemDetails extension (JSON body),
     // NOT as an HTTP Retry-After header. See ExceptionToHttpResultMapper.
-    Assert.True(
+    Assert.IsTrue(
       problem.Extensions.TryGetValue("retryAfterSeconds", out var retryHint),
       "Expected 'retryAfterSeconds' extension on 429 ProblemDetails body.");
-    Assert.Equal(42, Assert.IsType<int>(retryHint));
+    Assert.AreEqual(42, Assert.IsExactInstanceOfType<int>(retryHint));
   }
 
   /// <summary>
   /// Verifies that an <see cref="IDependencyException"/> thrown by the processing service
   /// is mapped to a 503 Service Unavailable <see cref="ProblemDetails"/> response by the endpoint.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task RetrieveSpecificInvoiceAsync_WhenServiceThrowsDependencyFailure_Returns503()
   {
     var mockService = CreateServiceMockThatThrowsOnRead(
@@ -314,8 +315,8 @@ public sealed class InvoiceEndpointsStatusCodeTests
       .RetrieveSpecificInvoiceAsync(mockService.Object, accessor, Guid.NewGuid(), CancellationToken.None)
 ;
 
-    Assert.Equal(StatusCodes.Status503ServiceUnavailable, GetStatusCode(result));
-    Assert.Equal(ProblemTypeUris.ServiceUnavailable, GetProblemDetails(result).Type);
+    Assert.AreEqual(StatusCodes.Status503ServiceUnavailable, GetStatusCode(result));
+    Assert.AreEqual(ProblemTypeUris.ServiceUnavailable, GetProblemDetails(result).Type);
   }
 
   /// <summary>
@@ -323,7 +324,7 @@ public sealed class InvoiceEndpointsStatusCodeTests
   /// is mapped to a 500 Internal Server Error without leaking the exception type name or stack trace
   /// into the <see cref="ProblemDetails"/> payload.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task RetrieveSpecificInvoiceAsync_WhenServiceThrowsUnclassifiedException_Returns500WithoutLeakingType()
   {
     // Arrange - a plain Exception that implements none of the marker interfaces
@@ -338,13 +339,13 @@ public sealed class InvoiceEndpointsStatusCodeTests
 ;
 
     // Assert
-    Assert.Equal(StatusCodes.Status500InternalServerError, GetStatusCode(result));
+    Assert.AreEqual(StatusCodes.Status500InternalServerError, GetStatusCode(result));
     var problem = GetProblemDetails(result);
-    Assert.Equal(ProblemTypeUris.InternalServerError, problem.Type);
+    Assert.AreEqual(ProblemTypeUris.InternalServerError, problem.Type);
 
     // The mapper's BuildSafeDetail surfaces Message only - it does NOT emit the
     // exception type name / namespace / stack into the ProblemDetails payload.
-    Assert.Equal("An unexpected error occurred. Please try again later.", problem.Detail);
+    Assert.AreEqual("An unexpected error occurred. Please try again later.", problem.Detail);
   }
   #endregion
 
@@ -353,7 +354,7 @@ public sealed class InvoiceEndpointsStatusCodeTests
   /// Verifies that the endpoint rejects a request with an empty user identifier by returning
   /// 400 Bad Request <em>before</em> invoking the processing service (endpoint-level validation).
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateNewInvoiceAsync_WhenUserIdentifierIsEmpty_Returns400ValidationProblem()
   {
     // Arrange - endpoint-level validation runs BEFORE any service call, so the mock
@@ -372,7 +373,7 @@ public sealed class InvoiceEndpointsStatusCodeTests
 ;
 
     // Assert
-    Assert.Equal(StatusCodes.Status400BadRequest, GetStatusCode(result));
+    Assert.AreEqual(StatusCodes.Status400BadRequest, GetStatusCode(result));
     mockService.VerifyNoOtherCalls();
   }
   #endregion
@@ -382,7 +383,7 @@ public sealed class InvoiceEndpointsStatusCodeTests
   /// Verifies that an <see cref="IUnauthorizedException"/> thrown by the processing service
   /// is mapped to a 401 Unauthorized <see cref="ProblemDetails"/> response by the endpoint.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task RetrieveSpecificInvoiceAsync_WhenServiceThrowsUnauthorized_Returns401()
   {
     var mockService = CreateServiceMockThatThrowsOnRead(new TestUnauthorizedException("authentication required"));
@@ -392,15 +393,15 @@ public sealed class InvoiceEndpointsStatusCodeTests
       .RetrieveSpecificInvoiceAsync(mockService.Object, accessor, Guid.NewGuid(), CancellationToken.None)
 ;
 
-    Assert.Equal(StatusCodes.Status401Unauthorized, GetStatusCode(result));
-    Assert.Equal(ProblemTypeUris.Unauthorized, GetProblemDetails(result).Type);
+    Assert.AreEqual(StatusCodes.Status401Unauthorized, GetStatusCode(result));
+    Assert.AreEqual(ProblemTypeUris.Unauthorized, GetProblemDetails(result).Type);
   }
 
   /// <summary>
   /// Verifies that an <see cref="IForbiddenException"/> thrown by the processing service
   /// is mapped to a 403 Forbidden <see cref="ProblemDetails"/> response by the endpoint.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task RetrieveSpecificInvoiceAsync_WhenServiceThrowsForbidden_Returns403()
   {
     var mockService = CreateServiceMockThatThrowsOnRead(new TestForbiddenException("access denied"));
@@ -410,8 +411,8 @@ public sealed class InvoiceEndpointsStatusCodeTests
       .RetrieveSpecificInvoiceAsync(mockService.Object, accessor, Guid.NewGuid(), CancellationToken.None)
 ;
 
-    Assert.Equal(StatusCodes.Status403Forbidden, GetStatusCode(result));
-    Assert.Equal(ProblemTypeUris.Forbidden, GetProblemDetails(result).Type);
+    Assert.AreEqual(StatusCodes.Status403Forbidden, GetStatusCode(result));
+    Assert.AreEqual(ProblemTypeUris.Forbidden, GetProblemDetails(result).Type);
   }
   #endregion
 
@@ -426,7 +427,7 @@ public sealed class InvoiceEndpointsStatusCodeTests
   /// Verifies that an <see cref="INotFoundException"/> thrown from <c>ReadMerchant</c>
   /// is mapped to a 404 Not Found <see cref="ProblemDetails"/> response by the endpoint.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task RetrieveSpecificMerchantAsync_WhenServiceThrowsNotFound_Returns404()
   {
     var mockService = CreateServiceMockThatThrowsOnMerchantRead(new TestNotFoundException("merchant not found"));
@@ -436,15 +437,15 @@ public sealed class InvoiceEndpointsStatusCodeTests
       .RetrieveSpecificMerchantAsync(mockService.Object, accessor, Guid.NewGuid(), parentCompanyId: null, CancellationToken.None)
 ;
 
-    Assert.Equal(StatusCodes.Status404NotFound, GetStatusCode(result));
-    Assert.Equal(ProblemTypeUris.NotFound, GetProblemDetails(result).Type);
+    Assert.AreEqual(StatusCodes.Status404NotFound, GetStatusCode(result));
+    Assert.AreEqual(ProblemTypeUris.NotFound, GetProblemDetails(result).Type);
   }
 
   /// <summary>
   /// Verifies that an <see cref="IAlreadyExistsException"/> thrown from <c>ReadMerchant</c>
   /// is mapped to a 409 Conflict <see cref="ProblemDetails"/> response by the endpoint.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task RetrieveSpecificMerchantAsync_WhenServiceThrowsConflict_Returns409()
   {
     var mockService = CreateServiceMockThatThrowsOnMerchantRead(new TestConflictException("merchant already exists"));
@@ -454,15 +455,15 @@ public sealed class InvoiceEndpointsStatusCodeTests
       .RetrieveSpecificMerchantAsync(mockService.Object, accessor, Guid.NewGuid(), parentCompanyId: null, CancellationToken.None)
 ;
 
-    Assert.Equal(StatusCodes.Status409Conflict, GetStatusCode(result));
-    Assert.Equal(ProblemTypeUris.Conflict, GetProblemDetails(result).Type);
+    Assert.AreEqual(StatusCodes.Status409Conflict, GetStatusCode(result));
+    Assert.AreEqual(ProblemTypeUris.Conflict, GetProblemDetails(result).Type);
   }
 
   /// <summary>
   /// Verifies that an <see cref="ILockedException"/> thrown from <c>ReadMerchant</c>
   /// is mapped to a 423 Locked <see cref="ProblemDetails"/> response by the endpoint.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task RetrieveSpecificMerchantAsync_WhenServiceThrowsLocked_Returns423()
   {
     var mockService = CreateServiceMockThatThrowsOnMerchantRead(new TestLockedException("merchant locked"));
@@ -472,8 +473,8 @@ public sealed class InvoiceEndpointsStatusCodeTests
       .RetrieveSpecificMerchantAsync(mockService.Object, accessor, Guid.NewGuid(), parentCompanyId: null, CancellationToken.None)
 ;
 
-    Assert.Equal(StatusCodes.Status423Locked, GetStatusCode(result));
-    Assert.Equal(ProblemTypeUris.Locked, GetProblemDetails(result).Type);
+    Assert.AreEqual(StatusCodes.Status423Locked, GetStatusCode(result));
+    Assert.AreEqual(ProblemTypeUris.Locked, GetProblemDetails(result).Type);
   }
 
   /// <summary>
@@ -481,7 +482,7 @@ public sealed class InvoiceEndpointsStatusCodeTests
   /// is mapped to a 429 Too Many Requests <see cref="ProblemDetails"/> response carrying
   /// the retry hint on the <c>retryAfterSeconds</c> extension member.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task RetrieveSpecificMerchantAsync_WhenServiceThrowsRateLimit_Returns429WithRetryAfterSecondsExtension()
   {
     var retryAfter = TimeSpan.FromSeconds(17);
@@ -493,21 +494,21 @@ public sealed class InvoiceEndpointsStatusCodeTests
       .RetrieveSpecificMerchantAsync(mockService.Object, accessor, Guid.NewGuid(), parentCompanyId: null, CancellationToken.None)
 ;
 
-    Assert.Equal(StatusCodes.Status429TooManyRequests, GetStatusCode(result));
+    Assert.AreEqual(StatusCodes.Status429TooManyRequests, GetStatusCode(result));
     var problem = GetProblemDetails(result);
-    Assert.Equal(ProblemTypeUris.RateLimited, problem.Type);
+    Assert.AreEqual(ProblemTypeUris.RateLimited, problem.Type);
 
-    Assert.True(
+    Assert.IsTrue(
       problem.Extensions.TryGetValue("retryAfterSeconds", out var retryHint),
       "Expected 'retryAfterSeconds' extension on 429 ProblemDetails body.");
-    Assert.Equal(17, Assert.IsType<int>(retryHint));
+    Assert.AreEqual(17, Assert.IsExactInstanceOfType<int>(retryHint));
   }
 
   /// <summary>
   /// Verifies that an <see cref="IUnauthorizedException"/> thrown from <c>ReadMerchant</c>
   /// is mapped to a 401 Unauthorized <see cref="ProblemDetails"/> response by the endpoint.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task RetrieveSpecificMerchantAsync_WhenServiceThrowsUnauthorized_Returns401()
   {
     var mockService = CreateServiceMockThatThrowsOnMerchantRead(new TestUnauthorizedException("authentication required"));
@@ -517,15 +518,15 @@ public sealed class InvoiceEndpointsStatusCodeTests
       .RetrieveSpecificMerchantAsync(mockService.Object, accessor, Guid.NewGuid(), parentCompanyId: null, CancellationToken.None)
 ;
 
-    Assert.Equal(StatusCodes.Status401Unauthorized, GetStatusCode(result));
-    Assert.Equal(ProblemTypeUris.Unauthorized, GetProblemDetails(result).Type);
+    Assert.AreEqual(StatusCodes.Status401Unauthorized, GetStatusCode(result));
+    Assert.AreEqual(ProblemTypeUris.Unauthorized, GetProblemDetails(result).Type);
   }
 
   /// <summary>
   /// Verifies that an <see cref="IForbiddenException"/> thrown from <c>ReadMerchant</c>
   /// is mapped to a 403 Forbidden <see cref="ProblemDetails"/> response by the endpoint.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task RetrieveSpecificMerchantAsync_WhenServiceThrowsForbidden_Returns403()
   {
     var mockService = CreateServiceMockThatThrowsOnMerchantRead(new TestForbiddenException("access denied"));
@@ -535,15 +536,15 @@ public sealed class InvoiceEndpointsStatusCodeTests
       .RetrieveSpecificMerchantAsync(mockService.Object, accessor, Guid.NewGuid(), parentCompanyId: null, CancellationToken.None)
 ;
 
-    Assert.Equal(StatusCodes.Status403Forbidden, GetStatusCode(result));
-    Assert.Equal(ProblemTypeUris.Forbidden, GetProblemDetails(result).Type);
+    Assert.AreEqual(StatusCodes.Status403Forbidden, GetStatusCode(result));
+    Assert.AreEqual(ProblemTypeUris.Forbidden, GetProblemDetails(result).Type);
   }
 
   /// <summary>
   /// Verifies that an <see cref="IDependencyException"/> thrown from <c>ReadMerchant</c>
   /// is mapped to a 503 Service Unavailable <see cref="ProblemDetails"/> response by the endpoint.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task RetrieveSpecificMerchantAsync_WhenServiceThrowsDependencyFailure_Returns503()
   {
     var mockService = CreateServiceMockThatThrowsOnMerchantRead(
@@ -554,8 +555,8 @@ public sealed class InvoiceEndpointsStatusCodeTests
       .RetrieveSpecificMerchantAsync(mockService.Object, accessor, Guid.NewGuid(), parentCompanyId: null, CancellationToken.None)
 ;
 
-    Assert.Equal(StatusCodes.Status503ServiceUnavailable, GetStatusCode(result));
-    Assert.Equal(ProblemTypeUris.ServiceUnavailable, GetProblemDetails(result).Type);
+    Assert.AreEqual(StatusCodes.Status503ServiceUnavailable, GetStatusCode(result));
+    Assert.AreEqual(ProblemTypeUris.ServiceUnavailable, GetProblemDetails(result).Type);
   }
   #endregion
 
@@ -572,7 +573,7 @@ public sealed class InvoiceEndpointsStatusCodeTests
   /// non-null <see cref="Activity"/>; default sampling yields <c>null</c> outside a hosted app.
   /// Mirrors the pattern used by <c>ExceptionMappingHandlerTests.TryHandleAsync_ClassifiableException_IncludesTraceIdWhenActivityPresent</c>.
   /// </remarks>
-  [Fact]
+  [TestMethod]
   public async Task RetrieveSpecificInvoiceAsync_WhenActivityActive_ProblemDetailsIncludesTraceId()
   {
     // Arrange - register a listener that samples EVERYTHING so StartActivity returns a real Activity.
@@ -585,7 +586,7 @@ public sealed class InvoiceEndpointsStatusCodeTests
 
     using var source = new ActivitySource("arolariu.tests.InvoiceEndpointsStatusCodeTests");
     using var activity = source.StartActivity("test-op");
-    Assert.NotNull(activity);
+    Assert.IsNotNull(activity);
 
     var mockService = CreateServiceMockThatThrowsOnRead(new TestNotFoundException("invoice not found"));
     var accessor = CreateAuthenticatedContextAccessor();
@@ -596,15 +597,15 @@ public sealed class InvoiceEndpointsStatusCodeTests
 ;
 
     // Assert
-    Assert.Equal(StatusCodes.Status404NotFound, GetStatusCode(result));
+    Assert.AreEqual(StatusCodes.Status404NotFound, GetStatusCode(result));
     var problem = GetProblemDetails(result);
 
-    Assert.True(
+    Assert.IsTrue(
       problem.Extensions.TryGetValue("traceId", out var traceIdValue),
       "Expected 'traceId' extension on ProblemDetails when an Activity is active.");
 
     var expectedTraceId = Activity.Current!.TraceId.ToString();
-    Assert.Equal(expectedTraceId, Assert.IsType<string>(traceIdValue));
+    Assert.AreEqual(expectedTraceId, Assert.IsExactInstanceOfType<string>(traceIdValue));
   }
   #endregion
 }

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Integration/RequestTimeoutBehaviourTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Integration/RequestTimeoutBehaviourTests.cs
@@ -13,7 +13,7 @@ using Microsoft.AspNetCore.Http.Timeouts;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 /// <summary>
 /// Pins the ASP.NET Core behaviours the cancellation contract depends on:
@@ -21,6 +21,7 @@ using Xunit;
 /// escapes the handler, (2) a handler that catches owns the response itself, and
 /// (3) IHttpRequestTimeoutFeature.RequestTimeoutToken lets such a handler still emit 504.
 /// </summary>
+[TestClass]
 public sealed class RequestTimeoutBehaviourTests
 {
   private const string PolicyName = "test-policy";
@@ -29,7 +30,7 @@ public sealed class RequestTimeoutBehaviourTests
   /// Verifies that when a cancellation token is signalled and the handler does not catch it,
   /// the RequestTimeouts middleware writes a 504 Gateway Timeout response.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task RequestTimeouts_WhenExceptionEscapesHandler_MiddlewareWrites504()
   {
     var app = BuildApp(handlerCatchesCancellation: false);
@@ -40,7 +41,7 @@ public sealed class RequestTimeoutBehaviourTests
     using var response = await client.GetAsync(new Uri("/slow", UriKind.Relative));
 
     // Nothing caught the cancellation, so the middleware owns the response.
-    Assert.Equal(HttpStatusCode.GatewayTimeout, response.StatusCode);
+    Assert.AreEqual(HttpStatusCode.GatewayTimeout, response.StatusCode);
 
     await app.StopAsync();
   }
@@ -49,7 +50,7 @@ public sealed class RequestTimeoutBehaviourTests
   /// Verifies that when a handler catches an OperationCanceledException and returns a 500
   /// response, the client receives that 500 status code, not a 504 from the middleware.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task RequestTimeouts_WhenHandlerCatches_HandlerOwnsTheResponse()
   {
     var app = BuildApp(handlerCatchesCancellation: true);
@@ -62,7 +63,7 @@ public sealed class RequestTimeoutBehaviourTests
     // The handler swallowed the cancellation and returned 500, so the middleware never saw a
     // fault. This is why every endpoint's catch block must produce the correct status itself —
     // the middleware is only a fallback for cancellations that escape.
-    Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+    Assert.AreEqual(HttpStatusCode.InternalServerError, response.StatusCode);
 
     await app.StopAsync();
   }
@@ -72,7 +73,7 @@ public sealed class RequestTimeoutBehaviourTests
   /// IHttpRequestTimeoutFeature.RequestTimeoutToken to discriminate a timeout from a client abort,
   /// and emit 504 Gateway Timeout for a timeout even though it caught the exception.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task RequestTimeoutToken_LetsAHandlerReturnTheCorrectStatus()
   {
     var app = BuildApp(handlerCatchesCancellation: true, discriminateWithTimeoutFeature: true);
@@ -84,7 +85,7 @@ public sealed class RequestTimeoutBehaviourTests
 
     // Proves the mechanism HandleCancellation relies on: a catching handler can still emit 504
     // by consulting IHttpRequestTimeoutFeature.RequestTimeoutToken.
-    Assert.Equal(HttpStatusCode.GatewayTimeout, response.StatusCode);
+    Assert.AreEqual(HttpStatusCode.GatewayTimeout, response.StatusCode);
 
     await app.StopAsync();
   }
@@ -94,12 +95,12 @@ public sealed class RequestTimeoutBehaviourTests
   /// so that Cosmos cancellation can be caught by a base OperationCanceledException catch block
   /// in the broker layer without being reclassified as a CosmosException.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void CosmosOperationCanceledException_DerivesFrom_OperationCanceledException()
   {
     // Guards the broker layer: TranslateInvoiceCosmosAsync catches only CosmosException,
     // so Cosmos cancellation must NOT be a CosmosException or it would be reclassified.
-    Assert.True(
+    Assert.IsTrue(
       typeof(OperationCanceledException).IsAssignableFrom(
         typeof(Microsoft.Azure.Cosmos.CosmosOperationCanceledException)),
       "CosmosOperationCanceledException must derive from OperationCanceledException.");

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Brokers/InvoiceBrokerExtendedTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Brokers/InvoiceBrokerExtendedTests.cs
@@ -13,12 +13,13 @@ using arolariu.Backend.Domain.Tests.Builders;
 
 using Moq;
 
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 /// <summary>
 /// Extended unit tests for invoice and merchant broker interfaces covering additional
 /// scenarios and boundary conditions.
 /// </summary>
+[TestClass]
 public sealed class InvoiceBrokerExtendedTests
 {
   private readonly Mock<IInvoiceNoSqlBroker> mockBroker;
@@ -36,7 +37,7 @@ public sealed class InvoiceBrokerExtendedTests
   /// <summary>
   /// Validates invoice creation returns the created invoice.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateInvoiceAsync_ValidInvoice_ReturnsCreatedInvoice()
   {
     // Arrange
@@ -49,13 +50,13 @@ public sealed class InvoiceBrokerExtendedTests
     var result = await mockBroker.Object.CreateInvoiceAsync(invoice, CancellationToken.None);
 
     // Assert
-    Assert.Same(invoice, result);
+    Assert.AreSame(invoice, result);
   }
 
   /// <summary>
   /// Validates invoice reading with specific identifiers.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoiceAsync_ValidIdentifiers_ReturnsInvoice()
   {
     // Arrange
@@ -71,13 +72,13 @@ public sealed class InvoiceBrokerExtendedTests
     var result = await mockBroker.Object.ReadInvoiceAsync(invoiceId, userId, CancellationToken.None);
 
     // Assert
-    Assert.Same(expectedInvoice, result);
+    Assert.AreSame(expectedInvoice, result);
   }
 
   /// <summary>
   /// Validates invoice reading with null user identifier.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoiceAsync_NullUserIdentifier_ReturnsInvoice()
   {
     // Arrange
@@ -92,13 +93,13 @@ public sealed class InvoiceBrokerExtendedTests
     var result = await mockBroker.Object.ReadInvoiceAsync(invoiceId, null, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
+    Assert.IsNotNull(result);
   }
 
   /// <summary>
   /// Validates bulk invoice reading returns multiple invoices.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoicesAsync_ValidUserIdentifier_ReturnsInvoices()
   {
     // Arrange
@@ -113,13 +114,13 @@ public sealed class InvoiceBrokerExtendedTests
     var result = await mockBroker.Object.ReadInvoicesAsync(userId, CancellationToken.None);
 
     // Assert
-    Assert.Equal(5, result.Count());
+    Assert.AreEqual(5, result.Count());
   }
 
   /// <summary>
   /// Validates bulk invoice reading returns empty when no invoices exist.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoicesAsync_NoInvoices_ReturnsEmptyCollection()
   {
     // Arrange
@@ -133,13 +134,13 @@ public sealed class InvoiceBrokerExtendedTests
     var result = await mockBroker.Object.ReadInvoicesAsync(userId, CancellationToken.None);
 
     // Assert
-    Assert.Empty(result);
+    Assert.IsEmpty(result);
   }
 
   /// <summary>
   /// Validates invoice update returns updated invoice.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateInvoiceAsync_ValidData_ReturnsUpdatedInvoice()
   {
     // Arrange
@@ -154,13 +155,13 @@ public sealed class InvoiceBrokerExtendedTests
     var result = await mockBroker.Object.UpdateInvoiceAsync(invoiceId, updatedInvoice, CancellationToken.None);
 
     // Assert
-    Assert.Same(updatedInvoice, result);
+    Assert.AreSame(updatedInvoice, result);
   }
 
   /// <summary>
   /// Validates invoice deletion completes without error.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteInvoiceAsync_ValidIdentifiers_CompletesSuccessfully()
   {
     // Arrange
@@ -181,7 +182,7 @@ public sealed class InvoiceBrokerExtendedTests
   /// <summary>
   /// Validates invoice deletion with null user identifier.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteInvoiceAsync_NullUserIdentifier_CompletesSuccessfully()
   {
     // Arrange
@@ -201,7 +202,7 @@ public sealed class InvoiceBrokerExtendedTests
   /// <summary>
   /// Validates bulk delete for user invoices.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteInvoicesAsync_ValidUserIdentifier_CompletesSuccessfully()
   {
     // Arrange
@@ -225,7 +226,7 @@ public sealed class InvoiceBrokerExtendedTests
   /// <summary>
   /// Validates merchant creation returns the created merchant.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateMerchantAsync_ValidMerchant_ReturnsCreatedMerchant()
   {
     // Arrange
@@ -239,13 +240,13 @@ public sealed class InvoiceBrokerExtendedTests
     var result = await mockBroker.Object.CreateMerchantAsync(merchant, CancellationToken.None);
 
     // Assert
-    Assert.Same(merchant, result);
+    Assert.AreSame(merchant, result);
   }
 
   /// <summary>
   /// Validates merchant reading with specific identifiers.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchantAsync_ValidIdentifiers_ReturnsMerchant()
   {
     // Arrange
@@ -261,13 +262,13 @@ public sealed class InvoiceBrokerExtendedTests
     var result = await mockBroker.Object.ReadMerchantAsync(merchantId, parentCompanyId, CancellationToken.None);
 
     // Assert
-    Assert.Same(expectedMerchant, result);
+    Assert.AreSame(expectedMerchant, result);
   }
 
   /// <summary>
   /// Validates merchant reading with null parent company ID.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchantAsync_NullParentCompanyId_ReturnsMerchant()
   {
     // Arrange
@@ -282,13 +283,13 @@ public sealed class InvoiceBrokerExtendedTests
     var result = await mockBroker.Object.ReadMerchantAsync(merchantId, null, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
+    Assert.IsNotNull(result);
   }
 
   /// <summary>
   /// Validates bulk merchant reading returns multiple merchants.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchantsAsync_ValidParentCompanyId_ReturnsMerchants()
   {
     // Arrange
@@ -305,13 +306,13 @@ public sealed class InvoiceBrokerExtendedTests
     var result = await mockBroker.Object.ReadMerchantsAsync(parentCompanyId, CancellationToken.None);
 
     // Assert
-    Assert.Equal(10, result.Count());
+    Assert.AreEqual(10, result.Count());
   }
 
   /// <summary>
   /// Validates bulk merchant reading returns empty when no merchants exist.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchantsAsync_NoMerchants_ReturnsEmptyCollection()
   {
     // Arrange
@@ -325,13 +326,13 @@ public sealed class InvoiceBrokerExtendedTests
     var result = await mockBroker.Object.ReadMerchantsAsync(parentCompanyId, CancellationToken.None);
 
     // Assert
-    Assert.Empty(result);
+    Assert.IsEmpty(result);
   }
 
   /// <summary>
   /// Validates merchant update returns updated merchant.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateMerchantAsync_ValidData_ReturnsUpdatedMerchant()
   {
     // Arrange
@@ -346,13 +347,13 @@ public sealed class InvoiceBrokerExtendedTests
     var result = await mockBroker.Object.UpdateMerchantAsync(currentMerchant, updatedMerchant, CancellationToken.None);
 
     // Assert
-    Assert.Same(updatedMerchant, result);
+    Assert.AreSame(updatedMerchant, result);
   }
 
   /// <summary>
   /// Validates merchant update by ID.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateMerchantAsync_ById_ReturnsUpdatedMerchant()
   {
     // Arrange
@@ -367,13 +368,13 @@ public sealed class InvoiceBrokerExtendedTests
     var result = await mockBroker.Object.UpdateMerchantAsync(merchantId, updatedMerchant, CancellationToken.None);
 
     // Assert
-    Assert.Same(updatedMerchant, result);
+    Assert.AreSame(updatedMerchant, result);
   }
 
   /// <summary>
   /// Validates merchant deletion completes without error.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteMerchantAsync_ValidIdentifiers_CompletesSuccessfully()
   {
     // Arrange
@@ -394,7 +395,7 @@ public sealed class InvoiceBrokerExtendedTests
   /// <summary>
   /// Validates merchant deletion with null parent company ID.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteMerchantAsync_NullParentCompanyId_CompletesSuccessfully()
   {
     // Arrange
@@ -418,7 +419,7 @@ public sealed class InvoiceBrokerExtendedTests
   /// <summary>
   /// Validates bulk invoice reading handles large collections.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoicesAsync_LargeCollection_ReturnsAllInvoices()
   {
     // Arrange
@@ -433,13 +434,13 @@ public sealed class InvoiceBrokerExtendedTests
     var result = await mockBroker.Object.ReadInvoicesAsync(userId, CancellationToken.None);
 
     // Assert
-    Assert.Equal(1000, result.Count());
+    Assert.AreEqual(1000, result.Count());
   }
 
   /// <summary>
   /// Validates bulk merchant reading handles large collections.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchantsAsync_LargeCollection_ReturnsAllMerchants()
   {
     // Arrange
@@ -456,7 +457,7 @@ public sealed class InvoiceBrokerExtendedTests
     var result = await mockBroker.Object.ReadMerchantsAsync(parentCompanyId, CancellationToken.None);
 
     // Assert
-    Assert.Equal(500, result.Count());
+    Assert.AreEqual(500, result.Count());
   }
 
   #endregion
@@ -466,7 +467,7 @@ public sealed class InvoiceBrokerExtendedTests
   /// <summary>
   /// Validates operations with empty Guid identifiers.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoiceAsync_EmptyGuidIdentifier_ReturnsInvoice()
   {
     // Arrange
@@ -480,13 +481,13 @@ public sealed class InvoiceBrokerExtendedTests
     var result = await mockBroker.Object.ReadInvoiceAsync(Guid.Empty, Guid.Empty, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
+    Assert.IsNotNull(result);
   }
 
   /// <summary>
   /// Validates operations with same source and target Guids.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoiceAsync_SameIdentifierForInvoiceAndUser_ReturnsInvoice()
   {
     // Arrange
@@ -501,13 +502,13 @@ public sealed class InvoiceBrokerExtendedTests
     var result = await mockBroker.Object.ReadInvoiceAsync(sameId, sameId, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
+    Assert.IsNotNull(result);
   }
 
   /// <summary>
   /// Validates merchant operations with empty Guid identifiers.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchantAsync_EmptyGuidIdentifier_ReturnsMerchant()
   {
     // Arrange
@@ -521,13 +522,13 @@ public sealed class InvoiceBrokerExtendedTests
     var result = await mockBroker.Object.ReadMerchantAsync(Guid.Empty, Guid.Empty, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
+    Assert.IsNotNull(result);
   }
 
   /// <summary>
   /// Validates invoice update with different overload.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateInvoiceAsync_TwoInvoices_ReturnsUpdatedInvoice()
   {
     // Arrange
@@ -542,13 +543,13 @@ public sealed class InvoiceBrokerExtendedTests
     var result = await mockBroker.Object.UpdateInvoiceAsync(currentInvoice, updatedInvoice, CancellationToken.None);
 
     // Assert
-    Assert.Same(updatedInvoice, result);
+    Assert.AreSame(updatedInvoice, result);
   }
 
   /// <summary>
   /// Validates reading invoices returns null when not found.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoiceAsync_NotFound_ReturnsNull()
   {
     // Arrange
@@ -562,13 +563,13 @@ public sealed class InvoiceBrokerExtendedTests
     var result = await mockBroker.Object.ReadInvoiceAsync(invoiceId, null, CancellationToken.None);
 
     // Assert
-    Assert.Null(result);
+    Assert.IsNull(result);
   }
 
   /// <summary>
   /// Validates reading merchants returns null when not found.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchantAsync_NotFound_ReturnsNull()
   {
     // Arrange
@@ -582,7 +583,7 @@ public sealed class InvoiceBrokerExtendedTests
     var result = await mockBroker.Object.ReadMerchantAsync(merchantId, null, CancellationToken.None);
 
     // Assert
-    Assert.Null(result);
+    Assert.IsNull(result);
   }
 
   #endregion

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Brokers/InvoiceNoSqlBrokerComprehensiveTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Brokers/InvoiceNoSqlBrokerComprehensiveTests.cs
@@ -16,13 +16,14 @@ using Microsoft.EntityFrameworkCore;
 
 using Moq;
 
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 /// <summary>
 /// Comprehensive invoice broker tests covering create, read (by id &amp; partition key / by id only),
 /// and bulk read scenarios against the Cosmos EF Core broker abstraction.
 /// Follows MethodName_Condition_ExpectedResult pattern; underscores intentional.
 /// </summary>
+[TestClass]
 public sealed partial class InvoiceNoSqlBrokerComprehensiveTests : InvoiceNoSqlBrokerTestsBase, IDisposable
 {
   private readonly InvoiceNoSqlBroker invoiceNoSqlBroker;
@@ -58,8 +59,8 @@ public sealed partial class InvoiceNoSqlBrokerComprehensiveTests : InvoiceNoSqlB
   /// Verifies that a valid invoice is created and returned with matching identity and basic fields.
   /// </summary>
   /// <param name="expectedInvoice">The invoice instance to persist.</param>
-  [Theory]
-  [MemberData(nameof(GetInvoiceTestData))]
+  [TestMethod]
+  [DynamicData(nameof(GetInvoiceTestData))]
   public async Task ShouldCreateInvoice_WhenInvoiceIsValid(Invoice expectedInvoice)
   {
     ArgumentNullException.ThrowIfNull(expectedInvoice);
@@ -80,16 +81,16 @@ public sealed partial class InvoiceNoSqlBrokerComprehensiveTests : InvoiceNoSqlB
     var actualInvoice = await invoiceNoSqlBroker.CreateInvoiceAsync(expectedInvoice, CancellationToken.None);
 
     // Then
-    Assert.NotNull(actualInvoice);
-    Assert.Equal(expectedInvoice.id, actualInvoice.id);
-    Assert.Equal(expectedInvoice.UserIdentifier, actualInvoice.UserIdentifier);
-    Assert.Equal(expectedInvoice.Name, actualInvoice.Name);
+    Assert.IsNotNull(actualInvoice);
+    Assert.AreEqual(expectedInvoice.id, actualInvoice.id);
+    Assert.AreEqual(expectedInvoice.UserIdentifier, actualInvoice.UserIdentifier);
+    Assert.AreEqual(expectedInvoice.Name, actualInvoice.Name);
   }
 
   /// <summary>
   /// Ensures a CosmosException surfaces when the underlying container throws during creation.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ShouldThrowCosmosException_WhenCreateFails()
   {
     // Given
@@ -105,9 +106,9 @@ public sealed partial class InvoiceNoSqlBrokerComprehensiveTests : InvoiceNoSqlB
       .ThrowsAsync(cosmosException);
 
     // When & Then
-    var exception = await Assert.ThrowsAsync<InvoiceFailedStorageException>(() => invoiceNoSqlBroker.CreateInvoiceAsync(invoice, CancellationToken.None).AsTask());
+    var exception = await Assert.ThrowsExactlyAsync<InvoiceFailedStorageException>(() => invoiceNoSqlBroker.CreateInvoiceAsync(invoice, CancellationToken.None).AsTask());
 
-    Assert.NotNull(exception.InnerException);
+    Assert.IsNotNull(exception.InnerException);
     Assert.Contains("Creation failed", exception.InnerException.Message, StringComparison.Ordinal);
   }
 
@@ -119,8 +120,8 @@ public sealed partial class InvoiceNoSqlBrokerComprehensiveTests : InvoiceNoSqlB
   /// Reads an invoice when providing both identifier and partition key (user identifier) returning expected data.
   /// </summary>
   /// <param name="expectedInvoice">The seeded invoice instance.</param>
-  [Theory]
-  [MemberData(nameof(GetInvoiceTestData))]
+  [TestMethod]
+  [DynamicData(nameof(GetInvoiceTestData))]
   public async Task ShouldReadInvoiceWithUserIdentifier_WhenInvoiceExists(Invoice expectedInvoice)
   {
     ArgumentNullException.ThrowIfNull(expectedInvoice);
@@ -141,17 +142,17 @@ public sealed partial class InvoiceNoSqlBrokerComprehensiveTests : InvoiceNoSqlB
     var actualInvoice = await invoiceNoSqlBroker.ReadInvoiceAsync(expectedInvoice.id, expectedInvoice.UserIdentifier, CancellationToken.None);
 
     // Then
-    Assert.NotNull(actualInvoice);
-    Assert.Equal(expectedInvoice.id, actualInvoice.id);
-    Assert.Equal(expectedInvoice.UserIdentifier, actualInvoice.UserIdentifier);
+    Assert.IsNotNull(actualInvoice);
+    Assert.AreEqual(expectedInvoice.id, actualInvoice.id);
+    Assert.AreEqual(expectedInvoice.UserIdentifier, actualInvoice.UserIdentifier);
   }
 
   /// <summary>
   /// Reads an invoice by identifier only (query path) when it exists, returning the correct instance.
   /// </summary>
   /// <param name="expectedInvoice">The seeded invoice instance.</param>
-  [Theory]
-  [MemberData(nameof(GetInvoiceTestData))]
+  [TestMethod]
+  [DynamicData(nameof(GetInvoiceTestData))]
   public async Task ShouldReadInvoiceWithoutUserIdentifier_WhenInvoiceExists(Invoice expectedInvoice)
   {
     ArgumentNullException.ThrowIfNull(expectedInvoice);
@@ -180,8 +181,8 @@ public sealed partial class InvoiceNoSqlBrokerComprehensiveTests : InvoiceNoSqlB
     var actualInvoice = await invoiceNoSqlBroker.ReadInvoiceAsync(expectedInvoice.id, null, CancellationToken.None);
 
     // Then
-    Assert.NotNull(actualInvoice);
-    Assert.Equal(expectedInvoice.id, actualInvoice.id);
+    Assert.IsNotNull(actualInvoice);
+    Assert.AreEqual(expectedInvoice.id, actualInvoice.id);
   }
 
   #endregion
@@ -191,7 +192,7 @@ public sealed partial class InvoiceNoSqlBrokerComprehensiveTests : InvoiceNoSqlB
   /// <summary>
   /// Verifies that reading invoices for a user returns all non-soft-deleted invoices.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ShouldReadInvoices_WhenInvoicesExist()
   {
     // Given
@@ -220,14 +221,14 @@ public sealed partial class InvoiceNoSqlBrokerComprehensiveTests : InvoiceNoSqlB
     var actualInvoices = await invoiceNoSqlBroker.ReadInvoicesAsync(userIdentifier, CancellationToken.None);
 
     // Then
-    Assert.NotNull(actualInvoices);
-    Assert.Equal(expectedInvoices.Count, actualInvoices.Count());
+    Assert.IsNotNull(actualInvoices);
+    Assert.AreEqual(expectedInvoices.Count, actualInvoices.Count());
   }
 
   /// <summary>
   /// Verifies soft-deleted invoices are filtered out from the results.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ShouldFilterSoftDeletedInvoices_WhenReadingInvoices()
   {
     // Given
@@ -262,14 +263,17 @@ public sealed partial class InvoiceNoSqlBrokerComprehensiveTests : InvoiceNoSqlB
     var actualInvoices = await invoiceNoSqlBroker.ReadInvoicesAsync(userIdentifier, CancellationToken.None);
 
     // Then
-    Assert.Single(actualInvoices);
-    Assert.All(actualInvoices, inv => Assert.False(inv.IsSoftDeleted));
+    Assert.ContainsSingle(actualInvoices);
+    foreach (var inv in actualInvoices)
+    {
+      Assert.IsFalse(inv.IsSoftDeleted);
+    }
   }
 
   /// <summary>
   /// Verifies empty result when no invoices exist for user.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ShouldReturnEmpty_WhenNoInvoicesExistForUser()
   {
     // Given
@@ -298,14 +302,14 @@ public sealed partial class InvoiceNoSqlBrokerComprehensiveTests : InvoiceNoSqlB
     var actualInvoices = await invoiceNoSqlBroker.ReadInvoicesAsync(userIdentifier, CancellationToken.None);
 
     // Then
-    Assert.NotNull(actualInvoices);
-    Assert.Empty(actualInvoices);
+    Assert.IsNotNull(actualInvoices);
+    Assert.IsEmpty(actualInvoices);
   }
 
   /// <summary>
   /// Verifies pagination is handled correctly when HasMoreResults is true.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ShouldHandlePagination_WhenMultiplePagesExist()
   {
     // Given
@@ -347,8 +351,8 @@ public sealed partial class InvoiceNoSqlBrokerComprehensiveTests : InvoiceNoSqlB
     var actualInvoices = await invoiceNoSqlBroker.ReadInvoicesAsync(userIdentifier, CancellationToken.None);
 
     // Then
-    Assert.NotNull(actualInvoices);
-    Assert.Equal(4, actualInvoices.Count());
+    Assert.IsNotNull(actualInvoices);
+    Assert.AreEqual(4, actualInvoices.Count());
   }
 
   #endregion
@@ -358,7 +362,7 @@ public sealed partial class InvoiceNoSqlBrokerComprehensiveTests : InvoiceNoSqlB
   /// <summary>
   /// Verifies that reading a soft-deleted invoice throws InvalidOperationException when using partition key.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ShouldThrowInvalidOperationException_WhenInvoiceIsSoftDeletedWithPartitionKey()
   {
     // Given
@@ -377,7 +381,7 @@ public sealed partial class InvoiceNoSqlBrokerComprehensiveTests : InvoiceNoSqlB
       .ReturnsAsync(itemResponseMock.Object);
 
     // When & Then
-    var exception = await Assert.ThrowsAsync<InvoiceLockedException>(
+    var exception = await Assert.ThrowsExactlyAsync<InvoiceLockedException>(
       () => invoiceNoSqlBroker.ReadInvoiceAsync(deletedInvoice.id, deletedInvoice.UserIdentifier, CancellationToken.None).AsTask());
 
     Assert.Contains(deletedInvoice.id.ToString(), exception.Message, StringComparison.Ordinal);
@@ -386,7 +390,7 @@ public sealed partial class InvoiceNoSqlBrokerComprehensiveTests : InvoiceNoSqlB
   /// <summary>
   /// Verifies that reading a soft-deleted invoice throws InvalidOperationException when using query path.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ShouldThrowInvalidOperationException_WhenInvoiceIsSoftDeletedWithoutPartitionKey()
   {
     // Given
@@ -413,7 +417,7 @@ public sealed partial class InvoiceNoSqlBrokerComprehensiveTests : InvoiceNoSqlB
       .Returns(mockFeedIterator.Object);
 
     // When & Then
-    var exception = await Assert.ThrowsAsync<InvoiceLockedException>(
+    var exception = await Assert.ThrowsExactlyAsync<InvoiceLockedException>(
       () => invoiceNoSqlBroker.ReadInvoiceAsync(deletedInvoice.id, null, CancellationToken.None).AsTask());
 
     Assert.Contains(deletedInvoice.id.ToString(), exception.Message, StringComparison.Ordinal);
@@ -422,7 +426,7 @@ public sealed partial class InvoiceNoSqlBrokerComprehensiveTests : InvoiceNoSqlB
   /// <summary>
   /// Verifies null is returned when invoice not found via query path.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ShouldReturnNull_WhenInvoiceNotFoundWithoutPartitionKey()
   {
     // Given
@@ -451,7 +455,7 @@ public sealed partial class InvoiceNoSqlBrokerComprehensiveTests : InvoiceNoSqlB
     var actualInvoice = await invoiceNoSqlBroker.ReadInvoiceAsync(invoiceId, null, CancellationToken.None);
 
     // Then
-    Assert.Null(actualInvoice);
+    Assert.IsNull(actualInvoice);
   }
 
   #endregion
@@ -461,8 +465,8 @@ public sealed partial class InvoiceNoSqlBrokerComprehensiveTests : InvoiceNoSqlB
   /// <summary>
   /// Verifies updating an invoice by identifier uses upsert and returns updated invoice.
   /// </summary>
-  [Theory]
-  [MemberData(nameof(GetInvoiceTestData))]
+  [TestMethod]
+  [DynamicData(nameof(GetInvoiceTestData))]
   public async Task ShouldUpdateInvoiceById_WhenValidInvoiceProvided(Invoice originalInvoice)
   {
     ArgumentNullException.ThrowIfNull(originalInvoice);
@@ -488,9 +492,9 @@ public sealed partial class InvoiceNoSqlBrokerComprehensiveTests : InvoiceNoSqlB
     var actualInvoice = await invoiceNoSqlBroker.UpdateInvoiceAsync(originalInvoice.id, updatedInvoice, CancellationToken.None);
 
     // Then
-    Assert.NotNull(actualInvoice);
-    Assert.Equal(updatedInvoice.id, actualInvoice.id);
-    Assert.Equal("Updated Invoice Name", actualInvoice.Name);
+    Assert.IsNotNull(actualInvoice);
+    Assert.AreEqual(updatedInvoice.id, actualInvoice.id);
+    Assert.AreEqual("Updated Invoice Name", actualInvoice.Name);
 
     mockInvoicesContainer.Verify(container => container.UpsertItemAsync(
         updatedInvoice,
@@ -503,8 +507,8 @@ public sealed partial class InvoiceNoSqlBrokerComprehensiveTests : InvoiceNoSqlB
   /// <summary>
   /// Verifies updating invoice using current and updated objects performs upsert.
   /// </summary>
-  [Theory]
-  [MemberData(nameof(GetInvoiceTestData))]
+  [TestMethod]
+  [DynamicData(nameof(GetInvoiceTestData))]
   public async Task ShouldUpdateInvoiceWithObjects_WhenValidInvoicesProvided(Invoice originalInvoice)
   {
     ArgumentNullException.ThrowIfNull(originalInvoice);
@@ -530,15 +534,15 @@ public sealed partial class InvoiceNoSqlBrokerComprehensiveTests : InvoiceNoSqlB
     var actualInvoice = await invoiceNoSqlBroker.UpdateInvoiceAsync(originalInvoice, updatedInvoice, CancellationToken.None);
 
     // Then
-    Assert.NotNull(actualInvoice);
-    Assert.Equal(updatedInvoice.id, actualInvoice.id);
-    Assert.Equal("Updated Name Via Objects", actualInvoice.Name);
+    Assert.IsNotNull(actualInvoice);
+    Assert.AreEqual(updatedInvoice.id, actualInvoice.id);
+    Assert.AreEqual("Updated Name Via Objects", actualInvoice.Name);
   }
 
   /// <summary>
   /// Verifies CosmosException propagates when update fails.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ShouldThrowCosmosException_WhenUpdateFails()
   {
     // Given
@@ -554,10 +558,10 @@ public sealed partial class InvoiceNoSqlBrokerComprehensiveTests : InvoiceNoSqlB
       .ThrowsAsync(cosmosException);
 
     // When & Then
-    var exception = await Assert.ThrowsAsync<InvoiceFailedStorageException>(
+    var exception = await Assert.ThrowsExactlyAsync<InvoiceFailedStorageException>(
       () => invoiceNoSqlBroker.UpdateInvoiceAsync(invoice.id, invoice, CancellationToken.None).AsTask());
 
-    Assert.NotNull(exception.InnerException);
+    Assert.IsNotNull(exception.InnerException);
     Assert.Contains("Update failed", exception.InnerException.Message, StringComparison.Ordinal);
   }
 
@@ -568,8 +572,8 @@ public sealed partial class InvoiceNoSqlBrokerComprehensiveTests : InvoiceNoSqlB
   /// <summary>
   /// Verifies deleting an invoice with partition key performs soft delete.
   /// </summary>
-  [Theory]
-  [MemberData(nameof(GetInvoiceTestData))]
+  [TestMethod]
+  [DynamicData(nameof(GetInvoiceTestData))]
   public async Task ShouldSoftDeleteInvoice_WhenInvoiceExistsWithPartitionKey(Invoice expectedInvoice)
   {
     ArgumentNullException.ThrowIfNull(expectedInvoice);
@@ -612,8 +616,8 @@ public sealed partial class InvoiceNoSqlBrokerComprehensiveTests : InvoiceNoSqlB
   /// <summary>
   /// Verifies deleting an invoice without partition key performs query then soft delete.
   /// </summary>
-  [Theory]
-  [MemberData(nameof(GetInvoiceTestData))]
+  [TestMethod]
+  [DynamicData(nameof(GetInvoiceTestData))]
   public async Task ShouldSoftDeleteInvoice_WhenInvoiceExistsWithoutPartitionKey(Invoice expectedInvoice)
   {
     ArgumentNullException.ThrowIfNull(expectedInvoice);
@@ -664,7 +668,7 @@ public sealed partial class InvoiceNoSqlBrokerComprehensiveTests : InvoiceNoSqlB
   /// <summary>
   /// Verifies no exception when invoice not found for deletion without partition key.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ShouldNotThrow_WhenInvoiceNotFoundForDeletionWithoutPartitionKey()
   {
     // Given
@@ -708,7 +712,7 @@ public sealed partial class InvoiceNoSqlBrokerComprehensiveTests : InvoiceNoSqlB
   /// <summary>
   /// Verifies all invoices for a user are soft-deleted along with their products.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ShouldSoftDeleteAllInvoices_WhenInvoicesExistForUser()
   {
     // Given
@@ -760,7 +764,7 @@ public sealed partial class InvoiceNoSqlBrokerComprehensiveTests : InvoiceNoSqlB
   /// <summary>
   /// Verifies products within invoices are also marked as soft-deleted.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ShouldSoftDeleteProducts_WhenDeletingAllInvoicesForUser()
   {
     // Given
@@ -804,15 +808,18 @@ public sealed partial class InvoiceNoSqlBrokerComprehensiveTests : InvoiceNoSqlB
     await invoiceNoSqlBroker.DeleteInvoicesAsync(userIdentifier, CancellationToken.None);
 
     // Then
-    Assert.NotNull(capturedInvoice);
-    Assert.True(capturedInvoice.IsSoftDeleted);
-    Assert.All(capturedInvoice.Items, product => Assert.True(product.Metadata.IsSoftDeleted));
+    Assert.IsNotNull(capturedInvoice);
+    Assert.IsTrue(capturedInvoice.IsSoftDeleted);
+    foreach (var product in capturedInvoice.Items)
+    {
+      Assert.IsTrue(product.Metadata.IsSoftDeleted);
+    }
   }
 
   /// <summary>
   /// Verifies no operations when no invoices exist for user.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ShouldNotThrow_WhenNoInvoicesExistForUserDeletion()
   {
     // Given
@@ -852,7 +859,7 @@ public sealed partial class InvoiceNoSqlBrokerComprehensiveTests : InvoiceNoSqlB
   /// <summary>
   /// Verifies pagination handling when deleting all invoices across multiple pages.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ShouldHandlePagination_WhenDeletingAllInvoicesForUser()
   {
     // Given

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Brokers/InvoiceNoSqlBrokerComprehensiveTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Brokers/InvoiceNoSqlBrokerComprehensiveTests.cs
@@ -921,7 +921,7 @@ public sealed partial class InvoiceNoSqlBrokerComprehensiveTests : InvoiceNoSqlB
   /// Provides theory data consisting of several randomized invoices.
   /// </summary>
   /// <returns>Collection of randomized <see cref="Invoice"/> instances.</returns>
-  public static TheoryData<Invoice> GetInvoiceTestData() => InvoiceBuilder.GetInvoiceTheoryData();
+  public static IEnumerable<object[]> GetInvoiceTestData() => InvoiceBuilder.GetInvoiceTheoryData();
 
   #endregion
 }

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Brokers/InvoiceNoSqlBrokerExceptionTranslationTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Brokers/InvoiceNoSqlBrokerExceptionTranslationTests.cs
@@ -14,11 +14,12 @@ using Microsoft.EntityFrameworkCore;
 
 using Moq;
 
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 /// <summary>
 /// Tests the translation layer that wraps CosmosException into typed invoice inner exceptions.
 /// </summary>
+[TestClass]
 public sealed class InvoiceNoSqlBrokerExceptionTranslationTests : InvoiceNoSqlBrokerTestsBase
 {
   private InvoiceNoSqlBroker BuildBroker()
@@ -35,7 +36,7 @@ public sealed class InvoiceNoSqlBrokerExceptionTranslationTests : InvoiceNoSqlBr
   /// <summary>
   /// Verifies that a Cosmos 404 (NotFound) during read is translated into <see cref="InvoiceNotFoundException"/>.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoiceAsync_WhenCosmos404_ThrowsInvoiceNotFoundException()
   {
     using var broker = BuildBroker();
@@ -46,14 +47,14 @@ public sealed class InvoiceNoSqlBrokerExceptionTranslationTests : InvoiceNoSqlBr
         It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(MakeCosmosException(HttpStatusCode.NotFound));
 
-    await Assert.ThrowsAsync<InvoiceNotFoundException>(
+    await Assert.ThrowsExactlyAsync<InvoiceNotFoundException>(
       async () => await broker.ReadInvoiceAsync(invoiceId, userId, CancellationToken.None).ConfigureAwait(false));
   }
 
   /// <summary>
   /// Verifies that a Cosmos 409 (Conflict) during create is translated into <see cref="InvoiceAlreadyExistsException"/>.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateInvoiceAsync_WhenCosmos409_ThrowsInvoiceAlreadyExistsException()
   {
     using var broker = BuildBroker();
@@ -63,14 +64,14 @@ public sealed class InvoiceNoSqlBrokerExceptionTranslationTests : InvoiceNoSqlBr
         It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(MakeCosmosException(HttpStatusCode.Conflict));
 
-    await Assert.ThrowsAsync<InvoiceAlreadyExistsException>(
+    await Assert.ThrowsExactlyAsync<InvoiceAlreadyExistsException>(
       async () => await broker.CreateInvoiceAsync(invoice, CancellationToken.None).ConfigureAwait(false));
   }
 
   /// <summary>
   /// Verifies that a Cosmos 429 (TooManyRequests) during read is translated into <see cref="InvoiceCosmosDbRateLimitException"/>.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoiceAsync_WhenCosmos429_ThrowsInvoiceCosmosDbRateLimitException()
   {
     using var broker = BuildBroker();
@@ -81,14 +82,14 @@ public sealed class InvoiceNoSqlBrokerExceptionTranslationTests : InvoiceNoSqlBr
         It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(MakeCosmosException((HttpStatusCode)429));
 
-    await Assert.ThrowsAsync<InvoiceCosmosDbRateLimitException>(
+    await Assert.ThrowsExactlyAsync<InvoiceCosmosDbRateLimitException>(
       async () => await broker.ReadInvoiceAsync(invoiceId, userId, CancellationToken.None).ConfigureAwait(false));
   }
 
   /// <summary>
   /// Verifies that a Cosmos 503 (ServiceUnavailable) during read is translated into <see cref="InvoiceFailedStorageException"/>.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoiceAsync_WhenCosmos503_ThrowsInvoiceFailedStorageException()
   {
     using var broker = BuildBroker();
@@ -99,14 +100,14 @@ public sealed class InvoiceNoSqlBrokerExceptionTranslationTests : InvoiceNoSqlBr
         It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(MakeCosmosException(HttpStatusCode.ServiceUnavailable));
 
-    await Assert.ThrowsAsync<InvoiceFailedStorageException>(
+    await Assert.ThrowsExactlyAsync<InvoiceFailedStorageException>(
       async () => await broker.ReadInvoiceAsync(invoiceId, userId, CancellationToken.None).ConfigureAwait(false));
   }
 
   /// <summary>
   /// Verifies that a Cosmos 401 (Unauthorized) during read is translated into <see cref="InvoiceUnauthorizedAccessException"/>.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoiceAsync_WhenCosmos401_ThrowsInvoiceUnauthorizedAccessException()
   {
     using var broker = BuildBroker();
@@ -117,14 +118,14 @@ public sealed class InvoiceNoSqlBrokerExceptionTranslationTests : InvoiceNoSqlBr
         It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(MakeCosmosException(HttpStatusCode.Unauthorized));
 
-    await Assert.ThrowsAsync<InvoiceUnauthorizedAccessException>(
+    await Assert.ThrowsExactlyAsync<InvoiceUnauthorizedAccessException>(
       async () => await broker.ReadInvoiceAsync(invoiceId, userId, CancellationToken.None).ConfigureAwait(false));
   }
 
   /// <summary>
   /// Verifies that a Cosmos 403 (Forbidden) during read is translated into <see cref="InvoiceForbiddenAccessException"/>.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoiceAsync_WhenCosmos403_ThrowsInvoiceForbiddenAccessException()
   {
     using var broker = BuildBroker();
@@ -135,7 +136,7 @@ public sealed class InvoiceNoSqlBrokerExceptionTranslationTests : InvoiceNoSqlBr
         It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(MakeCosmosException(HttpStatusCode.Forbidden));
 
-    await Assert.ThrowsAsync<InvoiceForbiddenAccessException>(
+    await Assert.ThrowsExactlyAsync<InvoiceForbiddenAccessException>(
       async () => await broker.ReadInvoiceAsync(invoiceId, userId, CancellationToken.None).ConfigureAwait(false));
   }
 
@@ -143,7 +144,7 @@ public sealed class InvoiceNoSqlBrokerExceptionTranslationTests : InvoiceNoSqlBr
   /// Verifies that a soft-deleted invoice returned by Cosmos is surfaced as <see cref="InvoiceLockedException"/>
   /// by the broker instead of being returned to the caller as a valid resource.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoiceAsync_WhenInvoiceSoftDeleted_ThrowsInvoiceLockedException()
   {
     using var broker = BuildBroker();
@@ -159,7 +160,7 @@ public sealed class InvoiceNoSqlBrokerExceptionTranslationTests : InvoiceNoSqlBr
         It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()))
       .ReturnsAsync(responseMock.Object);
 
-    await Assert.ThrowsAsync<InvoiceLockedException>(
+    await Assert.ThrowsExactlyAsync<InvoiceLockedException>(
       async () => await broker.ReadInvoiceAsync(invoiceId, userId, CancellationToken.None));
   }
 }

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Brokers/MerchantNoSqlBrokerExceptionTranslationTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Brokers/MerchantNoSqlBrokerExceptionTranslationTests.cs
@@ -14,11 +14,12 @@ using Microsoft.EntityFrameworkCore;
 
 using Moq;
 
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 /// <summary>
 /// Tests the translation layer that wraps CosmosException into typed merchant inner exceptions.
 /// </summary>
+[TestClass]
 public sealed class MerchantNoSqlBrokerExceptionTranslationTests : InvoiceNoSqlBrokerTestsBase
 {
   private InvoiceNoSqlBroker BuildBroker()
@@ -35,7 +36,7 @@ public sealed class MerchantNoSqlBrokerExceptionTranslationTests : InvoiceNoSqlB
   /// <summary>
   /// Verifies that a Cosmos 404 (NotFound) during read is translated into <see cref="MerchantNotFoundException"/>.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchantAsync_WhenCosmos404_ThrowsMerchantNotFoundException()
   {
     using var broker = BuildBroker();
@@ -46,14 +47,14 @@ public sealed class MerchantNoSqlBrokerExceptionTranslationTests : InvoiceNoSqlB
         It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(MakeCosmosException(HttpStatusCode.NotFound));
 
-    await Assert.ThrowsAsync<MerchantNotFoundException>(
+    await Assert.ThrowsExactlyAsync<MerchantNotFoundException>(
       async () => await broker.ReadMerchantAsync(merchantId, parentCompanyId, CancellationToken.None).ConfigureAwait(false));
   }
 
   /// <summary>
   /// Verifies that a Cosmos 409 (Conflict) during create is translated into <see cref="MerchantAlreadyExistsException"/>.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateMerchantAsync_WhenCosmos409_ThrowsMerchantAlreadyExistsException()
   {
     using var broker = BuildBroker();
@@ -63,14 +64,14 @@ public sealed class MerchantNoSqlBrokerExceptionTranslationTests : InvoiceNoSqlB
         It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(MakeCosmosException(HttpStatusCode.Conflict));
 
-    await Assert.ThrowsAsync<MerchantAlreadyExistsException>(
+    await Assert.ThrowsExactlyAsync<MerchantAlreadyExistsException>(
       async () => await broker.CreateMerchantAsync(merchant, CancellationToken.None).ConfigureAwait(false));
   }
 
   /// <summary>
   /// Verifies that a Cosmos 429 (TooManyRequests) during read is translated into <see cref="MerchantCosmosDbRateLimitException"/>.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchantAsync_WhenCosmos429_ThrowsMerchantCosmosDbRateLimitException()
   {
     using var broker = BuildBroker();
@@ -81,14 +82,14 @@ public sealed class MerchantNoSqlBrokerExceptionTranslationTests : InvoiceNoSqlB
         It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(MakeCosmosException((HttpStatusCode)429));
 
-    await Assert.ThrowsAsync<MerchantCosmosDbRateLimitException>(
+    await Assert.ThrowsExactlyAsync<MerchantCosmosDbRateLimitException>(
       async () => await broker.ReadMerchantAsync(merchantId, parentCompanyId, CancellationToken.None).ConfigureAwait(false));
   }
 
   /// <summary>
   /// Verifies that a Cosmos 503 (ServiceUnavailable) during read is translated into <see cref="MerchantFailedStorageException"/>.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchantAsync_WhenCosmos503_ThrowsMerchantFailedStorageException()
   {
     using var broker = BuildBroker();
@@ -99,14 +100,14 @@ public sealed class MerchantNoSqlBrokerExceptionTranslationTests : InvoiceNoSqlB
         It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(MakeCosmosException(HttpStatusCode.ServiceUnavailable));
 
-    await Assert.ThrowsAsync<MerchantFailedStorageException>(
+    await Assert.ThrowsExactlyAsync<MerchantFailedStorageException>(
       async () => await broker.ReadMerchantAsync(merchantId, parentCompanyId, CancellationToken.None).ConfigureAwait(false));
   }
 
   /// <summary>
   /// Verifies that a Cosmos 401 (Unauthorized) during read is translated into <see cref="MerchantUnauthorizedAccessException"/>.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchantAsync_WhenCosmos401_ThrowsMerchantUnauthorizedAccessException()
   {
     using var broker = BuildBroker();
@@ -117,14 +118,14 @@ public sealed class MerchantNoSqlBrokerExceptionTranslationTests : InvoiceNoSqlB
         It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(MakeCosmosException(HttpStatusCode.Unauthorized));
 
-    await Assert.ThrowsAsync<MerchantUnauthorizedAccessException>(
+    await Assert.ThrowsExactlyAsync<MerchantUnauthorizedAccessException>(
       async () => await broker.ReadMerchantAsync(merchantId, parentCompanyId, CancellationToken.None).ConfigureAwait(false));
   }
 
   /// <summary>
   /// Verifies that a Cosmos 403 (Forbidden) during read is translated into <see cref="MerchantForbiddenAccessException"/>.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchantAsync_WhenCosmos403_ThrowsMerchantForbiddenAccessException()
   {
     using var broker = BuildBroker();
@@ -135,7 +136,7 @@ public sealed class MerchantNoSqlBrokerExceptionTranslationTests : InvoiceNoSqlB
         It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(MakeCosmosException(HttpStatusCode.Forbidden));
 
-    await Assert.ThrowsAsync<MerchantForbiddenAccessException>(
+    await Assert.ThrowsExactlyAsync<MerchantForbiddenAccessException>(
       async () => await broker.ReadMerchantAsync(merchantId, parentCompanyId, CancellationToken.None).ConfigureAwait(false));
   }
 
@@ -143,7 +144,7 @@ public sealed class MerchantNoSqlBrokerExceptionTranslationTests : InvoiceNoSqlB
   /// Verifies that a soft-deleted merchant returned by Cosmos is surfaced as <see cref="MerchantLockedException"/>
   /// by the broker instead of being returned to the caller as a valid resource.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchantAsync_WhenMerchantSoftDeleted_ThrowsMerchantLockedException()
   {
     using var broker = BuildBroker();
@@ -159,7 +160,7 @@ public sealed class MerchantNoSqlBrokerExceptionTranslationTests : InvoiceNoSqlB
         It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()))
       .ReturnsAsync(responseMock.Object);
 
-    await Assert.ThrowsAsync<MerchantLockedException>(
+    await Assert.ThrowsExactlyAsync<MerchantLockedException>(
       async () => await broker.ReadMerchantAsync(merchantId, parentCompanyId, CancellationToken.None));
   }
 }

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Brokers/MerchantNoSqlBrokerTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Brokers/MerchantNoSqlBrokerTests.cs
@@ -398,7 +398,7 @@ It.IsAny<System.Threading.CancellationToken>()
   #region Test Data
 
   /// <summary>Merchant theory data provider.</summary>
-  public static TheoryData<Merchant> GetMerchantTestData() => MerchantTestDataBuilder.GetMerchantTheoryData();
+  public static IEnumerable<object[]> GetMerchantTestData() => MerchantTestDataBuilder.GetMerchantTheoryData();
 
   #endregion
 }

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Brokers/MerchantNoSqlBrokerTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Brokers/MerchantNoSqlBrokerTests.cs
@@ -17,13 +17,14 @@ using Microsoft.EntityFrameworkCore;
 
 using Moq;
 
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 /// <summary>
 /// Comprehensive test suite for <see cref="InvoiceNoSqlBroker"/> merchant operations following project test standards.
 /// Covers CRUD operations, exception pathways and query filtering scenarios. Method names follow
 /// the MethodName_Condition_ExpectedResult pattern by design; CA1707 suppressed accordingly.
 /// </summary>
+[TestClass]
 public sealed partial class MerchantNoSqlBrokerTests : InvoiceNoSqlBrokerTestsBase, IDisposable
 {
   private readonly InvoiceNoSqlBroker merchantNoSqlBroker;
@@ -52,8 +53,8 @@ public sealed partial class MerchantNoSqlBrokerTests : InvoiceNoSqlBrokerTestsBa
   #region CreateMerchantAsync Tests
 
   /// <summary>Verifies a valid merchant is persisted via CreateMerchantAsync.</summary>
-  [Theory]
-  [MemberData(nameof(GetMerchantTestData))]
+  [TestMethod]
+  [DynamicData(nameof(GetMerchantTestData))]
   public async Task ShouldCreateMerchant_WhenMerchantIsValid(Merchant expectedMerchant)
   {
     ArgumentNullException.ThrowIfNull(expectedMerchant);
@@ -73,10 +74,10 @@ public sealed partial class MerchantNoSqlBrokerTests : InvoiceNoSqlBrokerTestsBa
     var actualMerchant = await merchantNoSqlBroker.CreateMerchantAsync(expectedMerchant, CancellationToken.None);
 
     // Then
-    Assert.NotNull(actualMerchant);
-    Assert.Equal(expectedMerchant.id, actualMerchant.id);
-    Assert.Equal(expectedMerchant.ParentCompanyId, actualMerchant.ParentCompanyId);
-    Assert.Equal(expectedMerchant.Name, actualMerchant.Name);
+    Assert.IsNotNull(actualMerchant);
+    Assert.AreEqual(expectedMerchant.id, actualMerchant.id);
+    Assert.AreEqual(expectedMerchant.ParentCompanyId, actualMerchant.ParentCompanyId);
+    Assert.AreEqual(expectedMerchant.Name, actualMerchant.Name);
 
     mockMerchantsContainer.Verify(container => container.CreateItemAsync(
         expectedMerchant,
@@ -87,7 +88,7 @@ public sealed partial class MerchantNoSqlBrokerTests : InvoiceNoSqlBrokerTestsBa
   }
 
   /// <summary>Ensures passing null merchant throws an exception.</summary>
-  [Fact]
+  [TestMethod]
   public async Task ShouldThrowException_WhenMerchantIsNull()
   {
     // Given
@@ -95,11 +96,11 @@ public sealed partial class MerchantNoSqlBrokerTests : InvoiceNoSqlBrokerTestsBa
 
     // When & Then
     // Broker does not perform explicit null check, so NullReferenceException is thrown
-    await Assert.ThrowsAnyAsync<Exception>(() => merchantNoSqlBroker.CreateMerchantAsync(nullMerchant!, CancellationToken.None).AsTask());
+    await Assert.ThrowsAsync<Exception>(() => merchantNoSqlBroker.CreateMerchantAsync(nullMerchant!, CancellationToken.None).AsTask());
   }
 
   /// <summary>Validates Cosmos exception surfaces when container create fails.</summary>
-  [Fact]
+  [TestMethod]
   public async Task ShouldTranslateCosmosException_WhenCreateMerchantFails()
   {
     // Given
@@ -115,8 +116,8 @@ It.IsAny<System.Threading.CancellationToken>()
       .ThrowsAsync(cosmosException);
 
     // When & Then
-    var exception = await Assert.ThrowsAsync<MerchantFailedStorageException>(() => merchantNoSqlBroker.CreateMerchantAsync(merchant, CancellationToken.None).AsTask());
-    Assert.Same(cosmosException, exception.InnerException);
+    var exception = await Assert.ThrowsExactlyAsync<MerchantFailedStorageException>(() => merchantNoSqlBroker.CreateMerchantAsync(merchant, CancellationToken.None).AsTask());
+    Assert.AreSame(cosmosException, exception.InnerException);
   }
 
   #endregion
@@ -124,8 +125,8 @@ It.IsAny<System.Threading.CancellationToken>()
   #region ReadMerchantAsync Tests
 
   /// <summary>Ensures a merchant can be read when it exists.</summary>
-  [Theory]
-  [MemberData(nameof(GetMerchantTestData))]
+  [TestMethod]
+  [DynamicData(nameof(GetMerchantTestData))]
   public async Task ShouldReadMerchant_WhenMerchantExists(Merchant expectedMerchant)
   {
     ArgumentNullException.ThrowIfNull(expectedMerchant);
@@ -154,13 +155,13 @@ It.IsAny<System.Threading.CancellationToken>()
     var actualMerchant = await merchantNoSqlBroker.ReadMerchantAsync(expectedMerchant.id, null, CancellationToken.None);
 
     // Then
-    Assert.NotNull(actualMerchant);
-    Assert.Equal(expectedMerchant.id, actualMerchant.id);
-    Assert.Equal(expectedMerchant.ParentCompanyId, actualMerchant.ParentCompanyId);
+    Assert.IsNotNull(actualMerchant);
+    Assert.AreEqual(expectedMerchant.id, actualMerchant.id);
+    Assert.AreEqual(expectedMerchant.ParentCompanyId, actualMerchant.ParentCompanyId);
   }
 
   /// <summary>Returns null when merchant does not exist.</summary>
-  [Fact]
+  [TestMethod]
   public async Task ShouldReturnNull_WhenMerchantNotFound()
   {
     // Given
@@ -186,7 +187,7 @@ It.IsAny<System.Threading.CancellationToken>()
 
     // When
     var actualMerchant = await merchantNoSqlBroker.ReadMerchantAsync(merchantId, null, CancellationToken.None);
-    Assert.Null(actualMerchant);
+    Assert.IsNull(actualMerchant);
   }
 
   #endregion
@@ -194,7 +195,7 @@ It.IsAny<System.Threading.CancellationToken>()
   #region ReadMerchantsAsync Tests
 
   /// <summary>Reads merchants filtered by parent company id.</summary>
-  [Fact]
+  [TestMethod]
   public async Task ShouldReadMerchantsByParentCompanyId_WhenMerchantsExist()
   {
     // Given
@@ -224,9 +225,12 @@ It.IsAny<System.Threading.CancellationToken>()
     var actualMerchants = await merchantNoSqlBroker.ReadMerchantsAsync(parentCompanyId, CancellationToken.None);
 
     // Then
-    Assert.NotNull(actualMerchants);
-    Assert.Equal(expectedMerchants.Count, actualMerchants.Count());
-    Assert.All(actualMerchants, merchant => Assert.Equal(parentCompanyId, merchant.ParentCompanyId));
+    Assert.IsNotNull(actualMerchants);
+    Assert.AreEqual(expectedMerchants.Count, actualMerchants.Count());
+    foreach (var merchant in actualMerchants)
+    {
+      Assert.AreEqual(parentCompanyId, merchant.ParentCompanyId);
+    }
   }
 
   #endregion
@@ -234,8 +238,8 @@ It.IsAny<System.Threading.CancellationToken>()
   #region UpdateMerchantAsync Tests
 
   /// <summary>Updates a merchant by identifier, verifying replace semantics.</summary>
-  [Theory]
-  [MemberData(nameof(GetMerchantTestData))]
+  [TestMethod]
+  [DynamicData(nameof(GetMerchantTestData))]
   public async Task ShouldUpdateMerchantById_WhenValidMerchantProvided(Merchant originalMerchant)
   {
     ArgumentNullException.ThrowIfNull(originalMerchant);
@@ -283,14 +287,14 @@ It.IsAny<System.Threading.CancellationToken>()
     var actualMerchant = await merchantNoSqlBroker.UpdateMerchantAsync(originalMerchant.id, updatedMerchant, CancellationToken.None);
 
     // Then
-    Assert.NotNull(actualMerchant);
-    Assert.Equal(updatedMerchant.id, actualMerchant.id);
-    Assert.Equal("Updated Merchant Name", actualMerchant.Name);
+    Assert.IsNotNull(actualMerchant);
+    Assert.AreEqual(updatedMerchant.id, actualMerchant.id);
+    Assert.AreEqual("Updated Merchant Name", actualMerchant.Name);
   }
 
   /// <summary>Updates merchant via object upsert semantics.</summary>
-  [Theory]
-  [MemberData(nameof(GetMerchantTestData))]
+  [TestMethod]
+  [DynamicData(nameof(GetMerchantTestData))]
   public async Task ShouldUpdateMerchantWithObjects_WhenValidMerchantsProvided(Merchant originalMerchant)
   {
     ArgumentNullException.ThrowIfNull(originalMerchant);
@@ -315,9 +319,9 @@ It.IsAny<System.Threading.CancellationToken>()
     var actualMerchant = await merchantNoSqlBroker.UpdateMerchantAsync(originalMerchant, updatedMerchant, CancellationToken.None);
 
     // Then
-    Assert.NotNull(actualMerchant);
-    Assert.Equal(updatedMerchant.id, actualMerchant.id);
-    Assert.Equal("Updated Name", actualMerchant.Name);
+    Assert.IsNotNull(actualMerchant);
+    Assert.AreEqual(updatedMerchant.id, actualMerchant.id);
+    Assert.AreEqual("Updated Name", actualMerchant.Name);
   }
 
   #endregion
@@ -325,8 +329,8 @@ It.IsAny<System.Threading.CancellationToken>()
   #region DeleteMerchantAsync Tests
 
   /// <summary>Deletes a merchant when it exists.</summary>
-  [Theory]
-  [MemberData(nameof(GetMerchantTestData))]
+  [TestMethod]
+  [DynamicData(nameof(GetMerchantTestData))]
   public async Task ShouldDeleteMerchant_WhenMerchantExists(Merchant expectedMerchant)
   {
     ArgumentNullException.ThrowIfNull(expectedMerchant);
@@ -365,7 +369,7 @@ It.IsAny<System.Threading.CancellationToken>()
   }
 
   /// <summary>Does nothing when merchant is not found.</summary>
-  [Fact]
+  [TestMethod]
   public async Task ShouldNotDeleteMerchant_WhenMerchantNotFound()
   {
     // Given

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Brokers/TranslatorBrokerTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Brokers/TranslatorBrokerTests.cs
@@ -12,7 +12,7 @@ using arolariu.Backend.Domain.Invoices.Brokers.TranslatorBroker;
 using Moq;
 using Moq.Protected;
 
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 /// <summary>
 /// Unit tests for <see cref="AzureTranslatorBroker"/> covering constructor validation,
@@ -22,6 +22,7 @@ using Xunit;
 /// an external Azure service. These tests focus on constructor validation and exception paths
 /// that can be tested without hitting the actual Azure Translation API.
 /// </summary>
+[TestClass]
 public sealed class TranslatorBrokerTests : IDisposable
 {
   private readonly Mock<IOptionsManager> mockOptionsManager;
@@ -54,21 +55,21 @@ public sealed class TranslatorBrokerTests : IDisposable
   /// <summary>
   /// Verifies that constructor throws ArgumentNullException when options manager is null.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Constructor_ShouldThrowArgumentNullException_WhenOptionsManagerIsNull()
   {
     // Given
     IOptionsManager? nullOptionsManager = null;
 
     // When & Then
-    var exception = Assert.Throws<ArgumentNullException>(() => new AzureTranslatorBroker(nullOptionsManager!));
-    Assert.Equal("optionsManager", exception.ParamName);
+    var exception = Assert.ThrowsExactly<ArgumentNullException>(() => new AzureTranslatorBroker(nullOptionsManager!));
+    Assert.AreEqual("optionsManager", exception.ParamName);
   }
 
   /// <summary>
   /// Verifies that HTTP client constructor throws ArgumentNullException when options manager is null.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void ConstructorWithHttpClient_ShouldThrowArgumentNullException_WhenOptionsManagerIsNull()
   {
     // Given
@@ -76,42 +77,42 @@ public sealed class TranslatorBrokerTests : IDisposable
     using var httpClient = new HttpClient();
 
     // When & Then
-    var exception = Assert.Throws<ArgumentNullException>(() => new AzureTranslatorBroker(nullOptionsManager!, httpClient));
-    Assert.Equal("optionsManager", exception.ParamName);
+    var exception = Assert.ThrowsExactly<ArgumentNullException>(() => new AzureTranslatorBroker(nullOptionsManager!, httpClient));
+    Assert.AreEqual("optionsManager", exception.ParamName);
   }
 
   /// <summary>
   /// Verifies that HTTP client constructor throws ArgumentNullException when HTTP client is null.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void ConstructorWithHttpClient_ShouldThrowArgumentNullException_WhenHttpClientIsNull()
   {
     // Given
     HttpClient? nullHttpClient = null;
 
     // When & Then
-    var exception = Assert.Throws<ArgumentNullException>(() => new AzureTranslatorBroker(mockOptionsManager.Object, nullHttpClient!));
-    Assert.Equal("httpClient", exception.ParamName);
+    var exception = Assert.ThrowsExactly<ArgumentNullException>(() => new AzureTranslatorBroker(mockOptionsManager.Object, nullHttpClient!));
+    Assert.AreEqual("httpClient", exception.ParamName);
   }
 
   /// <summary>
   /// Verifies that the broker can be instantiated with valid options manager.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Constructor_ShouldSucceed_WhenOptionsManagerIsValid()
   {
     // Given & When
     var broker = new AzureTranslatorBroker(mockOptionsManager.Object);
 
     // Then
-    Assert.NotNull(broker);
+    Assert.IsNotNull(broker);
     mockOptionsManager.Verify(om => om.GetApplicationOptions(), Times.Once);
   }
 
   /// <summary>
   /// Verifies that the broker can be instantiated with valid options manager and HTTP client.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void ConstructorWithHttpClient_ShouldSucceed_WhenDependenciesAreValid()
   {
     // Given
@@ -121,7 +122,7 @@ public sealed class TranslatorBrokerTests : IDisposable
     var broker = new AzureTranslatorBroker(mockOptionsManager.Object, httpClient);
 
     // Then
-    Assert.NotNull(broker);
+    Assert.IsNotNull(broker);
     mockOptionsManager.Verify(om => om.GetApplicationOptions(), Times.Once);
   }
 
@@ -133,11 +134,11 @@ public sealed class TranslatorBrokerTests : IDisposable
   /// Verifies that Translate method accepts various BCP-47 language codes.
   /// This test verifies that the broker can be created for use with different target languages.
   /// </summary>
-  [Theory]
-  [InlineData("en")]
-  [InlineData("ro")]
-  [InlineData("de")]
-  [InlineData("fr")]
+  [TestMethod]
+  [DataRow("en")]
+  [DataRow("ro")]
+  [DataRow("de")]
+  [DataRow("fr")]
   public void Translate_ShouldAcceptVariousLanguageCodes(string languageCode)
   {
     // Given - verifying the broker accepts different language codes
@@ -145,14 +146,14 @@ public sealed class TranslatorBrokerTests : IDisposable
     var broker = new AzureTranslatorBroker(mockOptionsManager.Object, httpClient);
 
     // Then - broker should be created and language code should be valid BCP-47 format
-    Assert.NotNull(broker);
-    Assert.Matches(@"^[a-z]{2}(-[A-Z]{2})?$", languageCode);
+    Assert.IsNotNull(broker);
+    Assert.MatchesRegex(@"^[a-z]{2}(-[A-Z]{2})?$", languageCode);
   }
 
   /// <summary>
   /// Verifies that the default language parameter is "en" when not specified.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Translate_ShouldUseEnglishAsDefaultLanguage()
   {
     // This is verified by the interface contract - ITranslatorBroker.Translate has language = "en" as default
@@ -161,7 +162,7 @@ public sealed class TranslatorBrokerTests : IDisposable
     var broker = new AzureTranslatorBroker(mockOptionsManager.Object, httpClient);
 
     // Verify the broker implements ITranslatorBroker
-    Assert.IsAssignableFrom<ITranslatorBroker>(broker);
+    Assert.IsInstanceOfType<ITranslatorBroker>(broker);
   }
 
   #endregion
@@ -171,7 +172,7 @@ public sealed class TranslatorBrokerTests : IDisposable
   /// <summary>
   /// Verifies that DetectLanguage method exists and broker implements interface correctly.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void DetectLanguage_ShouldBeImplemented()
   {
     // Given
@@ -179,8 +180,8 @@ public sealed class TranslatorBrokerTests : IDisposable
     var broker = new AzureTranslatorBroker(mockOptionsManager.Object, httpClient);
 
     // Then - broker should implement ITranslatorBroker with DetectLanguage method
-    Assert.IsAssignableFrom<ITranslatorBroker>(broker);
-    Assert.NotNull(broker);
+    Assert.IsInstanceOfType<ITranslatorBroker>(broker);
+    Assert.IsNotNull(broker);
   }
 
   #endregion
@@ -190,7 +191,7 @@ public sealed class TranslatorBrokerTests : IDisposable
   /// <summary>
   /// Verifies that broker can be constructed with custom HTTP pipeline for testing.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Constructor_ShouldAllowCustomHttpPipeline_ForTestingPurposes()
   {
     // Given
@@ -215,13 +216,13 @@ public sealed class TranslatorBrokerTests : IDisposable
     var broker = new AzureTranslatorBroker(mockOptionsManager.Object, httpClient);
 
     // Then
-    Assert.NotNull(broker);
+    Assert.IsNotNull(broker);
   }
 
   /// <summary>
   /// Verifies that options are correctly retrieved from the options manager during construction.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Constructor_ShouldRetrieveOptionsFromManager()
   {
     // Given
@@ -235,7 +236,7 @@ public sealed class TranslatorBrokerTests : IDisposable
     var broker = new AzureTranslatorBroker(mockOptionsManager.Object, httpClient);
 
     // Then
-    Assert.Equal(1, callCount);
+    Assert.AreEqual(1, callCount);
     mockOptionsManager.Verify(om => om.GetApplicationOptions(), Times.Once);
   }
 

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/DDD/EdgeCases/InvoiceEdgeCaseTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/DDD/EdgeCases/InvoiceEdgeCaseTests.cs
@@ -11,13 +11,14 @@ using arolariu.Backend.Domain.Invoices.DDD.ValueObjects;
 using arolariu.Backend.Domain.Invoices.DDD.ValueObjects.Products;
 using arolariu.Backend.Domain.Tests.Builders;
 
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 /// <summary>
 /// Edge case tests for Invoice and related DDD entities.
 /// These tests focus on boundary conditions, null handling, and unusual scenarios.
 /// Method naming follows MethodName_Condition_ExpectedResult pattern per repository standards.
 /// </summary>
+[TestClass]
 public sealed class InvoiceEdgeCaseTests
 {
   #region Invoice Boundary Tests
@@ -25,7 +26,7 @@ public sealed class InvoiceEdgeCaseTests
   /// <summary>
   /// Verifies Invoice handles maximum items count.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Invoice_MaximumItemsCount_HandlesCorrectly()
   {
     // Arrange
@@ -37,13 +38,13 @@ public sealed class InvoiceEdgeCaseTests
     };
 
     // Assert
-    Assert.Equal(1000, invoice.Items.Count);
+    Assert.AreEqual(1000, invoice.Items.Count);
   }
 
   /// <summary>
   /// Verifies Invoice handles empty name.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Invoice_EmptyName_IsAllowed()
   {
     // Arrange
@@ -55,13 +56,13 @@ public sealed class InvoiceEdgeCaseTests
     };
 
     // Assert
-    Assert.Equal(string.Empty, invoice.Name);
+    Assert.AreEqual(string.Empty, invoice.Name);
   }
 
   /// <summary>
   /// Verifies Invoice handles whitespace name.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Invoice_WhitespaceName_IsAllowed()
   {
     // Arrange
@@ -73,13 +74,13 @@ public sealed class InvoiceEdgeCaseTests
     };
 
     // Assert
-    Assert.Equal("   ", invoice.Name);
+    Assert.AreEqual("   ", invoice.Name);
   }
 
   /// <summary>
   /// Verifies Invoice handles very long name.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Invoice_VeryLongName_IsAllowed()
   {
     // Arrange
@@ -92,13 +93,13 @@ public sealed class InvoiceEdgeCaseTests
     };
 
     // Assert
-    Assert.Equal(10000, invoice.Name.Length);
+    Assert.AreEqual(10000, invoice.Name.Length);
   }
 
   /// <summary>
   /// Verifies Invoice handles special characters in name.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Invoice_SpecialCharactersInName_AreAllowed()
   {
     // Arrange
@@ -111,13 +112,13 @@ public sealed class InvoiceEdgeCaseTests
     };
 
     // Assert
-    Assert.Equal(specialName, invoice.Name);
+    Assert.AreEqual(specialName, invoice.Name);
   }
 
   /// <summary>
   /// Verifies Invoice handles maximum shared users.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Invoice_MaximumSharedUsers_HandlesCorrectly()
   {
     // Arrange
@@ -130,13 +131,13 @@ public sealed class InvoiceEdgeCaseTests
     };
 
     // Assert
-    Assert.Equal(100, invoice.SharedWith.Count);
+    Assert.AreEqual(100, invoice.SharedWith.Count);
   }
 
   /// <summary>
   /// Verifies Invoice handles duplicate shared users.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Invoice_DuplicateSharedUsers_AreAllowed()
   {
     // Arrange
@@ -149,13 +150,13 @@ public sealed class InvoiceEdgeCaseTests
     };
 
     // Assert
-    Assert.Equal(3, invoice.SharedWith.Count);
+    Assert.AreEqual(3, invoice.SharedWith.Count);
   }
 
   /// <summary>
   /// Verifies Invoice handles empty GUID for shared user.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Invoice_EmptyGuidSharedUser_IsAllowed()
   {
     // Arrange
@@ -167,14 +168,14 @@ public sealed class InvoiceEdgeCaseTests
     };
 
     // Assert
-    Assert.Single(invoice.SharedWith);
+    Assert.ContainsSingle(invoice.SharedWith);
     Assert.Contains(Guid.Empty, invoice.SharedWith);
   }
 
   /// <summary>
   /// Verifies Invoice PerformUpdate with same user ID multiple times.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Invoice_PerformUpdate_SameUserId_MultipleUpdates_IncrementsCorrectly()
   {
     // Arrange
@@ -189,14 +190,14 @@ public sealed class InvoiceEdgeCaseTests
     }
 
     // Assert
-    Assert.Equal(initialCount + 10, invoice.NumberOfUpdates);
-    Assert.Equal(userId, invoice.LastUpdatedBy);
+    Assert.AreEqual(initialCount + 10, invoice.NumberOfUpdates);
+    Assert.AreEqual(userId, invoice.LastUpdatedBy);
   }
 
   /// <summary>
   /// Verifies Invoice handles null description.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Invoice_NullDescription_IsAllowed()
   {
     // Arrange
@@ -208,7 +209,7 @@ public sealed class InvoiceEdgeCaseTests
     };
 
     // Assert
-    Assert.Null(invoice.Description);
+    Assert.IsNull(invoice.Description);
   }
 
   #endregion
@@ -218,7 +219,7 @@ public sealed class InvoiceEdgeCaseTests
   /// <summary>
   /// Verifies Product handles zero price.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_ZeroPrice_IsValid()
   {
     // Arrange
@@ -230,14 +231,14 @@ public sealed class InvoiceEdgeCaseTests
     };
 
     // Assert
-    Assert.Equal(0, product.Price);
-    Assert.Equal(0, product.TotalPrice);
+    Assert.AreEqual(0, product.Price);
+    Assert.AreEqual(0, product.TotalPrice);
   }
 
   /// <summary>
   /// Verifies Product handles negative price.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_NegativePrice_IsAllowed()
   {
     // Arrange
@@ -249,14 +250,14 @@ public sealed class InvoiceEdgeCaseTests
     };
 
     // Assert
-    Assert.Equal(-10.00m, product.Price);
-    Assert.Equal(-10.00m, product.TotalPrice);
+    Assert.AreEqual(-10.00m, product.Price);
+    Assert.AreEqual(-10.00m, product.TotalPrice);
   }
 
   /// <summary>
   /// Verifies Product handles very large price.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_VeryLargePrice_IsAllowed()
   {
     // Arrange
@@ -268,13 +269,13 @@ public sealed class InvoiceEdgeCaseTests
     };
 
     // Assert
-    Assert.Equal(999999999.99m, product.Price);
+    Assert.AreEqual(999999999.99m, product.Price);
   }
 
   /// <summary>
   /// Verifies Product handles fractional quantity.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_FractionalQuantity_CalculatesTotalCorrectly()
   {
     // Arrange
@@ -286,13 +287,13 @@ public sealed class InvoiceEdgeCaseTests
     };
 
     // Assert
-    Assert.Equal(5.00m, product.TotalPrice);
+    Assert.AreEqual(5.00m, product.TotalPrice);
   }
 
   /// <summary>
   /// Verifies Product handles maximum decimal precision.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_MaxDecimalPrecision_HandlesCorrectly()
   {
     // Arrange
@@ -304,13 +305,13 @@ public sealed class InvoiceEdgeCaseTests
     };
 
     // Assert
-    Assert.Equal(0.0000000001m, product.TotalPrice);
+    Assert.AreEqual(0.0000000001m, product.TotalPrice);
   }
 
   /// <summary>
   /// Verifies Product handles empty name.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_EmptyName_IsAllowed()
   {
     // Arrange
@@ -320,13 +321,13 @@ public sealed class InvoiceEdgeCaseTests
     };
 
     // Assert
-    Assert.Equal(string.Empty, product.Name);
+    Assert.AreEqual(string.Empty, product.Name);
   }
 
   /// <summary>
   /// Verifies Product handles very long product code.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_VeryLongProductCode_IsAllowed()
   {
     // Arrange
@@ -337,13 +338,13 @@ public sealed class InvoiceEdgeCaseTests
     };
 
     // Assert
-    Assert.Equal(1000, product.ProductCode.Length);
+    Assert.AreEqual(1000, product.ProductCode.Length);
   }
 
   /// <summary>
   /// Verifies Product handles multiple allergens.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_MultipleAllergens_HandlesCorrectly()
   {
     // Arrange
@@ -361,7 +362,7 @@ public sealed class InvoiceEdgeCaseTests
     };
 
     // Assert
-    Assert.Equal(5, product.DetectedAllergens.Count());
+    Assert.AreEqual(5, product.DetectedAllergens.Count());
   }
 
   #endregion
@@ -371,7 +372,7 @@ public sealed class InvoiceEdgeCaseTests
   /// <summary>
   /// Verifies PaymentInformation handles zero total cost.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void PaymentInformation_ZeroTotalCost_IsValid()
   {
     // Arrange
@@ -382,14 +383,14 @@ public sealed class InvoiceEdgeCaseTests
     };
 
     // Assert
-    Assert.Equal(0, payment.TotalCostAmount);
-    Assert.Equal(0, payment.TotalTaxAmount);
+    Assert.AreEqual(0, payment.TotalCostAmount);
+    Assert.AreEqual(0, payment.TotalTaxAmount);
   }
 
   /// <summary>
   /// Verifies PaymentInformation handles negative tax.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void PaymentInformation_NegativeTax_IsAllowed()
   {
     // Arrange
@@ -400,13 +401,13 @@ public sealed class InvoiceEdgeCaseTests
     };
 
     // Assert
-    Assert.Equal(-10.00m, payment.TotalTaxAmount);
+    Assert.AreEqual(-10.00m, payment.TotalTaxAmount);
   }
 
   /// <summary>
   /// Verifies PaymentInformation handles tax greater than cost.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void PaymentInformation_TaxGreaterThanCost_IsAllowed()
   {
     // Arrange
@@ -417,13 +418,13 @@ public sealed class InvoiceEdgeCaseTests
     };
 
     // Assert
-    Assert.True(payment.TotalTaxAmount > payment.TotalCostAmount);
+    Assert.IsTrue(payment.TotalTaxAmount > payment.TotalCostAmount);
   }
 
   /// <summary>
   /// Verifies PaymentInformation handles future transaction date.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void PaymentInformation_FutureTransactionDate_IsAllowed()
   {
     // Arrange
@@ -434,13 +435,13 @@ public sealed class InvoiceEdgeCaseTests
     };
 
     // Assert
-    Assert.True(payment.TransactionDate > DateTimeOffset.UtcNow);
+    Assert.IsTrue(payment.TransactionDate > DateTimeOffset.UtcNow);
   }
 
   /// <summary>
   /// Verifies PaymentInformation handles very old transaction date.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void PaymentInformation_VeryOldTransactionDate_IsAllowed()
   {
     // Arrange
@@ -451,7 +452,7 @@ public sealed class InvoiceEdgeCaseTests
     };
 
     // Assert
-    Assert.Equal(1900, payment.TransactionDate.Year);
+    Assert.AreEqual(1900, payment.TransactionDate.Year);
   }
 
   #endregion
@@ -461,20 +462,20 @@ public sealed class InvoiceEdgeCaseTests
   /// <summary>
   /// Verifies Currency handles empty code.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Currency_EmptyCode_IsAllowed()
   {
     // Arrange
     var currency = new Currency("Test", string.Empty, "$");
 
     // Assert
-    Assert.Equal(string.Empty, currency.Code);
+    Assert.AreEqual(string.Empty, currency.Code);
   }
 
   /// <summary>
   /// Verifies Currency handles very long name.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Currency_VeryLongName_IsAllowed()
   {
     // Arrange
@@ -482,33 +483,33 @@ public sealed class InvoiceEdgeCaseTests
     var currency = new Currency(longName, "XXX", "X");
 
     // Assert
-    Assert.Equal(1000, currency.Name.Length);
+    Assert.AreEqual(1000, currency.Name.Length);
   }
 
   /// <summary>
   /// Verifies Currency handles multi-character symbol.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Currency_MultiCharacterSymbol_IsAllowed()
   {
     // Arrange
     var currency = new Currency("Test Currency", "TST", "TST$");
 
     // Assert
-    Assert.Equal("TST$", currency.Symbol);
+    Assert.AreEqual("TST$", currency.Symbol);
   }
 
   /// <summary>
   /// Verifies Currency handles emoji symbol.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Currency_EmojiSymbol_IsAllowed()
   {
     // Arrange
     var currency = new Currency("Crypto", "CRY", "🪙");
 
     // Assert
-    Assert.Equal("🪙", currency.Symbol);
+    Assert.AreEqual("🪙", currency.Symbol);
   }
 
   #endregion
@@ -518,7 +519,7 @@ public sealed class InvoiceEdgeCaseTests
   /// <summary>
   /// Verifies Merchant handles many referenced invoices.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Merchant_ManyReferencedInvoices_HandlesCorrectly()
   {
     // Arrange
@@ -529,13 +530,13 @@ public sealed class InvoiceEdgeCaseTests
     };
 
     // Assert
-    Assert.Equal(500, merchant.ReferencedInvoices.Count);
+    Assert.AreEqual(500, merchant.ReferencedInvoices.Count);
   }
 
   /// <summary>
   /// Verifies Merchant handles empty name.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Merchant_EmptyName_IsAllowed()
   {
     // Arrange
@@ -545,13 +546,13 @@ public sealed class InvoiceEdgeCaseTests
     };
 
     // Assert
-    Assert.Equal(string.Empty, merchant.Name);
+    Assert.AreEqual(string.Empty, merchant.Name);
   }
 
   /// <summary>
   /// Verifies Merchant handles very long description.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Merchant_VeryLongDescription_IsAllowed()
   {
     // Arrange
@@ -562,13 +563,13 @@ public sealed class InvoiceEdgeCaseTests
     };
 
     // Assert
-    Assert.Equal(50000, merchant.Description.Length);
+    Assert.AreEqual(50000, merchant.Description.Length);
   }
 
   /// <summary>
   /// Verifies Merchant handles complex contact information.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Merchant_ComplexContactInformation_HandlesCorrectly()
   {
     // Arrange
@@ -585,9 +586,9 @@ public sealed class InvoiceEdgeCaseTests
     };
 
     // Assert
-    Assert.NotNull(merchant.Address);
-    Assert.True(merchant.Address.FullName.Contains("Company", StringComparison.Ordinal));
-    Assert.True(merchant.Address.PhoneNumber.Contains("ext.", StringComparison.Ordinal));
+    Assert.IsNotNull(merchant.Address);
+    Assert.IsTrue(merchant.Address.FullName.Contains("Company", StringComparison.Ordinal));
+    Assert.IsTrue(merchant.Address.PhoneNumber.Contains("ext.", StringComparison.Ordinal));
   }
 
   #endregion
@@ -597,7 +598,7 @@ public sealed class InvoiceEdgeCaseTests
   /// <summary>
   /// Verifies Recipe handles negative duration.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Recipe_NegativeDuration_IsAllowed()
   {
     // Arrange
@@ -608,13 +609,13 @@ public sealed class InvoiceEdgeCaseTests
     };
 
     // Assert
-    Assert.Equal(-1, recipe.ApproximateTotalDuration);
+    Assert.AreEqual(-1, recipe.ApproximateTotalDuration);
   }
 
   /// <summary>
   /// Verifies Recipe handles very large duration.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Recipe_VeryLargeDuration_IsAllowed()
   {
     // Arrange
@@ -625,13 +626,13 @@ public sealed class InvoiceEdgeCaseTests
     };
 
     // Assert
-    Assert.Equal(int.MaxValue, recipe.ApproximateTotalDuration);
+    Assert.AreEqual(int.MaxValue, recipe.ApproximateTotalDuration);
   }
 
   /// <summary>
   /// Verifies Recipe handles empty ingredients list.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Recipe_EmptyIngredients_IsValid()
   {
     // Arrange
@@ -642,13 +643,13 @@ public sealed class InvoiceEdgeCaseTests
     };
 
     // Assert
-    Assert.Empty(recipe.Ingredients);
+    Assert.IsEmpty(recipe.Ingredients);
   }
 
   /// <summary>
   /// Verifies Recipe handles many ingredients.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Recipe_ManyIngredients_HandlesCorrectly()
   {
     // Arrange
@@ -660,7 +661,7 @@ public sealed class InvoiceEdgeCaseTests
     };
 
     // Assert
-    Assert.Equal(100, recipe.Ingredients.Count);
+    Assert.AreEqual(100, recipe.Ingredients.Count);
   }
 
   #endregion
@@ -670,7 +671,7 @@ public sealed class InvoiceEdgeCaseTests
   /// <summary>
   /// Verifies InvoiceScan handles complex URI.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceScan_ComplexUri_HandlesCorrectly()
   {
     // Arrange
@@ -678,13 +679,13 @@ public sealed class InvoiceEdgeCaseTests
     var scan = new InvoiceScan(ScanType.JPG, complexUri, null);
 
     // Assert
-    Assert.True(scan.Location.Query.Contains("token=", StringComparison.Ordinal));
+    Assert.IsTrue(scan.Location.Query.Contains("token=", StringComparison.Ordinal));
   }
 
   /// <summary>
   /// Verifies InvoiceScan handles file URI.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceScan_FileUri_HandlesCorrectly()
   {
     // Arrange
@@ -692,13 +693,13 @@ public sealed class InvoiceEdgeCaseTests
     var scan = new InvoiceScan(ScanType.PDF, fileUri, null);
 
     // Assert
-    Assert.Equal("file", scan.Location.Scheme);
+    Assert.AreEqual("file", scan.Location.Scheme);
   }
 
   /// <summary>
   /// Verifies InvoiceScan handles metadata with various types.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceScan_ComplexMetadata_HandlesCorrectly()
   {
     // Arrange
@@ -715,10 +716,10 @@ public sealed class InvoiceEdgeCaseTests
     var scan = new InvoiceScan(ScanType.JPG, new Uri("https://example.com/scan.jpg"), metadata);
 
     // Assert
-    Assert.Equal(7, scan.Metadata!.Count);
-    Assert.Equal("test", scan.Metadata["stringValue"]);
-    Assert.Equal(42, scan.Metadata["intValue"]);
-    Assert.Equal(true, scan.Metadata["boolValue"]);
+    Assert.AreEqual(7, scan.Metadata!.Count);
+    Assert.AreEqual("test", scan.Metadata["stringValue"]);
+    Assert.AreEqual(42, scan.Metadata["intValue"]);
+    Assert.AreEqual(true, scan.Metadata["boolValue"]);
   }
 
   #endregion
@@ -728,7 +729,7 @@ public sealed class InvoiceEdgeCaseTests
   /// <summary>
   /// Verifies Allergen handles special characters in name.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Allergen_SpecialCharactersInName_IsAllowed()
   {
     // Arrange
@@ -739,14 +740,14 @@ public sealed class InvoiceEdgeCaseTests
     };
 
     // Assert
-    Assert.True(allergen.Name.Contains('(', StringComparison.Ordinal));
-    Assert.True(allergen.Description.Contains('&', StringComparison.Ordinal));
+    Assert.IsTrue(allergen.Name.Contains('(', StringComparison.Ordinal));
+    Assert.IsTrue(allergen.Description.Contains('&', StringComparison.Ordinal));
   }
 
   /// <summary>
   /// Verifies Allergen handles international characters.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Allergen_InternationalCharacters_IsAllowed()
   {
     // Arrange
@@ -757,8 +758,8 @@ public sealed class InvoiceEdgeCaseTests
     };
 
     // Assert
-    Assert.True(allergen.Name.Contains('ü', StringComparison.Ordinal));
-    Assert.True(allergen.Description.Contains("日本語", StringComparison.Ordinal));
+    Assert.IsTrue(allergen.Name.Contains('ü', StringComparison.Ordinal));
+    Assert.IsTrue(allergen.Description.Contains("日本語", StringComparison.Ordinal));
   }
 
   #endregion
@@ -768,7 +769,7 @@ public sealed class InvoiceEdgeCaseTests
   /// <summary>
   /// Verifies Invoice AdditionalMetadata handles nested dictionaries.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Invoice_NestedMetadata_HandlesCorrectly()
   {
     // Arrange
@@ -788,13 +789,13 @@ public sealed class InvoiceEdgeCaseTests
     };
 
     // Assert
-    Assert.NotNull(invoice.AdditionalMetadata["level1"]);
+    Assert.IsNotNull(invoice.AdditionalMetadata["level1"]);
   }
 
   /// <summary>
   /// Verifies Invoice AdditionalMetadata handles null values.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Invoice_MetadataWithNullValue_HandlesCorrectly()
   {
     // Arrange
@@ -809,14 +810,14 @@ public sealed class InvoiceEdgeCaseTests
     };
 
     // Assert
-    Assert.True(invoice.AdditionalMetadata.ContainsKey("nullKey"));
-    Assert.Null(invoice.AdditionalMetadata["nullKey"]);
+    Assert.IsTrue(invoice.AdditionalMetadata.ContainsKey("nullKey"));
+    Assert.IsNull(invoice.AdditionalMetadata["nullKey"]);
   }
 
   /// <summary>
   /// Verifies Invoice AdditionalMetadata handles special key names.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Invoice_MetadataWithSpecialKeys_HandlesCorrectly()
   {
     // Arrange
@@ -835,8 +836,8 @@ public sealed class InvoiceEdgeCaseTests
     };
 
     // Assert
-    Assert.Equal(5, invoice.AdditionalMetadata.Count);
-    Assert.Equal("value1", invoice.AdditionalMetadata["key.with.dots"]);
+    Assert.AreEqual(5, invoice.AdditionalMetadata.Count);
+    Assert.AreEqual("value1", invoice.AdditionalMetadata["key.with.dots"]);
   }
 
   #endregion
@@ -846,7 +847,7 @@ public sealed class InvoiceEdgeCaseTests
   /// <summary>
   /// Verifies ContactInformation handles international phone numbers.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void ContactInformation_InternationalPhoneNumber_IsAllowed()
   {
     // Arrange
@@ -862,7 +863,7 @@ public sealed class InvoiceEdgeCaseTests
   /// <summary>
   /// Verifies ContactInformation handles invalid email format (no validation).
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void ContactInformation_InvalidEmailFormat_IsAllowed()
   {
     // Arrange - no validation on the model level
@@ -872,13 +873,13 @@ public sealed class InvoiceEdgeCaseTests
     };
 
     // Assert
-    Assert.Equal("not-a-valid-email", contact.EmailAddress);
+    Assert.AreEqual("not-a-valid-email", contact.EmailAddress);
   }
 
   /// <summary>
   /// Verifies ContactInformation handles empty website.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void ContactInformation_EmptyWebsite_IsAllowed()
   {
     // Arrange
@@ -888,7 +889,7 @@ public sealed class InvoiceEdgeCaseTests
     };
 
     // Assert
-    Assert.Equal(string.Empty, contact.Website);
+    Assert.AreEqual(string.Empty, contact.Website);
   }
 
   #endregion
@@ -898,7 +899,7 @@ public sealed class InvoiceEdgeCaseTests
   /// <summary>
   /// Verifies ProductMetadata all flags can be true.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void ProductMetadata_AllFlagsTrue_IsValid()
   {
     // Arrange
@@ -910,15 +911,15 @@ public sealed class InvoiceEdgeCaseTests
     };
 
     // Assert
-    Assert.True(metadata.IsEdited);
-    Assert.True(metadata.IsComplete);
-    Assert.True(metadata.IsSoftDeleted);
+    Assert.IsTrue(metadata.IsEdited);
+    Assert.IsTrue(metadata.IsComplete);
+    Assert.IsTrue(metadata.IsSoftDeleted);
   }
 
   /// <summary>
   /// Verifies ProductMetadata all flags can be false.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void ProductMetadata_AllFlagsFalse_IsValid()
   {
     // Arrange
@@ -930,9 +931,9 @@ public sealed class InvoiceEdgeCaseTests
     };
 
     // Assert
-    Assert.False(metadata.IsEdited);
-    Assert.False(metadata.IsComplete);
-    Assert.False(metadata.IsSoftDeleted);
+    Assert.IsFalse(metadata.IsEdited);
+    Assert.IsFalse(metadata.IsComplete);
+    Assert.IsFalse(metadata.IsSoftDeleted);
   }
 
   #endregion

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/DDD/Entities/EntityExtendedTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/DDD/Entities/EntityExtendedTests.cs
@@ -1,6 +1,7 @@
 namespace arolariu.Backend.Domain.Tests.Invoices.DDD.Entities;
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 using arolariu.Backend.Common.DDD.ValueObjects;
@@ -9,12 +10,13 @@ using arolariu.Backend.Domain.Invoices.DDD.Entities.Merchants;
 using arolariu.Backend.Domain.Invoices.DDD.ValueObjects.Products;
 using arolariu.Backend.Domain.Tests.Builders;
 
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 /// <summary>
 /// Extended tests for DDD entity behaviors covering construction,
 /// property assignment, and business rules.
 /// </summary>
+[TestClass]
 public sealed class EntityExtendedTests
 {
   #region Invoice Entity Extended Tests
@@ -22,7 +24,7 @@ public sealed class EntityExtendedTests
   /// <summary>
   /// Validates invoice can be created with minimal required properties.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Invoice_MinimalConstruction_CreatesSuccessfully()
   {
     // Arrange & Act
@@ -33,14 +35,14 @@ public sealed class EntityExtendedTests
     };
 
     // Assert
-    Assert.NotEqual(Guid.Empty, invoice.id);
-    Assert.NotEqual(Guid.Empty, invoice.UserIdentifier);
+    Assert.AreNotEqual(Guid.Empty, invoice.id);
+    Assert.AreNotEqual(Guid.Empty, invoice.UserIdentifier);
   }
 
   /// <summary>
   /// Validates invoice items collection starts empty.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Invoice_NewInstance_HasEmptyItems()
   {
     // Arrange
@@ -48,13 +50,13 @@ public sealed class EntityExtendedTests
     invoice.Items.Clear();
 
     // Assert
-    Assert.Empty(invoice.Items);
+    Assert.IsEmpty(invoice.Items);
   }
 
   /// <summary>
   /// Validates adding products to invoice.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Invoice_AddProducts_IncrementsCount()
   {
     // Arrange
@@ -67,13 +69,13 @@ public sealed class EntityExtendedTests
     invoice.Items.Add(new Product { Name = "Product 3" });
 
     // Assert
-    Assert.Equal(3, invoice.Items.Count);
+    Assert.AreEqual(3, invoice.Items.Count);
   }
 
   /// <summary>
   /// Validates removing products from invoice.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Invoice_RemoveProducts_DecrementsCount()
   {
     // Arrange
@@ -88,13 +90,13 @@ public sealed class EntityExtendedTests
     invoice.Items.Remove(product1);
 
     // Assert
-    Assert.Single(invoice.Items);
+    Assert.ContainsSingle(invoice.Items);
   }
 
   /// <summary>
   /// Validates NumberOfUpdates can be incremented.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Invoice_IncrementNumberOfUpdates_IncreasesValue()
   {
     // Arrange
@@ -105,13 +107,13 @@ public sealed class EntityExtendedTests
     invoice.NumberOfUpdates++;
 
     // Assert
-    Assert.Equal(initial + 1, invoice.NumberOfUpdates);
+    Assert.AreEqual(initial + 1, invoice.NumberOfUpdates);
   }
 
   /// <summary>
   /// Validates NumberOfUpdates starts at zero for new invoice.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Invoice_NewInstance_NumberOfUpdatesIsZero()
   {
     // Arrange
@@ -122,26 +124,26 @@ public sealed class EntityExtendedTests
     };
 
     // Assert
-    Assert.Equal(0, invoice.NumberOfUpdates);
+    Assert.AreEqual(0, invoice.NumberOfUpdates);
   }
 
   /// <summary>
   /// Validates CreatedAt is initialized with default value.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Invoice_CreatedAt_HasValue()
   {
     // Arrange & Act
     var invoice = InvoiceBuilder.CreateRandomInvoice();
 
     // Assert
-    Assert.NotEqual(default, invoice.CreatedAt);
+    Assert.AreNotEqual(default, invoice.CreatedAt);
   }
 
   /// <summary>
   /// Validates LastUpdatedAt has a value after creation.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Invoice_LastUpdatedAt_HasValue()
   {
     // Arrange & Act
@@ -149,13 +151,13 @@ public sealed class EntityExtendedTests
 
     // Assert
     // LastUpdatedAt should be set to a value (either default or initialized)
-    Assert.True(invoice.LastUpdatedAt >= default(DateTimeOffset));
+    Assert.IsTrue(invoice.LastUpdatedAt >= default(DateTimeOffset));
   }
 
   /// <summary>
   /// Validates invoice with large items collection.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Invoice_LargeItemsCollection_HandlesCorrectly()
   {
     // Arrange
@@ -169,7 +171,7 @@ public sealed class EntityExtendedTests
     }
 
     // Assert
-    Assert.Equal(1000, invoice.Items.Count);
+    Assert.AreEqual(1000, invoice.Items.Count);
   }
 
   #endregion
@@ -179,7 +181,7 @@ public sealed class EntityExtendedTests
   /// <summary>
   /// Validates merchant can be created with minimal required properties.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Merchant_MinimalConstruction_CreatesSuccessfully()
   {
     // Arrange & Act
@@ -190,13 +192,13 @@ public sealed class EntityExtendedTests
     };
 
     // Assert
-    Assert.NotEqual(Guid.Empty, merchant.id);
+    Assert.AreNotEqual(Guid.Empty, merchant.id);
   }
 
   /// <summary>
   /// Validates merchant name property can be set.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Merchant_SetName_StoresValue()
   {
     // Arrange
@@ -206,13 +208,13 @@ public sealed class EntityExtendedTests
     merchant.Name = "Test Merchant Name";
 
     // Assert
-    Assert.Equal("Test Merchant Name", merchant.Name);
+    Assert.AreEqual("Test Merchant Name", merchant.Name);
   }
 
   /// <summary>
   /// Validates merchant address can be assigned.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Merchant_SetAddress_StoresValue()
   {
     // Arrange
@@ -227,14 +229,14 @@ public sealed class EntityExtendedTests
     merchant.Address = address;
 
     // Assert
-    Assert.Equal("123 Test Street", merchant.Address.Address);
-    Assert.Equal("555-1234", merchant.Address.PhoneNumber);
+    Assert.AreEqual("123 Test Street", merchant.Address.Address);
+    Assert.AreEqual("555-1234", merchant.Address.PhoneNumber);
   }
 
   /// <summary>
   /// Validates merchant parent company ID can be set.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Merchant_SetParentCompanyId_StoresValue()
   {
     // Arrange
@@ -245,13 +247,13 @@ public sealed class EntityExtendedTests
     merchant.ParentCompanyId = parentId;
 
     // Assert
-    Assert.Equal(parentId, merchant.ParentCompanyId);
+    Assert.AreEqual(parentId, merchant.ParentCompanyId);
   }
 
   /// <summary>
   /// Validates merchant with empty name.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Merchant_EmptyName_IsAllowed()
   {
     // Arrange
@@ -261,13 +263,13 @@ public sealed class EntityExtendedTests
     merchant.Name = string.Empty;
 
     // Assert
-    Assert.Equal(string.Empty, merchant.Name);
+    Assert.AreEqual(string.Empty, merchant.Name);
   }
 
   /// <summary>
   /// Validates merchant with null name.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Merchant_NullName_IsAllowed()
   {
     // Arrange
@@ -277,13 +279,13 @@ public sealed class EntityExtendedTests
     merchant.Name = null!;
 
     // Assert
-    Assert.Null(merchant.Name);
+    Assert.IsNull(merchant.Name);
   }
 
   /// <summary>
   /// Validates merchant with long name.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Merchant_LongName_IsAllowed()
   {
     // Arrange
@@ -294,13 +296,13 @@ public sealed class EntityExtendedTests
     merchant.Name = longName;
 
     // Assert
-    Assert.Equal(1000, merchant.Name.Length);
+    Assert.AreEqual(1000, merchant.Name.Length);
   }
 
   /// <summary>
   /// Validates merchant with unicode name.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Merchant_UnicodeName_IsAllowed()
   {
     // Arrange
@@ -311,7 +313,7 @@ public sealed class EntityExtendedTests
     merchant.Name = unicodeName;
 
     // Assert
-    Assert.Equal(unicodeName, merchant.Name);
+    Assert.AreEqual(unicodeName, merchant.Name);
   }
 
   #endregion
@@ -321,20 +323,20 @@ public sealed class EntityExtendedTests
   /// <summary>
   /// Validates invoice scan can be created with required properties.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceScan_MinimalConstruction_CreatesSuccessfully()
   {
     // Arrange & Act
     var scan = new InvoiceScan(ScanType.JPG, new Uri("https://example.com/scan.jpg"), null);
 
     // Assert
-    Assert.NotNull(scan.Location);
+    Assert.IsNotNull(scan.Location);
   }
 
   /// <summary>
   /// Validates invoice scan location is stored correctly.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceScan_SetLocation_StoresValue()
   {
     // Arrange
@@ -344,37 +346,37 @@ public sealed class EntityExtendedTests
     var scan = new InvoiceScan(ScanType.PNG, uri, null);
 
     // Assert
-    Assert.Equal(uri, scan.Location);
+    Assert.AreEqual(uri, scan.Location);
   }
 
   /// <summary>
   /// Validates invoice scan with various URI schemes.
   /// </summary>
-  [Theory]
-  [MemberData(nameof(GetVariousUriSchemes))]
+  [TestMethod]
+  [DynamicData(nameof(GetVariousUriSchemes))]
   public void InvoiceScan_VariousUriSchemes_AreAllowed(Uri uri)
   {
     // Arrange & Act
     var scan = new InvoiceScan(ScanType.OTHER, uri, null);
 
     // Assert
-    Assert.NotNull(scan.Location);
+    Assert.IsNotNull(scan.Location);
   }
 
   /// <summary>
   /// Gets various URI schemes for testing.
   /// </summary>
-  public static TheoryData<Uri> GetVariousUriSchemes() => new()
-    {
-        new Uri("https://example.com/scan.jpg"),
-        new Uri("http://example.com/scan.jpg"),
-        new Uri("file:///c:/scans/scan.jpg")
-    };
+  public static IEnumerable<object[]> GetVariousUriSchemes =>
+  [
+    [new Uri("https://example.com/scan.jpg")],
+    [new Uri("http://example.com/scan.jpg")],
+    [new Uri("file:///c:/scans/scan.jpg")]
+  ];
 
   /// <summary>
   /// Validates invoice scan with complex URI.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceScan_ComplexUri_HandlesCorrectly()
   {
     // Arrange
@@ -384,27 +386,27 @@ public sealed class EntityExtendedTests
     var scan = new InvoiceScan(ScanType.JPG, complexUri, null);
 
     // Assert
-    Assert.Equal("storage.azure.com", scan.Location.Host);
-    Assert.True(scan.Location.LocalPath.Contains("scan-123_abc.jpg", StringComparison.Ordinal));
+    Assert.AreEqual("storage.azure.com", scan.Location.Host);
+    Assert.IsTrue(scan.Location.LocalPath.Contains("scan-123_abc.jpg", StringComparison.Ordinal));
   }
 
   /// <summary>
   /// Validates invoice scan default factory method.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceScan_Default_ReturnsUnknownType()
   {
     // Act
     var scan = InvoiceScan.Default();
 
     // Assert
-    Assert.Equal(ScanType.UNKNOWN, scan.Type);
+    Assert.AreEqual(ScanType.UNKNOWN, scan.Type);
   }
 
   /// <summary>
   /// Validates NotDefault returns false for default scan.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceScan_NotDefault_ReturnsFalseForDefault()
   {
     // Arrange
@@ -414,13 +416,13 @@ public sealed class EntityExtendedTests
     var result = InvoiceScan.NotDefault(scan);
 
     // Assert
-    Assert.False(result);
+    Assert.IsFalse(result);
   }
 
   /// <summary>
   /// Validates NotDefault returns true for non-default scan.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceScan_NotDefault_ReturnsTrueForNonDefault()
   {
     // Arrange
@@ -430,26 +432,26 @@ public sealed class EntityExtendedTests
     var result = InvoiceScan.NotDefault(scan);
 
     // Assert
-    Assert.True(result);
+    Assert.IsTrue(result);
   }
 
   /// <summary>
   /// Validates all scan types are supported.
   /// </summary>
-  [Theory]
-  [InlineData(ScanType.JPG)]
-  [InlineData(ScanType.JPEG)]
-  [InlineData(ScanType.PNG)]
-  [InlineData(ScanType.PDF)]
-  [InlineData(ScanType.OTHER)]
-  [InlineData(ScanType.UNKNOWN)]
+  [TestMethod]
+  [DataRow(ScanType.JPG)]
+  [DataRow(ScanType.JPEG)]
+  [DataRow(ScanType.PNG)]
+  [DataRow(ScanType.PDF)]
+  [DataRow(ScanType.OTHER)]
+  [DataRow(ScanType.UNKNOWN)]
   public void InvoiceScan_AllScanTypes_AreSupported(ScanType type)
   {
     // Arrange & Act
     var scan = new InvoiceScan(type, new Uri("https://example.com/scan"), null);
 
     // Assert
-    Assert.Equal(type, scan.Type);
+    Assert.AreEqual(type, scan.Type);
   }
 
   #endregion
@@ -459,20 +461,20 @@ public sealed class EntityExtendedTests
   /// <summary>
   /// Validates product can be created with minimal properties.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_MinimalConstruction_CreatesSuccessfully()
   {
     // Arrange & Act
     var product = new Product();
 
     // Assert
-    Assert.NotNull(product);
+    Assert.IsNotNull(product);
   }
 
   /// <summary>
   /// Validates product name can be set.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_SetName_StoresValue()
   {
     // Arrange
@@ -482,13 +484,13 @@ public sealed class EntityExtendedTests
     product.Name = "Test Product";
 
     // Assert
-    Assert.Equal("Test Product", product.Name);
+    Assert.AreEqual("Test Product", product.Name);
   }
 
   /// <summary>
   /// Validates product name can be updated.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_SetName_UpdatesValue()
   {
     // Arrange
@@ -498,13 +500,13 @@ public sealed class EntityExtendedTests
     product.Name = "Generic Name";
 
     // Assert
-    Assert.Equal("Generic Name", product.Name);
+    Assert.AreEqual("Generic Name", product.Name);
   }
 
   /// <summary>
   /// Validates product quantity can be set.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_SetQuantity_StoresValue()
   {
     // Arrange
@@ -514,13 +516,13 @@ public sealed class EntityExtendedTests
     product.Quantity = 5;
 
     // Assert
-    Assert.Equal(5, product.Quantity);
+    Assert.AreEqual(5, product.Quantity);
   }
 
   /// <summary>
   /// Validates product price can be set.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_SetPrice_StoresValue()
   {
     // Arrange
@@ -530,13 +532,13 @@ public sealed class EntityExtendedTests
     product.Price = 19.99m;
 
     // Assert
-    Assert.Equal(19.99m, product.Price);
+    Assert.AreEqual(19.99m, product.Price);
   }
 
   /// <summary>
   /// Validates product with zero quantity.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_ZeroQuantity_IsAllowed()
   {
     // Arrange
@@ -546,13 +548,13 @@ public sealed class EntityExtendedTests
     product.Quantity = 0;
 
     // Assert
-    Assert.Equal(0, product.Quantity);
+    Assert.AreEqual(0, product.Quantity);
   }
 
   /// <summary>
   /// Validates product with zero price.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_ZeroPrice_IsAllowed()
   {
     // Arrange
@@ -562,13 +564,13 @@ public sealed class EntityExtendedTests
     product.Price = 0m;
 
     // Assert
-    Assert.Equal(0m, product.Price);
+    Assert.AreEqual(0m, product.Price);
   }
 
   /// <summary>
   /// Validates product with negative price.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_NegativePrice_IsAllowed()
   {
     // Arrange
@@ -578,13 +580,13 @@ public sealed class EntityExtendedTests
     product.Price = -10.00m;
 
     // Assert
-    Assert.Equal(-10.00m, product.Price);
+    Assert.AreEqual(-10.00m, product.Price);
   }
 
   /// <summary>
   /// Validates product with large quantity.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_LargeQuantity_IsAllowed()
   {
     // Arrange
@@ -594,13 +596,13 @@ public sealed class EntityExtendedTests
     product.Quantity = 999999;
 
     // Assert
-    Assert.Equal(999999, product.Quantity);
+    Assert.AreEqual(999999, product.Quantity);
   }
 
   /// <summary>
   /// Validates product with high precision price.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_HighPrecisionPrice_IsAllowed()
   {
     // Arrange
@@ -610,7 +612,7 @@ public sealed class EntityExtendedTests
     product.Price = 123.456789m;
 
     // Assert
-    Assert.Equal(123.456789m, product.Price);
+    Assert.AreEqual(123.456789m, product.Price);
   }
 
   #endregion
@@ -620,20 +622,20 @@ public sealed class EntityExtendedTests
   /// <summary>
   /// Validates contact information can be created with minimal properties.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void ContactInformation_MinimalConstruction_CreatesSuccessfully()
   {
     // Arrange & Act
     var contact = new ContactInformation();
 
     // Assert
-    Assert.NotNull(contact);
+    Assert.IsNotNull(contact);
   }
 
   /// <summary>
   /// Validates contact information full name can be set.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void ContactInformation_SetFullName_StoresValue()
   {
     // Arrange
@@ -643,13 +645,13 @@ public sealed class EntityExtendedTests
     contact.FullName = "John Doe";
 
     // Assert
-    Assert.Equal("John Doe", contact.FullName);
+    Assert.AreEqual("John Doe", contact.FullName);
   }
 
   /// <summary>
   /// Validates contact information address can be set.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void ContactInformation_SetAddress_StoresValue()
   {
     // Arrange
@@ -659,13 +661,13 @@ public sealed class EntityExtendedTests
     contact.Address = "123 Main Street, New York, NY 10001";
 
     // Assert
-    Assert.Equal("123 Main Street, New York, NY 10001", contact.Address);
+    Assert.AreEqual("123 Main Street, New York, NY 10001", contact.Address);
   }
 
   /// <summary>
   /// Validates contact information phone number can be set.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void ContactInformation_SetPhoneNumber_StoresValue()
   {
     // Arrange
@@ -675,13 +677,13 @@ public sealed class EntityExtendedTests
     contact.PhoneNumber = "+1-555-123-4567";
 
     // Assert
-    Assert.Equal("+1-555-123-4567", contact.PhoneNumber);
+    Assert.AreEqual("+1-555-123-4567", contact.PhoneNumber);
   }
 
   /// <summary>
   /// Validates contact information email can be set.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void ContactInformation_SetEmailAddress_StoresValue()
   {
     // Arrange
@@ -691,13 +693,13 @@ public sealed class EntityExtendedTests
     contact.EmailAddress = "test@example.com";
 
     // Assert
-    Assert.Equal("test@example.com", contact.EmailAddress);
+    Assert.AreEqual("test@example.com", contact.EmailAddress);
   }
 
   /// <summary>
   /// Validates contact information website can be set.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void ContactInformation_SetWebsite_StoresValue()
   {
     // Arrange
@@ -707,13 +709,13 @@ public sealed class EntityExtendedTests
     contact.Website = "https://www.example.com";
 
     // Assert
-    Assert.Equal("https://www.example.com", contact.Website);
+    Assert.AreEqual("https://www.example.com", contact.Website);
   }
 
   /// <summary>
   /// Validates contact information with empty values.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void ContactInformation_EmptyValues_AreAllowed()
   {
     // Arrange
@@ -721,15 +723,15 @@ public sealed class EntityExtendedTests
 
     // Act - default values are empty string
     // Assert
-    Assert.Equal(string.Empty, contact.FullName);
-    Assert.Equal(string.Empty, contact.Address);
-    Assert.Equal(string.Empty, contact.PhoneNumber);
+    Assert.AreEqual(string.Empty, contact.FullName);
+    Assert.AreEqual(string.Empty, contact.Address);
+    Assert.AreEqual(string.Empty, contact.PhoneNumber);
   }
 
   /// <summary>
   /// Validates contact information with unicode values.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void ContactInformation_UnicodeValues_AreAllowed()
   {
     // Arrange
@@ -740,8 +742,8 @@ public sealed class EntityExtendedTests
     contact.Address = "東京都渋谷区";
 
     // Assert
-    Assert.Equal("山田太郎", contact.FullName);
-    Assert.Equal("東京都渋谷区", contact.Address);
+    Assert.AreEqual("山田太郎", contact.FullName);
+    Assert.AreEqual("東京都渋谷区", contact.Address);
   }
 
   #endregion
@@ -751,7 +753,7 @@ public sealed class EntityExtendedTests
   /// <summary>
   /// Validates invoice identity is unique per instance.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Invoice_MultipleInstances_HaveUniqueIds()
   {
     // Arrange & Act
@@ -759,13 +761,13 @@ public sealed class EntityExtendedTests
 
     // Assert
     var uniqueIds = invoices.Select(i => i.id).Distinct();
-    Assert.Equal(100, uniqueIds.Count());
+    Assert.AreEqual(100, uniqueIds.Count());
   }
 
   /// <summary>
   /// Validates merchant identity is unique per instance.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Merchant_MultipleInstances_HaveUniqueIds()
   {
     // Arrange & Act
@@ -775,7 +777,7 @@ public sealed class EntityExtendedTests
 
     // Assert
     var uniqueIds = merchants.Select(m => m.id).Distinct();
-    Assert.Equal(100, uniqueIds.Count());
+    Assert.AreEqual(100, uniqueIds.Count());
   }
 
   #endregion

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/DDD/Entities/EntityTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/DDD/Entities/EntityTests.cs
@@ -10,13 +10,14 @@ using arolariu.Backend.Domain.Invoices.DDD.ValueObjects;
 using arolariu.Backend.Domain.Invoices.DDD.ValueObjects.Products;
 using arolariu.Backend.Domain.Tests.Builders;
 
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 /// <summary>
 /// Comprehensive unit tests for all Entity classes in the invoicing domain.
 /// Tests validate property initialization, public API behavior, and entity constraints.
 /// Method naming follows MethodName_Condition_ExpectedResult pattern per repository standards.
 /// </summary>
+[TestClass]
 public sealed class EntityTests
 {
   #region Invoice Property Tests
@@ -24,7 +25,7 @@ public sealed class EntityTests
   /// <summary>
   /// Verifies Invoice can be created with required properties.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Invoice_Creation_WithRequiredProperties_Succeeds()
   {
     // Act
@@ -35,32 +36,32 @@ public sealed class EntityTests
     };
 
     // Assert
-    Assert.NotNull(invoice);
-    Assert.NotEqual(Guid.Empty, invoice.id);
-    Assert.NotEqual(Guid.Empty, invoice.UserIdentifier);
+    Assert.IsNotNull(invoice);
+    Assert.AreNotEqual(Guid.Empty, invoice.id);
+    Assert.AreNotEqual(Guid.Empty, invoice.UserIdentifier);
   }
 
   /// <summary>
   /// Verifies Invoice has default empty collections.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Invoice_DefaultCollections_AreEmpty()
   {
     // Arrange
     var invoice = InvoiceBuilder.CreateRandomInvoice();
 
     // Assert
-    Assert.NotNull(invoice.SharedWith);
-    Assert.NotNull(invoice.Scans);
-    Assert.NotNull(invoice.Items);
-    Assert.NotNull(invoice.PossibleRecipes);
-    Assert.NotNull(invoice.AdditionalMetadata);
+    Assert.IsNotNull(invoice.SharedWith);
+    Assert.IsNotNull(invoice.Scans);
+    Assert.IsNotNull(invoice.Items);
+    Assert.IsNotNull(invoice.PossibleRecipes);
+    Assert.IsNotNull(invoice.AdditionalMetadata);
   }
 
   /// <summary>
   /// Verifies Invoice default category is NOT_DEFINED.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Invoice_DefaultCategory_IsNotDefined()
   {
     // Arrange
@@ -71,13 +72,13 @@ public sealed class EntityTests
     };
 
     // Assert
-    Assert.Equal(InvoiceCategory.NOT_DEFINED, invoice.Category);
+    Assert.AreEqual(InvoiceCategory.NOT_DEFINED, invoice.Category);
   }
 
   /// <summary>
   /// Verifies Invoice default MerchantReference is empty GUID.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Invoice_DefaultMerchantReference_IsEmptyGuid()
   {
     // Arrange
@@ -88,19 +89,19 @@ public sealed class EntityTests
     };
 
     // Assert
-    Assert.Equal(Guid.Empty, invoice.MerchantReference);
+    Assert.AreEqual(Guid.Empty, invoice.MerchantReference);
   }
 
   /// <summary>
   /// Verifies Invoice category can be set to different values.
   /// </summary>
-  [Theory]
-  [InlineData(InvoiceCategory.NOT_DEFINED)]
-  [InlineData(InvoiceCategory.GROCERY)]
-  [InlineData(InvoiceCategory.FAST_FOOD)]
-  [InlineData(InvoiceCategory.HOME_CLEANING)]
-  [InlineData(InvoiceCategory.CAR_AUTO)]
-  [InlineData(InvoiceCategory.OTHER)]
+  [TestMethod]
+  [DataRow(InvoiceCategory.NOT_DEFINED)]
+  [DataRow(InvoiceCategory.GROCERY)]
+  [DataRow(InvoiceCategory.FAST_FOOD)]
+  [DataRow(InvoiceCategory.HOME_CLEANING)]
+  [DataRow(InvoiceCategory.CAR_AUTO)]
+  [DataRow(InvoiceCategory.OTHER)]
   public void Invoice_SetCategory_CategoryIsSet(InvoiceCategory category)
   {
     // Arrange
@@ -112,13 +113,13 @@ public sealed class EntityTests
     };
 
     // Assert
-    Assert.Equal(category, invoice.Category);
+    Assert.AreEqual(category, invoice.Category);
   }
 
   /// <summary>
   /// Verifies Invoice Name can be set.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Invoice_SetName_NameIsSet()
   {
     // Arrange
@@ -130,13 +131,13 @@ public sealed class EntityTests
     };
 
     // Assert
-    Assert.Equal("Test Invoice", invoice.Name);
+    Assert.AreEqual("Test Invoice", invoice.Name);
   }
 
   /// <summary>
   /// Verifies Invoice Description can be set.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Invoice_SetDescription_DescriptionIsSet()
   {
     // Arrange
@@ -148,13 +149,13 @@ public sealed class EntityTests
     };
 
     // Assert
-    Assert.Equal("Test Description", invoice.Description);
+    Assert.AreEqual("Test Description", invoice.Description);
   }
 
   /// <summary>
   /// Verifies Invoice IsImportant defaults to false.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Invoice_DefaultIsImportant_IsFalse()
   {
     // Arrange
@@ -165,13 +166,13 @@ public sealed class EntityTests
     };
 
     // Assert
-    Assert.False(invoice.IsImportant);
+    Assert.IsFalse(invoice.IsImportant);
   }
 
   /// <summary>
   /// Verifies Invoice IsImportant can be set to true.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Invoice_SetIsImportant_IsImportantIsSet()
   {
     // Arrange
@@ -183,13 +184,13 @@ public sealed class EntityTests
     };
 
     // Assert
-    Assert.True(invoice.IsImportant);
+    Assert.IsTrue(invoice.IsImportant);
   }
 
   /// <summary>
   /// Verifies Invoice Items collection can be populated.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Invoice_AddItems_ItemsAreAdded()
   {
     // Arrange
@@ -205,13 +206,13 @@ public sealed class EntityTests
     };
 
     // Assert
-    Assert.Equal(2, invoice.Items.Count);
+    Assert.AreEqual(2, invoice.Items.Count);
   }
 
   /// <summary>
   /// Verifies Invoice PaymentInformation can be set.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Invoice_SetPaymentInformation_PaymentInformationIsSet()
   {
     // Arrange
@@ -229,15 +230,15 @@ public sealed class EntityTests
     };
 
     // Assert
-    Assert.Equal(PaymentType.CARD, invoice.PaymentInformation.PaymentType);
-    Assert.Equal(100.00m, invoice.PaymentInformation.TotalCostAmount);
-    Assert.Equal(19.00m, invoice.PaymentInformation.TotalTaxAmount);
+    Assert.AreEqual(PaymentType.CARD, invoice.PaymentInformation.PaymentType);
+    Assert.AreEqual(100.00m, invoice.PaymentInformation.TotalCostAmount);
+    Assert.AreEqual(19.00m, invoice.PaymentInformation.TotalTaxAmount);
   }
 
   /// <summary>
   /// Verifies Invoice MerchantReference can be set.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Invoice_SetMerchantReference_MerchantReferenceIsSet()
   {
     // Arrange
@@ -250,13 +251,13 @@ public sealed class EntityTests
     };
 
     // Assert
-    Assert.Equal(merchantId, invoice.MerchantReference);
+    Assert.AreEqual(merchantId, invoice.MerchantReference);
   }
 
   /// <summary>
   /// Verifies Invoice PossibleRecipes collection can be populated.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Invoice_AddPossibleRecipes_RecipesAreAdded()
   {
     // Arrange
@@ -272,13 +273,13 @@ public sealed class EntityTests
     };
 
     // Assert
-    Assert.Equal(2, invoice.PossibleRecipes.Count);
+    Assert.AreEqual(2, invoice.PossibleRecipes.Count);
   }
 
   /// <summary>
   /// Verifies Invoice AdditionalMetadata can be populated.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Invoice_AddMetadata_MetadataIsAdded()
   {
     // Arrange
@@ -294,15 +295,15 @@ public sealed class EntityTests
     };
 
     // Assert
-    Assert.Equal(2, invoice.AdditionalMetadata.Count);
-    Assert.Equal("value1", invoice.AdditionalMetadata["key1"]);
-    Assert.Equal(42, invoice.AdditionalMetadata["key2"]);
+    Assert.AreEqual(2, invoice.AdditionalMetadata.Count);
+    Assert.AreEqual("value1", invoice.AdditionalMetadata["key1"]);
+    Assert.AreEqual(42, invoice.AdditionalMetadata["key2"]);
   }
 
   /// <summary>
   /// Verifies PerformUpdate sets LastUpdatedBy.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Invoice_PerformUpdate_SetsLastUpdatedBy()
   {
     // Arrange
@@ -313,13 +314,13 @@ public sealed class EntityTests
     invoice.PerformUpdate(updatedById);
 
     // Assert
-    Assert.Equal(updatedById, invoice.LastUpdatedBy);
+    Assert.AreEqual(updatedById, invoice.LastUpdatedBy);
   }
 
   /// <summary>
   /// Verifies PerformUpdate sets LastUpdatedAt to current time.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Invoice_PerformUpdate_SetsLastUpdatedAt()
   {
     // Arrange
@@ -330,13 +331,13 @@ public sealed class EntityTests
     invoice.PerformUpdate(Guid.NewGuid());
 
     // Assert
-    Assert.True(invoice.LastUpdatedAt >= beforeUpdate);
+    Assert.IsTrue(invoice.LastUpdatedAt >= beforeUpdate);
   }
 
   /// <summary>
   /// Verifies PerformUpdate increments NumberOfUpdates.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Invoice_PerformUpdate_IncrementsNumberOfUpdates()
   {
     // Arrange
@@ -347,13 +348,13 @@ public sealed class EntityTests
     invoice.PerformUpdate(Guid.NewGuid());
 
     // Assert
-    Assert.Equal(initialCount + 1, invoice.NumberOfUpdates);
+    Assert.AreEqual(initialCount + 1, invoice.NumberOfUpdates);
   }
 
   /// <summary>
   /// Verifies multiple PerformUpdate calls increment count correctly.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Invoice_PerformUpdate_MultipleCalls_IncrementsCorrectly()
   {
     // Arrange
@@ -366,7 +367,7 @@ public sealed class EntityTests
     invoice.PerformUpdate(Guid.NewGuid());
 
     // Assert
-    Assert.Equal(initialCount + 3, invoice.NumberOfUpdates);
+    Assert.AreEqual(initialCount + 3, invoice.NumberOfUpdates);
   }
 
   #endregion
@@ -376,7 +377,7 @@ public sealed class EntityTests
   /// <summary>
   /// Verifies Merchant can be created with valid properties.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Merchant_Creation_WithValidProperties_Succeeds()
   {
     // Act
@@ -389,71 +390,71 @@ public sealed class EntityTests
     };
 
     // Assert
-    Assert.NotNull(merchant);
-    Assert.NotEqual(Guid.Empty, merchant.id);
-    Assert.Equal("Test Merchant", merchant.Name);
-    Assert.Equal(MerchantCategory.SUPERMARKET, merchant.Category);
+    Assert.IsNotNull(merchant);
+    Assert.AreNotEqual(Guid.Empty, merchant.id);
+    Assert.AreEqual("Test Merchant", merchant.Name);
+    Assert.AreEqual(MerchantCategory.SUPERMARKET, merchant.Category);
   }
 
   /// <summary>
   /// Verifies Merchant default category is OTHER.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Merchant_DefaultCategory_IsOther()
   {
     // Arrange
     var merchant = new Merchant();
 
     // Assert
-    Assert.Equal(MerchantCategory.OTHER, merchant.Category);
+    Assert.AreEqual(MerchantCategory.OTHER, merchant.Category);
   }
 
   /// <summary>
   /// Verifies Merchant has default empty Address.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Merchant_DefaultAddress_IsEmpty()
   {
     // Arrange
     var merchant = new Merchant();
 
     // Assert
-    Assert.NotNull(merchant.Address);
-    Assert.Equal(string.Empty, merchant.Address.FullName);
+    Assert.IsNotNull(merchant.Address);
+    Assert.AreEqual(string.Empty, merchant.Address.FullName);
   }
 
   /// <summary>
   /// Verifies Merchant has default empty ReferencedInvoices.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Merchant_DefaultReferencedInvoices_IsEmpty()
   {
     // Arrange
     var merchant = new Merchant();
 
     // Assert
-    Assert.NotNull(merchant.ReferencedInvoices);
-    Assert.Empty(merchant.ReferencedInvoices);
+    Assert.IsNotNull(merchant.ReferencedInvoices);
+    Assert.IsEmpty(merchant.ReferencedInvoices);
   }
 
   /// <summary>
   /// Verifies Merchant has default empty AdditionalMetadata.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Merchant_DefaultAdditionalMetadata_IsEmpty()
   {
     // Arrange
     var merchant = new Merchant();
 
     // Assert
-    Assert.NotNull(merchant.AdditionalMetadata);
-    Assert.Empty(merchant.AdditionalMetadata);
+    Assert.IsNotNull(merchant.AdditionalMetadata);
+    Assert.IsEmpty(merchant.AdditionalMetadata);
   }
 
   /// <summary>
   /// Verifies Merchant Address can be set.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Merchant_SetAddress_AddressIsSet()
   {
     // Arrange
@@ -468,34 +469,34 @@ public sealed class EntityTests
     };
 
     // Assert
-    Assert.Equal("Test Store", merchant.Address.FullName);
-    Assert.Equal("123 Main St", merchant.Address.Address);
-    Assert.Equal("+1234567890", merchant.Address.PhoneNumber);
+    Assert.AreEqual("Test Store", merchant.Address.FullName);
+    Assert.AreEqual("123 Main St", merchant.Address.Address);
+    Assert.AreEqual("+1234567890", merchant.Address.PhoneNumber);
   }
 
   /// <summary>
   /// Verifies MerchantCategory can be set on Merchant.
   /// </summary>
-  [Theory]
-  [InlineData(MerchantCategory.NOT_DEFINED)]
-  [InlineData(MerchantCategory.LOCAL_SHOP)]
-  [InlineData(MerchantCategory.SUPERMARKET)]
-  [InlineData(MerchantCategory.HYPERMARKET)]
-  [InlineData(MerchantCategory.ONLINE_SHOP)]
-  [InlineData(MerchantCategory.OTHER)]
+  [TestMethod]
+  [DataRow(MerchantCategory.NOT_DEFINED)]
+  [DataRow(MerchantCategory.LOCAL_SHOP)]
+  [DataRow(MerchantCategory.SUPERMARKET)]
+  [DataRow(MerchantCategory.HYPERMARKET)]
+  [DataRow(MerchantCategory.ONLINE_SHOP)]
+  [DataRow(MerchantCategory.OTHER)]
   public void MerchantCategory_CanBeSetOnMerchant(MerchantCategory category)
   {
     // Arrange
     var merchant = new Merchant { Category = category };
 
     // Assert
-    Assert.Equal(category, merchant.Category);
+    Assert.AreEqual(category, merchant.Category);
   }
 
   /// <summary>
   /// Verifies Merchant ParentCompanyId can be set.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Merchant_SetParentCompanyId_ParentCompanyIdIsSet()
   {
     // Arrange
@@ -506,20 +507,20 @@ public sealed class EntityTests
     };
 
     // Assert
-    Assert.Equal(parentId, merchant.ParentCompanyId);
+    Assert.AreEqual(parentId, merchant.ParentCompanyId);
   }
 
   /// <summary>
   /// Verifies Merchant default ParentCompanyId is empty GUID.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Merchant_DefaultParentCompanyId_IsEmptyGuid()
   {
     // Arrange
     var merchant = new Merchant();
 
     // Assert
-    Assert.Equal(Guid.Empty, merchant.ParentCompanyId);
+    Assert.AreEqual(Guid.Empty, merchant.ParentCompanyId);
   }
 
   #endregion
@@ -529,47 +530,47 @@ public sealed class EntityTests
   /// <summary>
   /// Verifies InvoiceScan.Default() creates instance with UNKNOWN type.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceScan_Default_SetsTypeToUnknown()
   {
     // Act
     var scan = InvoiceScan.Default();
 
     // Assert
-    Assert.Equal(ScanType.UNKNOWN, scan.Type);
+    Assert.AreEqual(ScanType.UNKNOWN, scan.Type);
   }
 
   /// <summary>
   /// Verifies InvoiceScan.Default() sets location to default URI.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceScan_Default_SetsDefaultLocation()
   {
     // Act
     var scan = InvoiceScan.Default();
 
     // Assert
-    Assert.Equal("https://arolariu.ro/", scan.Location.ToString());
+    Assert.AreEqual("https://arolariu.ro/", scan.Location.ToString());
   }
 
   /// <summary>
   /// Verifies InvoiceScan.Default() creates empty metadata.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceScan_Default_CreatesEmptyMetadata()
   {
     // Act
     var scan = InvoiceScan.Default();
 
     // Assert
-    Assert.NotNull(scan.Metadata);
-    Assert.Empty(scan.Metadata);
+    Assert.IsNotNull(scan.Metadata);
+    Assert.IsEmpty(scan.Metadata);
   }
 
   /// <summary>
   /// Verifies InvoiceScan.NotDefault() returns false for default scan.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceScan_NotDefault_DefaultScan_ReturnsFalse()
   {
     // Arrange
@@ -579,13 +580,13 @@ public sealed class EntityTests
     var result = InvoiceScan.NotDefault(scan);
 
     // Assert
-    Assert.False(result);
+    Assert.IsFalse(result);
   }
 
   /// <summary>
   /// Verifies InvoiceScan.NotDefault() returns true for valid scan.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceScan_NotDefault_ValidScan_ReturnsTrue()
   {
     // Arrange
@@ -595,13 +596,13 @@ public sealed class EntityTests
     var result = InvoiceScan.NotDefault(scan);
 
     // Assert
-    Assert.True(result);
+    Assert.IsTrue(result);
   }
 
   /// <summary>
   /// Verifies InvoiceScan.NotDefault() returns false when type is UNKNOWN.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceScan_NotDefault_UnknownType_ReturnsFalse()
   {
     // Arrange
@@ -611,13 +612,13 @@ public sealed class EntityTests
     var result = InvoiceScan.NotDefault(scan);
 
     // Assert
-    Assert.False(result);
+    Assert.IsFalse(result);
   }
 
   /// <summary>
   /// Verifies InvoiceScan.NotDefault() returns false when location is default.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceScan_NotDefault_DefaultLocation_ReturnsFalse()
   {
     // Arrange
@@ -627,13 +628,13 @@ public sealed class EntityTests
     var result = InvoiceScan.NotDefault(scan);
 
     // Assert
-    Assert.False(result);
+    Assert.IsFalse(result);
   }
 
   /// <summary>
   /// Verifies InvoiceScan can be created with all parameters.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceScan_ParameterizedConstructor_SetsAllProperties()
   {
     // Arrange
@@ -645,15 +646,15 @@ public sealed class EntityTests
     var scan = new InvoiceScan(type, location, metadata);
 
     // Assert
-    Assert.Equal(ScanType.JPG, scan.Type);
-    Assert.Equal("https://example.com/invoice.jpg", scan.Location.ToString());
-    Assert.Equal("mobile", scan.Metadata!["source"]);
+    Assert.AreEqual(ScanType.JPG, scan.Type);
+    Assert.AreEqual("https://example.com/invoice.jpg", scan.Location.ToString());
+    Assert.AreEqual("mobile", scan.Metadata!["source"]);
   }
 
   /// <summary>
   /// Verifies InvoiceScan equality based on value.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceScan_SameValues_AreEqual()
   {
     // Arrange
@@ -661,13 +662,13 @@ public sealed class EntityTests
     var scan2 = new InvoiceScan(ScanType.PDF, new Uri("https://example.com/doc.pdf"), null);
 
     // Assert
-    Assert.Equal(scan1, scan2);
+    Assert.AreEqual(scan1, scan2);
   }
 
   /// <summary>
   /// Verifies InvoiceScan inequality for different values.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceScan_DifferentValues_AreNotEqual()
   {
     // Arrange
@@ -675,17 +676,17 @@ public sealed class EntityTests
     var scan2 = new InvoiceScan(ScanType.PDF, new Uri("https://example.com/doc2.pdf"), null);
 
     // Assert
-    Assert.NotEqual(scan1, scan2);
+    Assert.AreNotEqual(scan1, scan2);
   }
 
   /// <summary>
   /// Verifies InvoiceScan has Serializable attribute.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceScan_HasSerializableAttribute()
   {
     // Assert
-    Assert.True(Attribute.IsDefined(typeof(InvoiceScan), typeof(SerializableAttribute)));
+    Assert.IsTrue(Attribute.IsDefined(typeof(InvoiceScan), typeof(SerializableAttribute)));
   }
 
   #endregion
@@ -695,36 +696,36 @@ public sealed class EntityTests
   /// <summary>
   /// Verifies ScanType enum has expected values.
   /// </summary>
-  [Theory]
-  [InlineData(ScanType.JPG)]
-  [InlineData(ScanType.JPEG)]
-  [InlineData(ScanType.PNG)]
-  [InlineData(ScanType.PDF)]
-  [InlineData(ScanType.OTHER)]
-  [InlineData(ScanType.UNKNOWN)]
+  [TestMethod]
+  [DataRow(ScanType.JPG)]
+  [DataRow(ScanType.JPEG)]
+  [DataRow(ScanType.PNG)]
+  [DataRow(ScanType.PDF)]
+  [DataRow(ScanType.OTHER)]
+  [DataRow(ScanType.UNKNOWN)]
   public void ScanType_AllValues_AreDefined(ScanType scanType)
   {
     // Assert
-    Assert.True(Enum.IsDefined<ScanType>(scanType));
+    Assert.IsTrue(Enum.IsDefined<ScanType>(scanType));
   }
 
   /// <summary>
   /// Verifies ScanType can be parsed from string.
   /// </summary>
-  [Theory]
-  [InlineData("JPG")]
-  [InlineData("JPEG")]
-  [InlineData("PNG")]
-  [InlineData("PDF")]
-  [InlineData("OTHER")]
-  [InlineData("UNKNOWN")]
+  [TestMethod]
+  [DataRow("JPG")]
+  [DataRow("JPEG")]
+  [DataRow("PNG")]
+  [DataRow("PDF")]
+  [DataRow("OTHER")]
+  [DataRow("UNKNOWN")]
   public void ScanType_ParseFromString_ReturnsCorrectValue(string scanTypeName)
   {
     // Act
     var parsed = Enum.Parse<ScanType>(scanTypeName);
 
     // Assert
-    Assert.True(Enum.IsDefined<ScanType>(parsed));
+    Assert.IsTrue(Enum.IsDefined<ScanType>(parsed));
   }
 
   #endregion
@@ -734,27 +735,27 @@ public sealed class EntityTests
   /// <summary>
   /// Verifies InvoiceCategory enum has NOT_DEFINED as valid value.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceCategory_NotDefined_IsDefined()
   {
     // Assert
-    Assert.True(Enum.IsDefined<InvoiceCategory>(InvoiceCategory.NOT_DEFINED));
+    Assert.IsTrue(Enum.IsDefined<InvoiceCategory>(InvoiceCategory.NOT_DEFINED));
   }
 
   /// <summary>
   /// Verifies InvoiceCategory has multiple category options.
   /// </summary>
-  [Theory]
-  [InlineData(InvoiceCategory.NOT_DEFINED)]
-  [InlineData(InvoiceCategory.GROCERY)]
-  [InlineData(InvoiceCategory.FAST_FOOD)]
-  [InlineData(InvoiceCategory.HOME_CLEANING)]
-  [InlineData(InvoiceCategory.CAR_AUTO)]
-  [InlineData(InvoiceCategory.OTHER)]
+  [TestMethod]
+  [DataRow(InvoiceCategory.NOT_DEFINED)]
+  [DataRow(InvoiceCategory.GROCERY)]
+  [DataRow(InvoiceCategory.FAST_FOOD)]
+  [DataRow(InvoiceCategory.HOME_CLEANING)]
+  [DataRow(InvoiceCategory.CAR_AUTO)]
+  [DataRow(InvoiceCategory.OTHER)]
   public void InvoiceCategory_AllValues_AreDefined(InvoiceCategory category)
   {
     // Assert
-    Assert.True(Enum.IsDefined<InvoiceCategory>(category));
+    Assert.IsTrue(Enum.IsDefined<InvoiceCategory>(category));
   }
 
   #endregion
@@ -764,27 +765,27 @@ public sealed class EntityTests
   /// <summary>
   /// Verifies MerchantCategory enum has OTHER as valid value.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void MerchantCategory_Other_IsDefined()
   {
     // Assert
-    Assert.True(Enum.IsDefined<MerchantCategory>(MerchantCategory.OTHER));
+    Assert.IsTrue(Enum.IsDefined<MerchantCategory>(MerchantCategory.OTHER));
   }
 
   /// <summary>
   /// Verifies MerchantCategory has multiple category options.
   /// </summary>
-  [Theory]
-  [InlineData(MerchantCategory.NOT_DEFINED)]
-  [InlineData(MerchantCategory.LOCAL_SHOP)]
-  [InlineData(MerchantCategory.SUPERMARKET)]
-  [InlineData(MerchantCategory.HYPERMARKET)]
-  [InlineData(MerchantCategory.ONLINE_SHOP)]
-  [InlineData(MerchantCategory.OTHER)]
+  [TestMethod]
+  [DataRow(MerchantCategory.NOT_DEFINED)]
+  [DataRow(MerchantCategory.LOCAL_SHOP)]
+  [DataRow(MerchantCategory.SUPERMARKET)]
+  [DataRow(MerchantCategory.HYPERMARKET)]
+  [DataRow(MerchantCategory.ONLINE_SHOP)]
+  [DataRow(MerchantCategory.OTHER)]
   public void MerchantCategory_AllValues_AreDefined(MerchantCategory category)
   {
     // Assert
-    Assert.True(Enum.IsDefined<MerchantCategory>(category));
+    Assert.IsTrue(Enum.IsDefined<MerchantCategory>(category));
   }
 
   #endregion

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/DDD/Exceptions/InvoiceExceptionTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/DDD/Exceptions/InvoiceExceptionTests.cs
@@ -9,13 +9,14 @@ using arolariu.Backend.Domain.Invoices.DDD.AggregatorRoots.Invoices.Exceptions.O
 using arolariu.Backend.Domain.Invoices.DDD.AggregatorRoots.Invoices.Exceptions.Outer.Orchestration;
 using arolariu.Backend.Domain.Invoices.DDD.AggregatorRoots.Invoices.Exceptions.Outer.Processing;
 
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 /// <summary>
 /// Comprehensive unit tests for all Invoice exception classes.
 /// Tests validate all constructors, serialization, and inheritance.
 /// Method naming follows MethodName_Condition_ExpectedResult pattern per repository standards.
 /// </summary>
+[TestClass]
 public sealed class InvoiceExceptionTests
 {
   #region InvoiceIdNotSetException Tests
@@ -23,22 +24,22 @@ public sealed class InvoiceExceptionTests
   /// <summary>
   /// Verifies default constructor creates instance.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceIdNotSetException_DefaultConstructor_CreatesInstance()
   {
     // Act
     var exception = new InvoiceIdNotSetException();
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.IsType<InvoiceIdNotSetException>(exception);
-    Assert.IsAssignableFrom<Exception>(exception);
+    Assert.IsNotNull(exception);
+    Assert.IsExactInstanceOfType<InvoiceIdNotSetException>(exception);
+    Assert.IsInstanceOfType<Exception>(exception);
   }
 
   /// <summary>
   /// Verifies constructor with inner exception sets message and inner exception.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceIdNotSetException_InnerExceptionConstructor_SetsPropertiesCorrectly()
   {
     // Arrange
@@ -48,23 +49,23 @@ public sealed class InvoiceExceptionTests
     var exception = new InvoiceIdNotSetException(innerException);
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.Equal("Invoice identifier not set Exception", exception.Message);
-    Assert.Same(innerException, exception.InnerException);
+    Assert.IsNotNull(exception);
+    Assert.AreEqual("Invoice identifier not set Exception", exception.Message);
+    Assert.AreSame(innerException, exception.InnerException);
   }
 
   /// <summary>
   /// Verifies constructor with null inner exception works.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceIdNotSetException_NullInnerException_CreatesInstance()
   {
     // Act
     var exception = new InvoiceIdNotSetException(null!);
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.Null(exception.InnerException);
+    Assert.IsNotNull(exception);
+    Assert.IsNull(exception.InnerException);
   }
 
   #endregion
@@ -74,21 +75,21 @@ public sealed class InvoiceExceptionTests
   /// <summary>
   /// Verifies default constructor creates instance.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceDescriptionNotSetException_DefaultConstructor_CreatesInstance()
   {
     // Act
     var exception = new InvoiceDescriptionNotSetException();
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.IsType<InvoiceDescriptionNotSetException>(exception);
+    Assert.IsNotNull(exception);
+    Assert.IsExactInstanceOfType<InvoiceDescriptionNotSetException>(exception);
   }
 
   /// <summary>
   /// Verifies constructor with inner exception sets properties correctly.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceDescriptionNotSetException_InnerExceptionConstructor_SetsPropertiesCorrectly()
   {
     // Arrange
@@ -98,9 +99,9 @@ public sealed class InvoiceExceptionTests
     var exception = new InvoiceDescriptionNotSetException(innerException);
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.Equal("Invoice description not set Exception", exception.Message);
-    Assert.Same(innerException, exception.InnerException);
+    Assert.IsNotNull(exception);
+    Assert.AreEqual("Invoice description not set Exception", exception.Message);
+    Assert.AreSame(innerException, exception.InnerException);
   }
 
   #endregion
@@ -110,21 +111,21 @@ public sealed class InvoiceExceptionTests
   /// <summary>
   /// Verifies default constructor creates instance.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoicePaymentInformationNotCorrectException_DefaultConstructor_CreatesInstance()
   {
     // Act
     var exception = new InvoicePaymentInformationNotCorrectException();
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.IsType<InvoicePaymentInformationNotCorrectException>(exception);
+    Assert.IsNotNull(exception);
+    Assert.IsExactInstanceOfType<InvoicePaymentInformationNotCorrectException>(exception);
   }
 
   /// <summary>
   /// Verifies constructor with inner exception sets properties correctly.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoicePaymentInformationNotCorrectException_InnerExceptionConstructor_SetsPropertiesCorrectly()
   {
     // Arrange
@@ -134,9 +135,9 @@ public sealed class InvoiceExceptionTests
     var exception = new InvoicePaymentInformationNotCorrectException(innerException);
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.Equal("Invoice payment information not correct Exception", exception.Message);
-    Assert.Same(innerException, exception.InnerException);
+    Assert.IsNotNull(exception);
+    Assert.AreEqual("Invoice payment information not correct Exception", exception.Message);
+    Assert.AreSame(innerException, exception.InnerException);
   }
 
   #endregion
@@ -146,21 +147,21 @@ public sealed class InvoiceExceptionTests
   /// <summary>
   /// Verifies default constructor creates instance.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoicePhotoLocationNotCorrectException_DefaultConstructor_CreatesInstance()
   {
     // Act
     var exception = new InvoicePhotoLocationNotCorrectException();
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.IsType<InvoicePhotoLocationNotCorrectException>(exception);
+    Assert.IsNotNull(exception);
+    Assert.IsExactInstanceOfType<InvoicePhotoLocationNotCorrectException>(exception);
   }
 
   /// <summary>
   /// Verifies constructor with inner exception sets properties correctly.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoicePhotoLocationNotCorrectException_InnerExceptionConstructor_SetsPropertiesCorrectly()
   {
     // Arrange
@@ -170,9 +171,9 @@ public sealed class InvoiceExceptionTests
     var exception = new InvoicePhotoLocationNotCorrectException(innerException);
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.Equal("Invoice photo location not correct Exception", exception.Message);
-    Assert.Same(innerException, exception.InnerException);
+    Assert.IsNotNull(exception);
+    Assert.AreEqual("Invoice photo location not correct Exception", exception.Message);
+    Assert.AreSame(innerException, exception.InnerException);
   }
 
   #endregion
@@ -182,21 +183,21 @@ public sealed class InvoiceExceptionTests
   /// <summary>
   /// Verifies default constructor creates instance.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceTimeInformationNotCorrectException_DefaultConstructor_CreatesInstance()
   {
     // Act
     var exception = new InvoiceTimeInformationNotCorrectException();
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.IsType<InvoiceTimeInformationNotCorrectException>(exception);
+    Assert.IsNotNull(exception);
+    Assert.IsExactInstanceOfType<InvoiceTimeInformationNotCorrectException>(exception);
   }
 
   /// <summary>
   /// Verifies constructor with inner exception sets properties correctly.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceTimeInformationNotCorrectException_InnerExceptionConstructor_SetsPropertiesCorrectly()
   {
     // Arrange
@@ -206,9 +207,9 @@ public sealed class InvoiceExceptionTests
     var exception = new InvoiceTimeInformationNotCorrectException(innerException);
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.Equal("Invoice time information not correct Exception", exception.Message);
-    Assert.Same(innerException, exception.InnerException);
+    Assert.IsNotNull(exception);
+    Assert.AreEqual("Invoice time information not correct Exception", exception.Message);
+    Assert.AreSame(innerException, exception.InnerException);
   }
 
   #endregion
@@ -218,21 +219,21 @@ public sealed class InvoiceExceptionTests
   /// <summary>
   /// Verifies default constructor creates instance.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceFoundationValidationException_DefaultConstructor_CreatesInstance()
   {
     // Act
     var exception = new InvoiceFoundationValidationException();
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.IsType<InvoiceFoundationValidationException>(exception);
+    Assert.IsNotNull(exception);
+    Assert.IsExactInstanceOfType<InvoiceFoundationValidationException>(exception);
   }
 
   /// <summary>
   /// Verifies constructor with inner exception sets properties correctly.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceFoundationValidationException_InnerExceptionConstructor_SetsPropertiesCorrectly()
   {
     // Arrange
@@ -242,15 +243,15 @@ public sealed class InvoiceExceptionTests
     var exception = new InvoiceFoundationValidationException(innerException);
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.Equal("Invoice Validation Exception", exception.Message);
-    Assert.Same(innerException, exception.InnerException);
+    Assert.IsNotNull(exception);
+    Assert.AreEqual("Invoice Validation Exception", exception.Message);
+    Assert.AreSame(innerException, exception.InnerException);
   }
 
   /// <summary>
   /// Verifies constructor with nested inner exceptions preserves exception chain.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceFoundationValidationException_NestedInnerExceptions_PreservesExceptionChain()
   {
     // Arrange
@@ -261,9 +262,9 @@ public sealed class InvoiceExceptionTests
     var exception = new InvoiceFoundationValidationException(innerException);
 
     // Assert
-    Assert.NotNull(exception.InnerException);
-    Assert.NotNull(exception.InnerException.InnerException);
-    Assert.IsType<ArgumentException>(exception.InnerException.InnerException);
+    Assert.IsNotNull(exception.InnerException);
+    Assert.IsNotNull(exception.InnerException.InnerException);
+    Assert.IsExactInstanceOfType<ArgumentException>(exception.InnerException.InnerException);
   }
 
   #endregion
@@ -273,21 +274,21 @@ public sealed class InvoiceExceptionTests
   /// <summary>
   /// Verifies default constructor creates instance.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceFoundationDependencyException_DefaultConstructor_CreatesInstance()
   {
     // Act
     var exception = new InvoiceFoundationDependencyException();
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.IsType<InvoiceFoundationDependencyException>(exception);
+    Assert.IsNotNull(exception);
+    Assert.IsExactInstanceOfType<InvoiceFoundationDependencyException>(exception);
   }
 
   /// <summary>
   /// Verifies constructor with inner exception sets properties correctly.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceFoundationDependencyException_InnerExceptionConstructor_SetsPropertiesCorrectly()
   {
     // Arrange
@@ -297,9 +298,9 @@ public sealed class InvoiceExceptionTests
     var exception = new InvoiceFoundationDependencyException(innerException);
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.Equal("Invoice Dependency Exception", exception.Message);
-    Assert.Same(innerException, exception.InnerException);
+    Assert.IsNotNull(exception);
+    Assert.AreEqual("Invoice Dependency Exception", exception.Message);
+    Assert.AreSame(innerException, exception.InnerException);
   }
 
   #endregion
@@ -309,21 +310,21 @@ public sealed class InvoiceExceptionTests
   /// <summary>
   /// Verifies default constructor creates instance.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceFoundationDependencyValidationException_DefaultConstructor_CreatesInstance()
   {
     // Act
     var exception = new InvoiceFoundationDependencyValidationException();
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.IsType<InvoiceFoundationDependencyValidationException>(exception);
+    Assert.IsNotNull(exception);
+    Assert.IsExactInstanceOfType<InvoiceFoundationDependencyValidationException>(exception);
   }
 
   /// <summary>
   /// Verifies constructor with inner exception sets properties correctly.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceFoundationDependencyValidationException_InnerExceptionConstructor_SetsPropertiesCorrectly()
   {
     // Arrange
@@ -333,9 +334,9 @@ public sealed class InvoiceExceptionTests
     var exception = new InvoiceFoundationDependencyValidationException(innerException);
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.Equal("Invoice Dependency Validation Exception", exception.Message);
-    Assert.Same(innerException, exception.InnerException);
+    Assert.IsNotNull(exception);
+    Assert.AreEqual("Invoice Dependency Validation Exception", exception.Message);
+    Assert.AreSame(innerException, exception.InnerException);
   }
 
   #endregion
@@ -345,21 +346,21 @@ public sealed class InvoiceExceptionTests
   /// <summary>
   /// Verifies default constructor creates instance.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceFoundationServiceException_DefaultConstructor_CreatesInstance()
   {
     // Act
     var exception = new InvoiceFoundationServiceException();
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.IsType<InvoiceFoundationServiceException>(exception);
+    Assert.IsNotNull(exception);
+    Assert.IsExactInstanceOfType<InvoiceFoundationServiceException>(exception);
   }
 
   /// <summary>
   /// Verifies constructor with inner exception sets properties correctly.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceFoundationServiceException_InnerExceptionConstructor_SetsPropertiesCorrectly()
   {
     // Arrange
@@ -369,9 +370,9 @@ public sealed class InvoiceExceptionTests
     var exception = new InvoiceFoundationServiceException(innerException);
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.Equal("Invoice Service Exception", exception.Message);
-    Assert.Same(innerException, exception.InnerException);
+    Assert.IsNotNull(exception);
+    Assert.AreEqual("Invoice Service Exception", exception.Message);
+    Assert.AreSame(innerException, exception.InnerException);
   }
 
   #endregion
@@ -381,21 +382,21 @@ public sealed class InvoiceExceptionTests
   /// <summary>
   /// Verifies default constructor creates instance.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceOrchestrationValidationException_DefaultConstructor_CreatesInstance()
   {
     // Act
     var exception = new InvoiceOrchestrationValidationException();
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.IsType<InvoiceOrchestrationValidationException>(exception);
+    Assert.IsNotNull(exception);
+    Assert.IsExactInstanceOfType<InvoiceOrchestrationValidationException>(exception);
   }
 
   /// <summary>
   /// Verifies constructor with inner exception sets properties correctly.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceOrchestrationValidationException_InnerExceptionConstructor_SetsPropertiesCorrectly()
   {
     // Arrange
@@ -405,9 +406,9 @@ public sealed class InvoiceExceptionTests
     var exception = new InvoiceOrchestrationValidationException(innerException);
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.Equal("Invoice Orchestration Validation Exception", exception.Message);
-    Assert.Same(innerException, exception.InnerException);
+    Assert.IsNotNull(exception);
+    Assert.AreEqual("Invoice Orchestration Validation Exception", exception.Message);
+    Assert.AreSame(innerException, exception.InnerException);
   }
 
   #endregion
@@ -417,21 +418,21 @@ public sealed class InvoiceExceptionTests
   /// <summary>
   /// Verifies default constructor creates instance.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceOrchestrationDependencyException_DefaultConstructor_CreatesInstance()
   {
     // Act
     var exception = new InvoiceOrchestrationDependencyException();
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.IsType<InvoiceOrchestrationDependencyException>(exception);
+    Assert.IsNotNull(exception);
+    Assert.IsExactInstanceOfType<InvoiceOrchestrationDependencyException>(exception);
   }
 
   /// <summary>
   /// Verifies constructor with inner exception sets properties correctly.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceOrchestrationDependencyException_InnerExceptionConstructor_SetsPropertiesCorrectly()
   {
     // Arrange
@@ -441,9 +442,9 @@ public sealed class InvoiceExceptionTests
     var exception = new InvoiceOrchestrationDependencyException(innerException);
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.Equal("Invoice Orchestration Dependency Exception", exception.Message);
-    Assert.Same(innerException, exception.InnerException);
+    Assert.IsNotNull(exception);
+    Assert.AreEqual("Invoice Orchestration Dependency Exception", exception.Message);
+    Assert.AreSame(innerException, exception.InnerException);
   }
 
   #endregion
@@ -453,21 +454,21 @@ public sealed class InvoiceExceptionTests
   /// <summary>
   /// Verifies default constructor creates instance.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceOrchestrationDependencyValidationException_DefaultConstructor_CreatesInstance()
   {
     // Act
     var exception = new InvoiceOrchestrationDependencyValidationException();
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.IsType<InvoiceOrchestrationDependencyValidationException>(exception);
+    Assert.IsNotNull(exception);
+    Assert.IsExactInstanceOfType<InvoiceOrchestrationDependencyValidationException>(exception);
   }
 
   /// <summary>
   /// Verifies constructor with inner exception sets properties correctly.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceOrchestrationDependencyValidationException_InnerExceptionConstructor_SetsPropertiesCorrectly()
   {
     // Arrange
@@ -477,9 +478,9 @@ public sealed class InvoiceExceptionTests
     var exception = new InvoiceOrchestrationDependencyValidationException(innerException);
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.Equal("Invoice Orchestration Dependency Validation Exception", exception.Message);
-    Assert.Same(innerException, exception.InnerException);
+    Assert.IsNotNull(exception);
+    Assert.AreEqual("Invoice Orchestration Dependency Validation Exception", exception.Message);
+    Assert.AreSame(innerException, exception.InnerException);
   }
 
   #endregion
@@ -489,21 +490,21 @@ public sealed class InvoiceExceptionTests
   /// <summary>
   /// Verifies default constructor creates instance.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceOrchestrationServiceException_DefaultConstructor_CreatesInstance()
   {
     // Act
     var exception = new InvoiceOrchestrationServiceException();
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.IsType<InvoiceOrchestrationServiceException>(exception);
+    Assert.IsNotNull(exception);
+    Assert.IsExactInstanceOfType<InvoiceOrchestrationServiceException>(exception);
   }
 
   /// <summary>
   /// Verifies constructor with inner exception sets properties correctly.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceOrchestrationServiceException_InnerExceptionConstructor_SetsPropertiesCorrectly()
   {
     // Arrange
@@ -513,9 +514,9 @@ public sealed class InvoiceExceptionTests
     var exception = new InvoiceOrchestrationServiceException(innerException);
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.Equal("Invoice Orchestration Service Exception", exception.Message);
-    Assert.Same(innerException, exception.InnerException);
+    Assert.IsNotNull(exception);
+    Assert.AreEqual("Invoice Orchestration Service Exception", exception.Message);
+    Assert.AreSame(innerException, exception.InnerException);
   }
 
   #endregion
@@ -525,21 +526,21 @@ public sealed class InvoiceExceptionTests
   /// <summary>
   /// Verifies default constructor creates instance.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceProcessingServiceValidationException_DefaultConstructor_CreatesInstance()
   {
     // Act
     var exception = new InvoiceProcessingServiceValidationException();
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.IsType<InvoiceProcessingServiceValidationException>(exception);
+    Assert.IsNotNull(exception);
+    Assert.IsExactInstanceOfType<InvoiceProcessingServiceValidationException>(exception);
   }
 
   /// <summary>
   /// Verifies constructor with inner exception sets properties correctly.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceProcessingServiceValidationException_InnerExceptionConstructor_SetsPropertiesCorrectly()
   {
     // Arrange
@@ -549,9 +550,9 @@ public sealed class InvoiceExceptionTests
     var exception = new InvoiceProcessingServiceValidationException(innerException);
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.Equal("Invoice Processing Validation Exception", exception.Message);
-    Assert.Same(innerException, exception.InnerException);
+    Assert.IsNotNull(exception);
+    Assert.AreEqual("Invoice Processing Validation Exception", exception.Message);
+    Assert.AreSame(innerException, exception.InnerException);
   }
 
   #endregion
@@ -561,21 +562,21 @@ public sealed class InvoiceExceptionTests
   /// <summary>
   /// Verifies default constructor creates instance.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceProcessingServiceDependencyException_DefaultConstructor_CreatesInstance()
   {
     // Act
     var exception = new InvoiceProcessingServiceDependencyException();
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.IsType<InvoiceProcessingServiceDependencyException>(exception);
+    Assert.IsNotNull(exception);
+    Assert.IsExactInstanceOfType<InvoiceProcessingServiceDependencyException>(exception);
   }
 
   /// <summary>
   /// Verifies constructor with inner exception sets properties correctly.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceProcessingServiceDependencyException_InnerExceptionConstructor_SetsPropertiesCorrectly()
   {
     // Arrange
@@ -585,9 +586,9 @@ public sealed class InvoiceExceptionTests
     var exception = new InvoiceProcessingServiceDependencyException(innerException);
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.Equal("Invoice Processing Dependency Exception", exception.Message);
-    Assert.Same(innerException, exception.InnerException);
+    Assert.IsNotNull(exception);
+    Assert.AreEqual("Invoice Processing Dependency Exception", exception.Message);
+    Assert.AreSame(innerException, exception.InnerException);
   }
 
   #endregion
@@ -597,21 +598,21 @@ public sealed class InvoiceExceptionTests
   /// <summary>
   /// Verifies default constructor creates instance.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceProcessingServiceDependencyValidationException_DefaultConstructor_CreatesInstance()
   {
     // Act
     var exception = new InvoiceProcessingServiceDependencyValidationException();
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.IsType<InvoiceProcessingServiceDependencyValidationException>(exception);
+    Assert.IsNotNull(exception);
+    Assert.IsExactInstanceOfType<InvoiceProcessingServiceDependencyValidationException>(exception);
   }
 
   /// <summary>
   /// Verifies constructor with inner exception sets properties correctly.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceProcessingServiceDependencyValidationException_InnerExceptionConstructor_SetsPropertiesCorrectly()
   {
     // Arrange
@@ -621,9 +622,9 @@ public sealed class InvoiceExceptionTests
     var exception = new InvoiceProcessingServiceDependencyValidationException(innerException);
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.Equal("Invoice Processing Dependency Validation Exception", exception.Message);
-    Assert.Same(innerException, exception.InnerException);
+    Assert.IsNotNull(exception);
+    Assert.AreEqual("Invoice Processing Dependency Validation Exception", exception.Message);
+    Assert.AreSame(innerException, exception.InnerException);
   }
 
   #endregion
@@ -633,21 +634,21 @@ public sealed class InvoiceExceptionTests
   /// <summary>
   /// Verifies default constructor creates instance.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceProcessingServiceException_DefaultConstructor_CreatesInstance()
   {
     // Act
     var exception = new InvoiceProcessingServiceException();
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.IsType<InvoiceProcessingServiceException>(exception);
+    Assert.IsNotNull(exception);
+    Assert.IsExactInstanceOfType<InvoiceProcessingServiceException>(exception);
   }
 
   /// <summary>
   /// Verifies constructor with inner exception sets properties correctly.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void InvoiceProcessingServiceException_InnerExceptionConstructor_SetsPropertiesCorrectly()
   {
     // Arrange
@@ -657,9 +658,9 @@ public sealed class InvoiceExceptionTests
     var exception = new InvoiceProcessingServiceException(innerException);
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.Equal("Invoice Processing Exception", exception.Message);
-    Assert.Same(innerException, exception.InnerException);
+    Assert.IsNotNull(exception);
+    Assert.AreEqual("Invoice Processing Exception", exception.Message);
+    Assert.AreSame(innerException, exception.InnerException);
   }
 
   #endregion
@@ -669,85 +670,85 @@ public sealed class InvoiceExceptionTests
   /// <summary>
   /// Verifies all inner exceptions inherit from Exception base class.
   /// </summary>
-  [Theory]
-  [InlineData(typeof(InvoiceIdNotSetException))]
-  [InlineData(typeof(InvoiceDescriptionNotSetException))]
-  [InlineData(typeof(InvoicePaymentInformationNotCorrectException))]
-  [InlineData(typeof(InvoicePhotoLocationNotCorrectException))]
-  [InlineData(typeof(InvoiceTimeInformationNotCorrectException))]
+  [TestMethod]
+  [DataRow(typeof(InvoiceIdNotSetException))]
+  [DataRow(typeof(InvoiceDescriptionNotSetException))]
+  [DataRow(typeof(InvoicePaymentInformationNotCorrectException))]
+  [DataRow(typeof(InvoicePhotoLocationNotCorrectException))]
+  [DataRow(typeof(InvoiceTimeInformationNotCorrectException))]
   public void InnerExceptions_InheritFromException_TypeVerification(Type exceptionType)
   {
     // Assert
-    Assert.True(typeof(Exception).IsAssignableFrom(exceptionType));
+    Assert.IsTrue(typeof(Exception).IsAssignableFrom(exceptionType));
   }
 
   /// <summary>
   /// Verifies all foundation exceptions inherit from Exception base class.
   /// </summary>
-  [Theory]
-  [InlineData(typeof(InvoiceFoundationValidationException))]
-  [InlineData(typeof(InvoiceFoundationDependencyException))]
-  [InlineData(typeof(InvoiceFoundationDependencyValidationException))]
-  [InlineData(typeof(InvoiceFoundationServiceException))]
+  [TestMethod]
+  [DataRow(typeof(InvoiceFoundationValidationException))]
+  [DataRow(typeof(InvoiceFoundationDependencyException))]
+  [DataRow(typeof(InvoiceFoundationDependencyValidationException))]
+  [DataRow(typeof(InvoiceFoundationServiceException))]
   public void FoundationExceptions_InheritFromException_TypeVerification(Type exceptionType)
   {
     // Assert
-    Assert.True(typeof(Exception).IsAssignableFrom(exceptionType));
+    Assert.IsTrue(typeof(Exception).IsAssignableFrom(exceptionType));
   }
 
   /// <summary>
   /// Verifies all orchestration exceptions inherit from Exception base class.
   /// </summary>
-  [Theory]
-  [InlineData(typeof(InvoiceOrchestrationValidationException))]
-  [InlineData(typeof(InvoiceOrchestrationDependencyException))]
-  [InlineData(typeof(InvoiceOrchestrationDependencyValidationException))]
-  [InlineData(typeof(InvoiceOrchestrationServiceException))]
+  [TestMethod]
+  [DataRow(typeof(InvoiceOrchestrationValidationException))]
+  [DataRow(typeof(InvoiceOrchestrationDependencyException))]
+  [DataRow(typeof(InvoiceOrchestrationDependencyValidationException))]
+  [DataRow(typeof(InvoiceOrchestrationServiceException))]
   public void OrchestrationExceptions_InheritFromException_TypeVerification(Type exceptionType)
   {
     // Assert
-    Assert.True(typeof(Exception).IsAssignableFrom(exceptionType));
+    Assert.IsTrue(typeof(Exception).IsAssignableFrom(exceptionType));
   }
 
   /// <summary>
   /// Verifies all processing exceptions inherit from Exception base class.
   /// </summary>
-  [Theory]
-  [InlineData(typeof(InvoiceProcessingServiceValidationException))]
-  [InlineData(typeof(InvoiceProcessingServiceDependencyException))]
-  [InlineData(typeof(InvoiceProcessingServiceDependencyValidationException))]
-  [InlineData(typeof(InvoiceProcessingServiceException))]
+  [TestMethod]
+  [DataRow(typeof(InvoiceProcessingServiceValidationException))]
+  [DataRow(typeof(InvoiceProcessingServiceDependencyException))]
+  [DataRow(typeof(InvoiceProcessingServiceDependencyValidationException))]
+  [DataRow(typeof(InvoiceProcessingServiceException))]
   public void ProcessingExceptions_InheritFromException_TypeVerification(Type exceptionType)
   {
     // Assert
-    Assert.True(typeof(Exception).IsAssignableFrom(exceptionType));
+    Assert.IsTrue(typeof(Exception).IsAssignableFrom(exceptionType));
   }
 
   /// <summary>
   /// Verifies all invoice exceptions have the Serializable attribute.
   /// </summary>
-  [Theory]
-  [InlineData(typeof(InvoiceIdNotSetException))]
-  [InlineData(typeof(InvoiceDescriptionNotSetException))]
-  [InlineData(typeof(InvoicePaymentInformationNotCorrectException))]
-  [InlineData(typeof(InvoicePhotoLocationNotCorrectException))]
-  [InlineData(typeof(InvoiceTimeInformationNotCorrectException))]
-  [InlineData(typeof(InvoiceFoundationValidationException))]
-  [InlineData(typeof(InvoiceFoundationDependencyException))]
-  [InlineData(typeof(InvoiceFoundationDependencyValidationException))]
-  [InlineData(typeof(InvoiceFoundationServiceException))]
-  [InlineData(typeof(InvoiceOrchestrationValidationException))]
-  [InlineData(typeof(InvoiceOrchestrationDependencyException))]
-  [InlineData(typeof(InvoiceOrchestrationDependencyValidationException))]
-  [InlineData(typeof(InvoiceOrchestrationServiceException))]
-  [InlineData(typeof(InvoiceProcessingServiceValidationException))]
-  [InlineData(typeof(InvoiceProcessingServiceDependencyException))]
-  [InlineData(typeof(InvoiceProcessingServiceDependencyValidationException))]
-  [InlineData(typeof(InvoiceProcessingServiceException))]
+  [TestMethod]
+  [DataRow(typeof(InvoiceIdNotSetException))]
+  [DataRow(typeof(InvoiceDescriptionNotSetException))]
+  [DataRow(typeof(InvoicePaymentInformationNotCorrectException))]
+  [DataRow(typeof(InvoicePhotoLocationNotCorrectException))]
+  [DataRow(typeof(InvoiceTimeInformationNotCorrectException))]
+  [DataRow(typeof(InvoiceFoundationValidationException))]
+  [DataRow(typeof(InvoiceFoundationDependencyException))]
+  [DataRow(typeof(InvoiceFoundationDependencyValidationException))]
+  [DataRow(typeof(InvoiceFoundationServiceException))]
+  [DataRow(typeof(InvoiceOrchestrationValidationException))]
+  [DataRow(typeof(InvoiceOrchestrationDependencyException))]
+  [DataRow(typeof(InvoiceOrchestrationDependencyValidationException))]
+  [DataRow(typeof(InvoiceOrchestrationServiceException))]
+  [DataRow(typeof(InvoiceProcessingServiceValidationException))]
+  [DataRow(typeof(InvoiceProcessingServiceDependencyException))]
+  [DataRow(typeof(InvoiceProcessingServiceDependencyValidationException))]
+  [DataRow(typeof(InvoiceProcessingServiceException))]
   public void AllExceptions_HaveSerializableAttribute_AttributeVerification(Type exceptionType)
   {
     // Assert
-    Assert.True(Attribute.IsDefined(exceptionType, typeof(SerializableAttribute)));
+    Assert.IsTrue(Attribute.IsDefined(exceptionType, typeof(SerializableAttribute)));
   }
 
   #endregion
@@ -757,7 +758,7 @@ public sealed class InvoiceExceptionTests
   /// <summary>
   /// Verifies full exception chain from Processing to Foundation layers.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void ExceptionChain_ProcessingToFoundation_PreservesFullChain()
   {
     // Arrange
@@ -770,26 +771,26 @@ public sealed class InvoiceExceptionTests
     var processingException = new InvoiceProcessingServiceValidationException(orchestrationException);
 
     // Assert
-    Assert.NotNull(processingException.InnerException);
-    Assert.IsType<InvoiceOrchestrationValidationException>(processingException.InnerException);
+    Assert.IsNotNull(processingException.InnerException);
+    Assert.IsExactInstanceOfType<InvoiceOrchestrationValidationException>(processingException.InnerException);
 
     var orchestration = processingException.InnerException;
-    Assert.NotNull(orchestration.InnerException);
-    Assert.IsType<InvoiceFoundationValidationException>(orchestration.InnerException);
+    Assert.IsNotNull(orchestration.InnerException);
+    Assert.IsExactInstanceOfType<InvoiceFoundationValidationException>(orchestration.InnerException);
 
     var foundation = orchestration.InnerException;
-    Assert.NotNull(foundation.InnerException);
-    Assert.IsType<InvoiceIdNotSetException>(foundation.InnerException);
+    Assert.IsNotNull(foundation.InnerException);
+    Assert.IsExactInstanceOfType<InvoiceIdNotSetException>(foundation.InnerException);
 
     var inner = foundation.InnerException;
-    Assert.NotNull(inner.InnerException);
-    Assert.IsType<ArgumentException>(inner.InnerException);
+    Assert.IsNotNull(inner.InnerException);
+    Assert.IsExactInstanceOfType<ArgumentException>(inner.InnerException);
   }
 
   /// <summary>
   /// Verifies dependency exception chain preservation.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void DependencyExceptionChain_ProcessingToFoundation_PreservesFullChain()
   {
     // Arrange
@@ -801,16 +802,16 @@ public sealed class InvoiceExceptionTests
     var processingException = new InvoiceProcessingServiceDependencyException(orchestrationException);
 
     // Assert
-    Assert.NotNull(processingException.InnerException);
-    Assert.IsType<InvoiceOrchestrationDependencyException>(processingException.InnerException);
+    Assert.IsNotNull(processingException.InnerException);
+    Assert.IsExactInstanceOfType<InvoiceOrchestrationDependencyException>(processingException.InnerException);
 
     var orchestration = processingException.InnerException;
-    Assert.NotNull(orchestration.InnerException);
-    Assert.IsType<InvoiceFoundationDependencyException>(orchestration.InnerException);
+    Assert.IsNotNull(orchestration.InnerException);
+    Assert.IsExactInstanceOfType<InvoiceFoundationDependencyException>(orchestration.InnerException);
 
     var foundation = orchestration.InnerException;
-    Assert.NotNull(foundation.InnerException);
-    Assert.IsType<InvalidOperationException>(foundation.InnerException);
+    Assert.IsNotNull(foundation.InnerException);
+    Assert.IsExactInstanceOfType<InvalidOperationException>(foundation.InnerException);
   }
 
   #endregion

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/DDD/Exceptions/MerchantExceptionTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/DDD/Exceptions/MerchantExceptionTests.cs
@@ -6,13 +6,14 @@ using arolariu.Backend.Domain.Invoices.DDD.Entities.Merchants.Exceptions.Inner;
 using arolariu.Backend.Domain.Invoices.DDD.Entities.Merchants.Exceptions.Outer.Foundation;
 using arolariu.Backend.Domain.Invoices.DDD.Entities.Merchants.Exceptions.Outer.Orchestration;
 
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 /// <summary>
 /// Comprehensive unit tests for all Merchant exception classes.
 /// Tests validate all constructors, serialization, and inheritance.
 /// Method naming follows MethodName_Condition_ExpectedResult pattern per repository standards.
 /// </summary>
+[TestClass]
 public sealed class MerchantExceptionTests
 {
   #region MerchantIdNotSetException Tests
@@ -20,22 +21,22 @@ public sealed class MerchantExceptionTests
   /// <summary>
   /// Verifies default constructor creates instance.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void MerchantIdNotSetException_DefaultConstructor_CreatesInstance()
   {
     // Act
     var exception = new MerchantIdNotSetException();
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.IsType<MerchantIdNotSetException>(exception);
-    Assert.IsAssignableFrom<Exception>(exception);
+    Assert.IsNotNull(exception);
+    Assert.IsExactInstanceOfType<MerchantIdNotSetException>(exception);
+    Assert.IsInstanceOfType<Exception>(exception);
   }
 
   /// <summary>
   /// Verifies constructor with inner exception sets message and inner exception.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void MerchantIdNotSetException_InnerExceptionConstructor_SetsPropertiesCorrectly()
   {
     // Arrange
@@ -45,23 +46,23 @@ public sealed class MerchantExceptionTests
     var exception = new MerchantIdNotSetException(innerException);
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.Equal("Merchant identifier not set Exception", exception.Message);
-    Assert.Same(innerException, exception.InnerException);
+    Assert.IsNotNull(exception);
+    Assert.AreEqual("Merchant identifier not set Exception", exception.Message);
+    Assert.AreSame(innerException, exception.InnerException);
   }
 
   /// <summary>
   /// Verifies constructor with null inner exception works.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void MerchantIdNotSetException_NullInnerException_CreatesInstance()
   {
     // Act
     var exception = new MerchantIdNotSetException(null!);
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.Null(exception.InnerException);
+    Assert.IsNotNull(exception);
+    Assert.IsNull(exception.InnerException);
   }
 
   #endregion
@@ -71,21 +72,21 @@ public sealed class MerchantExceptionTests
   /// <summary>
   /// Verifies default constructor creates instance.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void MerchantParentCompanyIdNotSetException_DefaultConstructor_CreatesInstance()
   {
     // Act
     var exception = new MerchantParentCompanyIdNotSetException();
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.IsType<MerchantParentCompanyIdNotSetException>(exception);
+    Assert.IsNotNull(exception);
+    Assert.IsExactInstanceOfType<MerchantParentCompanyIdNotSetException>(exception);
   }
 
   /// <summary>
   /// Verifies constructor with inner exception sets properties correctly.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void MerchantParentCompanyIdNotSetException_InnerExceptionConstructor_SetsPropertiesCorrectly()
   {
     // Arrange
@@ -95,9 +96,9 @@ public sealed class MerchantExceptionTests
     var exception = new MerchantParentCompanyIdNotSetException(innerException);
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.Equal("Merchant parent company identifier not set Exception", exception.Message);
-    Assert.Same(innerException, exception.InnerException);
+    Assert.IsNotNull(exception);
+    Assert.AreEqual("Merchant parent company identifier not set Exception", exception.Message);
+    Assert.AreSame(innerException, exception.InnerException);
   }
 
   #endregion
@@ -107,21 +108,21 @@ public sealed class MerchantExceptionTests
   /// <summary>
   /// Verifies default constructor creates instance.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void MerchantFoundationServiceValidationException_DefaultConstructor_CreatesInstance()
   {
     // Act
     var exception = new MerchantFoundationServiceValidationException();
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.IsType<MerchantFoundationServiceValidationException>(exception);
+    Assert.IsNotNull(exception);
+    Assert.IsExactInstanceOfType<MerchantFoundationServiceValidationException>(exception);
   }
 
   /// <summary>
   /// Verifies constructor with inner exception sets properties correctly.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void MerchantFoundationServiceValidationException_InnerExceptionConstructor_SetsPropertiesCorrectly()
   {
     // Arrange
@@ -131,15 +132,15 @@ public sealed class MerchantExceptionTests
     var exception = new MerchantFoundationServiceValidationException(innerException);
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.Equal("Merchant Foundation Service Validation Exception", exception.Message);
-    Assert.Same(innerException, exception.InnerException);
+    Assert.IsNotNull(exception);
+    Assert.AreEqual("Merchant Foundation Service Validation Exception", exception.Message);
+    Assert.AreSame(innerException, exception.InnerException);
   }
 
   /// <summary>
   /// Verifies constructor with nested inner exceptions preserves exception chain.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void MerchantFoundationServiceValidationException_NestedInnerExceptions_PreservesExceptionChain()
   {
     // Arrange
@@ -150,9 +151,9 @@ public sealed class MerchantExceptionTests
     var exception = new MerchantFoundationServiceValidationException(innerException);
 
     // Assert
-    Assert.NotNull(exception.InnerException);
-    Assert.NotNull(exception.InnerException.InnerException);
-    Assert.IsType<ArgumentException>(exception.InnerException.InnerException);
+    Assert.IsNotNull(exception.InnerException);
+    Assert.IsNotNull(exception.InnerException.InnerException);
+    Assert.IsExactInstanceOfType<ArgumentException>(exception.InnerException.InnerException);
   }
 
   #endregion
@@ -162,21 +163,21 @@ public sealed class MerchantExceptionTests
   /// <summary>
   /// Verifies default constructor creates instance.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void MerchantFoundationServiceDependencyException_DefaultConstructor_CreatesInstance()
   {
     // Act
     var exception = new MerchantFoundationServiceDependencyException();
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.IsType<MerchantFoundationServiceDependencyException>(exception);
+    Assert.IsNotNull(exception);
+    Assert.IsExactInstanceOfType<MerchantFoundationServiceDependencyException>(exception);
   }
 
   /// <summary>
   /// Verifies constructor with inner exception sets properties correctly.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void MerchantFoundationServiceDependencyException_InnerExceptionConstructor_SetsPropertiesCorrectly()
   {
     // Arrange
@@ -186,9 +187,9 @@ public sealed class MerchantExceptionTests
     var exception = new MerchantFoundationServiceDependencyException(innerException);
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.Equal("Merchant Foundation Service Dependency Exception", exception.Message);
-    Assert.Same(innerException, exception.InnerException);
+    Assert.IsNotNull(exception);
+    Assert.AreEqual("Merchant Foundation Service Dependency Exception", exception.Message);
+    Assert.AreSame(innerException, exception.InnerException);
   }
 
   #endregion
@@ -198,21 +199,21 @@ public sealed class MerchantExceptionTests
   /// <summary>
   /// Verifies default constructor creates instance.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void MerchantFoundationServiceDependencyValidationException_DefaultConstructor_CreatesInstance()
   {
     // Act
     var exception = new MerchantFoundationServiceDependencyValidationException();
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.IsType<MerchantFoundationServiceDependencyValidationException>(exception);
+    Assert.IsNotNull(exception);
+    Assert.IsExactInstanceOfType<MerchantFoundationServiceDependencyValidationException>(exception);
   }
 
   /// <summary>
   /// Verifies constructor with inner exception sets properties correctly.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void MerchantFoundationServiceDependencyValidationException_InnerExceptionConstructor_SetsPropertiesCorrectly()
   {
     // Arrange
@@ -222,9 +223,9 @@ public sealed class MerchantExceptionTests
     var exception = new MerchantFoundationServiceDependencyValidationException(innerException);
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.Equal("Merchant Foundation Service Dependency Validation Exception", exception.Message);
-    Assert.Same(innerException, exception.InnerException);
+    Assert.IsNotNull(exception);
+    Assert.AreEqual("Merchant Foundation Service Dependency Validation Exception", exception.Message);
+    Assert.AreSame(innerException, exception.InnerException);
   }
 
   #endregion
@@ -234,21 +235,21 @@ public sealed class MerchantExceptionTests
   /// <summary>
   /// Verifies default constructor creates instance.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void MerchantFoundationServiceException_DefaultConstructor_CreatesInstance()
   {
     // Act
     var exception = new MerchantFoundationServiceException();
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.IsType<MerchantFoundationServiceException>(exception);
+    Assert.IsNotNull(exception);
+    Assert.IsExactInstanceOfType<MerchantFoundationServiceException>(exception);
   }
 
   /// <summary>
   /// Verifies constructor with inner exception sets properties correctly.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void MerchantFoundationServiceException_InnerExceptionConstructor_SetsPropertiesCorrectly()
   {
     // Arrange
@@ -258,9 +259,9 @@ public sealed class MerchantExceptionTests
     var exception = new MerchantFoundationServiceException(innerException);
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.Equal("Merchant Foundation Service Exception", exception.Message);
-    Assert.Same(innerException, exception.InnerException);
+    Assert.IsNotNull(exception);
+    Assert.AreEqual("Merchant Foundation Service Exception", exception.Message);
+    Assert.AreSame(innerException, exception.InnerException);
   }
 
   #endregion
@@ -270,21 +271,21 @@ public sealed class MerchantExceptionTests
   /// <summary>
   /// Verifies default constructor creates instance.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void MerchantOrchestrationServiceValidationException_DefaultConstructor_CreatesInstance()
   {
     // Act
     var exception = new MerchantOrchestrationServiceValidationException();
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.IsType<MerchantOrchestrationServiceValidationException>(exception);
+    Assert.IsNotNull(exception);
+    Assert.IsExactInstanceOfType<MerchantOrchestrationServiceValidationException>(exception);
   }
 
   /// <summary>
   /// Verifies constructor with inner exception sets properties correctly.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void MerchantOrchestrationServiceValidationException_InnerExceptionConstructor_SetsPropertiesCorrectly()
   {
     // Arrange
@@ -294,9 +295,9 @@ public sealed class MerchantExceptionTests
     var exception = new MerchantOrchestrationServiceValidationException(innerException);
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.Equal("Merchant Orchestration Service Validation Exception", exception.Message);
-    Assert.Same(innerException, exception.InnerException);
+    Assert.IsNotNull(exception);
+    Assert.AreEqual("Merchant Orchestration Service Validation Exception", exception.Message);
+    Assert.AreSame(innerException, exception.InnerException);
   }
 
   #endregion
@@ -306,21 +307,21 @@ public sealed class MerchantExceptionTests
   /// <summary>
   /// Verifies default constructor creates instance.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void MerchantOrchestrationServiceDependencyException_DefaultConstructor_CreatesInstance()
   {
     // Act
     var exception = new MerchantOrchestrationServiceDependencyException();
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.IsType<MerchantOrchestrationServiceDependencyException>(exception);
+    Assert.IsNotNull(exception);
+    Assert.IsExactInstanceOfType<MerchantOrchestrationServiceDependencyException>(exception);
   }
 
   /// <summary>
   /// Verifies constructor with inner exception sets properties correctly.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void MerchantOrchestrationServiceDependencyException_InnerExceptionConstructor_SetsPropertiesCorrectly()
   {
     // Arrange
@@ -330,9 +331,9 @@ public sealed class MerchantExceptionTests
     var exception = new MerchantOrchestrationServiceDependencyException(innerException);
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.Equal("Merchant Orchestration Service Dependency Exception", exception.Message);
-    Assert.Same(innerException, exception.InnerException);
+    Assert.IsNotNull(exception);
+    Assert.AreEqual("Merchant Orchestration Service Dependency Exception", exception.Message);
+    Assert.AreSame(innerException, exception.InnerException);
   }
 
   #endregion
@@ -342,21 +343,21 @@ public sealed class MerchantExceptionTests
   /// <summary>
   /// Verifies default constructor creates instance.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void MerchantOrchestrationServiceDependencyValidationException_DefaultConstructor_CreatesInstance()
   {
     // Act
     var exception = new MerchantOrchestrationServiceDependencyValidationException();
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.IsType<MerchantOrchestrationServiceDependencyValidationException>(exception);
+    Assert.IsNotNull(exception);
+    Assert.IsExactInstanceOfType<MerchantOrchestrationServiceDependencyValidationException>(exception);
   }
 
   /// <summary>
   /// Verifies constructor with inner exception sets properties correctly.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void MerchantOrchestrationServiceDependencyValidationException_InnerExceptionConstructor_SetsPropertiesCorrectly()
   {
     // Arrange
@@ -366,9 +367,9 @@ public sealed class MerchantExceptionTests
     var exception = new MerchantOrchestrationServiceDependencyValidationException(innerException);
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.Equal("Merchant Orchestration Service Dependency Validation Exception", exception.Message);
-    Assert.Same(innerException, exception.InnerException);
+    Assert.IsNotNull(exception);
+    Assert.AreEqual("Merchant Orchestration Service Dependency Validation Exception", exception.Message);
+    Assert.AreSame(innerException, exception.InnerException);
   }
 
   #endregion
@@ -378,21 +379,21 @@ public sealed class MerchantExceptionTests
   /// <summary>
   /// Verifies default constructor creates instance.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void MerchantOrchestrationServiceException_DefaultConstructor_CreatesInstance()
   {
     // Act
     var exception = new MerchantOrchestrationServiceException();
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.IsType<MerchantOrchestrationServiceException>(exception);
+    Assert.IsNotNull(exception);
+    Assert.IsExactInstanceOfType<MerchantOrchestrationServiceException>(exception);
   }
 
   /// <summary>
   /// Verifies constructor with inner exception sets properties correctly.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void MerchantOrchestrationServiceException_InnerExceptionConstructor_SetsPropertiesCorrectly()
   {
     // Arrange
@@ -402,9 +403,9 @@ public sealed class MerchantExceptionTests
     var exception = new MerchantOrchestrationServiceException(innerException);
 
     // Assert
-    Assert.NotNull(exception);
-    Assert.Equal("Merchant Orchestration Service Exception", exception.Message);
-    Assert.Same(innerException, exception.InnerException);
+    Assert.IsNotNull(exception);
+    Assert.AreEqual("Merchant Orchestration Service Exception", exception.Message);
+    Assert.AreSame(innerException, exception.InnerException);
   }
 
   #endregion
@@ -414,61 +415,61 @@ public sealed class MerchantExceptionTests
   /// <summary>
   /// Verifies all inner exceptions inherit from Exception base class.
   /// </summary>
-  [Theory]
-  [InlineData(typeof(MerchantIdNotSetException))]
-  [InlineData(typeof(MerchantParentCompanyIdNotSetException))]
+  [TestMethod]
+  [DataRow(typeof(MerchantIdNotSetException))]
+  [DataRow(typeof(MerchantParentCompanyIdNotSetException))]
   public void InnerExceptions_InheritFromException_TypeVerification(Type exceptionType)
   {
     // Assert
-    Assert.True(typeof(Exception).IsAssignableFrom(exceptionType));
+    Assert.IsTrue(typeof(Exception).IsAssignableFrom(exceptionType));
   }
 
   /// <summary>
   /// Verifies all foundation exceptions inherit from Exception base class.
   /// </summary>
-  [Theory]
-  [InlineData(typeof(MerchantFoundationServiceValidationException))]
-  [InlineData(typeof(MerchantFoundationServiceDependencyException))]
-  [InlineData(typeof(MerchantFoundationServiceDependencyValidationException))]
-  [InlineData(typeof(MerchantFoundationServiceException))]
+  [TestMethod]
+  [DataRow(typeof(MerchantFoundationServiceValidationException))]
+  [DataRow(typeof(MerchantFoundationServiceDependencyException))]
+  [DataRow(typeof(MerchantFoundationServiceDependencyValidationException))]
+  [DataRow(typeof(MerchantFoundationServiceException))]
   public void FoundationExceptions_InheritFromException_TypeVerification(Type exceptionType)
   {
     // Assert
-    Assert.True(typeof(Exception).IsAssignableFrom(exceptionType));
+    Assert.IsTrue(typeof(Exception).IsAssignableFrom(exceptionType));
   }
 
   /// <summary>
   /// Verifies all orchestration exceptions inherit from Exception base class.
   /// </summary>
-  [Theory]
-  [InlineData(typeof(MerchantOrchestrationServiceValidationException))]
-  [InlineData(typeof(MerchantOrchestrationServiceDependencyException))]
-  [InlineData(typeof(MerchantOrchestrationServiceDependencyValidationException))]
-  [InlineData(typeof(MerchantOrchestrationServiceException))]
+  [TestMethod]
+  [DataRow(typeof(MerchantOrchestrationServiceValidationException))]
+  [DataRow(typeof(MerchantOrchestrationServiceDependencyException))]
+  [DataRow(typeof(MerchantOrchestrationServiceDependencyValidationException))]
+  [DataRow(typeof(MerchantOrchestrationServiceException))]
   public void OrchestrationExceptions_InheritFromException_TypeVerification(Type exceptionType)
   {
     // Assert
-    Assert.True(typeof(Exception).IsAssignableFrom(exceptionType));
+    Assert.IsTrue(typeof(Exception).IsAssignableFrom(exceptionType));
   }
 
   /// <summary>
   /// Verifies all merchant exceptions have the Serializable attribute.
   /// </summary>
-  [Theory]
-  [InlineData(typeof(MerchantIdNotSetException))]
-  [InlineData(typeof(MerchantParentCompanyIdNotSetException))]
-  [InlineData(typeof(MerchantFoundationServiceValidationException))]
-  [InlineData(typeof(MerchantFoundationServiceDependencyException))]
-  [InlineData(typeof(MerchantFoundationServiceDependencyValidationException))]
-  [InlineData(typeof(MerchantFoundationServiceException))]
-  [InlineData(typeof(MerchantOrchestrationServiceValidationException))]
-  [InlineData(typeof(MerchantOrchestrationServiceDependencyException))]
-  [InlineData(typeof(MerchantOrchestrationServiceDependencyValidationException))]
-  [InlineData(typeof(MerchantOrchestrationServiceException))]
+  [TestMethod]
+  [DataRow(typeof(MerchantIdNotSetException))]
+  [DataRow(typeof(MerchantParentCompanyIdNotSetException))]
+  [DataRow(typeof(MerchantFoundationServiceValidationException))]
+  [DataRow(typeof(MerchantFoundationServiceDependencyException))]
+  [DataRow(typeof(MerchantFoundationServiceDependencyValidationException))]
+  [DataRow(typeof(MerchantFoundationServiceException))]
+  [DataRow(typeof(MerchantOrchestrationServiceValidationException))]
+  [DataRow(typeof(MerchantOrchestrationServiceDependencyException))]
+  [DataRow(typeof(MerchantOrchestrationServiceDependencyValidationException))]
+  [DataRow(typeof(MerchantOrchestrationServiceException))]
   public void AllExceptions_HaveSerializableAttribute_AttributeVerification(Type exceptionType)
   {
     // Assert
-    Assert.True(Attribute.IsDefined(exceptionType, typeof(SerializableAttribute)));
+    Assert.IsTrue(Attribute.IsDefined(exceptionType, typeof(SerializableAttribute)));
   }
 
   #endregion
@@ -478,7 +479,7 @@ public sealed class MerchantExceptionTests
   /// <summary>
   /// Verifies full exception chain from Orchestration to Foundation layers.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void ExceptionChain_OrchestrationToFoundation_PreservesFullChain()
   {
     // Arrange
@@ -490,22 +491,22 @@ public sealed class MerchantExceptionTests
     var orchestrationException = new MerchantOrchestrationServiceValidationException(foundationException);
 
     // Assert
-    Assert.NotNull(orchestrationException.InnerException);
-    Assert.IsType<MerchantFoundationServiceValidationException>(orchestrationException.InnerException);
+    Assert.IsNotNull(orchestrationException.InnerException);
+    Assert.IsExactInstanceOfType<MerchantFoundationServiceValidationException>(orchestrationException.InnerException);
 
     var foundation = orchestrationException.InnerException;
-    Assert.NotNull(foundation.InnerException);
-    Assert.IsType<MerchantIdNotSetException>(foundation.InnerException);
+    Assert.IsNotNull(foundation.InnerException);
+    Assert.IsExactInstanceOfType<MerchantIdNotSetException>(foundation.InnerException);
 
     var inner = foundation.InnerException;
-    Assert.NotNull(inner.InnerException);
-    Assert.IsType<ArgumentException>(inner.InnerException);
+    Assert.IsNotNull(inner.InnerException);
+    Assert.IsExactInstanceOfType<ArgumentException>(inner.InnerException);
   }
 
   /// <summary>
   /// Verifies dependency exception chain preservation.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void DependencyExceptionChain_OrchestrationToFoundation_PreservesFullChain()
   {
     // Arrange
@@ -516,12 +517,12 @@ public sealed class MerchantExceptionTests
     var orchestrationException = new MerchantOrchestrationServiceDependencyException(foundationException);
 
     // Assert
-    Assert.NotNull(orchestrationException.InnerException);
-    Assert.IsType<MerchantFoundationServiceDependencyException>(orchestrationException.InnerException);
+    Assert.IsNotNull(orchestrationException.InnerException);
+    Assert.IsExactInstanceOfType<MerchantFoundationServiceDependencyException>(orchestrationException.InnerException);
 
     var foundation = orchestrationException.InnerException;
-    Assert.NotNull(foundation.InnerException);
-    Assert.IsType<InvalidOperationException>(foundation.InnerException);
+    Assert.IsNotNull(foundation.InnerException);
+    Assert.IsExactInstanceOfType<InvalidOperationException>(foundation.InnerException);
   }
 
   #endregion

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/DDD/ValueObjects/PaymentInformationExtendedTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/DDD/ValueObjects/PaymentInformationExtendedTests.cs
@@ -5,11 +5,12 @@ using System;
 using arolariu.Backend.Common.DDD.ValueObjects;
 using arolariu.Backend.Domain.Invoices.DDD.ValueObjects;
 
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 /// <summary>
 /// Extended unit tests for the PaymentInformation value object.
 /// </summary>
+[TestClass]
 public sealed class PaymentInformationExtendedTests
 {
   #region PaymentInformation Property Tests
@@ -17,23 +18,23 @@ public sealed class PaymentInformationExtendedTests
   /// <summary>
   /// Validates default PaymentInformation creation.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void PaymentInformation_DefaultCreation_HasDefaultValues()
   {
     // Arrange & Act
     var payment = new PaymentInformation();
 
     // Assert
-    Assert.Equal(PaymentType.UNKNOWN, payment.PaymentType);
-    Assert.Equal(0.0m, payment.TotalCostAmount);
-    Assert.Equal(0.0m, payment.TotalTaxAmount);
-    Assert.NotEqual(default, payment.Currency);
+    Assert.AreEqual(PaymentType.UNKNOWN, payment.PaymentType);
+    Assert.AreEqual(0.0m, payment.TotalCostAmount);
+    Assert.AreEqual(0.0m, payment.TotalTaxAmount);
+    Assert.AreNotEqual(default, payment.Currency);
   }
 
   /// <summary>
   /// Validates TransactionDate property.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void PaymentInformation_SetTransactionDate_StoresValue()
   {
     // Arrange
@@ -44,13 +45,13 @@ public sealed class PaymentInformationExtendedTests
     payment.TransactionDate = date;
 
     // Assert
-    Assert.Equal(date, payment.TransactionDate);
+    Assert.AreEqual(date, payment.TransactionDate);
   }
 
   /// <summary>
   /// Validates PaymentType property.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void PaymentInformation_SetPaymentType_StoresValue()
   {
     // Arrange
@@ -60,13 +61,13 @@ public sealed class PaymentInformationExtendedTests
     payment.PaymentType = PaymentType.CARD;
 
     // Assert
-    Assert.Equal(PaymentType.CARD, payment.PaymentType);
+    Assert.AreEqual(PaymentType.CARD, payment.PaymentType);
   }
 
   /// <summary>
   /// Validates TotalCostAmount property.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void PaymentInformation_SetTotalCostAmount_StoresValue()
   {
     // Arrange
@@ -76,13 +77,13 @@ public sealed class PaymentInformationExtendedTests
     payment.TotalCostAmount = 150.99m;
 
     // Assert
-    Assert.Equal(150.99m, payment.TotalCostAmount);
+    Assert.AreEqual(150.99m, payment.TotalCostAmount);
   }
 
   /// <summary>
   /// Validates TotalTaxAmount property.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void PaymentInformation_SetTotalTaxAmount_StoresValue()
   {
     // Arrange
@@ -92,13 +93,13 @@ public sealed class PaymentInformationExtendedTests
     payment.TotalTaxAmount = 28.69m;
 
     // Assert
-    Assert.Equal(28.69m, payment.TotalTaxAmount);
+    Assert.AreEqual(28.69m, payment.TotalTaxAmount);
   }
 
   /// <summary>
   /// Validates Currency property.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void PaymentInformation_SetCurrency_StoresValue()
   {
     // Arrange
@@ -109,22 +110,22 @@ public sealed class PaymentInformationExtendedTests
     payment.Currency = currency;
 
     // Assert
-    Assert.Equal("Euro", payment.Currency.Name);
-    Assert.Equal("EUR", payment.Currency.Code);
+    Assert.AreEqual("Euro", payment.Currency.Name);
+    Assert.AreEqual("EUR", payment.Currency.Code);
   }
 
   /// <summary>
   /// Validates default Currency is Romanian Leu.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void PaymentInformation_DefaultCurrency_IsRomanianLeu()
   {
     // Arrange & Act
     var payment = new PaymentInformation();
 
     // Assert
-    Assert.Equal("Romanian Leu", payment.Currency.Name);
-    Assert.Equal("RON", payment.Currency.Code);
+    Assert.AreEqual("Romanian Leu", payment.Currency.Name);
+    Assert.AreEqual("RON", payment.Currency.Code);
   }
 
   #endregion
@@ -134,7 +135,7 @@ public sealed class PaymentInformationExtendedTests
   /// <summary>
   /// Validates all PaymentType enum values.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void PaymentType_AllValues_AreValid()
   {
     // Arrange
@@ -144,84 +145,84 @@ public sealed class PaymentInformationExtendedTests
     foreach (var type in paymentTypes)
     {
       var payment = new PaymentInformation { PaymentType = type };
-      Assert.Equal(type, payment.PaymentType);
+      Assert.AreEqual(type, payment.PaymentType);
     }
   }
 
   /// <summary>
   /// Validates PaymentType.UNKNOWN exists.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void PaymentType_Unknown_Exists()
   {
-    Assert.True(Enum.IsDefined<PaymentType>(PaymentType.UNKNOWN));
+    Assert.IsTrue(Enum.IsDefined<PaymentType>(PaymentType.UNKNOWN));
   }
 
   /// <summary>
   /// Validates PaymentType.CASH exists.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void PaymentType_Cash_Exists()
   {
-    Assert.True(Enum.IsDefined<PaymentType>(PaymentType.CASH));
+    Assert.IsTrue(Enum.IsDefined<PaymentType>(PaymentType.CASH));
   }
 
   /// <summary>
   /// Validates PaymentType.CARD exists.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void PaymentType_Card_Exists()
   {
-    Assert.True(Enum.IsDefined<PaymentType>(PaymentType.CARD));
+    Assert.IsTrue(Enum.IsDefined<PaymentType>(PaymentType.CARD));
   }
 
   /// <summary>
   /// Validates PaymentType.TRANSFER exists.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void PaymentType_Transfer_Exists()
   {
-    Assert.True(Enum.IsDefined<PaymentType>(PaymentType.TRANSFER));
+    Assert.IsTrue(Enum.IsDefined<PaymentType>(PaymentType.TRANSFER));
   }
 
   /// <summary>
   /// Validates PaymentType.MOBILEPAYMENT exists.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void PaymentType_MobilePayment_Exists()
   {
-    Assert.True(Enum.IsDefined<PaymentType>(PaymentType.MOBILEPAYMENT));
+    Assert.IsTrue(Enum.IsDefined<PaymentType>(PaymentType.MOBILEPAYMENT));
   }
 
   /// <summary>
   /// Validates PaymentType.VOUCHER exists.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void PaymentType_Voucher_Exists()
   {
-    Assert.True(Enum.IsDefined<PaymentType>(PaymentType.VOUCHER));
+    Assert.IsTrue(Enum.IsDefined<PaymentType>(PaymentType.VOUCHER));
   }
 
   /// <summary>
   /// Validates PaymentType.Other exists.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void PaymentType_Other_Exists()
   {
-    Assert.True(Enum.IsDefined<PaymentType>(PaymentType.Other));
+    Assert.IsTrue(Enum.IsDefined<PaymentType>(PaymentType.Other));
   }
 
   /// <summary>
   /// Validates PaymentType enum has expected count.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void PaymentType_HasExpectedValueCount()
   {
     // Arrange
     var values = Enum.GetValues<PaymentType>();
 
     // Assert - Should have 7 payment types
-    Assert.Equal(7, values.Length);
+    Assert.AreEqual(7, values.Length);
   }
 
   #endregion
@@ -231,33 +232,33 @@ public sealed class PaymentInformationExtendedTests
   /// <summary>
   /// Validates zero cost amount is allowed.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void PaymentInformation_ZeroCostAmount_IsAllowed()
   {
     // Arrange & Act
     var payment = new PaymentInformation { TotalCostAmount = 0 };
 
     // Assert
-    Assert.Equal(0, payment.TotalCostAmount);
+    Assert.AreEqual(0, payment.TotalCostAmount);
   }
 
   /// <summary>
   /// Validates large cost amount is allowed.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void PaymentInformation_LargeCostAmount_IsAllowed()
   {
     // Arrange & Act
     var payment = new PaymentInformation { TotalCostAmount = 999999.99m };
 
     // Assert
-    Assert.Equal(999999.99m, payment.TotalCostAmount);
+    Assert.AreEqual(999999.99m, payment.TotalCostAmount);
   }
 
   /// <summary>
   /// Validates tax amount greater than cost amount (edge case).
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void PaymentInformation_TaxGreaterThanCost_IsAllowed()
   {
     // Arrange & Act
@@ -268,14 +269,14 @@ public sealed class PaymentInformationExtendedTests
     };
 
     // Assert - No validation preventing this edge case
-    Assert.Equal(100m, payment.TotalCostAmount);
-    Assert.Equal(200m, payment.TotalTaxAmount);
+    Assert.AreEqual(100m, payment.TotalCostAmount);
+    Assert.AreEqual(200m, payment.TotalTaxAmount);
   }
 
   /// <summary>
   /// Validates very old transaction date.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void PaymentInformation_VeryOldDate_IsAllowed()
   {
     // Arrange & Act
@@ -285,13 +286,13 @@ public sealed class PaymentInformationExtendedTests
     };
 
     // Assert
-    Assert.Equal(1900, payment.TransactionDate.Year);
+    Assert.AreEqual(1900, payment.TransactionDate.Year);
   }
 
   /// <summary>
   /// Validates future transaction date.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void PaymentInformation_FutureDate_IsAllowed()
   {
     // Arrange & Act
@@ -301,13 +302,13 @@ public sealed class PaymentInformationExtendedTests
     };
 
     // Assert
-    Assert.Equal(2100, payment.TransactionDate.Year);
+    Assert.AreEqual(2100, payment.TransactionDate.Year);
   }
 
   /// <summary>
   /// Validates high precision decimal amounts.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void PaymentInformation_HighPrecisionAmount_IsAllowed()
   {
     // Arrange & Act
@@ -318,14 +319,14 @@ public sealed class PaymentInformationExtendedTests
     };
 
     // Assert
-    Assert.Equal(123.456789m, payment.TotalCostAmount);
-    Assert.Equal(23.456789m, payment.TotalTaxAmount);
+    Assert.AreEqual(123.456789m, payment.TotalCostAmount);
+    Assert.AreEqual(23.456789m, payment.TotalTaxAmount);
   }
 
   /// <summary>
   /// Validates record equality.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void PaymentInformation_SameValues_AreEqual()
   {
     // Arrange
@@ -346,13 +347,13 @@ public sealed class PaymentInformationExtendedTests
     };
 
     // Assert
-    Assert.Equal(payment1, payment2);
+    Assert.AreEqual(payment1, payment2);
   }
 
   /// <summary>
   /// Validates record inequality.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void PaymentInformation_DifferentValues_AreNotEqual()
   {
     // Arrange
@@ -360,7 +361,7 @@ public sealed class PaymentInformationExtendedTests
     var payment2 = new PaymentInformation { TotalCostAmount = 200m };
 
     // Assert
-    Assert.NotEqual(payment1, payment2);
+    Assert.AreNotEqual(payment1, payment2);
   }
 
   #endregion
@@ -370,35 +371,35 @@ public sealed class PaymentInformationExtendedTests
   /// <summary>
   /// Validates Currency can be created.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Currency_Creation_StoresValues()
   {
     // Arrange & Act
     var currency = new Currency("US Dollar", "USD", "$");
 
     // Assert
-    Assert.Equal("US Dollar", currency.Name);
-    Assert.Equal("USD", currency.Code);
-    Assert.Equal("$", currency.Symbol);
+    Assert.AreEqual("US Dollar", currency.Name);
+    Assert.AreEqual("USD", currency.Code);
+    Assert.AreEqual("$", currency.Symbol);
   }
 
   /// <summary>
   /// Validates common currencies.
   /// </summary>
-  [Theory]
-  [InlineData("US Dollar", "USD", "$")]
-  [InlineData("Euro", "EUR", "Euro")]
-  [InlineData("British Pound", "GBP", "Pounds")]
-  [InlineData("Romanian Leu", "RON", "lei")]
+  [TestMethod]
+  [DataRow("US Dollar", "USD", "$")]
+  [DataRow("Euro", "EUR", "Euro")]
+  [DataRow("British Pound", "GBP", "Pounds")]
+  [DataRow("Romanian Leu", "RON", "lei")]
   public void Currency_CommonCurrencies_AreAccepted(string name, string code, string symbol)
   {
     // Arrange & Act
     var currency = new Currency(name, code, symbol);
 
     // Assert
-    Assert.Equal(name, currency.Name);
-    Assert.Equal(code, currency.Code);
-    Assert.Equal(symbol, currency.Symbol);
+    Assert.AreEqual(name, currency.Name);
+    Assert.AreEqual(code, currency.Code);
+    Assert.AreEqual(symbol, currency.Symbol);
   }
 
   #endregion

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/DDD/ValueObjects/ProductExtendedTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/DDD/ValueObjects/ProductExtendedTests.cs
@@ -6,12 +6,13 @@ using System.Linq;
 using arolariu.Backend.Domain.Invoices.DDD.ValueObjects;
 using arolariu.Backend.Domain.Invoices.DDD.ValueObjects.Products;
 
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 /// <summary>
 /// Extended unit tests for the Product value object covering edge cases
 /// and boundary conditions for comprehensive code coverage.
 /// </summary>
+[TestClass]
 public sealed class ProductExtendedTests
 {
   #region Product Property Tests
@@ -19,7 +20,7 @@ public sealed class ProductExtendedTests
   /// <summary>
   /// Validates Name property can be set.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_SetName_StoresValue()
   {
     // Arrange
@@ -30,26 +31,26 @@ public sealed class ProductExtendedTests
     product.Name = name;
 
     // Assert
-    Assert.Equal(name, product.Name);
+    Assert.AreEqual(name, product.Name);
   }
 
   /// <summary>
   /// Validates Name with empty string.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_EmptyName_IsAllowed()
   {
     // Arrange & Act
     var product = new Product { Name = string.Empty };
 
     // Assert
-    Assert.Equal(string.Empty, product.Name);
+    Assert.AreEqual(string.Empty, product.Name);
   }
 
   /// <summary>
   /// Validates product with long name.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_LongName_IsAllowed()
   {
     // Arrange
@@ -59,13 +60,13 @@ public sealed class ProductExtendedTests
     var product = new Product { Name = longName };
 
     // Assert
-    Assert.Equal(1000, product.Name.Length);
+    Assert.AreEqual(1000, product.Name.Length);
   }
 
   /// <summary>
   /// Validates product with special characters in name.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_SpecialCharactersInName_IsAllowed()
   {
     // Arrange
@@ -75,13 +76,13 @@ public sealed class ProductExtendedTests
     var product = new Product { Name = specialName };
 
     // Assert
-    Assert.Equal(specialName, product.Name);
+    Assert.AreEqual(specialName, product.Name);
   }
 
   /// <summary>
   /// Validates product with unicode characters.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_UnicodeCharacters_IsAllowed()
   {
     // Arrange
@@ -91,13 +92,13 @@ public sealed class ProductExtendedTests
     var product = new Product { Name = unicodeName };
 
     // Assert
-    Assert.Equal(unicodeName, product.Name);
+    Assert.AreEqual(unicodeName, product.Name);
   }
 
   /// <summary>
   /// Validates product with emoji.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_Emoji_IsAllowed()
   {
     // Arrange
@@ -107,13 +108,13 @@ public sealed class ProductExtendedTests
     var product = new Product { Name = emojiName };
 
     // Assert
-    Assert.True(product.Name.Contains("🍕", StringComparison.Ordinal));
+    Assert.IsTrue(product.Name.Contains("🍕", StringComparison.Ordinal));
   }
 
   /// <summary>
   /// Validates product with whitespace.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_WhitespaceInName_IsAllowed()
   {
     // Arrange
@@ -123,13 +124,13 @@ public sealed class ProductExtendedTests
     var product = new Product { Name = spaceName };
 
     // Assert
-    Assert.Equal(spaceName, product.Name);
+    Assert.AreEqual(spaceName, product.Name);
   }
 
   /// <summary>
   /// Validates product with newline characters.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_NewlineInName_IsAllowed()
   {
     // Arrange
@@ -139,13 +140,13 @@ public sealed class ProductExtendedTests
     var product = new Product { Name = multilineName };
 
     // Assert
-    Assert.True(product.Name.Contains('\n', StringComparison.Ordinal));
+    Assert.IsTrue(product.Name.Contains('\n', StringComparison.Ordinal));
   }
 
   /// <summary>
   /// Validates product with tab characters.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_TabInName_IsAllowed()
   {
     // Arrange
@@ -155,7 +156,7 @@ public sealed class ProductExtendedTests
     var product = new Product { Name = tabbedName };
 
     // Assert
-    Assert.True(product.Name.Contains('\t', StringComparison.Ordinal));
+    Assert.IsTrue(product.Name.Contains('\t', StringComparison.Ordinal));
   }
 
   #endregion
@@ -165,7 +166,7 @@ public sealed class ProductExtendedTests
   /// <summary>
   /// Validates Quantity property.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_SetQuantity_StoresValue()
   {
     // Arrange
@@ -175,104 +176,104 @@ public sealed class ProductExtendedTests
     product.Quantity = 10;
 
     // Assert
-    Assert.Equal(10, product.Quantity);
+    Assert.AreEqual(10, product.Quantity);
   }
 
   /// <summary>
   /// Validates Quantity with zero.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_ZeroQuantity_IsAllowed()
   {
     // Arrange & Act
     var product = new Product { Quantity = 0 };
 
     // Assert
-    Assert.Equal(0, product.Quantity);
+    Assert.AreEqual(0, product.Quantity);
   }
 
   /// <summary>
   /// Validates Quantity with large number.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_LargeQuantity_IsAllowed()
   {
     // Arrange & Act
     var product = new Product { Quantity = decimal.MaxValue };
 
     // Assert
-    Assert.Equal(decimal.MaxValue, product.Quantity);
+    Assert.AreEqual(decimal.MaxValue, product.Quantity);
   }
 
   /// <summary>
   /// Validates Quantity with decimal value.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_DecimalQuantity_IsAllowed()
   {
     // Arrange & Act
     var product = new Product { Quantity = 2.5m };
 
     // Assert
-    Assert.Equal(2.5m, product.Quantity);
+    Assert.AreEqual(2.5m, product.Quantity);
   }
 
   /// <summary>
   /// Validates TotalPrice is computed correctly.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_TotalPrice_IsComputedFromQuantityAndPrice()
   {
     // Arrange & Act
     var product = new Product { Quantity = 3, Price = 10M };
 
     // Assert
-    Assert.Equal(30M, product.TotalPrice);
+    Assert.AreEqual(30M, product.TotalPrice);
   }
 
   /// <summary>
   /// Validates TotalPrice with zero quantity.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_ZeroQuantity_TotalPriceIsZero()
   {
     // Arrange & Act
     var product = new Product { Quantity = 0, Price = 10M };
 
     // Assert
-    Assert.Equal(0, product.TotalPrice);
+    Assert.AreEqual(0, product.TotalPrice);
   }
 
   /// <summary>
   /// Validates TotalPrice with zero price.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_ZeroPrice_TotalPriceIsZero()
   {
     // Arrange & Act
     var product = new Product { Quantity = 5, Price = 0 };
 
     // Assert
-    Assert.Equal(0, product.TotalPrice);
+    Assert.AreEqual(0, product.TotalPrice);
   }
 
   /// <summary>
   /// Validates TotalPrice with decimal precision.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_HighPrecisionPrice_TotalPriceCalculatedCorrectly()
   {
     // Arrange & Act
     var product = new Product { Quantity = 2.5m, Price = 3.33m };
 
     // Assert
-    Assert.Equal(8.325m, product.TotalPrice);
+    Assert.AreEqual(8.325m, product.TotalPrice);
   }
 
   /// <summary>
   /// Validates Price property.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_SetPrice_StoresValue()
   {
     // Arrange
@@ -282,20 +283,20 @@ public sealed class ProductExtendedTests
     product.Price = 5.99M;
 
     // Assert
-    Assert.Equal(5.99M, product.Price);
+    Assert.AreEqual(5.99M, product.Price);
   }
 
   /// <summary>
   /// Validates Price with large value.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_LargePrice_IsAllowed()
   {
     // Arrange & Act
     var product = new Product { Price = 999999.99M };
 
     // Assert
-    Assert.Equal(999999.99M, product.Price);
+    Assert.AreEqual(999999.99M, product.Price);
   }
 
   #endregion
@@ -305,7 +306,7 @@ public sealed class ProductExtendedTests
   /// <summary>
   /// Validates Category can be set.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_SetCategory_StoresValue()
   {
     // Arrange
@@ -315,13 +316,13 @@ public sealed class ProductExtendedTests
     product.Category = ProductCategory.GROCERIES;
 
     // Assert
-    Assert.Equal(ProductCategory.GROCERIES, product.Category);
+    Assert.AreEqual(ProductCategory.GROCERIES, product.Category);
   }
 
   /// <summary>
   /// Validates all ProductCategory enum values are valid.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_AllCategoryValues_AreValid()
   {
     // Arrange
@@ -331,106 +332,106 @@ public sealed class ProductExtendedTests
     foreach (var category in categories)
     {
       var product = new Product { Category = category };
-      Assert.Equal(category, product.Category);
+      Assert.AreEqual(category, product.Category);
     }
   }
 
   /// <summary>
   /// Validates default ProductCategory.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_DefaultCategory_IsOther()
   {
     // Arrange & Act
     var product = new Product();
 
     // Assert
-    Assert.Equal(ProductCategory.OTHER, product.Category);
+    Assert.AreEqual(ProductCategory.OTHER, product.Category);
   }
 
   /// <summary>
   /// Validates ProductCategory.NOT_DEFINED exists.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void ProductCategory_NotDefined_Exists()
   {
-    Assert.True(Enum.IsDefined<ProductCategory>(ProductCategory.NOT_DEFINED));
+    Assert.IsTrue(Enum.IsDefined<ProductCategory>(ProductCategory.NOT_DEFINED));
   }
 
   /// <summary>
   /// Validates ProductCategory.BEVERAGES exists.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void ProductCategory_Beverages_Exists()
   {
-    Assert.True(Enum.IsDefined<ProductCategory>(ProductCategory.BEVERAGES));
+    Assert.IsTrue(Enum.IsDefined<ProductCategory>(ProductCategory.BEVERAGES));
   }
 
   /// <summary>
   /// Validates ProductCategory.CLEANING_SUPPLIES exists.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void ProductCategory_CleaningSupplies_Exists()
   {
-    Assert.True(Enum.IsDefined<ProductCategory>(ProductCategory.CLEANING_SUPPLIES));
+    Assert.IsTrue(Enum.IsDefined<ProductCategory>(ProductCategory.CLEANING_SUPPLIES));
   }
 
   /// <summary>
   /// Validates ProductCategory.OTHER exists.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void ProductCategory_Other_Exists()
   {
-    Assert.True(Enum.IsDefined<ProductCategory>(ProductCategory.OTHER));
+    Assert.IsTrue(Enum.IsDefined<ProductCategory>(ProductCategory.OTHER));
   }
 
   /// <summary>
   /// Validates ProductCategory enum has expected values.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void ProductCategory_HasExpectedValueCount()
   {
     // Arrange
     var values = Enum.GetValues<ProductCategory>();
 
     // Assert - Should have multiple categories (14 total)
-    Assert.True(values.Length >= 14);
+    Assert.IsTrue(values.Length >= 14);
   }
 
   /// <summary>
   /// Validates ProductCategory.DAIRY exists.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void ProductCategory_Dairy_Exists()
   {
-    Assert.True(Enum.IsDefined<ProductCategory>(ProductCategory.DAIRY));
+    Assert.IsTrue(Enum.IsDefined<ProductCategory>(ProductCategory.DAIRY));
   }
 
   /// <summary>
   /// Validates ProductCategory.MEAT exists.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void ProductCategory_Meat_Exists()
   {
-    Assert.True(Enum.IsDefined<ProductCategory>(ProductCategory.MEAT));
+    Assert.IsTrue(Enum.IsDefined<ProductCategory>(ProductCategory.MEAT));
   }
 
   /// <summary>
   /// Validates ProductCategory.FRUITS exists.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void ProductCategory_Fruits_Exists()
   {
-    Assert.True(Enum.IsDefined<ProductCategory>(ProductCategory.FRUITS));
+    Assert.IsTrue(Enum.IsDefined<ProductCategory>(ProductCategory.FRUITS));
   }
 
   /// <summary>
   /// Validates ProductCategory.VEGETABLES exists.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void ProductCategory_Vegetables_Exists()
   {
-    Assert.True(Enum.IsDefined<ProductCategory>(ProductCategory.VEGETABLES));
+    Assert.IsTrue(Enum.IsDefined<ProductCategory>(ProductCategory.VEGETABLES));
   }
 
   #endregion
@@ -440,72 +441,72 @@ public sealed class ProductExtendedTests
   /// <summary>
   /// Validates new product has default Name.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_NewProduct_HasDefaultName()
   {
     // Arrange & Act
     var product = new Product();
 
     // Assert - Name should be initialized to empty string
-    Assert.Equal(string.Empty, product.Name);
+    Assert.AreEqual(string.Empty, product.Name);
   }
 
   /// <summary>
   /// Validates new product has default Quantity.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_NewProduct_HasDefaultQuantity()
   {
     // Arrange & Act
     var product = new Product();
 
     // Assert - Quantity should be 0
-    Assert.Equal(0, product.Quantity);
+    Assert.AreEqual(0, product.Quantity);
   }
 
   /// <summary>
   /// Validates new product has default Price.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_NewProduct_HasDefaultPrice()
   {
     // Arrange & Act
     var product = new Product();
 
     // Assert - Price should be 0
-    Assert.Equal(0, product.Price);
+    Assert.AreEqual(0, product.Price);
   }
 
   /// <summary>
   /// Validates new product has default QuantityUnit.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_NewProduct_HasDefaultQuantityUnit()
   {
     // Arrange & Act
     var product = new Product();
 
     // Assert - QuantityUnit should be empty string
-    Assert.Equal(string.Empty, product.QuantityUnit);
+    Assert.AreEqual(string.Empty, product.QuantityUnit);
   }
 
   /// <summary>
   /// Validates new product has default ProductCode.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_NewProduct_HasDefaultProductCode()
   {
     // Arrange & Act
     var product = new Product();
 
     // Assert - ProductCode should be empty string
-    Assert.Equal(string.Empty, product.ProductCode);
+    Assert.AreEqual(string.Empty, product.ProductCode);
   }
 
   /// <summary>
   /// Validates multiple products can be created.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_CreateMultiple_AllAreIndependent()
   {
     // Arrange & Act
@@ -514,8 +515,11 @@ public sealed class ProductExtendedTests
         .ToList();
 
     // Assert
-    Assert.Equal(100, products.Count);
-    Assert.All(products, p => Assert.NotNull(p.Name));
+    Assert.AreEqual(100, products.Count);
+    foreach (var p in products)
+    {
+      Assert.IsNotNull(p.Name);
+    }
   }
 
   #endregion
@@ -525,7 +529,7 @@ public sealed class ProductExtendedTests
   /// <summary>
   /// Validates QuantityUnit property.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_SetQuantityUnit_StoresValue()
   {
     // Arrange
@@ -536,32 +540,32 @@ public sealed class ProductExtendedTests
     product.QuantityUnit = unit;
 
     // Assert
-    Assert.Equal(unit, product.QuantityUnit);
+    Assert.AreEqual(unit, product.QuantityUnit);
   }
 
   /// <summary>
   /// Validates various quantity units.
   /// </summary>
-  [Theory]
-  [InlineData("kg")]
-  [InlineData("g")]
-  [InlineData("L")]
-  [InlineData("ml")]
-  [InlineData("pcs")]
-  [InlineData("units")]
+  [TestMethod]
+  [DataRow("kg")]
+  [DataRow("g")]
+  [DataRow("L")]
+  [DataRow("ml")]
+  [DataRow("pcs")]
+  [DataRow("units")]
   public void Product_VariousQuantityUnits_AreAllowed(string unit)
   {
     // Arrange & Act
     var product = new Product { QuantityUnit = unit };
 
     // Assert
-    Assert.Equal(unit, product.QuantityUnit);
+    Assert.AreEqual(unit, product.QuantityUnit);
   }
 
   /// <summary>
   /// Validates ProductCode property.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_SetProductCode_StoresValue()
   {
     // Arrange
@@ -572,23 +576,23 @@ public sealed class ProductExtendedTests
     product.ProductCode = code;
 
     // Assert
-    Assert.Equal(code, product.ProductCode);
+    Assert.AreEqual(code, product.ProductCode);
   }
 
   /// <summary>
   /// Validates ProductCode with barcode format.
   /// </summary>
-  [Theory]
-  [InlineData("1234567890123")]
-  [InlineData("ABC-123-XYZ")]
-  [InlineData("")]
+  [TestMethod]
+  [DataRow("1234567890123")]
+  [DataRow("ABC-123-XYZ")]
+  [DataRow("")]
   public void Product_VariousProductCodes_AreAllowed(string code)
   {
     // Arrange & Act
     var product = new Product { ProductCode = code };
 
     // Assert
-    Assert.Equal(code, product.ProductCode);
+    Assert.AreEqual(code, product.ProductCode);
   }
 
   #endregion
@@ -598,7 +602,7 @@ public sealed class ProductExtendedTests
   /// <summary>
   /// Validates DetectedAllergens can be set.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_SetDetectedAllergens_StoresValue()
   {
     // Arrange
@@ -614,27 +618,27 @@ public sealed class ProductExtendedTests
     product.DetectedAllergens = allergens;
 
     // Assert
-    Assert.Equal(3, product.DetectedAllergens.Count());
-    Assert.Contains(product.DetectedAllergens, a => a.Name == "Gluten");
+    Assert.AreEqual(3, product.DetectedAllergens.Count());
+    Assert.Contains(a => a.Name == "Gluten", product.DetectedAllergens);
   }
 
   /// <summary>
   /// Validates empty allergens collection.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_EmptyAllergens_IsAllowed()
   {
     // Arrange & Act
     var product = new Product { DetectedAllergens = Array.Empty<Allergen>() };
 
     // Assert
-    Assert.Empty(product.DetectedAllergens);
+    Assert.IsEmpty(product.DetectedAllergens);
   }
 
   /// <summary>
   /// Validates large allergens collection.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_LargeAllergensCollection_IsAllowed()
   {
     // Arrange
@@ -646,21 +650,21 @@ public sealed class ProductExtendedTests
     var product = new Product { DetectedAllergens = allergens };
 
     // Assert
-    Assert.Equal(100, product.DetectedAllergens.Count());
+    Assert.AreEqual(100, product.DetectedAllergens.Count());
   }
 
   /// <summary>
   /// Validates default allergens is empty collection.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_DefaultAllergens_IsEmptyCollection()
   {
     // Arrange & Act
     var product = new Product();
 
     // Assert
-    Assert.NotNull(product.DetectedAllergens);
-    Assert.Empty(product.DetectedAllergens);
+    Assert.IsNotNull(product.DetectedAllergens);
+    Assert.IsEmpty(product.DetectedAllergens);
   }
 
   #endregion
@@ -670,7 +674,7 @@ public sealed class ProductExtendedTests
   /// <summary>
   /// Validates two products with same properties.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_SameProperties_AreDistinctInstances()
   {
     // Arrange
@@ -678,13 +682,13 @@ public sealed class ProductExtendedTests
     var product2 = new Product { Name = "Product A" };
 
     // Assert - They are different instances
-    Assert.NotSame(product1, product2);
+    Assert.AreNotSame(product1, product2);
   }
 
   /// <summary>
   /// Validates product reference equality.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_SameReference_AreEqual()
   {
     // Arrange
@@ -692,7 +696,7 @@ public sealed class ProductExtendedTests
     var product2 = product1;
 
     // Assert
-    Assert.Same(product1, product2);
+    Assert.AreSame(product1, product2);
   }
 
   #endregion
@@ -702,7 +706,7 @@ public sealed class ProductExtendedTests
   /// <summary>
   /// Validates product can be initialized with object initializer.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_ObjectInitializer_Works()
   {
     // Arrange & Act
@@ -714,16 +718,16 @@ public sealed class ProductExtendedTests
     };
 
     // Assert
-    Assert.Equal("Test", product.Name);
-    Assert.Equal(5, product.Quantity);
-    Assert.Equal(2.00M, product.Price);
-    Assert.Equal(10.00M, product.TotalPrice);
+    Assert.AreEqual("Test", product.Name);
+    Assert.AreEqual(5, product.Quantity);
+    Assert.AreEqual(2.00M, product.Price);
+    Assert.AreEqual(10.00M, product.TotalPrice);
   }
 
   /// <summary>
   /// Validates product properties can be modified after creation.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_ModifyAfterCreation_Works()
   {
     // Arrange
@@ -733,13 +737,13 @@ public sealed class ProductExtendedTests
     product.Name = "Modified";
 
     // Assert
-    Assert.Equal("Modified", product.Name);
+    Assert.AreEqual("Modified", product.Name);
   }
 
   /// <summary>
   /// Validates full product initialization with all properties.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_FullInitialization_Works()
   {
     // Arrange & Act
@@ -755,14 +759,14 @@ public sealed class ProductExtendedTests
     };
 
     // Assert
-    Assert.Equal("MONSTER ENERGY 500ML", product.Name);
-    Assert.Equal(ProductCategory.BEVERAGES, product.Category);
-    Assert.Equal(2, product.Quantity);
-    Assert.Equal("pcs", product.QuantityUnit);
-    Assert.Equal("5449000131805", product.ProductCode);
-    Assert.Equal(4.99M, product.Price);
-    Assert.Equal(9.98M, product.TotalPrice);
-    Assert.Single(product.DetectedAllergens);
+    Assert.AreEqual("MONSTER ENERGY 500ML", product.Name);
+    Assert.AreEqual(ProductCategory.BEVERAGES, product.Category);
+    Assert.AreEqual(2, product.Quantity);
+    Assert.AreEqual("pcs", product.QuantityUnit);
+    Assert.AreEqual("5449000131805", product.ProductCode);
+    Assert.AreEqual(4.99M, product.Price);
+    Assert.AreEqual(9.98M, product.TotalPrice);
+    Assert.ContainsSingle(product.DetectedAllergens);
   }
 
   #endregion
@@ -772,20 +776,20 @@ public sealed class ProductExtendedTests
   /// <summary>
   /// Validates Allergen can be created with defaults.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Allergen_DefaultCreation_HasEmptyName()
   {
     // Arrange & Act
     var allergen = new Allergen();
 
     // Assert
-    Assert.Equal(string.Empty, allergen.Name);
+    Assert.AreEqual(string.Empty, allergen.Name);
   }
 
   /// <summary>
   /// Validates Allergen Name property.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Allergen_SetName_StoresValue()
   {
     // Arrange
@@ -795,13 +799,13 @@ public sealed class ProductExtendedTests
     allergen.Name = "Peanuts";
 
     // Assert
-    Assert.Equal("Peanuts", allergen.Name);
+    Assert.AreEqual("Peanuts", allergen.Name);
   }
 
   /// <summary>
   /// Validates Allergen Description property.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Allergen_SetDescription_StoresValue()
   {
     // Arrange
@@ -811,13 +815,13 @@ public sealed class ProductExtendedTests
     allergen.Description = "Contains tree nuts";
 
     // Assert
-    Assert.Equal("Contains tree nuts", allergen.Description);
+    Assert.AreEqual("Contains tree nuts", allergen.Description);
   }
 
   /// <summary>
   /// Validates Allergen LearnMoreAddress property.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Allergen_SetLearnMoreAddress_StoresValue()
   {
     // Arrange
@@ -828,26 +832,26 @@ public sealed class ProductExtendedTests
     allergen.LearnMoreAddress = uri;
 
     // Assert
-    Assert.Equal(uri, allergen.LearnMoreAddress);
+    Assert.AreEqual(uri, allergen.LearnMoreAddress);
   }
 
   /// <summary>
   /// Validates Allergen default LearnMoreAddress.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Allergen_DefaultLearnMoreAddress_IsArolariu()
   {
     // Arrange & Act
     var allergen = new Allergen();
 
     // Assert
-    Assert.Equal("https://arolariu.ro/", allergen.LearnMoreAddress.ToString());
+    Assert.AreEqual("https://arolariu.ro/", allergen.LearnMoreAddress.ToString());
   }
 
   /// <summary>
   /// Validates Allergen record equality.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Allergen_SameValues_AreEqual()
   {
     // Arrange
@@ -855,13 +859,13 @@ public sealed class ProductExtendedTests
     var allergen2 = new Allergen { Name = "Gluten", Description = "Contains gluten" };
 
     // Assert - Records with same values should be equal
-    Assert.Equal(allergen1, allergen2);
+    Assert.AreEqual(allergen1, allergen2);
   }
 
   /// <summary>
   /// Validates Allergen record inequality.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Allergen_DifferentValues_AreNotEqual()
   {
     // Arrange
@@ -869,30 +873,30 @@ public sealed class ProductExtendedTests
     var allergen2 = new Allergen { Name = "Dairy" };
 
     // Assert
-    Assert.NotEqual(allergen1, allergen2);
+    Assert.AreNotEqual(allergen1, allergen2);
   }
 
   /// <summary>
   /// Validates common allergen names.
   /// </summary>
-  [Theory]
-  [InlineData("Gluten")]
-  [InlineData("Dairy")]
-  [InlineData("Eggs")]
-  [InlineData("Peanuts")]
-  [InlineData("Tree Nuts")]
-  [InlineData("Fish")]
-  [InlineData("Shellfish")]
-  [InlineData("Soy")]
-  [InlineData("Wheat")]
-  [InlineData("Sesame")]
+  [TestMethod]
+  [DataRow("Gluten")]
+  [DataRow("Dairy")]
+  [DataRow("Eggs")]
+  [DataRow("Peanuts")]
+  [DataRow("Tree Nuts")]
+  [DataRow("Fish")]
+  [DataRow("Shellfish")]
+  [DataRow("Soy")]
+  [DataRow("Wheat")]
+  [DataRow("Sesame")]
   public void Allergen_CommonAllergenNames_AreAccepted(string name)
   {
     // Arrange & Act
     var allergen = new Allergen { Name = name };
 
     // Assert
-    Assert.Equal(name, allergen.Name);
+    Assert.AreEqual(name, allergen.Name);
   }
 
   #endregion

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/DDD/ValueObjects/RecipeExtendedTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/DDD/ValueObjects/RecipeExtendedTests.cs
@@ -6,11 +6,12 @@ using System.Linq;
 
 using arolariu.Backend.Domain.Invoices.DDD.ValueObjects;
 
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 /// <summary>
 /// Extended unit tests for the Recipe value object.
 /// </summary>
+[TestClass]
 public sealed class RecipeExtendedTests
 {
   #region Recipe Creation Tests
@@ -18,24 +19,24 @@ public sealed class RecipeExtendedTests
   /// <summary>
   /// Validates default Recipe creation.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Recipe_DefaultCreation_HasDefaultValues()
   {
     // Arrange & Act
     var recipe = new Recipe();
 
     // Assert
-    Assert.Equal(string.Empty, recipe.Name);
-    Assert.Equal(string.Empty, recipe.Description);
-    Assert.Equal(-1, recipe.ApproximateTotalDuration);
-    Assert.Equal(RecipeComplexity.UNKNOWN, recipe.Complexity);
-    Assert.Empty(recipe.Ingredients);
+    Assert.AreEqual(string.Empty, recipe.Name);
+    Assert.AreEqual(string.Empty, recipe.Description);
+    Assert.AreEqual(-1, recipe.ApproximateTotalDuration);
+    Assert.AreEqual(RecipeComplexity.UNKNOWN, recipe.Complexity);
+    Assert.IsEmpty(recipe.Ingredients);
   }
 
   /// <summary>
   /// Validates parameterized Recipe creation.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Recipe_ParameterizedCreation_StoresValues()
   {
     // Arrange
@@ -52,12 +53,12 @@ public sealed class RecipeExtendedTests
         uri);
 
     // Assert
-    Assert.Equal("Chocolate Cake", recipe.Name);
-    Assert.Equal("A delicious chocolate cake", recipe.Description);
-    Assert.Equal(60, recipe.ApproximateTotalDuration);
-    Assert.Equal(RecipeComplexity.NORMAL, recipe.Complexity);
-    Assert.Equal(3, recipe.Ingredients.Count);
-    Assert.Equal(uri, recipe.ReferenceForMoreDetails);
+    Assert.AreEqual("Chocolate Cake", recipe.Name);
+    Assert.AreEqual("A delicious chocolate cake", recipe.Description);
+    Assert.AreEqual(60, recipe.ApproximateTotalDuration);
+    Assert.AreEqual(RecipeComplexity.NORMAL, recipe.Complexity);
+    Assert.AreEqual(3, recipe.Ingredients.Count);
+    Assert.AreEqual(uri, recipe.ReferenceForMoreDetails);
   }
 
   #endregion
@@ -67,7 +68,7 @@ public sealed class RecipeExtendedTests
   /// <summary>
   /// Validates Name property.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Recipe_SetName_StoresValue()
   {
     // Arrange
@@ -77,13 +78,13 @@ public sealed class RecipeExtendedTests
     recipe.Name = "Pasta Carbonara";
 
     // Assert
-    Assert.Equal("Pasta Carbonara", recipe.Name);
+    Assert.AreEqual("Pasta Carbonara", recipe.Name);
   }
 
   /// <summary>
   /// Validates Description property.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Recipe_SetDescription_StoresValue()
   {
     // Arrange
@@ -93,13 +94,13 @@ public sealed class RecipeExtendedTests
     recipe.Description = "A classic Italian pasta dish";
 
     // Assert
-    Assert.Equal("A classic Italian pasta dish", recipe.Description);
+    Assert.AreEqual("A classic Italian pasta dish", recipe.Description);
   }
 
   /// <summary>
   /// Validates ApproximateTotalDuration property.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Recipe_SetDuration_StoresValue()
   {
     // Arrange
@@ -109,13 +110,13 @@ public sealed class RecipeExtendedTests
     recipe.ApproximateTotalDuration = 45;
 
     // Assert
-    Assert.Equal(45, recipe.ApproximateTotalDuration);
+    Assert.AreEqual(45, recipe.ApproximateTotalDuration);
   }
 
   /// <summary>
   /// Validates Complexity property.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Recipe_SetComplexity_StoresValue()
   {
     // Arrange
@@ -125,13 +126,13 @@ public sealed class RecipeExtendedTests
     recipe.Complexity = RecipeComplexity.HARD;
 
     // Assert
-    Assert.Equal(RecipeComplexity.HARD, recipe.Complexity);
+    Assert.AreEqual(RecipeComplexity.HARD, recipe.Complexity);
   }
 
   /// <summary>
   /// Validates ReferenceForMoreDetails property.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Recipe_SetReferenceForMoreDetails_StoresValue()
   {
     // Arrange
@@ -142,20 +143,20 @@ public sealed class RecipeExtendedTests
     recipe.ReferenceForMoreDetails = uri;
 
     // Assert
-    Assert.Equal(uri, recipe.ReferenceForMoreDetails);
+    Assert.AreEqual(uri, recipe.ReferenceForMoreDetails);
   }
 
   /// <summary>
   /// Validates default ReferenceForMoreDetails.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Recipe_DefaultReferenceForMoreDetails_IsArolariu()
   {
     // Arrange & Act
     var recipe = new Recipe();
 
     // Assert
-    Assert.Equal("https://arolariu.ro/", recipe.ReferenceForMoreDetails.ToString());
+    Assert.AreEqual("https://arolariu.ro/", recipe.ReferenceForMoreDetails.ToString());
   }
 
   #endregion
@@ -165,56 +166,56 @@ public sealed class RecipeExtendedTests
   /// <summary>
   /// Validates RecipeComplexity.UNKNOWN exists.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void RecipeComplexity_Unknown_Exists()
   {
-    Assert.True(Enum.IsDefined<RecipeComplexity>(RecipeComplexity.UNKNOWN));
+    Assert.IsTrue(Enum.IsDefined<RecipeComplexity>(RecipeComplexity.UNKNOWN));
   }
 
   /// <summary>
   /// Validates RecipeComplexity.EASY exists.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void RecipeComplexity_Easy_Exists()
   {
-    Assert.True(Enum.IsDefined<RecipeComplexity>(RecipeComplexity.EASY));
+    Assert.IsTrue(Enum.IsDefined<RecipeComplexity>(RecipeComplexity.EASY));
   }
 
   /// <summary>
   /// Validates RecipeComplexity.NORMAL exists.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void RecipeComplexity_Normal_Exists()
   {
-    Assert.True(Enum.IsDefined<RecipeComplexity>(RecipeComplexity.NORMAL));
+    Assert.IsTrue(Enum.IsDefined<RecipeComplexity>(RecipeComplexity.NORMAL));
   }
 
   /// <summary>
   /// Validates RecipeComplexity.HARD exists.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void RecipeComplexity_Hard_Exists()
   {
-    Assert.True(Enum.IsDefined<RecipeComplexity>(RecipeComplexity.HARD));
+    Assert.IsTrue(Enum.IsDefined<RecipeComplexity>(RecipeComplexity.HARD));
   }
 
   /// <summary>
   /// Validates RecipeComplexity enum has expected count.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void RecipeComplexity_HasExpectedValueCount()
   {
     // Arrange
     var values = Enum.GetValues<RecipeComplexity>();
 
     // Assert - Should have 4 complexity levels
-    Assert.Equal(4, values.Length);
+    Assert.AreEqual(4, values.Length);
   }
 
   /// <summary>
   /// Validates all RecipeComplexity values can be assigned.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Recipe_AllComplexityValues_AreValid()
   {
     // Arrange
@@ -224,7 +225,7 @@ public sealed class RecipeExtendedTests
     foreach (var complexity in complexities)
     {
       var recipe = new Recipe { Complexity = complexity };
-      Assert.Equal(complexity, recipe.Complexity);
+      Assert.AreEqual(complexity, recipe.Complexity);
     }
   }
 
@@ -235,20 +236,20 @@ public sealed class RecipeExtendedTests
   /// <summary>
   /// Validates empty name is allowed.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Recipe_EmptyName_IsAllowed()
   {
     // Arrange & Act
     var recipe = new Recipe { Name = string.Empty };
 
     // Assert
-    Assert.Equal(string.Empty, recipe.Name);
+    Assert.AreEqual(string.Empty, recipe.Name);
   }
 
   /// <summary>
   /// Validates long name is allowed.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Recipe_LongName_IsAllowed()
   {
     // Arrange
@@ -258,72 +259,72 @@ public sealed class RecipeExtendedTests
     var recipe = new Recipe { Name = longName };
 
     // Assert
-    Assert.Equal(1000, recipe.Name.Length);
+    Assert.AreEqual(1000, recipe.Name.Length);
   }
 
   /// <summary>
   /// Validates negative duration (default).
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Recipe_NegativeDuration_IsAllowed()
   {
     // Arrange & Act
     var recipe = new Recipe { ApproximateTotalDuration = -1 };
 
     // Assert
-    Assert.Equal(-1, recipe.ApproximateTotalDuration);
+    Assert.AreEqual(-1, recipe.ApproximateTotalDuration);
   }
 
   /// <summary>
   /// Validates zero duration.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Recipe_ZeroDuration_IsAllowed()
   {
     // Arrange & Act
     var recipe = new Recipe { ApproximateTotalDuration = 0 };
 
     // Assert
-    Assert.Equal(0, recipe.ApproximateTotalDuration);
+    Assert.AreEqual(0, recipe.ApproximateTotalDuration);
   }
 
   /// <summary>
   /// Validates large duration.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Recipe_LargeDuration_IsAllowed()
   {
     // Arrange & Act
     var recipe = new Recipe { ApproximateTotalDuration = 10000 };
 
     // Assert
-    Assert.Equal(10000, recipe.ApproximateTotalDuration);
+    Assert.AreEqual(10000, recipe.ApproximateTotalDuration);
   }
 
   /// <summary>
   /// Validates unicode in name.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Recipe_UnicodeInName_IsAllowed()
   {
     // Arrange & Act
     var recipe = new Recipe { Name = "Crème brûlée à la française" };
 
     // Assert
-    Assert.True(recipe.Name.Contains("brûlée", StringComparison.Ordinal));
+    Assert.IsTrue(recipe.Name.Contains("brûlée", StringComparison.Ordinal));
   }
 
   /// <summary>
   /// Validates special characters in description.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Recipe_SpecialCharactersInDescription_IsAllowed()
   {
     // Arrange & Act
     var recipe = new Recipe { Description = "Use 2-3 eggs & 1/2 cup sugar (or more!)" };
 
     // Assert
-    Assert.True(recipe.Description.Contains('&', StringComparison.Ordinal));
+    Assert.IsTrue(recipe.Description.Contains('&', StringComparison.Ordinal));
   }
 
   #endregion
@@ -333,21 +334,21 @@ public sealed class RecipeExtendedTests
   /// <summary>
   /// Validates ingredients collection is initialized.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Recipe_DefaultIngredients_IsEmpty()
   {
     // Arrange & Act
     var recipe = new Recipe();
 
     // Assert
-    Assert.NotNull(recipe.Ingredients);
-    Assert.Empty(recipe.Ingredients);
+    Assert.IsNotNull(recipe.Ingredients);
+    Assert.IsEmpty(recipe.Ingredients);
   }
 
   /// <summary>
   /// Validates multiple ingredients.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Recipe_MultipleIngredients_AreStored()
   {
     // Arrange
@@ -363,7 +364,7 @@ public sealed class RecipeExtendedTests
         new Uri("https://example.com"));
 
     // Assert
-    Assert.Equal(5, recipe.Ingredients.Count);
+    Assert.AreEqual(5, recipe.Ingredients.Count);
     Assert.Contains("Flour", recipe.Ingredients);
     Assert.Contains("Butter", recipe.Ingredients);
   }
@@ -371,7 +372,7 @@ public sealed class RecipeExtendedTests
   /// <summary>
   /// Validates large ingredients collection.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Recipe_LargeIngredientsCollection_IsAllowed()
   {
     // Arrange
@@ -389,7 +390,7 @@ public sealed class RecipeExtendedTests
         new Uri("https://example.com"));
 
     // Assert
-    Assert.Equal(100, recipe.Ingredients.Count);
+    Assert.AreEqual(100, recipe.Ingredients.Count);
   }
 
   #endregion
@@ -399,7 +400,7 @@ public sealed class RecipeExtendedTests
   /// <summary>
   /// Validates record equality.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Recipe_SameValues_AreEqual()
   {
     // Arrange
@@ -410,13 +411,13 @@ public sealed class RecipeExtendedTests
     var recipe2 = new Recipe("Cake", "Delicious", 60, RecipeComplexity.NORMAL, ingredients, uri);
 
     // Assert - Note: Same reference for ingredients means they're equal
-    Assert.Equal(recipe1, recipe2);
+    Assert.AreEqual(recipe1, recipe2);
   }
 
   /// <summary>
   /// Validates record inequality for different names.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Recipe_DifferentNames_AreNotEqual()
   {
     // Arrange
@@ -424,13 +425,13 @@ public sealed class RecipeExtendedTests
     var recipe2 = new Recipe { Name = "Pie" };
 
     // Assert
-    Assert.NotEqual(recipe1, recipe2);
+    Assert.AreNotEqual(recipe1, recipe2);
   }
 
   /// <summary>
   /// Validates record inequality for different complexity.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Recipe_DifferentComplexity_AreNotEqual()
   {
     // Arrange
@@ -438,7 +439,7 @@ public sealed class RecipeExtendedTests
     var recipe2 = new Recipe { Complexity = RecipeComplexity.HARD };
 
     // Assert
-    Assert.NotEqual(recipe1, recipe2);
+    Assert.AreNotEqual(recipe1, recipe2);
   }
 
   #endregion

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/DDD/ValueObjects/ValueObjectTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/DDD/ValueObjects/ValueObjectTests.cs
@@ -7,13 +7,14 @@ using arolariu.Backend.Common.DDD.ValueObjects;
 using arolariu.Backend.Domain.Invoices.DDD.ValueObjects;
 using arolariu.Backend.Domain.Invoices.DDD.ValueObjects.Products;
 
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 /// <summary>
 /// Comprehensive unit tests for all Value Object classes in the invoicing domain.
 /// Tests validate property initialization, equality semantics, default values, and record behavior.
 /// Method naming follows MethodName_Condition_ExpectedResult pattern per repository standards.
 /// </summary>
+[TestClass]
 public sealed class ValueObjectTests
 {
   #region Currency Tests
@@ -21,37 +22,37 @@ public sealed class ValueObjectTests
   /// <summary>
   /// Verifies Currency struct can be created with all parameters.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Currency_ParameterizedConstructor_SetsAllProperties()
   {
     // Arrange & Act
     var currency = new Currency("US Dollar", "USD", "$");
 
     // Assert
-    Assert.Equal("US Dollar", currency.Name);
-    Assert.Equal("USD", currency.Code);
-    Assert.Equal("$", currency.Symbol);
+    Assert.AreEqual("US Dollar", currency.Name);
+    Assert.AreEqual("USD", currency.Code);
+    Assert.AreEqual("$", currency.Symbol);
   }
 
   /// <summary>
   /// Verifies Currency default constructor creates instance with default values.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Currency_DefaultConstructor_CreatesInstanceWithDefaults()
   {
     // Act
     var currency = new Currency();
 
     // Assert
-    Assert.Null(currency.Name);
-    Assert.Null(currency.Code);
-    Assert.Null(currency.Symbol);
+    Assert.IsNull(currency.Name);
+    Assert.IsNull(currency.Code);
+    Assert.IsNull(currency.Symbol);
   }
 
   /// <summary>
   /// Verifies Currency equality based on value.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Currency_SameValues_AreEqual()
   {
     // Arrange
@@ -59,14 +60,14 @@ public sealed class ValueObjectTests
     var currency2 = new Currency("Euro", "EUR", "€");
 
     // Assert
-    Assert.Equal(currency1, currency2);
-    Assert.True(currency1 == currency2);
+    Assert.AreEqual(currency1, currency2);
+    Assert.IsTrue(currency1 == currency2);
   }
 
   /// <summary>
   /// Verifies Currency inequality for different values.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Currency_DifferentValues_AreNotEqual()
   {
     // Arrange
@@ -74,14 +75,14 @@ public sealed class ValueObjectTests
     var currency2 = new Currency("Euro", "EUR", "€");
 
     // Assert
-    Assert.NotEqual(currency1, currency2);
-    Assert.True(currency1 != currency2);
+    Assert.AreNotEqual(currency1, currency2);
+    Assert.IsTrue(currency1 != currency2);
   }
 
   /// <summary>
   /// Verifies Currency has consistent hash code for same values.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Currency_SameValues_HaveSameHashCode()
   {
     // Arrange
@@ -89,17 +90,17 @@ public sealed class ValueObjectTests
     var currency2 = new Currency("British Pound", "GBP", "£");
 
     // Assert
-    Assert.Equal(currency1.GetHashCode(), currency2.GetHashCode());
+    Assert.AreEqual(currency1.GetHashCode(), currency2.GetHashCode());
   }
 
   /// <summary>
   /// Verifies Currency has Serializable attribute.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Currency_HasSerializableAttribute()
   {
     // Assert
-    Assert.True(Attribute.IsDefined(typeof(Currency), typeof(SerializableAttribute)));
+    Assert.IsTrue(Attribute.IsDefined(typeof(Currency), typeof(SerializableAttribute)));
   }
 
   #endregion
@@ -109,24 +110,24 @@ public sealed class ValueObjectTests
   /// <summary>
   /// Verifies ContactInformation creates instance with default empty values.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void ContactInformation_DefaultConstructor_CreatesInstanceWithDefaults()
   {
     // Act
     var contact = new ContactInformation();
 
     // Assert
-    Assert.Equal(string.Empty, contact.FullName);
-    Assert.Equal(string.Empty, contact.Address);
-    Assert.Equal(string.Empty, contact.PhoneNumber);
-    Assert.Equal(string.Empty, contact.EmailAddress);
-    Assert.Equal(string.Empty, contact.Website);
+    Assert.AreEqual(string.Empty, contact.FullName);
+    Assert.AreEqual(string.Empty, contact.Address);
+    Assert.AreEqual(string.Empty, contact.PhoneNumber);
+    Assert.AreEqual(string.Empty, contact.EmailAddress);
+    Assert.AreEqual(string.Empty, contact.Website);
   }
 
   /// <summary>
   /// Verifies ContactInformation properties can be set.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void ContactInformation_SetProperties_PropertiesAreSet()
   {
     // Arrange
@@ -140,17 +141,17 @@ public sealed class ValueObjectTests
     };
 
     // Assert
-    Assert.Equal("John Doe", contact.FullName);
-    Assert.Equal("123 Main St", contact.Address);
-    Assert.Equal("+1234567890", contact.PhoneNumber);
-    Assert.Equal("john@example.com", contact.EmailAddress);
-    Assert.Equal("https://example.com", contact.Website);
+    Assert.AreEqual("John Doe", contact.FullName);
+    Assert.AreEqual("123 Main St", contact.Address);
+    Assert.AreEqual("+1234567890", contact.PhoneNumber);
+    Assert.AreEqual("john@example.com", contact.EmailAddress);
+    Assert.AreEqual("https://example.com", contact.Website);
   }
 
   /// <summary>
   /// Verifies ContactInformation equality based on value.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void ContactInformation_SameValues_AreEqual()
   {
     // Arrange
@@ -158,17 +159,17 @@ public sealed class ValueObjectTests
     var contact2 = new ContactInformation { FullName = "Test", EmailAddress = "test@test.com" };
 
     // Assert
-    Assert.Equal(contact1, contact2);
+    Assert.AreEqual(contact1, contact2);
   }
 
   /// <summary>
   /// Verifies ContactInformation has Serializable attribute.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void ContactInformation_HasSerializableAttribute()
   {
     // Assert
-    Assert.True(Attribute.IsDefined(typeof(ContactInformation), typeof(SerializableAttribute)));
+    Assert.IsTrue(Attribute.IsDefined(typeof(ContactInformation), typeof(SerializableAttribute)));
   }
 
   #endregion
@@ -178,26 +179,26 @@ public sealed class ValueObjectTests
   /// <summary>
   /// Verifies PaymentInformation creates instance with default values.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void PaymentInformation_DefaultConstructor_CreatesInstanceWithDefaults()
   {
     // Act
     var payment = new PaymentInformation();
 
     // Assert
-    Assert.Equal(PaymentType.UNKNOWN, payment.PaymentType);
-    Assert.Equal(0.0m, payment.TotalCostAmount);
-    Assert.Equal(0.0m, payment.TotalTaxAmount);
-    Assert.NotEqual(default, payment.TransactionDate);
-    Assert.Equal("Romanian Leu", payment.Currency.Name);
-    Assert.Equal("RON", payment.Currency.Code);
-    Assert.Equal("lei", payment.Currency.Symbol);
+    Assert.AreEqual(PaymentType.UNKNOWN, payment.PaymentType);
+    Assert.AreEqual(0.0m, payment.TotalCostAmount);
+    Assert.AreEqual(0.0m, payment.TotalTaxAmount);
+    Assert.AreNotEqual(default, payment.TransactionDate);
+    Assert.AreEqual("Romanian Leu", payment.Currency.Name);
+    Assert.AreEqual("RON", payment.Currency.Code);
+    Assert.AreEqual("lei", payment.Currency.Symbol);
   }
 
   /// <summary>
   /// Verifies PaymentInformation properties can be set.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void PaymentInformation_SetProperties_PropertiesAreSet()
   {
     // Arrange
@@ -212,17 +213,17 @@ public sealed class ValueObjectTests
     };
 
     // Assert
-    Assert.Equal(transactionDate, payment.TransactionDate);
-    Assert.Equal(PaymentType.CARD, payment.PaymentType);
-    Assert.Equal("USD", payment.Currency.Code);
-    Assert.Equal(100.50m, payment.TotalCostAmount);
-    Assert.Equal(19.00m, payment.TotalTaxAmount);
+    Assert.AreEqual(transactionDate, payment.TransactionDate);
+    Assert.AreEqual(PaymentType.CARD, payment.PaymentType);
+    Assert.AreEqual("USD", payment.Currency.Code);
+    Assert.AreEqual(100.50m, payment.TotalCostAmount);
+    Assert.AreEqual(19.00m, payment.TotalTaxAmount);
   }
 
   /// <summary>
   /// Verifies PaymentInformation equality based on value.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void PaymentInformation_SameValues_AreEqual()
   {
     // Arrange
@@ -231,17 +232,17 @@ public sealed class ValueObjectTests
     var payment2 = new PaymentInformation { TransactionDate = date, TotalCostAmount = 50m };
 
     // Assert
-    Assert.Equal(payment1, payment2);
+    Assert.AreEqual(payment1, payment2);
   }
 
   /// <summary>
   /// Verifies PaymentInformation has Serializable attribute.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void PaymentInformation_HasSerializableAttribute()
   {
     // Assert
-    Assert.True(Attribute.IsDefined(typeof(PaymentInformation), typeof(SerializableAttribute)));
+    Assert.IsTrue(Attribute.IsDefined(typeof(PaymentInformation), typeof(SerializableAttribute)));
   }
 
   #endregion
@@ -251,38 +252,38 @@ public sealed class ValueObjectTests
   /// <summary>
   /// Verifies PaymentType enum has expected values.
   /// </summary>
-  [Theory]
-  [InlineData(PaymentType.UNKNOWN, 0)]
-  [InlineData(PaymentType.CASH, 100)]
-  [InlineData(PaymentType.CARD, 200)]
-  [InlineData(PaymentType.TRANSFER, 300)]
-  [InlineData(PaymentType.MOBILEPAYMENT, 400)]
-  [InlineData(PaymentType.VOUCHER, 500)]
-  [InlineData(PaymentType.Other, 9999)]
+  [TestMethod]
+  [DataRow(PaymentType.UNKNOWN, 0)]
+  [DataRow(PaymentType.CASH, 100)]
+  [DataRow(PaymentType.CARD, 200)]
+  [DataRow(PaymentType.TRANSFER, 300)]
+  [DataRow(PaymentType.MOBILEPAYMENT, 400)]
+  [DataRow(PaymentType.VOUCHER, 500)]
+  [DataRow(PaymentType.Other, 9999)]
   public void PaymentType_EnumValues_HaveCorrectUnderlyingValues(PaymentType paymentType, int expectedValue)
   {
     // Assert
-    Assert.Equal(expectedValue, (int)paymentType);
+    Assert.AreEqual(expectedValue, (int)paymentType);
   }
 
   /// <summary>
   /// Verifies all PaymentType enum values can be parsed.
   /// </summary>
-  [Theory]
-  [InlineData("UNKNOWN")]
-  [InlineData("CASH")]
-  [InlineData("CARD")]
-  [InlineData("TRANSFER")]
-  [InlineData("MOBILEPAYMENT")]
-  [InlineData("VOUCHER")]
-  [InlineData("Other")]
+  [TestMethod]
+  [DataRow("UNKNOWN")]
+  [DataRow("CASH")]
+  [DataRow("CARD")]
+  [DataRow("TRANSFER")]
+  [DataRow("MOBILEPAYMENT")]
+  [DataRow("VOUCHER")]
+  [DataRow("Other")]
   public void PaymentType_ParseFromString_ReturnsCorrectValue(string paymentTypeName)
   {
     // Act
     var parsed = Enum.Parse<PaymentType>(paymentTypeName);
 
     // Assert
-    Assert.True(Enum.IsDefined<PaymentType>(parsed));
+    Assert.IsTrue(Enum.IsDefined<PaymentType>(parsed));
   }
 
   #endregion
@@ -292,23 +293,23 @@ public sealed class ValueObjectTests
   /// <summary>
   /// Verifies Allergen creates instance with default values.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Allergen_DefaultConstructor_CreatesInstanceWithDefaults()
   {
     // Act
     var allergen = new Allergen();
 
     // Assert
-    Assert.Equal(string.Empty, allergen.Name);
-    Assert.Equal(string.Empty, allergen.Description);
-    Assert.NotNull(allergen.LearnMoreAddress);
-    Assert.Equal("https://arolariu.ro/", allergen.LearnMoreAddress.ToString());
+    Assert.AreEqual(string.Empty, allergen.Name);
+    Assert.AreEqual(string.Empty, allergen.Description);
+    Assert.IsNotNull(allergen.LearnMoreAddress);
+    Assert.AreEqual("https://arolariu.ro/", allergen.LearnMoreAddress.ToString());
   }
 
   /// <summary>
   /// Verifies Allergen properties can be set.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Allergen_SetProperties_PropertiesAreSet()
   {
     // Arrange
@@ -320,15 +321,15 @@ public sealed class ValueObjectTests
     };
 
     // Assert
-    Assert.Equal("Peanuts", allergen.Name);
-    Assert.Equal("Common tree nut allergen", allergen.Description);
-    Assert.Equal("https://example.com/allergens/peanuts", allergen.LearnMoreAddress.ToString());
+    Assert.AreEqual("Peanuts", allergen.Name);
+    Assert.AreEqual("Common tree nut allergen", allergen.Description);
+    Assert.AreEqual("https://example.com/allergens/peanuts", allergen.LearnMoreAddress.ToString());
   }
 
   /// <summary>
   /// Verifies Allergen equality based on value.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Allergen_SameValues_AreEqual()
   {
     // Arrange
@@ -336,13 +337,13 @@ public sealed class ValueObjectTests
     var allergen2 = new Allergen { Name = "Gluten", Description = "Wheat protein" };
 
     // Assert
-    Assert.Equal(allergen1, allergen2);
+    Assert.AreEqual(allergen1, allergen2);
   }
 
   /// <summary>
   /// Verifies Allergen inequality for different values.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Allergen_DifferentValues_AreNotEqual()
   {
     // Arrange
@@ -350,7 +351,7 @@ public sealed class ValueObjectTests
     var allergen2 = new Allergen { Name = "Dairy" };
 
     // Assert
-    Assert.NotEqual(allergen1, allergen2);
+    Assert.AreNotEqual(allergen1, allergen2);
   }
 
   #endregion
@@ -360,26 +361,26 @@ public sealed class ValueObjectTests
   /// <summary>
   /// Verifies Recipe creates instance with default values using parameterless constructor.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Recipe_ParameterlessConstructor_CreatesInstanceWithDefaults()
   {
     // Act
     var recipe = new Recipe();
 
     // Assert
-    Assert.Equal(string.Empty, recipe.Name);
-    Assert.Equal(string.Empty, recipe.Description);
-    Assert.Equal(-1, recipe.ApproximateTotalDuration);
-    Assert.Equal(RecipeComplexity.UNKNOWN, recipe.Complexity);
-    Assert.Empty(recipe.Ingredients);
-    Assert.NotNull(recipe.ReferenceForMoreDetails);
-    Assert.Equal("https://arolariu.ro/", recipe.ReferenceForMoreDetails.ToString());
+    Assert.AreEqual(string.Empty, recipe.Name);
+    Assert.AreEqual(string.Empty, recipe.Description);
+    Assert.AreEqual(-1, recipe.ApproximateTotalDuration);
+    Assert.AreEqual(RecipeComplexity.UNKNOWN, recipe.Complexity);
+    Assert.IsEmpty(recipe.Ingredients);
+    Assert.IsNotNull(recipe.ReferenceForMoreDetails);
+    Assert.AreEqual("https://arolariu.ro/", recipe.ReferenceForMoreDetails.ToString());
   }
 
   /// <summary>
   /// Verifies Recipe parameterized constructor sets all properties.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Recipe_ParameterizedConstructor_SetsAllProperties()
   {
     // Arrange
@@ -394,18 +395,18 @@ public sealed class ValueObjectTests
     var recipe = new Recipe(name, description, duration, complexity, ingredients, reference);
 
     // Assert
-    Assert.Equal(name, recipe.Name);
-    Assert.Equal(description, recipe.Description);
-    Assert.Equal(duration, recipe.ApproximateTotalDuration);
-    Assert.Equal(complexity, recipe.Complexity);
-    Assert.Equal(ingredients, recipe.Ingredients);
-    Assert.Equal(reference, recipe.ReferenceForMoreDetails);
+    Assert.AreEqual(name, recipe.Name);
+    Assert.AreEqual(description, recipe.Description);
+    Assert.AreEqual(duration, recipe.ApproximateTotalDuration);
+    Assert.AreEqual(complexity, recipe.Complexity);
+    Assert.AreSequenceEqual(ingredients, recipe.Ingredients);
+    Assert.AreEqual(reference, recipe.ReferenceForMoreDetails);
   }
 
   /// <summary>
   /// Verifies Recipe properties can be set.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Recipe_SetProperties_PropertiesAreSet()
   {
     // Arrange
@@ -418,25 +419,25 @@ public sealed class ValueObjectTests
     };
 
     // Assert
-    Assert.Equal("Pizza Margherita", recipe.Name);
-    Assert.Equal("Traditional Italian pizza", recipe.Description);
-    Assert.Equal(45, recipe.ApproximateTotalDuration);
-    Assert.Equal(RecipeComplexity.EASY, recipe.Complexity);
+    Assert.AreEqual("Pizza Margherita", recipe.Name);
+    Assert.AreEqual("Traditional Italian pizza", recipe.Description);
+    Assert.AreEqual(45, recipe.ApproximateTotalDuration);
+    Assert.AreEqual(RecipeComplexity.EASY, recipe.Complexity);
   }
 
   /// <summary>
   /// Verifies Recipe same instance is equal to itself.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Recipe_SameInstance_IsEqual()
   {
     // Arrange
     var recipe = new Recipe { Name = "Test Recipe", ApproximateTotalDuration = 30 };
 
     // Assert
-    Assert.Equal(recipe, recipe);
-    Assert.Equal("Test Recipe", recipe.Name);
-    Assert.Equal(30, recipe.ApproximateTotalDuration);
+    Assert.AreEqual(recipe, recipe);
+    Assert.AreEqual("Test Recipe", recipe.Name);
+    Assert.AreEqual(30, recipe.ApproximateTotalDuration);
   }
 
   #endregion
@@ -446,32 +447,32 @@ public sealed class ValueObjectTests
   /// <summary>
   /// Verifies RecipeComplexity enum has expected values.
   /// </summary>
-  [Theory]
-  [InlineData(RecipeComplexity.UNKNOWN, 0)]
-  [InlineData(RecipeComplexity.EASY, 1)]
-  [InlineData(RecipeComplexity.NORMAL, 2)]
-  [InlineData(RecipeComplexity.HARD, 3)]
+  [TestMethod]
+  [DataRow(RecipeComplexity.UNKNOWN, 0)]
+  [DataRow(RecipeComplexity.EASY, 1)]
+  [DataRow(RecipeComplexity.NORMAL, 2)]
+  [DataRow(RecipeComplexity.HARD, 3)]
   public void RecipeComplexity_EnumValues_HaveCorrectUnderlyingValues(RecipeComplexity complexity, int expectedValue)
   {
     // Assert
-    Assert.Equal(expectedValue, (int)complexity);
+    Assert.AreEqual(expectedValue, (int)complexity);
   }
 
   /// <summary>
   /// Verifies all RecipeComplexity enum values can be parsed.
   /// </summary>
-  [Theory]
-  [InlineData("UNKNOWN")]
-  [InlineData("EASY")]
-  [InlineData("NORMAL")]
-  [InlineData("HARD")]
+  [TestMethod]
+  [DataRow("UNKNOWN")]
+  [DataRow("EASY")]
+  [DataRow("NORMAL")]
+  [DataRow("HARD")]
   public void RecipeComplexity_ParseFromString_ReturnsCorrectValue(string complexityName)
   {
     // Act
     var parsed = Enum.Parse<RecipeComplexity>(complexityName);
 
     // Assert
-    Assert.True(Enum.IsDefined<RecipeComplexity>(parsed));
+    Assert.IsTrue(Enum.IsDefined<RecipeComplexity>(parsed));
   }
 
   #endregion
@@ -481,27 +482,27 @@ public sealed class ValueObjectTests
   /// <summary>
   /// Verifies Product creates instance with default values.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_DefaultConstructor_CreatesInstanceWithDefaults()
   {
     // Act
     var product = new Product();
 
     // Assert
-    Assert.Equal(string.Empty, product.Name);
-    Assert.Equal(ProductCategory.OTHER, product.Category);
-    Assert.Equal(0, product.Quantity);
-    Assert.Equal(string.Empty, product.QuantityUnit);
-    Assert.Equal(string.Empty, product.ProductCode);
-    Assert.Equal(0, product.Price);
-    Assert.Empty(product.DetectedAllergens);
-    Assert.Equal(default, product.Metadata);
+    Assert.AreEqual(string.Empty, product.Name);
+    Assert.AreEqual(ProductCategory.OTHER, product.Category);
+    Assert.AreEqual(0, product.Quantity);
+    Assert.AreEqual(string.Empty, product.QuantityUnit);
+    Assert.AreEqual(string.Empty, product.ProductCode);
+    Assert.AreEqual(0, product.Price);
+    Assert.IsEmpty(product.DetectedAllergens);
+    Assert.AreEqual(default, product.Metadata);
   }
 
   /// <summary>
   /// Verifies Product properties can be set.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_SetProperties_PropertiesAreSet()
   {
     // Arrange
@@ -518,19 +519,19 @@ public sealed class ValueObjectTests
     };
 
     // Assert
-    Assert.Equal("MONSTER ENERGY DRINK 500ML", product.Name);
-    Assert.Equal(ProductCategory.BEVERAGES, product.Category);
-    Assert.Equal(2, product.Quantity);
-    Assert.Equal("pcs", product.QuantityUnit);
-    Assert.Equal("SKU12345", product.ProductCode);
-    Assert.Equal(5.99m, product.Price);
-    Assert.Single(product.DetectedAllergens);
+    Assert.AreEqual("MONSTER ENERGY DRINK 500ML", product.Name);
+    Assert.AreEqual(ProductCategory.BEVERAGES, product.Category);
+    Assert.AreEqual(2, product.Quantity);
+    Assert.AreEqual("pcs", product.QuantityUnit);
+    Assert.AreEqual("SKU12345", product.ProductCode);
+    Assert.AreEqual(5.99m, product.Price);
+    Assert.ContainsSingle(product.DetectedAllergens);
   }
 
   /// <summary>
   /// Verifies Product TotalPrice computed property calculates correctly.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_TotalPrice_CalculatesCorrectly()
   {
     // Arrange
@@ -541,13 +542,13 @@ public sealed class ValueObjectTests
     };
 
     // Assert
-    Assert.Equal(30.00m, product.TotalPrice);
+    Assert.AreEqual(30.00m, product.TotalPrice);
   }
 
   /// <summary>
   /// Verifies Product TotalPrice returns zero when quantity is zero.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_TotalPrice_QuantityZero_ReturnsZero()
   {
     // Arrange
@@ -558,13 +559,13 @@ public sealed class ValueObjectTests
     };
 
     // Assert
-    Assert.Equal(0, product.TotalPrice);
+    Assert.AreEqual(0, product.TotalPrice);
   }
 
   /// <summary>
   /// Verifies Product TotalPrice returns zero when price is zero.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_TotalPrice_PriceZero_ReturnsZero()
   {
     // Arrange
@@ -575,13 +576,13 @@ public sealed class ValueObjectTests
     };
 
     // Assert
-    Assert.Equal(0, product.TotalPrice);
+    Assert.AreEqual(0, product.TotalPrice);
   }
 
   /// <summary>
   /// Verifies Product TotalPrice handles decimal calculations correctly.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Product_TotalPrice_DecimalValues_CalculatesCorrectly()
   {
     // Arrange
@@ -592,7 +593,7 @@ public sealed class ValueObjectTests
     };
 
     // Assert
-    Assert.Equal(12.475m, product.TotalPrice);
+    Assert.AreEqual(12.475m, product.TotalPrice);
   }
 
   #endregion
@@ -602,22 +603,22 @@ public sealed class ValueObjectTests
   /// <summary>
   /// Verifies ProductMetadata creates instance with default false values.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void ProductMetadata_DefaultConstructor_CreatesInstanceWithDefaults()
   {
     // Act
     var metadata = new ProductMetadata();
 
     // Assert
-    Assert.False(metadata.IsEdited);
-    Assert.False(metadata.IsComplete);
-    Assert.False(metadata.IsSoftDeleted);
+    Assert.IsFalse(metadata.IsEdited);
+    Assert.IsFalse(metadata.IsComplete);
+    Assert.IsFalse(metadata.IsSoftDeleted);
   }
 
   /// <summary>
   /// Verifies ProductMetadata properties can be set.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void ProductMetadata_SetProperties_PropertiesAreSet()
   {
     // Arrange
@@ -629,15 +630,15 @@ public sealed class ValueObjectTests
     };
 
     // Assert
-    Assert.True(metadata.IsEdited);
-    Assert.True(metadata.IsComplete);
-    Assert.False(metadata.IsSoftDeleted);
+    Assert.IsTrue(metadata.IsEdited);
+    Assert.IsTrue(metadata.IsComplete);
+    Assert.IsFalse(metadata.IsSoftDeleted);
   }
 
   /// <summary>
   /// Verifies ProductMetadata equality based on value.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void ProductMetadata_SameValues_AreEqual()
   {
     // Arrange
@@ -645,13 +646,13 @@ public sealed class ValueObjectTests
     var metadata2 = new ProductMetadata { IsEdited = true, IsComplete = false, IsSoftDeleted = false };
 
     // Assert
-    Assert.Equal(metadata1, metadata2);
+    Assert.AreEqual(metadata1, metadata2);
   }
 
   /// <summary>
   /// Verifies ProductMetadata inequality for different values.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void ProductMetadata_DifferentValues_AreNotEqual()
   {
     // Arrange
@@ -659,26 +660,26 @@ public sealed class ValueObjectTests
     var metadata2 = new ProductMetadata { IsEdited = false };
 
     // Assert
-    Assert.NotEqual(metadata1, metadata2);
+    Assert.AreNotEqual(metadata1, metadata2);
   }
 
   /// <summary>
   /// Verifies ProductMetadata represents soft delete state correctly.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void ProductMetadata_SoftDeleted_StateIsCorrect()
   {
     // Arrange
     var metadata = new ProductMetadata { IsSoftDeleted = true };
 
     // Assert
-    Assert.True(metadata.IsSoftDeleted);
+    Assert.IsTrue(metadata.IsSoftDeleted);
   }
 
   /// <summary>
   /// Verifies ProductMetadata hash code is consistent for same values.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void ProductMetadata_SameValues_HaveSameHashCode()
   {
     // Arrange
@@ -686,7 +687,7 @@ public sealed class ValueObjectTests
     var metadata2 = new ProductMetadata { IsEdited = true, IsComplete = true, IsSoftDeleted = false };
 
     // Assert
-    Assert.Equal(metadata1.GetHashCode(), metadata2.GetHashCode());
+    Assert.AreEqual(metadata1.GetHashCode(), metadata2.GetHashCode());
   }
 
   #endregion
@@ -696,42 +697,42 @@ public sealed class ValueObjectTests
   /// <summary>
   /// Verifies ProductCategory.OTHER is the default category.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void ProductCategory_Default_IsOther()
   {
     // Arrange
     var product = new Product();
 
     // Assert
-    Assert.Equal(ProductCategory.OTHER, product.Category);
+    Assert.AreEqual(ProductCategory.OTHER, product.Category);
   }
 
   /// <summary>
   /// Verifies ProductCategory can be set to different values.
   /// </summary>
-  [Theory]
-  [InlineData(ProductCategory.NOT_DEFINED)]
-  [InlineData(ProductCategory.BAKED_GOODS)]
-  [InlineData(ProductCategory.GROCERIES)]
-  [InlineData(ProductCategory.DAIRY)]
-  [InlineData(ProductCategory.MEAT)]
-  [InlineData(ProductCategory.FISH)]
-  [InlineData(ProductCategory.FRUITS)]
-  [InlineData(ProductCategory.VEGETABLES)]
-  [InlineData(ProductCategory.BEVERAGES)]
-  [InlineData(ProductCategory.ALCOHOLIC_BEVERAGES)]
-  [InlineData(ProductCategory.TOBACCO)]
-  [InlineData(ProductCategory.CLEANING_SUPPLIES)]
-  [InlineData(ProductCategory.PERSONAL_CARE)]
-  [InlineData(ProductCategory.MEDICINE)]
-  [InlineData(ProductCategory.OTHER)]
+  [TestMethod]
+  [DataRow(ProductCategory.NOT_DEFINED)]
+  [DataRow(ProductCategory.BAKED_GOODS)]
+  [DataRow(ProductCategory.GROCERIES)]
+  [DataRow(ProductCategory.DAIRY)]
+  [DataRow(ProductCategory.MEAT)]
+  [DataRow(ProductCategory.FISH)]
+  [DataRow(ProductCategory.FRUITS)]
+  [DataRow(ProductCategory.VEGETABLES)]
+  [DataRow(ProductCategory.BEVERAGES)]
+  [DataRow(ProductCategory.ALCOHOLIC_BEVERAGES)]
+  [DataRow(ProductCategory.TOBACCO)]
+  [DataRow(ProductCategory.CLEANING_SUPPLIES)]
+  [DataRow(ProductCategory.PERSONAL_CARE)]
+  [DataRow(ProductCategory.MEDICINE)]
+  [DataRow(ProductCategory.OTHER)]
   public void ProductCategory_CanBeSetToAnyValue(ProductCategory category)
   {
     // Arrange
     var product = new Product { Category = category };
 
     // Assert
-    Assert.Equal(category, product.Category);
+    Assert.AreEqual(category, product.Category);
   }
 
   #endregion

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/CancellationPassthroughTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/CancellationPassthroughTests.cs
@@ -21,13 +21,14 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 using Moq;
 
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 /// <summary>
 /// Guards the single most regression-prone rule of the cancellation contract:
 /// cancellation must never be reclassified into a domain exception, because that
 /// turns a client disconnect into an HTTP 500/503 and a false failure metric.
 /// </summary>
+[TestClass]
 public sealed class CancellationPassthroughTests
 {
   private static InvoiceStorageFoundationService CreateStorageService(Mock<IInvoiceNoSqlBroker> broker) =>
@@ -37,7 +38,7 @@ public sealed class CancellationPassthroughTests
   /// Verifies that <see cref="InvoiceStorageFoundationService.ReadInvoiceObject"/> propagates
   /// <see cref="OperationCanceledException"/> thrown by the broker without reclassifying it.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoiceObject_WhenBrokerCancels_PropagatesOperationCanceledException()
   {
     var broker = new Mock<IInvoiceNoSqlBroker>();
@@ -47,7 +48,7 @@ public sealed class CancellationPassthroughTests
 
     var service = CreateStorageService(broker);
 
-    await Assert.ThrowsAsync<OperationCanceledException>(
+    await Assert.ThrowsExactlyAsync<OperationCanceledException>(
       () => service.ReadInvoiceObject(Guid.NewGuid(), null, CancellationToken.None)).ConfigureAwait(true);
   }
 
@@ -55,7 +56,7 @@ public sealed class CancellationPassthroughTests
   /// Verifies that <see cref="InvoiceStorageFoundationService.ReadAllInvoiceObjects"/> propagates
   /// <see cref="TaskCanceledException"/> thrown by the broker without reclassifying it.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadAllInvoiceObjects_WhenBrokerCancels_PropagatesOperationCanceledException()
   {
     var broker = new Mock<IInvoiceNoSqlBroker>();
@@ -66,7 +67,7 @@ public sealed class CancellationPassthroughTests
     var service = CreateStorageService(broker);
 
     // TaskCanceledException derives from OperationCanceledException — one clause covers both.
-    await Assert.ThrowsAsync<TaskCanceledException>(
+    await Assert.ThrowsExactlyAsync<TaskCanceledException>(
       () => service.ReadAllInvoiceObjects(Guid.NewGuid(), CancellationToken.None)).ConfigureAwait(true);
   }
 
@@ -74,7 +75,7 @@ public sealed class CancellationPassthroughTests
   /// Verifies that <see cref="InvoiceStorageFoundationService.CreateInvoiceObject"/> propagates
   /// <see cref="OperationCanceledException"/> thrown by the broker without reclassifying it.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateInvoiceObject_WhenBrokerCancels_PropagatesOperationCanceledException()
   {
     var broker = new Mock<IInvoiceNoSqlBroker>();
@@ -85,7 +86,7 @@ public sealed class CancellationPassthroughTests
     var service = CreateStorageService(broker);
     var invoice = InvoiceBuilder.CreateRandomInvoice();
 
-    await Assert.ThrowsAsync<OperationCanceledException>(
+    await Assert.ThrowsExactlyAsync<OperationCanceledException>(
       () => service.CreateInvoiceObject(invoice, null, CancellationToken.None)).ConfigureAwait(true);
   }
 
@@ -93,7 +94,7 @@ public sealed class CancellationPassthroughTests
   /// Verifies that <see cref="InvoiceOrchestrationService.ReadInvoiceObject"/> propagates
   /// <see cref="OperationCanceledException"/> thrown by a foundation service without reclassifying it.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task OrchestrationLayer_WhenFoundationCancels_PropagatesOperationCanceledException()
   {
     var storage = new Mock<IInvoiceStorageFoundationService>();
@@ -104,7 +105,7 @@ public sealed class CancellationPassthroughTests
     var analysis = new Mock<IInvoiceAnalysisFoundationService>();
     var service = new InvoiceOrchestrationService(analysis.Object, storage.Object, NullLoggerFactory.Instance);
 
-    await Assert.ThrowsAsync<OperationCanceledException>(
+    await Assert.ThrowsExactlyAsync<OperationCanceledException>(
       () => service.ReadInvoiceObject(Guid.NewGuid(), null, CancellationToken.None)).ConfigureAwait(true);
   }
 
@@ -112,7 +113,7 @@ public sealed class CancellationPassthroughTests
   /// Verifies that <see cref="InvoiceProcessingService.ReadInvoice"/> propagates
   /// <see cref="OperationCanceledException"/> through all three wrapping layers without reclassifying it.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ProcessingLayer_WhenOrchestrationCancels_PropagatesOperationCanceledException()
   {
     var invoiceOrchestration = new Mock<IInvoiceOrchestrationService>();
@@ -127,7 +128,7 @@ public sealed class CancellationPassthroughTests
       NullLoggerFactory.Instance);
 
     // Proves the exception survives all three wrapping layers, not just the innermost one.
-    await Assert.ThrowsAsync<OperationCanceledException>(
+    await Assert.ThrowsExactlyAsync<OperationCanceledException>(
       () => service.ReadInvoice(Guid.NewGuid(), null, CancellationToken.None)).ConfigureAwait(true);
   }
 
@@ -135,7 +136,7 @@ public sealed class CancellationPassthroughTests
   /// Verifies that <see cref="MerchantStorageFoundationService.ReadMerchantObject"/> propagates
   /// <see cref="OperationCanceledException"/> thrown by the broker without reclassifying it.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task MerchantStorage_WhenBrokerCancels_PropagatesOperationCanceledException()
   {
     var broker = new Mock<IInvoiceNoSqlBroker>();
@@ -145,7 +146,7 @@ public sealed class CancellationPassthroughTests
 
     var service = new MerchantStorageFoundationService(broker.Object, NullLoggerFactory.Instance);
 
-    await Assert.ThrowsAsync<OperationCanceledException>(
+    await Assert.ThrowsExactlyAsync<OperationCanceledException>(
       () => service.ReadMerchantObject(Guid.NewGuid(), null, CancellationToken.None)).ConfigureAwait(true);
   }
 
@@ -153,7 +154,7 @@ public sealed class CancellationPassthroughTests
   /// Verifies that <see cref="InvoiceOrchestrationService.AnalyzeInvoiceWithOptions"/> does not
   /// persist the result when cancellation is requested after the analysis stage completes.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoiceWithOptions_WhenCancelledAfterAnalysis_DoesNotPersistTheResult()
   {
     var invoice = InvoiceBuilder.CreateRandomInvoice();
@@ -176,7 +177,7 @@ public sealed class CancellationPassthroughTests
 
     var service = new InvoiceOrchestrationService(analysis.Object, storage.Object, NullLoggerFactory.Instance);
 
-    await Assert.ThrowsAnyAsync<OperationCanceledException>(
+    await Assert.ThrowsAsync<OperationCanceledException>(
       () => service.AnalyzeInvoiceWithOptions(AnalysisOptions.CompleteAnalysis, Guid.NewGuid(), null, cts.Token))
       .ConfigureAwait(true);
 
@@ -192,7 +193,7 @@ public sealed class CancellationPassthroughTests
   /// This checkpoint is the load-bearing guard that prevents both expensive AI stages from
   /// running after the caller has already given up.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoiceAsync_WhenCancelledAfterOcrStage_DoesNotInvokeGptStage()
   {
     var invoice = InvoiceBuilder.CreateRandomInvoice();
@@ -217,7 +218,7 @@ public sealed class CancellationPassthroughTests
       ocrBroker.Object,
       NullLoggerFactory.Instance);
 
-    await Assert.ThrowsAnyAsync<OperationCanceledException>(
+    await Assert.ThrowsAsync<OperationCanceledException>(
       () => service.AnalyzeInvoiceAsync(AnalysisOptions.CompleteAnalysis, invoice, cts.Token))
       .ConfigureAwait(true);
 
@@ -232,7 +233,7 @@ public sealed class CancellationPassthroughTests
   /// fan-out loop as soon as cancellation is requested, instead of deleting every remaining
   /// invoice after the caller has already given up.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteInvoices_WhenCancelledMidFanOut_StopsIterating()
   {
     var invoices = new[]
@@ -266,9 +267,9 @@ public sealed class CancellationPassthroughTests
       merchantOrchestration.Object,
       NullLoggerFactory.Instance);
 
-    await Assert.ThrowsAnyAsync<OperationCanceledException>(
+    await Assert.ThrowsAsync<OperationCanceledException>(
       () => service.DeleteInvoices(Guid.NewGuid(), cts.Token)).ConfigureAwait(true);
 
-    Assert.Equal(1, deleteCount);
+    Assert.AreEqual(1, deleteCount);
   }
 }

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Foundation/InvoiceAnalysisFoundationServiceExceptionsTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Foundation/InvoiceAnalysisFoundationServiceExceptionsTests.cs
@@ -16,13 +16,14 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 using Moq;
 
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 /// <summary>
 /// Verifies that inner exceptions propagated from the analysis brokers (OCR + GPT) are
 /// classified into the correct Foundation-tier outer exceptions by the TryCatch boundary.
 /// Mirrors the tiering contract validated in <see cref="InvoiceStorageFoundationServiceExceptionsTests"/>.
 /// </summary>
+[TestClass]
 public class InvoiceAnalysisFoundationServiceExceptionsTests
 {
   private readonly Mock<IClassifierBroker> _classifierBroker = new();
@@ -39,56 +40,56 @@ public class InvoiceAnalysisFoundationServiceExceptionsTests
   }
 
   /// <summary>Verifies that an <see cref="InvoiceIdNotSetException"/> from the OCR broker is wrapped into an <see cref="InvoiceFoundationValidationException"/>.</summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoiceAsync_WhenBrokerThrowsIdNotSet_ThrowsFoundationValidationException()
   {
     _formRecognizerBroker
       .Setup(b => b.PerformOcrAnalysisOnSingleInvoice(It.IsAny<Invoice>(), It.IsAny<AnalysisOptions>()))
       .ThrowsAsync(new InvoiceIdNotSetException());
 
-    var ex = await Assert.ThrowsAsync<InvoiceFoundationValidationException>(
+    var ex = await Assert.ThrowsExactlyAsync<InvoiceFoundationValidationException>(
       () => _sut.AnalyzeInvoiceAsync(AnalysisOptions.CompleteAnalysis, new Invoice { id = Guid.NewGuid(), UserIdentifier = Guid.NewGuid() }, CancellationToken.None));
 
-    Assert.IsType<InvoiceIdNotSetException>(ex.InnerException);
+    Assert.IsExactInstanceOfType<InvoiceIdNotSetException>(ex.InnerException);
   }
 
   /// <summary>Verifies that an <see cref="InvoiceCosmosDbRateLimitException"/> from the OCR broker is wrapped into an <see cref="InvoiceFoundationDependencyValidationException"/> (caller-correctable 429, not 500).</summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoiceAsync_WhenBrokerThrowsCosmosRateLimit_ThrowsFoundationDependencyValidationException()
   {
     _formRecognizerBroker
       .Setup(b => b.PerformOcrAnalysisOnSingleInvoice(It.IsAny<Invoice>(), It.IsAny<AnalysisOptions>()))
       .ThrowsAsync(new InvoiceCosmosDbRateLimitException(TimeSpan.FromSeconds(5), new InvalidOperationException()));
 
-    var ex = await Assert.ThrowsAsync<InvoiceFoundationDependencyValidationException>(
+    var ex = await Assert.ThrowsExactlyAsync<InvoiceFoundationDependencyValidationException>(
       () => _sut.AnalyzeInvoiceAsync(AnalysisOptions.CompleteAnalysis, new Invoice { id = Guid.NewGuid(), UserIdentifier = Guid.NewGuid() }, CancellationToken.None));
 
-    Assert.IsType<InvoiceCosmosDbRateLimitException>(ex.InnerException);
+    Assert.IsExactInstanceOfType<InvoiceCosmosDbRateLimitException>(ex.InnerException);
   }
 
   /// <summary>Verifies that an <see cref="OperationCanceledException"/> from the OCR broker propagates unchanged per the cancellation-passthrough contract. Cancellation is never a server fault.</summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoiceAsync_WhenBrokerThrowsOperationCanceled_PropagatesOperationCanceledException()
   {
     _formRecognizerBroker
       .Setup(b => b.PerformOcrAnalysisOnSingleInvoice(It.IsAny<Invoice>(), It.IsAny<AnalysisOptions>()))
       .ThrowsAsync(new OperationCanceledException());
 
-    await Assert.ThrowsAsync<OperationCanceledException>(
+    await Assert.ThrowsExactlyAsync<OperationCanceledException>(
       () => _sut.AnalyzeInvoiceAsync(AnalysisOptions.CompleteAnalysis, new Invoice { id = Guid.NewGuid(), UserIdentifier = Guid.NewGuid() }, CancellationToken.None));
   }
 
   /// <summary>Verifies that an unclassified exception from the OCR broker is wrapped into an <see cref="InvoiceFoundationServiceException"/> (catch-all tier, 500).</summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoiceAsync_WhenBrokerThrowsUnknown_ThrowsFoundationServiceException()
   {
     _formRecognizerBroker
       .Setup(b => b.PerformOcrAnalysisOnSingleInvoice(It.IsAny<Invoice>(), It.IsAny<AnalysisOptions>()))
       .ThrowsAsync(new InvalidOperationException("ai model failure"));
 
-    var ex = await Assert.ThrowsAsync<InvoiceFoundationServiceException>(
+    var ex = await Assert.ThrowsExactlyAsync<InvoiceFoundationServiceException>(
       () => _sut.AnalyzeInvoiceAsync(AnalysisOptions.CompleteAnalysis, new Invoice { id = Guid.NewGuid(), UserIdentifier = Guid.NewGuid() }, CancellationToken.None));
 
-    Assert.IsType<InvalidOperationException>(ex.InnerException);
+    Assert.IsExactInstanceOfType<InvalidOperationException>(ex.InnerException);
   }
 }

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Foundation/InvoiceAnalysisFoundationServiceExtendedTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Foundation/InvoiceAnalysisFoundationServiceExtendedTests.cs
@@ -19,12 +19,13 @@ using Microsoft.Extensions.Logging;
 
 using Moq;
 
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 /// <summary>
 /// Extended unit tests for <see cref="InvoiceAnalysisFoundationService"/> covering additional
 /// edge cases, exception scenarios, and boundary conditions for comprehensive code coverage.
 /// </summary>
+[TestClass]
 public sealed class InvoiceAnalysisFoundationServiceExtendedTests
 {
   private readonly Mock<IClassifierBroker> mockOpenAiBroker;
@@ -58,7 +59,7 @@ public sealed class InvoiceAnalysisFoundationServiceExtendedTests
   /// <summary>
   /// Validates TimeoutException from OCR broker is wrapped correctly.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoiceAsync_OcrBrokerTimesOut_ThrowsFoundationServiceException()
   {
     // Arrange
@@ -70,15 +71,15 @@ public sealed class InvoiceAnalysisFoundationServiceExtendedTests
         .ThrowsAsync(new TimeoutException("OCR service timeout"));
 
     // Act & Assert
-    var exception = await Assert.ThrowsAsync<InvoiceFoundationServiceException>(() =>
+    var exception = await Assert.ThrowsExactlyAsync<InvoiceFoundationServiceException>(() =>
         service.AnalyzeInvoiceAsync(options, invoice, CancellationToken.None));
-    Assert.NotNull(exception.InnerException);
+    Assert.IsNotNull(exception.InnerException);
   }
 
   /// <summary>
   /// Validates TimeoutException from GPT broker is wrapped correctly.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoiceAsync_GptBrokerTimesOut_ThrowsFoundationServiceException()
   {
     // Arrange
@@ -94,14 +95,14 @@ public sealed class InvoiceAnalysisFoundationServiceExtendedTests
         .ThrowsAsync(new TimeoutException("GPT service timeout"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceFoundationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceFoundationServiceException>(() =>
         service.AnalyzeInvoiceAsync(options, invoice, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates HttpRequestException from OCR broker is wrapped correctly.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoiceAsync_OcrNetworkError_ThrowsFoundationServiceException()
   {
     // Arrange
@@ -113,14 +114,14 @@ public sealed class InvoiceAnalysisFoundationServiceExtendedTests
         .ThrowsAsync(new System.Net.Http.HttpRequestException("Network error"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceFoundationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceFoundationServiceException>(() =>
         service.AnalyzeInvoiceAsync(options, invoice, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates NotSupportedException is wrapped correctly.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoiceAsync_NotSupportedException_ThrowsFoundationServiceException()
   {
     // Arrange
@@ -132,14 +133,14 @@ public sealed class InvoiceAnalysisFoundationServiceExtendedTests
         .ThrowsAsync(new NotSupportedException("Not supported"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceFoundationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceFoundationServiceException>(() =>
         service.AnalyzeInvoiceAsync(options, invoice, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates InvalidOperationException is wrapped correctly.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoiceAsync_InvalidOperationException_ThrowsFoundationServiceException()
   {
     // Arrange
@@ -151,9 +152,9 @@ public sealed class InvoiceAnalysisFoundationServiceExtendedTests
         .ThrowsAsync(new InvalidOperationException("Invalid operation"));
 
     // Act & Assert
-    var exception = await Assert.ThrowsAsync<InvoiceFoundationServiceException>(() =>
+    var exception = await Assert.ThrowsExactlyAsync<InvoiceFoundationServiceException>(() =>
         service.AnalyzeInvoiceAsync(options, invoice, CancellationToken.None));
-    Assert.IsType<InvalidOperationException>(exception.InnerException);
+    Assert.IsExactInstanceOfType<InvalidOperationException>(exception.InnerException);
   }
 
   #endregion
@@ -163,7 +164,7 @@ public sealed class InvoiceAnalysisFoundationServiceExtendedTests
   /// <summary>
   /// Validates OCR is called before GPT.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoiceAsync_ValidInput_OcrCalledBeforeGpt()
   {
     // Arrange
@@ -185,7 +186,7 @@ public sealed class InvoiceAnalysisFoundationServiceExtendedTests
     await service.AnalyzeInvoiceAsync(options, invoice, CancellationToken.None);
 
     // Assert
-    Assert.True(callOrder.IndexOf("OCR") < callOrder.IndexOf("GPT"));
+    Assert.IsTrue(callOrder.IndexOf("OCR") < callOrder.IndexOf("GPT"));
   }
 
   #endregion
@@ -195,12 +196,12 @@ public sealed class InvoiceAnalysisFoundationServiceExtendedTests
   /// <summary>
   /// Validates all analysis options are passed to OCR broker correctly.
   /// </summary>
-  [Theory]
-  [InlineData(AnalysisOptions.NoAnalysis)]
-  [InlineData(AnalysisOptions.InvoiceOnly)]
-  [InlineData(AnalysisOptions.InvoiceItemsOnly)]
-  [InlineData(AnalysisOptions.InvoiceMerchantOnly)]
-  [InlineData(AnalysisOptions.CompleteAnalysis)]
+  [TestMethod]
+  [DataRow(AnalysisOptions.NoAnalysis)]
+  [DataRow(AnalysisOptions.InvoiceOnly)]
+  [DataRow(AnalysisOptions.InvoiceItemsOnly)]
+  [DataRow(AnalysisOptions.InvoiceMerchantOnly)]
+  [DataRow(AnalysisOptions.CompleteAnalysis)]
   public async Task AnalyzeInvoiceAsync_DifferentOptions_PassesCorrectOptionsToOcr(AnalysisOptions options)
   {
     // Arrange
@@ -224,12 +225,12 @@ public sealed class InvoiceAnalysisFoundationServiceExtendedTests
   /// <summary>
   /// Validates all analysis options are passed to GPT broker correctly.
   /// </summary>
-  [Theory]
-  [InlineData(AnalysisOptions.NoAnalysis)]
-  [InlineData(AnalysisOptions.InvoiceOnly)]
-  [InlineData(AnalysisOptions.InvoiceItemsOnly)]
-  [InlineData(AnalysisOptions.InvoiceMerchantOnly)]
-  [InlineData(AnalysisOptions.CompleteAnalysis)]
+  [TestMethod]
+  [DataRow(AnalysisOptions.NoAnalysis)]
+  [DataRow(AnalysisOptions.InvoiceOnly)]
+  [DataRow(AnalysisOptions.InvoiceItemsOnly)]
+  [DataRow(AnalysisOptions.InvoiceMerchantOnly)]
+  [DataRow(AnalysisOptions.CompleteAnalysis)]
   public async Task AnalyzeInvoiceAsync_DifferentOptions_PassesCorrectOptionsToGpt(AnalysisOptions options)
   {
     // Arrange
@@ -257,7 +258,7 @@ public sealed class InvoiceAnalysisFoundationServiceExtendedTests
   /// <summary>
   /// Validates invoice returned by OCR broker is passed to translation.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoiceAsync_OcrReturnsModifiedInvoice_PassesToTranslation()
   {
     // Arrange
@@ -285,7 +286,7 @@ public sealed class InvoiceAnalysisFoundationServiceExtendedTests
   /// <summary>
   /// Validates NumberOfUpdates starts at initial value before increment.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoiceAsync_InvoiceWithExistingUpdates_IncrementsFromExistingValue()
   {
     // Arrange
@@ -305,7 +306,7 @@ public sealed class InvoiceAnalysisFoundationServiceExtendedTests
     var result = await service.AnalyzeInvoiceAsync(options, invoice, CancellationToken.None);
 
     // Assert
-    Assert.Equal(6, result.NumberOfUpdates);
+    Assert.AreEqual(6, result.NumberOfUpdates);
   }
 
   #endregion
@@ -315,7 +316,7 @@ public sealed class InvoiceAnalysisFoundationServiceExtendedTests
   /// <summary>
   /// Validates concurrent analysis calls complete successfully.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoiceAsync_ConcurrentCalls_AllComplete()
   {
     // Arrange
@@ -335,14 +336,17 @@ public sealed class InvoiceAnalysisFoundationServiceExtendedTests
     var results = await Task.WhenAll(tasks);
 
     // Assert
-    Assert.Equal(10, results.Length);
-    Assert.All(results, r => Assert.NotNull(r));
+    Assert.AreEqual(10, results.Length);
+    foreach (var r in results)
+    {
+      Assert.IsNotNull(r);
+    }
   }
 
   /// <summary>
   /// Validates concurrent analysis with failures handles correctly.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoiceAsync_ConcurrentCallsWithFailures_IndependentExceptions()
   {
     // Arrange
@@ -368,8 +372,8 @@ public sealed class InvoiceAnalysisFoundationServiceExtendedTests
 
     // Assert
     var result1 = await task1;
-    Assert.NotNull(result1);
-    await Assert.ThrowsAsync<InvoiceFoundationServiceException>(() => task2);
+    Assert.IsNotNull(result1);
+    await Assert.ThrowsExactlyAsync<InvoiceFoundationServiceException>(() => task2);
   }
 
   #endregion
@@ -379,7 +383,7 @@ public sealed class InvoiceAnalysisFoundationServiceExtendedTests
   /// <summary>
   /// Validates analysis with single character product name succeeds.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoiceAsync_SingleCharacterProductName_AnalyzesSuccessfully()
   {
     // Arrange
@@ -400,13 +404,13 @@ public sealed class InvoiceAnalysisFoundationServiceExtendedTests
     var result = await service.AnalyzeInvoiceAsync(options, invoice, CancellationToken.None);
 
     // Assert
-    Assert.Equal("A", result.Items.First().Name);
+    Assert.AreEqual("A", result.Items.First().Name);
   }
 
   /// <summary>
   /// Validates analysis with very long product name succeeds.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoiceAsync_VeryLongProductName_AnalyzesSuccessfully()
   {
     // Arrange
@@ -428,13 +432,13 @@ public sealed class InvoiceAnalysisFoundationServiceExtendedTests
     var result = await service.AnalyzeInvoiceAsync(options, invoice, CancellationToken.None);
 
     // Assert
-    Assert.Equal(longName, result.Items.First().Name);
+    Assert.AreEqual(longName, result.Items.First().Name);
   }
 
   /// <summary>
   /// Validates analysis with unicode product name succeeds.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoiceAsync_UnicodeProductName_AnalyzesSuccessfully()
   {
     // Arrange
@@ -456,13 +460,13 @@ public sealed class InvoiceAnalysisFoundationServiceExtendedTests
     var result = await service.AnalyzeInvoiceAsync(options, invoice, CancellationToken.None);
 
     // Assert
-    Assert.Equal(unicodeName, result.Items.First().Name);
+    Assert.AreEqual(unicodeName, result.Items.First().Name);
   }
 
   /// <summary>
   /// Validates analysis with special characters in product name succeeds.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoiceAsync_SpecialCharactersInProductName_AnalyzesSuccessfully()
   {
     // Arrange
@@ -484,13 +488,13 @@ public sealed class InvoiceAnalysisFoundationServiceExtendedTests
     var result = await service.AnalyzeInvoiceAsync(options, invoice, CancellationToken.None);
 
     // Assert
-    Assert.Equal(specialName, result.Items.First().Name);
+    Assert.AreEqual(specialName, result.Items.First().Name);
   }
 
   /// <summary>
   /// Validates analysis with whitespace-only product name succeeds.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoiceAsync_WhitespaceProductName_AnalyzesSuccessfully()
   {
     // Arrange
@@ -511,7 +515,7 @@ public sealed class InvoiceAnalysisFoundationServiceExtendedTests
     var result = await service.AnalyzeInvoiceAsync(options, invoice, CancellationToken.None);
 
     // Assert
-    Assert.Equal("   ", result.Items.First().Name);
+    Assert.AreEqual("   ", result.Items.First().Name);
   }
 
   #endregion

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Foundation/InvoiceAnalysisFoundationServiceTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Foundation/InvoiceAnalysisFoundationServiceTests.cs
@@ -18,13 +18,14 @@ using Microsoft.Extensions.Logging;
 
 using Moq;
 
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 /// <summary>
 /// Comprehensive unit tests for <see cref="InvoiceAnalysisFoundationService"/> targeting 95%+ code coverage.
 /// Tests validate analysis pipeline orchestration, exception handling, and broker coordination.
 /// Method naming follows MethodName_Condition_ExpectedResult pattern per repository standards.
 /// </summary>
+[TestClass]
 public sealed class InvoiceAnalysisFoundationServiceTests
 {
   private readonly Mock<IClassifierBroker> mockOpenAiBroker;
@@ -58,7 +59,7 @@ public sealed class InvoiceAnalysisFoundationServiceTests
   /// <summary>
   /// Validates successful instantiation with all valid dependencies.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Constructor_ValidDependencies_CreatesInstance()
   {
     // Arrange & Act
@@ -68,7 +69,7 @@ public sealed class InvoiceAnalysisFoundationServiceTests
         mockLoggerFactory.Object);
 
     // Assert
-    Assert.NotNull(svc);
+    Assert.IsNotNull(svc);
   }
 
   #endregion
@@ -78,7 +79,7 @@ public sealed class InvoiceAnalysisFoundationServiceTests
   /// <summary>
   /// Validates successful complete analysis workflow execution.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoiceAsync_ValidInput_ExecutesCompleteWorkflow()
   {
     // Arrange
@@ -98,8 +99,8 @@ public sealed class InvoiceAnalysisFoundationServiceTests
     var result = await service.AnalyzeInvoiceAsync(options, invoice, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
-    Assert.Equal(initialUpdates + 1, result.NumberOfUpdates);
+    Assert.IsNotNull(result);
+    Assert.AreEqual(initialUpdates + 1, result.NumberOfUpdates);
     mockFormRecognizerBroker.Verify(b => b.PerformOcrAnalysisOnSingleInvoice(invoice, options), Times.Once);
     mockOpenAiBroker.Verify(b => b.PerformGptAnalysisOnSingleInvoice(invoice, options), Times.Once);
   }
@@ -107,7 +108,7 @@ public sealed class InvoiceAnalysisFoundationServiceTests
   /// <summary>
   /// Validates analysis workflow with invoice only option.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoiceAsync_InvoiceOnlyOption_ExecutesWorkflow()
   {
     // Arrange
@@ -126,13 +127,13 @@ public sealed class InvoiceAnalysisFoundationServiceTests
     var result = await service.AnalyzeInvoiceAsync(options, invoice, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
+    Assert.IsNotNull(result);
   }
 
   /// <summary>
   /// Validates analysis workflow with no analysis option.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoiceAsync_NoAnalysisOption_ExecutesWorkflow()
   {
     // Arrange
@@ -151,13 +152,13 @@ public sealed class InvoiceAnalysisFoundationServiceTests
     var result = await service.AnalyzeInvoiceAsync(options, invoice, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
+    Assert.IsNotNull(result);
   }
 
   /// <summary>
   /// Validates analysis with multiple products completes successfully.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoiceAsync_MultipleProducts_AnalyzesAllProducts()
   {
     // Arrange
@@ -176,14 +177,14 @@ public sealed class InvoiceAnalysisFoundationServiceTests
     var result = await service.AnalyzeInvoiceAsync(options, invoice, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
-    Assert.Equal(invoice.Items.Count, result.Items.Count);
+    Assert.IsNotNull(result);
+    Assert.AreEqual(invoice.Items.Count, result.Items.Count);
   }
 
   /// <summary>
   /// Validates analysis with empty products collection completes.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoiceAsync_EmptyProducts_CompletesSuccessfully()
   {
     // Arrange
@@ -203,14 +204,14 @@ public sealed class InvoiceAnalysisFoundationServiceTests
     var result = await service.AnalyzeInvoiceAsync(options, invoice, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
-    Assert.Empty(result.Items);
+    Assert.IsNotNull(result);
+    Assert.IsEmpty(result.Items);
   }
 
   /// <summary>
   /// Validates NumberOfUpdates is incremented after analysis.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoiceAsync_ValidInput_IncrementsNumberOfUpdates()
   {
     // Arrange
@@ -230,13 +231,13 @@ public sealed class InvoiceAnalysisFoundationServiceTests
     var result = await service.AnalyzeInvoiceAsync(options, invoice, CancellationToken.None);
 
     // Assert
-    Assert.Equal(initialUpdates + 1, result.NumberOfUpdates);
+    Assert.AreEqual(initialUpdates + 1, result.NumberOfUpdates);
   }
 
   /// <summary>
   /// Validates OCR broker exception is wrapped into foundation service exception.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoiceAsync_OcrBrokerThrows_ThrowsFoundationServiceException()
   {
     // Arrange
@@ -248,14 +249,14 @@ public sealed class InvoiceAnalysisFoundationServiceTests
         .ThrowsAsync(new InvalidOperationException("OCR failed"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceFoundationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceFoundationServiceException>(() =>
         service.AnalyzeInvoiceAsync(options, invoice, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates GPT broker exception is wrapped into foundation service exception.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoiceAsync_GptBrokerThrows_ThrowsFoundationServiceException()
   {
     // Arrange
@@ -271,14 +272,14 @@ public sealed class InvoiceAnalysisFoundationServiceTests
         .ThrowsAsync(new InvalidOperationException("GPT failed"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceFoundationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceFoundationServiceException>(() =>
         service.AnalyzeInvoiceAsync(options, invoice, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates ArgumentNullException is wrapped into foundation service exception.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoiceAsync_ArgumentNullException_ThrowsFoundationServiceException()
   {
     // Arrange
@@ -290,7 +291,7 @@ public sealed class InvoiceAnalysisFoundationServiceTests
         .ThrowsAsync(new ArgumentNullException("invoice"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceFoundationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceFoundationServiceException>(() =>
         service.AnalyzeInvoiceAsync(options, invoice, CancellationToken.None));
   }
 
@@ -298,7 +299,7 @@ public sealed class InvoiceAnalysisFoundationServiceTests
   /// Validates that OperationCanceledException from the OCR broker propagates unchanged,
   /// per the cancellation-passthrough contract. Cancellation is never a server fault.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoiceAsync_OperationCanceledException_PropagatesOperationCanceledException()
   {
     // Arrange
@@ -310,14 +311,14 @@ public sealed class InvoiceAnalysisFoundationServiceTests
         .ThrowsAsync(new OperationCanceledException("Cancelled"));
 
     // Act & Assert — cancellation must not be reclassified into a domain exception (bug fix)
-    await Assert.ThrowsAsync<OperationCanceledException>(() =>
+    await Assert.ThrowsExactlyAsync<OperationCanceledException>(() =>
         service.AnalyzeInvoiceAsync(options, invoice, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates analysis with InvoiceItemsOnly option.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoiceAsync_InvoiceItemsOnlyOption_ExecutesWorkflow()
   {
     // Arrange
@@ -336,13 +337,13 @@ public sealed class InvoiceAnalysisFoundationServiceTests
     var result = await service.AnalyzeInvoiceAsync(options, invoice, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
+    Assert.IsNotNull(result);
   }
 
   /// <summary>
   /// Validates analysis with InvoiceMerchantOnly option.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoiceAsync_InvoiceMerchantOnlyOption_ExecutesWorkflow()
   {
     // Arrange
@@ -361,13 +362,13 @@ public sealed class InvoiceAnalysisFoundationServiceTests
     var result = await service.AnalyzeInvoiceAsync(options, invoice, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
+    Assert.IsNotNull(result);
   }
 
   /// <summary>
   /// Validates analysis workflow preserves invoice properties.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoiceAsync_ValidInput_PreservesInvoiceProperties()
   {
     // Arrange
@@ -388,15 +389,15 @@ public sealed class InvoiceAnalysisFoundationServiceTests
     var result = await service.AnalyzeInvoiceAsync(options, invoice, CancellationToken.None);
 
     // Assert
-    Assert.Equal(originalId, result.id);
-    Assert.Equal(originalUserIdentifier, result.UserIdentifier);
+    Assert.AreEqual(originalId, result.id);
+    Assert.AreEqual(originalUserIdentifier, result.UserIdentifier);
   }
 
   /// <summary>
   /// Validates multiple sequential analyses work correctly.
   /// </summary>
-  [Theory]
-  [MemberData(nameof(GetInvoiceTestData))]
+  [TestMethod]
+  [DynamicData(nameof(GetInvoiceTestData))]
   public async Task AnalyzeInvoiceAsync_MultipleInvoices_AllAnalyzeSuccessfully(Invoice invoice)
   {
     // Arrange
@@ -414,7 +415,7 @@ public sealed class InvoiceAnalysisFoundationServiceTests
     var result = await service.AnalyzeInvoiceAsync(options, invoice, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
+    Assert.IsNotNull(result);
   }
 
   #endregion

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Foundation/InvoiceAnalysisFoundationServiceTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Foundation/InvoiceAnalysisFoundationServiceTests.cs
@@ -424,7 +424,7 @@ public sealed class InvoiceAnalysisFoundationServiceTests
   /// <summary>
   /// Provides theory data containing several randomized invoices for parameterized tests.
   /// </summary>
-  public static TheoryData<Invoice> GetInvoiceTestData() => InvoiceBuilder.GetInvoiceTheoryData();
+  public static IEnumerable<object[]> GetInvoiceTestData() => InvoiceBuilder.GetInvoiceTheoryData();
 
   #endregion
 }

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Foundation/InvoiceStorageFoundationServiceExceptionsTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Foundation/InvoiceStorageFoundationServiceExceptionsTests.cs
@@ -14,12 +14,13 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 using Moq;
 
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 /// <summary>
 /// Verifies that inner exceptions propagated from the Cosmos broker are classified
 /// into the proper Foundation-tier outer exceptions by the TryCatch boundary.
 /// </summary>
+[TestClass]
 public class InvoiceStorageFoundationServiceExceptionsTests
 {
   private readonly Mock<IInvoiceNoSqlBroker> _broker = new();
@@ -32,92 +33,92 @@ public class InvoiceStorageFoundationServiceExceptionsTests
   }
 
   /// <summary>Verifies that an <see cref="InvoiceNotFoundException"/> from the broker is wrapped into an <see cref="InvoiceFoundationDependencyValidationException"/>.</summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoiceObject_WhenBrokerThrowsNotFound_ThrowsFoundationDependencyValidationException()
   {
     _broker.Setup(b => b.ReadInvoiceAsync(It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new InvoiceNotFoundException(Guid.NewGuid()));
 
-    var ex = await Assert.ThrowsAsync<InvoiceFoundationDependencyValidationException>(
+    var ex = await Assert.ThrowsExactlyAsync<InvoiceFoundationDependencyValidationException>(
       () => _sut.ReadInvoiceObject(Guid.NewGuid(), Guid.NewGuid(), CancellationToken.None));
 
-    Assert.IsType<InvoiceNotFoundException>(ex.InnerException);
+    Assert.IsExactInstanceOfType<InvoiceNotFoundException>(ex.InnerException);
   }
 
   /// <summary>Verifies that an <see cref="InvoiceAlreadyExistsException"/> from the broker is wrapped into an <see cref="InvoiceFoundationDependencyValidationException"/>.</summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateInvoiceObject_WhenBrokerThrowsAlreadyExists_ThrowsFoundationDependencyValidationException()
   {
     _broker.Setup(b => b.CreateInvoiceAsync(It.IsAny<Invoice>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new InvoiceAlreadyExistsException(Guid.NewGuid()));
     var invoice = new Invoice { id = Guid.NewGuid(), UserIdentifier = Guid.NewGuid() };
 
-    var ex = await Assert.ThrowsAsync<InvoiceFoundationDependencyValidationException>(
+    var ex = await Assert.ThrowsExactlyAsync<InvoiceFoundationDependencyValidationException>(
       () => _sut.CreateInvoiceObject(invoice, null, CancellationToken.None));
 
-    Assert.IsType<InvoiceAlreadyExistsException>(ex.InnerException);
+    Assert.IsExactInstanceOfType<InvoiceAlreadyExistsException>(ex.InnerException);
   }
 
   /// <summary>Verifies that an <see cref="InvoiceUnauthorizedAccessException"/> from the broker is wrapped into an <see cref="InvoiceFoundationDependencyValidationException"/> (caller-correctable 401, not 503).</summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoiceObject_WhenBrokerThrowsUnauthorized_ThrowsFoundationDependencyValidationException()
   {
     _broker.Setup(b => b.ReadInvoiceAsync(It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new InvoiceUnauthorizedAccessException("unauthorized"));
 
-    var ex = await Assert.ThrowsAsync<InvoiceFoundationDependencyValidationException>(
+    var ex = await Assert.ThrowsExactlyAsync<InvoiceFoundationDependencyValidationException>(
       () => _sut.ReadInvoiceObject(Guid.NewGuid(), Guid.NewGuid(), CancellationToken.None));
 
-    Assert.IsType<InvoiceUnauthorizedAccessException>(ex.InnerException);
+    Assert.IsExactInstanceOfType<InvoiceUnauthorizedAccessException>(ex.InnerException);
   }
 
   /// <summary>Verifies that an <see cref="InvoiceForbiddenAccessException"/> from the broker is wrapped into an <see cref="InvoiceFoundationDependencyValidationException"/> (caller-correctable 403, not 503).</summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoiceObject_WhenBrokerThrowsForbidden_ThrowsFoundationDependencyValidationException()
   {
     _broker.Setup(b => b.ReadInvoiceAsync(It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new InvoiceForbiddenAccessException(Guid.NewGuid(), Guid.NewGuid()));
 
-    var ex = await Assert.ThrowsAsync<InvoiceFoundationDependencyValidationException>(
+    var ex = await Assert.ThrowsExactlyAsync<InvoiceFoundationDependencyValidationException>(
       () => _sut.ReadInvoiceObject(Guid.NewGuid(), Guid.NewGuid(), CancellationToken.None));
 
-    Assert.IsType<InvoiceForbiddenAccessException>(ex.InnerException);
+    Assert.IsExactInstanceOfType<InvoiceForbiddenAccessException>(ex.InnerException);
   }
 
   /// <summary>Verifies that an <see cref="InvoiceCosmosDbRateLimitException"/> from the broker is wrapped into an <see cref="InvoiceFoundationDependencyValidationException"/> (caller-correctable 429, not 503).</summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoiceObject_WhenBrokerThrowsRateLimit_ThrowsFoundationDependencyValidationException()
   {
     _broker.Setup(b => b.ReadInvoiceAsync(It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new InvoiceCosmosDbRateLimitException(TimeSpan.FromSeconds(2), new InvalidOperationException()));
 
-    var ex = await Assert.ThrowsAsync<InvoiceFoundationDependencyValidationException>(
+    var ex = await Assert.ThrowsExactlyAsync<InvoiceFoundationDependencyValidationException>(
       () => _sut.ReadInvoiceObject(Guid.NewGuid(), Guid.NewGuid(), CancellationToken.None));
 
-    Assert.IsType<InvoiceCosmosDbRateLimitException>(ex.InnerException);
+    Assert.IsExactInstanceOfType<InvoiceCosmosDbRateLimitException>(ex.InnerException);
   }
 
   /// <summary>Regression guard: <see cref="InvoiceFailedStorageException"/> must remain in the Dependency tier (downstream unreachable, 503).</summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoiceObject_WhenBrokerThrowsFailedStorage_ThrowsFoundationDependencyException()
   {
     _broker.Setup(b => b.ReadInvoiceAsync(It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new InvoiceFailedStorageException("down"));
 
-    var ex = await Assert.ThrowsAsync<InvoiceFoundationDependencyException>(
+    var ex = await Assert.ThrowsExactlyAsync<InvoiceFoundationDependencyException>(
       () => _sut.ReadInvoiceObject(Guid.NewGuid(), Guid.NewGuid(), CancellationToken.None));
 
-    Assert.IsType<InvoiceFailedStorageException>(ex.InnerException);
+    Assert.IsExactInstanceOfType<InvoiceFailedStorageException>(ex.InnerException);
   }
 
   /// <summary>Verifies that an unclassified exception from the broker is wrapped into an <see cref="InvoiceFoundationServiceException"/>.</summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoiceObject_WhenBrokerThrowsUnknown_ThrowsFoundationServiceException()
   {
     _broker.Setup(b => b.ReadInvoiceAsync(It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new InvalidOperationException("boom"));
 
-    await Assert.ThrowsAsync<InvoiceFoundationServiceException>(
+    await Assert.ThrowsExactlyAsync<InvoiceFoundationServiceException>(
       () => _sut.ReadInvoiceObject(Guid.NewGuid(), Guid.NewGuid(), CancellationToken.None));
   }
 }

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Foundation/InvoiceStorageFoundationServiceExtendedTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Foundation/InvoiceStorageFoundationServiceExtendedTests.cs
@@ -16,13 +16,14 @@ using Microsoft.Extensions.Logging;
 
 using Moq;
 
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 /// <summary>
 /// Extended unit tests for <see cref="InvoiceStorageFoundationService"/> covering additional edge cases,
 /// boundary conditions, and exception scenarios for comprehensive code coverage.
 /// Method naming follows MethodName_Condition_ExpectedResult pattern per repository standards.
 /// </summary>
+[TestClass]
 public sealed class InvoiceStorageFoundationServiceExtendedTests
 {
   private readonly Mock<IInvoiceNoSqlBroker> mockBroker;
@@ -53,7 +54,7 @@ public sealed class InvoiceStorageFoundationServiceExtendedTests
   /// <summary>
   /// Validates invoice creation with empty Guid user identifier.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateInvoiceObject_EmptyGuidUserIdentifier_CreatesSuccessfully()
   {
     // Arrange
@@ -73,7 +74,7 @@ public sealed class InvoiceStorageFoundationServiceExtendedTests
   /// <summary>
   /// Validates invoice creation with minimal invoice data.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateInvoiceObject_MinimalInvoice_CreatesSuccessfully()
   {
     // Arrange
@@ -93,7 +94,7 @@ public sealed class InvoiceStorageFoundationServiceExtendedTests
   /// <summary>
   /// Validates generic exception is wrapped into foundation service exception.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateInvoiceObject_GenericException_ThrowsFoundationServiceException()
   {
     // Arrange
@@ -104,14 +105,14 @@ public sealed class InvoiceStorageFoundationServiceExtendedTests
         .ThrowsAsync(new InvalidOperationException("Unexpected error"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceFoundationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceFoundationServiceException>(() =>
         service.CreateInvoiceObject(invoice, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates TimeoutException during creation is wrapped appropriately.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateInvoiceObject_TimeoutException_ThrowsFoundationServiceException()
   {
     // Arrange
@@ -122,14 +123,14 @@ public sealed class InvoiceStorageFoundationServiceExtendedTests
         .ThrowsAsync(new TimeoutException("Connection timeout"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceFoundationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceFoundationServiceException>(() =>
         service.CreateInvoiceObject(invoice, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates ArgumentException during creation is wrapped appropriately.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateInvoiceObject_ArgumentException_ThrowsFoundationServiceException()
   {
     // Arrange
@@ -140,7 +141,7 @@ public sealed class InvoiceStorageFoundationServiceExtendedTests
         .ThrowsAsync(new ArgumentException("Invalid argument"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceFoundationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceFoundationServiceException>(() =>
         service.CreateInvoiceObject(invoice, null, CancellationToken.None));
   }
 
@@ -151,7 +152,7 @@ public sealed class InvoiceStorageFoundationServiceExtendedTests
   /// <summary>
   /// Validates read with specific user identifier.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoiceObject_WithUserIdentifier_ReturnsInvoice()
   {
     // Arrange
@@ -168,14 +169,14 @@ public sealed class InvoiceStorageFoundationServiceExtendedTests
     var result = await service.ReadInvoiceObject(invoiceId, userId, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
-    Assert.Equal(userId, result.UserIdentifier);
+    Assert.IsNotNull(result);
+    Assert.AreEqual(userId, result.UserIdentifier);
   }
 
   /// <summary>
   /// Validates read with null user identifier.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoiceObject_NullUserIdentifier_ReturnsInvoice()
   {
     // Arrange
@@ -190,13 +191,13 @@ public sealed class InvoiceStorageFoundationServiceExtendedTests
     var result = await service.ReadInvoiceObject(invoiceId, null, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
+    Assert.IsNotNull(result);
   }
 
   /// <summary>
   /// Validates generic exception during read is wrapped.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoiceObject_GenericException_ThrowsFoundationServiceException()
   {
     // Arrange
@@ -207,14 +208,14 @@ public sealed class InvoiceStorageFoundationServiceExtendedTests
         .ThrowsAsync(new InvalidOperationException("Unexpected error"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceFoundationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceFoundationServiceException>(() =>
         service.ReadInvoiceObject(invoiceId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates NotSupportedException during read is wrapped.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoiceObject_NotSupportedException_ThrowsFoundationServiceException()
   {
     // Arrange
@@ -225,7 +226,7 @@ public sealed class InvoiceStorageFoundationServiceExtendedTests
         .ThrowsAsync(new NotSupportedException("Not supported"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceFoundationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceFoundationServiceException>(() =>
         service.ReadInvoiceObject(invoiceId, null, CancellationToken.None));
   }
 
@@ -236,7 +237,7 @@ public sealed class InvoiceStorageFoundationServiceExtendedTests
   /// <summary>
   /// Validates bulk read returns empty collection when no invoices exist.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadAllInvoiceObjects_NoInvoices_ReturnsEmptyCollection()
   {
     // Arrange
@@ -250,14 +251,14 @@ public sealed class InvoiceStorageFoundationServiceExtendedTests
     var result = await service.ReadAllInvoiceObjects(userId, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
-    Assert.Empty(result);
+    Assert.IsNotNull(result);
+    Assert.IsEmpty(result);
   }
 
   /// <summary>
   /// Validates bulk read returns large collection.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadAllInvoiceObjects_LargeCollection_ReturnsAllInvoices()
   {
     // Arrange
@@ -272,13 +273,13 @@ public sealed class InvoiceStorageFoundationServiceExtendedTests
     var result = await service.ReadAllInvoiceObjects(userId, CancellationToken.None);
 
     // Assert
-    Assert.Equal(500, result.Count());
+    Assert.AreEqual(500, result.Count());
   }
 
   /// <summary>
   /// Validates bulk read with single invoice.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadAllInvoiceObjects_SingleInvoice_ReturnsSingleElement()
   {
     // Arrange
@@ -293,13 +294,13 @@ public sealed class InvoiceStorageFoundationServiceExtendedTests
     var result = await service.ReadAllInvoiceObjects(userId, CancellationToken.None);
 
     // Assert
-    Assert.Single(result);
+    Assert.ContainsSingle(result);
   }
 
   /// <summary>
   /// Validates generic exception during bulk read is wrapped.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadAllInvoiceObjects_GenericException_ThrowsFoundationServiceException()
   {
     // Arrange
@@ -310,7 +311,7 @@ public sealed class InvoiceStorageFoundationServiceExtendedTests
         .ThrowsAsync(new InvalidOperationException("Unexpected error"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceFoundationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceFoundationServiceException>(() =>
         service.ReadAllInvoiceObjects(userId, CancellationToken.None));
   }
 
@@ -321,7 +322,7 @@ public sealed class InvoiceStorageFoundationServiceExtendedTests
   /// <summary>
   /// Validates successful invoice update.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateInvoiceObject_ValidInvoice_ReturnsUpdatedInvoice()
   {
     // Arrange
@@ -336,13 +337,13 @@ public sealed class InvoiceStorageFoundationServiceExtendedTests
     var result = await service.UpdateInvoiceObject(invoice, invoiceId, null, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
+    Assert.IsNotNull(result);
   }
 
   /// <summary>
   /// Validates generic exception during update is wrapped.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateInvoiceObject_GenericException_ThrowsFoundationServiceException()
   {
     // Arrange
@@ -354,14 +355,14 @@ public sealed class InvoiceStorageFoundationServiceExtendedTests
         .ThrowsAsync(new InvalidOperationException("Unexpected error"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceFoundationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceFoundationServiceException>(() =>
         service.UpdateInvoiceObject(invoice, invoiceId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates update with user identifier.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateInvoiceObject_WithUserIdentifier_ReturnsUpdatedInvoice()
   {
     // Arrange
@@ -377,7 +378,7 @@ public sealed class InvoiceStorageFoundationServiceExtendedTests
     var result = await service.UpdateInvoiceObject(invoice, invoiceId, userId, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
+    Assert.IsNotNull(result);
   }
 
   #endregion
@@ -387,7 +388,7 @@ public sealed class InvoiceStorageFoundationServiceExtendedTests
   /// <summary>
   /// Validates successful invoice deletion.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteInvoiceObject_ValidIdentifier_DeletesSuccessfully()
   {
     // Arrange
@@ -407,7 +408,7 @@ public sealed class InvoiceStorageFoundationServiceExtendedTests
   /// <summary>
   /// Validates deletion with user identifier.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteInvoiceObject_WithUserIdentifier_DeletesSuccessfully()
   {
     // Arrange
@@ -428,7 +429,7 @@ public sealed class InvoiceStorageFoundationServiceExtendedTests
   /// <summary>
   /// Validates generic exception during deletion is wrapped.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteInvoiceObject_GenericException_ThrowsFoundationServiceException()
   {
     // Arrange
@@ -439,14 +440,14 @@ public sealed class InvoiceStorageFoundationServiceExtendedTests
         .ThrowsAsync(new InvalidOperationException("Unexpected error"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceFoundationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceFoundationServiceException>(() =>
         service.DeleteInvoiceObject(invoiceId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates idempotent deletion.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteInvoiceObject_MultipleCalls_ExecutesEachTime()
   {
     // Arrange
@@ -472,7 +473,7 @@ public sealed class InvoiceStorageFoundationServiceExtendedTests
   /// <summary>
   /// Validates concurrent create operations complete successfully.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateInvoiceObject_ConcurrentOperations_AllComplete()
   {
     // Arrange
@@ -493,7 +494,7 @@ public sealed class InvoiceStorageFoundationServiceExtendedTests
   /// <summary>
   /// Validates concurrent read operations complete successfully.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoiceObject_ConcurrentOperations_AllComplete()
   {
     // Arrange
@@ -508,7 +509,10 @@ public sealed class InvoiceStorageFoundationServiceExtendedTests
     var results = await Task.WhenAll(tasks);
 
     // Assert
-    Assert.All(results, result => Assert.NotNull(result));
+    foreach (var result in results)
+    {
+      Assert.IsNotNull(result);
+    }
   }
 
   #endregion
@@ -518,7 +522,7 @@ public sealed class InvoiceStorageFoundationServiceExtendedTests
   /// <summary>
   /// Validates handling of OperationCanceledException.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateInvoiceObject_OperationCanceledException_ThrowsFoundationDependencyException()
   {
     // Arrange
@@ -529,14 +533,14 @@ public sealed class InvoiceStorageFoundationServiceExtendedTests
         .ThrowsAsync(new OperationCanceledException("Operation cancelled"));
 
     // Act & Assert — cancellation must not be reclassified into a domain exception (bug fix)
-    await Assert.ThrowsAsync<OperationCanceledException>(() =>
+    await Assert.ThrowsExactlyAsync<OperationCanceledException>(() =>
         service.CreateInvoiceObject(invoice, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates handling of NullReferenceException.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoiceObject_ArgumentNullException_ThrowsFoundationServiceException()
   {
     // Arrange
@@ -547,14 +551,14 @@ public sealed class InvoiceStorageFoundationServiceExtendedTests
         .ThrowsAsync(new ArgumentNullException("parameter", "Null reference"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceFoundationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceFoundationServiceException>(() =>
         service.ReadInvoiceObject(invoiceId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates handling of FormatException.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadAllInvoiceObjects_FormatException_ThrowsFoundationServiceException()
   {
     // Arrange
@@ -565,7 +569,7 @@ public sealed class InvoiceStorageFoundationServiceExtendedTests
         .ThrowsAsync(new FormatException("Format error"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceFoundationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceFoundationServiceException>(() =>
         service.ReadAllInvoiceObjects(userId, CancellationToken.None));
   }
 

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Foundation/InvoiceStorageFoundationServiceTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Foundation/InvoiceStorageFoundationServiceTests.cs
@@ -15,13 +15,14 @@ using Microsoft.Extensions.Logging;
 
 using Moq;
 
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 /// <summary>
 /// Comprehensive unit tests for <see cref="InvoiceStorageFoundationService"/> targeting 95%+ code coverage.
 /// Tests validate CRUD operations, exception handling, validation, and broker coordination.
 /// Method naming follows MethodName_Condition_ExpectedResult pattern per repository standards.
 /// </summary>
+[TestClass]
 public sealed class InvoiceStorageFoundationServiceTests
 {
   private readonly Mock<IInvoiceNoSqlBroker> mockBroker;
@@ -52,15 +53,15 @@ public sealed class InvoiceStorageFoundationServiceTests
   /// <summary>
   /// Verifies constructor throws ArgumentNullException when broker is null.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Constructor_NullBroker_ThrowsArgumentNullException() =>
-      Assert.Throws<ArgumentNullException>(() =>
+      Assert.ThrowsExactly<ArgumentNullException>(() =>
           new InvoiceStorageFoundationService(null!, mockLoggerFactory.Object));
 
   /// <summary>
   /// Validates successful instantiation with all valid dependencies.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Constructor_ValidDependencies_CreatesInstance()
   {
     // Arrange & Act
@@ -69,7 +70,7 @@ public sealed class InvoiceStorageFoundationServiceTests
         mockLoggerFactory.Object);
 
     // Assert
-    Assert.NotNull(svc);
+    Assert.IsNotNull(svc);
   }
 
   #endregion
@@ -79,7 +80,7 @@ public sealed class InvoiceStorageFoundationServiceTests
   /// <summary>
   /// Validates successful invoice creation through foundation layer.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateInvoiceObject_ValidInvoice_CallsBrokerSuccessfully()
   {
     // Arrange
@@ -100,7 +101,7 @@ public sealed class InvoiceStorageFoundationServiceTests
   /// <summary>
   /// Ensures creation succeeds without user identifier.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateInvoiceObject_NoUserIdentifier_CreatesSuccessfully()
   {
     // Arrange
@@ -120,7 +121,7 @@ public sealed class InvoiceStorageFoundationServiceTests
   /// <summary>
   /// Validates OperationCanceledException during creation is wrapped into foundation dependency exception.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateInvoiceObject_OperationCanceledException_PropagatesOperationCanceledException()
   {
     // Arrange
@@ -131,14 +132,14 @@ public sealed class InvoiceStorageFoundationServiceTests
         .ThrowsAsync(new OperationCanceledException("Operation cancelled"));
 
     // Act & Assert — cancellation must not be reclassified into a domain exception (bug fix)
-    await Assert.ThrowsAsync<OperationCanceledException>(() =>
+    await Assert.ThrowsExactlyAsync<OperationCanceledException>(() =>
         service.CreateInvoiceObject(invoice, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Ensures generic exceptions during creation are wrapped into foundation service exceptions.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateInvoiceObject_GenericException_ThrowsFoundationServiceException()
   {
     // Arrange
@@ -149,15 +150,15 @@ public sealed class InvoiceStorageFoundationServiceTests
         .ThrowsAsync(new InvalidOperationException("Unexpected error"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceFoundationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceFoundationServiceException>(() =>
         service.CreateInvoiceObject(invoice, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates multiple invoice creations work in sequence.
   /// </summary>
-  [Theory]
-  [MemberData(nameof(GetInvoiceTestData))]
+  [TestMethod]
+  [DynamicData(nameof(GetInvoiceTestData))]
   public async Task CreateInvoiceObject_MultipleInvoices_AllCreateSuccessfully(Invoice invoice)
   {
     // Arrange
@@ -179,7 +180,7 @@ public sealed class InvoiceStorageFoundationServiceTests
   /// <summary>
   /// Validates successful retrieval of single invoice by identifier.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoiceObject_ValidIdentifier_ReturnsInvoice()
   {
     // Arrange
@@ -195,15 +196,15 @@ public sealed class InvoiceStorageFoundationServiceTests
     var result = await service.ReadInvoiceObject(invoiceId, userId, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
-    Assert.Equal(expectedInvoice.id, result.id);
+    Assert.IsNotNull(result);
+    Assert.AreEqual(expectedInvoice.id, result.id);
     mockBroker.Verify(b => b.ReadInvoiceAsync(invoiceId, userId, It.IsAny<CancellationToken>()), Times.Once);
   }
 
   /// <summary>
   /// Ensures read operation succeeds without user identifier.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoiceObject_NoUserIdentifier_ReturnsInvoice()
   {
     // Arrange
@@ -218,7 +219,7 @@ public sealed class InvoiceStorageFoundationServiceTests
     var result = await service.ReadInvoiceObject(invoiceId, null, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
+    Assert.IsNotNull(result);
     mockBroker.Verify(b => b.ReadInvoiceAsync(invoiceId, null, It.IsAny<CancellationToken>()), Times.Once);
   }
 
@@ -227,14 +228,14 @@ public sealed class InvoiceStorageFoundationServiceTests
   /// Note: The validation exception class lacks the required constructor for Validator.ValidateAndThrow,
   /// causing a MissingMethodException that falls through to the generic exception handler.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoiceObject_EmptyGuidIdentifier_ThrowsFoundationServiceException()
   {
     // Arrange
     var emptyId = Guid.Empty;
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceFoundationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceFoundationServiceException>(() =>
         service.ReadInvoiceObject(emptyId, null, CancellationToken.None));
   }
 
@@ -243,21 +244,21 @@ public sealed class InvoiceStorageFoundationServiceTests
   /// Note: The validation exception class lacks the required constructor for Validator.ValidateAndThrow,
   /// causing a MissingMethodException that falls through to the generic exception handler.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoiceObject_DefaultGuidIdentifier_ThrowsFoundationServiceException()
   {
     // Arrange
     var defaultId = default(Guid);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceFoundationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceFoundationServiceException>(() =>
         service.ReadInvoiceObject(defaultId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates OperationCanceledException during read is wrapped into foundation dependency exception.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoiceObject_OperationCanceledException_PropagatesOperationCanceledException()
   {
     // Arrange
@@ -268,14 +269,14 @@ public sealed class InvoiceStorageFoundationServiceTests
         .ThrowsAsync(new OperationCanceledException("Cancelled"));
 
     // Act & Assert — cancellation must not be reclassified into a domain exception (bug fix)
-    await Assert.ThrowsAsync<OperationCanceledException>(() =>
+    await Assert.ThrowsExactlyAsync<OperationCanceledException>(() =>
         service.ReadInvoiceObject(invoiceId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Ensures generic exceptions during read are wrapped into foundation service exceptions.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoiceObject_GenericException_ThrowsFoundationServiceException()
   {
     // Arrange
@@ -286,7 +287,7 @@ public sealed class InvoiceStorageFoundationServiceTests
         .ThrowsAsync(new InvalidOperationException("Unexpected error"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceFoundationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceFoundationServiceException>(() =>
         service.ReadInvoiceObject(invoiceId, null, CancellationToken.None));
   }
 
@@ -297,7 +298,7 @@ public sealed class InvoiceStorageFoundationServiceTests
   /// <summary>
   /// Validates successful retrieval of all invoices for a user.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadAllInvoiceObjects_WithUserIdentifier_ReturnsInvoiceCollection()
   {
     // Arrange
@@ -312,15 +313,15 @@ public sealed class InvoiceStorageFoundationServiceTests
     var result = await service.ReadAllInvoiceObjects(userId, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
-    Assert.Equal(5, ((List<Invoice>)result).Count);
+    Assert.IsNotNull(result);
+    Assert.AreEqual(5, ((List<Invoice>)result).Count);
     mockBroker.Verify(b => b.ReadInvoicesAsync(userId, It.IsAny<CancellationToken>()), Times.Once);
   }
 
   /// <summary>
   /// Validates empty collection is returned when no invoices exist.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadAllInvoiceObjects_NoInvoices_ReturnsEmptyCollection()
   {
     // Arrange
@@ -335,14 +336,14 @@ public sealed class InvoiceStorageFoundationServiceTests
     var result = await service.ReadAllInvoiceObjects(userId, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
-    Assert.Empty(result);
+    Assert.IsNotNull(result);
+    Assert.IsEmpty(result);
   }
 
   /// <summary>
   /// Validates OperationCanceledException during bulk read is wrapped appropriately.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadAllInvoiceObjects_OperationCanceledException_PropagatesOperationCanceledException()
   {
     // Arrange
@@ -353,14 +354,14 @@ public sealed class InvoiceStorageFoundationServiceTests
         .ThrowsAsync(new OperationCanceledException("Query timeout"));
 
     // Act & Assert — cancellation must not be reclassified into a domain exception (bug fix)
-    await Assert.ThrowsAsync<OperationCanceledException>(() =>
+    await Assert.ThrowsExactlyAsync<OperationCanceledException>(() =>
         service.ReadAllInvoiceObjects(userId, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates generic exceptions during bulk read propagate as foundation service exceptions.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadAllInvoiceObjects_GenericException_ThrowsFoundationServiceException()
   {
     // Arrange
@@ -371,7 +372,7 @@ public sealed class InvoiceStorageFoundationServiceTests
         .ThrowsAsync(new InvalidOperationException("Unexpected error"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceFoundationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceFoundationServiceException>(() =>
         service.ReadAllInvoiceObjects(userId, CancellationToken.None));
   }
 
@@ -382,7 +383,7 @@ public sealed class InvoiceStorageFoundationServiceTests
   /// <summary>
   /// Validates successful invoice update through foundation layer.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateInvoiceObject_ValidUpdate_ReturnsUpdatedInvoice()
   {
     // Arrange
@@ -398,15 +399,15 @@ public sealed class InvoiceStorageFoundationServiceTests
     var result = await service.UpdateInvoiceObject(updatedInvoice, invoiceId, userId, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
-    Assert.Equal(updatedInvoice.id, result.id);
+    Assert.IsNotNull(result);
+    Assert.AreEqual(updatedInvoice.id, result.id);
     mockBroker.Verify(b => b.UpdateInvoiceAsync(invoiceId, updatedInvoice, It.IsAny<CancellationToken>()), Times.Once);
   }
 
   /// <summary>
   /// Ensures update succeeds without user identifier.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateInvoiceObject_NoUserIdentifier_UpdatesSuccessfully()
   {
     // Arrange
@@ -421,7 +422,7 @@ public sealed class InvoiceStorageFoundationServiceTests
     var result = await service.UpdateInvoiceObject(updatedInvoice, invoiceId, null, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
+    Assert.IsNotNull(result);
     mockBroker.Verify(b => b.UpdateInvoiceAsync(invoiceId, updatedInvoice, It.IsAny<CancellationToken>()), Times.Once);
   }
 
@@ -430,7 +431,7 @@ public sealed class InvoiceStorageFoundationServiceTests
   /// Note: The validation exception class lacks the required constructor for Validator.ValidateAndThrow,
   /// causing a MissingMethodException that falls through to the generic exception handler.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateInvoiceObject_EmptyGuidIdentifier_ThrowsFoundationServiceException()
   {
     // Arrange
@@ -438,14 +439,14 @@ public sealed class InvoiceStorageFoundationServiceTests
     var updatedInvoice = InvoiceBuilder.CreateRandomInvoice();
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceFoundationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceFoundationServiceException>(() =>
         service.UpdateInvoiceObject(updatedInvoice, emptyId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Ensures generic exceptions during update are wrapped into foundation service exceptions.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateInvoiceObject_GenericException_ThrowsFoundationServiceException()
   {
     // Arrange
@@ -457,7 +458,7 @@ public sealed class InvoiceStorageFoundationServiceTests
         .ThrowsAsync(new InvalidOperationException("Update failed"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceFoundationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceFoundationServiceException>(() =>
         service.UpdateInvoiceObject(updatedInvoice, invoiceId, null, CancellationToken.None));
   }
 
@@ -468,7 +469,7 @@ public sealed class InvoiceStorageFoundationServiceTests
   /// <summary>
   /// Validates successful invoice deletion through foundation layer.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteInvoiceObject_ValidIdentifier_DeletesSuccessfully()
   {
     // Arrange
@@ -489,7 +490,7 @@ public sealed class InvoiceStorageFoundationServiceTests
   /// <summary>
   /// Ensures deletion succeeds without user identifier.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteInvoiceObject_NoUserIdentifier_DeletesSuccessfully()
   {
     // Arrange
@@ -511,21 +512,21 @@ public sealed class InvoiceStorageFoundationServiceTests
   /// Note: The validation exception class lacks the required constructor for Validator.ValidateAndThrow,
   /// causing a MissingMethodException that falls through to the generic exception handler.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteInvoiceObject_EmptyGuidIdentifier_ThrowsFoundationServiceException()
   {
     // Arrange
     var emptyId = Guid.Empty;
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceFoundationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceFoundationServiceException>(() =>
         service.DeleteInvoiceObject(emptyId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates OperationCanceledException during delete is wrapped into foundation dependency exception.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteInvoiceObject_OperationCanceledException_PropagatesOperationCanceledException()
   {
     // Arrange
@@ -536,14 +537,14 @@ public sealed class InvoiceStorageFoundationServiceTests
         .ThrowsAsync(new OperationCanceledException("Cancelled"));
 
     // Act & Assert — cancellation must not be reclassified into a domain exception (bug fix)
-    await Assert.ThrowsAsync<OperationCanceledException>(() =>
+    await Assert.ThrowsExactlyAsync<OperationCanceledException>(() =>
         service.DeleteInvoiceObject(invoiceId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Ensures generic exceptions during delete are wrapped into foundation service exceptions.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteInvoiceObject_GenericException_ThrowsFoundationServiceException()
   {
     // Arrange
@@ -554,14 +555,14 @@ public sealed class InvoiceStorageFoundationServiceTests
         .ThrowsAsync(new InvalidOperationException("Deletion failed"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceFoundationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceFoundationServiceException>(() =>
         service.DeleteInvoiceObject(invoiceId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates idempotency of delete operation (repeated calls succeed).
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteInvoiceObject_IdempotentCalls_SucceedMultipleTimes()
   {
     // Arrange

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Foundation/InvoiceStorageFoundationServiceTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Foundation/InvoiceStorageFoundationServiceTests.cs
@@ -587,7 +587,7 @@ public sealed class InvoiceStorageFoundationServiceTests
   /// <summary>
   /// Provides theory data containing several randomized invoices for parameterized tests.
   /// </summary>
-  public static TheoryData<Invoice> GetInvoiceTestData() => InvoiceBuilder.GetInvoiceTheoryData();
+  public static IEnumerable<object[]> GetInvoiceTestData() => InvoiceBuilder.GetInvoiceTheoryData();
 
   #endregion
 }

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Foundation/MerchantStorageFoundationServiceExceptionsTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Foundation/MerchantStorageFoundationServiceExceptionsTests.cs
@@ -14,12 +14,13 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 using Moq;
 
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 /// <summary>
 /// Verifies that inner exceptions propagated from the Cosmos broker are classified
 /// into the proper Foundation-tier outer exceptions by the TryCatch boundary.
 /// </summary>
+[TestClass]
 public class MerchantStorageFoundationServiceExceptionsTests
 {
   private readonly Mock<IInvoiceNoSqlBroker> _broker = new();
@@ -32,92 +33,92 @@ public class MerchantStorageFoundationServiceExceptionsTests
   }
 
   /// <summary>Verifies that a <see cref="MerchantNotFoundException"/> from the broker is wrapped into a <see cref="MerchantFoundationServiceDependencyValidationException"/>.</summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchantObject_WhenBrokerThrowsNotFound_ThrowsFoundationDependencyValidationException()
   {
     _broker.Setup(b => b.ReadMerchantAsync(It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new MerchantNotFoundException(Guid.NewGuid()));
 
-    var ex = await Assert.ThrowsAsync<MerchantFoundationServiceDependencyValidationException>(
+    var ex = await Assert.ThrowsExactlyAsync<MerchantFoundationServiceDependencyValidationException>(
       () => _sut.ReadMerchantObject(Guid.NewGuid(), Guid.NewGuid(), CancellationToken.None));
 
-    Assert.IsType<MerchantNotFoundException>(ex.InnerException);
+    Assert.IsExactInstanceOfType<MerchantNotFoundException>(ex.InnerException);
   }
 
   /// <summary>Verifies that a <see cref="MerchantAlreadyExistsException"/> from the broker is wrapped into a <see cref="MerchantFoundationServiceDependencyValidationException"/>.</summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateMerchantObject_WhenBrokerThrowsAlreadyExists_ThrowsFoundationDependencyValidationException()
   {
     _broker.Setup(b => b.CreateMerchantAsync(It.IsAny<Merchant>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new MerchantAlreadyExistsException(Guid.NewGuid()));
     var merchant = new Merchant { id = Guid.NewGuid(), ParentCompanyId = Guid.NewGuid() };
 
-    var ex = await Assert.ThrowsAsync<MerchantFoundationServiceDependencyValidationException>(
+    var ex = await Assert.ThrowsExactlyAsync<MerchantFoundationServiceDependencyValidationException>(
       () => _sut.CreateMerchantObject(merchant, null, CancellationToken.None));
 
-    Assert.IsType<MerchantAlreadyExistsException>(ex.InnerException);
+    Assert.IsExactInstanceOfType<MerchantAlreadyExistsException>(ex.InnerException);
   }
 
   /// <summary>Verifies that a <see cref="MerchantUnauthorizedAccessException"/> from the broker is wrapped into a <see cref="MerchantFoundationServiceDependencyValidationException"/> (caller-correctable 401, not 503).</summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchantObject_WhenBrokerThrowsUnauthorized_ThrowsFoundationDependencyValidationException()
   {
     _broker.Setup(b => b.ReadMerchantAsync(It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new MerchantUnauthorizedAccessException("unauthorized"));
 
-    var ex = await Assert.ThrowsAsync<MerchantFoundationServiceDependencyValidationException>(
+    var ex = await Assert.ThrowsExactlyAsync<MerchantFoundationServiceDependencyValidationException>(
       () => _sut.ReadMerchantObject(Guid.NewGuid(), Guid.NewGuid(), CancellationToken.None));
 
-    Assert.IsType<MerchantUnauthorizedAccessException>(ex.InnerException);
+    Assert.IsExactInstanceOfType<MerchantUnauthorizedAccessException>(ex.InnerException);
   }
 
   /// <summary>Verifies that a <see cref="MerchantForbiddenAccessException"/> from the broker is wrapped into a <see cref="MerchantFoundationServiceDependencyValidationException"/> (caller-correctable 403, not 503).</summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchantObject_WhenBrokerThrowsForbidden_ThrowsFoundationDependencyValidationException()
   {
     _broker.Setup(b => b.ReadMerchantAsync(It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new MerchantForbiddenAccessException(Guid.NewGuid(), Guid.NewGuid()));
 
-    var ex = await Assert.ThrowsAsync<MerchantFoundationServiceDependencyValidationException>(
+    var ex = await Assert.ThrowsExactlyAsync<MerchantFoundationServiceDependencyValidationException>(
       () => _sut.ReadMerchantObject(Guid.NewGuid(), Guid.NewGuid(), CancellationToken.None));
 
-    Assert.IsType<MerchantForbiddenAccessException>(ex.InnerException);
+    Assert.IsExactInstanceOfType<MerchantForbiddenAccessException>(ex.InnerException);
   }
 
   /// <summary>Verifies that a <see cref="MerchantCosmosDbRateLimitException"/> from the broker is wrapped into a <see cref="MerchantFoundationServiceDependencyValidationException"/> (caller-correctable 429, not 503).</summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchantObject_WhenBrokerThrowsRateLimit_ThrowsFoundationDependencyValidationException()
   {
     _broker.Setup(b => b.ReadMerchantAsync(It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new MerchantCosmosDbRateLimitException(TimeSpan.FromSeconds(2), new InvalidOperationException()));
 
-    var ex = await Assert.ThrowsAsync<MerchantFoundationServiceDependencyValidationException>(
+    var ex = await Assert.ThrowsExactlyAsync<MerchantFoundationServiceDependencyValidationException>(
       () => _sut.ReadMerchantObject(Guid.NewGuid(), Guid.NewGuid(), CancellationToken.None));
 
-    Assert.IsType<MerchantCosmosDbRateLimitException>(ex.InnerException);
+    Assert.IsExactInstanceOfType<MerchantCosmosDbRateLimitException>(ex.InnerException);
   }
 
   /// <summary>Regression guard: <see cref="MerchantFailedStorageException"/> must remain in the Dependency tier (downstream unreachable, 503).</summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchantObject_WhenBrokerThrowsFailedStorage_ThrowsFoundationDependencyException()
   {
     _broker.Setup(b => b.ReadMerchantAsync(It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new MerchantFailedStorageException("down"));
 
-    var ex = await Assert.ThrowsAsync<MerchantFoundationServiceDependencyException>(
+    var ex = await Assert.ThrowsExactlyAsync<MerchantFoundationServiceDependencyException>(
       () => _sut.ReadMerchantObject(Guid.NewGuid(), Guid.NewGuid(), CancellationToken.None));
 
-    Assert.IsType<MerchantFailedStorageException>(ex.InnerException);
+    Assert.IsExactInstanceOfType<MerchantFailedStorageException>(ex.InnerException);
   }
 
   /// <summary>Verifies that an unclassified exception from the broker is wrapped into a <see cref="MerchantFoundationServiceException"/>.</summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchantObject_WhenBrokerThrowsUnknown_ThrowsFoundationServiceException()
   {
     _broker.Setup(b => b.ReadMerchantAsync(It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new InvalidOperationException("boom"));
 
-    await Assert.ThrowsAsync<MerchantFoundationServiceException>(
+    await Assert.ThrowsExactlyAsync<MerchantFoundationServiceException>(
       () => _sut.ReadMerchantObject(Guid.NewGuid(), Guid.NewGuid(), CancellationToken.None));
   }
 }

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Foundation/MerchantStorageFoundationServiceExtendedTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Foundation/MerchantStorageFoundationServiceExtendedTests.cs
@@ -16,13 +16,14 @@ using Microsoft.Extensions.Logging;
 
 using Moq;
 
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 /// <summary>
 /// Extended unit tests for <see cref="MerchantStorageFoundationService"/> covering additional edge cases,
 /// boundary conditions, and exception scenarios for comprehensive code coverage.
 /// Method naming follows MethodName_Condition_ExpectedResult pattern per repository standards.
 /// </summary>
+[TestClass]
 public sealed class MerchantStorageFoundationServiceExtendedTests
 {
   private readonly Mock<IInvoiceNoSqlBroker> mockBroker;
@@ -53,7 +54,7 @@ public sealed class MerchantStorageFoundationServiceExtendedTests
   /// <summary>
   /// Validates merchant creation with empty Guid parent company.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateMerchantObject_EmptyGuidParentCompany_CreatesSuccessfully()
   {
     // Arrange
@@ -73,7 +74,7 @@ public sealed class MerchantStorageFoundationServiceExtendedTests
   /// <summary>
   /// Validates merchant creation with null parent company ID.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateMerchantObject_NullParentCompanyId_CreatesSuccessfully()
   {
     // Arrange
@@ -93,7 +94,7 @@ public sealed class MerchantStorageFoundationServiceExtendedTests
   /// <summary>
   /// Validates generic exception during creation is wrapped.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateMerchantObject_GenericException_ThrowsFoundationServiceException()
   {
     // Arrange
@@ -104,14 +105,14 @@ public sealed class MerchantStorageFoundationServiceExtendedTests
         .ThrowsAsync(new InvalidOperationException("Unexpected error"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantFoundationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantFoundationServiceException>(() =>
         service.CreateMerchantObject(merchant, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates TimeoutException during creation is wrapped.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateMerchantObject_TimeoutException_ThrowsFoundationServiceException()
   {
     // Arrange
@@ -122,7 +123,7 @@ public sealed class MerchantStorageFoundationServiceExtendedTests
         .ThrowsAsync(new TimeoutException("Connection timeout"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantFoundationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantFoundationServiceException>(() =>
         service.CreateMerchantObject(merchant, null, CancellationToken.None));
   }
 
@@ -133,7 +134,7 @@ public sealed class MerchantStorageFoundationServiceExtendedTests
   /// <summary>
   /// Validates merchant read with specific parent company ID.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchantObject_WithParentCompanyId_ReturnsMerchant()
   {
     // Arrange
@@ -150,14 +151,14 @@ public sealed class MerchantStorageFoundationServiceExtendedTests
     var result = await service.ReadMerchantObject(merchantId, parentCompanyId, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
-    Assert.Equal(parentCompanyId, result.ParentCompanyId);
+    Assert.IsNotNull(result);
+    Assert.AreEqual(parentCompanyId, result.ParentCompanyId);
   }
 
   /// <summary>
   /// Validates merchant read with null parent company ID.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchantObject_NullParentCompanyId_ReturnsMerchant()
   {
     // Arrange
@@ -172,13 +173,13 @@ public sealed class MerchantStorageFoundationServiceExtendedTests
     var result = await service.ReadMerchantObject(merchantId, null, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
+    Assert.IsNotNull(result);
   }
 
   /// <summary>
   /// Validates generic exception during read is wrapped.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchantObject_GenericException_ThrowsFoundationServiceException()
   {
     // Arrange
@@ -189,7 +190,7 @@ public sealed class MerchantStorageFoundationServiceExtendedTests
         .ThrowsAsync(new InvalidOperationException("Unexpected error"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantFoundationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantFoundationServiceException>(() =>
         service.ReadMerchantObject(merchantId, null, CancellationToken.None));
   }
 
@@ -200,7 +201,7 @@ public sealed class MerchantStorageFoundationServiceExtendedTests
   /// <summary>
   /// Validates bulk read returns empty collection when no merchants exist.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadAllMerchantObjects_NoMerchants_ReturnsEmptyCollection()
   {
     // Arrange
@@ -214,14 +215,14 @@ public sealed class MerchantStorageFoundationServiceExtendedTests
     var result = await service.ReadAllMerchantObjects(parentCompanyId, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
-    Assert.Empty(result);
+    Assert.IsNotNull(result);
+    Assert.IsEmpty(result);
   }
 
   /// <summary>
   /// Validates bulk read returns large collection.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadAllMerchantObjects_LargeCollection_ReturnsAllMerchants()
   {
     // Arrange
@@ -238,13 +239,13 @@ public sealed class MerchantStorageFoundationServiceExtendedTests
     var result = await service.ReadAllMerchantObjects(parentCompanyId, CancellationToken.None);
 
     // Assert
-    Assert.Equal(200, result.Count());
+    Assert.AreEqual(200, result.Count());
   }
 
   /// <summary>
   /// Validates bulk read with single merchant.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadAllMerchantObjects_SingleMerchant_ReturnsSingleElement()
   {
     // Arrange
@@ -259,13 +260,13 @@ public sealed class MerchantStorageFoundationServiceExtendedTests
     var result = await service.ReadAllMerchantObjects(parentCompanyId, CancellationToken.None);
 
     // Assert
-    Assert.Single(result);
+    Assert.ContainsSingle(result);
   }
 
   /// <summary>
   /// Validates generic exception during bulk read is wrapped.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadAllMerchantObjects_GenericException_ThrowsFoundationServiceException()
   {
     // Arrange
@@ -276,7 +277,7 @@ public sealed class MerchantStorageFoundationServiceExtendedTests
         .ThrowsAsync(new InvalidOperationException("Unexpected error"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantFoundationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantFoundationServiceException>(() =>
         service.ReadAllMerchantObjects(parentCompanyId, CancellationToken.None));
   }
 
@@ -287,7 +288,7 @@ public sealed class MerchantStorageFoundationServiceExtendedTests
   /// <summary>
   /// Validates successful merchant update.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateMerchantObject_ValidMerchant_ReturnsUpdatedMerchant()
   {
     // Arrange
@@ -307,13 +308,13 @@ public sealed class MerchantStorageFoundationServiceExtendedTests
     var result = await service.UpdateMerchantObject(merchant, merchantId, parentCompanyId, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
+    Assert.IsNotNull(result);
   }
 
   /// <summary>
   /// Validates generic exception during update is wrapped.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateMerchantObject_GenericException_ThrowsFoundationServiceException()
   {
     // Arrange
@@ -325,7 +326,7 @@ public sealed class MerchantStorageFoundationServiceExtendedTests
         .ThrowsAsync(new InvalidOperationException("Unexpected error"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantFoundationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantFoundationServiceException>(() =>
         service.UpdateMerchantObject(merchant, merchantId, null, CancellationToken.None));
   }
 
@@ -336,7 +337,7 @@ public sealed class MerchantStorageFoundationServiceExtendedTests
   /// <summary>
   /// Validates successful merchant deletion.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteMerchantObject_ValidIdentifier_DeletesSuccessfully()
   {
     // Arrange
@@ -357,7 +358,7 @@ public sealed class MerchantStorageFoundationServiceExtendedTests
   /// <summary>
   /// Validates generic exception during deletion is wrapped.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteMerchantObject_GenericException_ThrowsFoundationServiceException()
   {
     // Arrange
@@ -369,14 +370,14 @@ public sealed class MerchantStorageFoundationServiceExtendedTests
         .ThrowsAsync(new InvalidOperationException("Unexpected error"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantFoundationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantFoundationServiceException>(() =>
         service.DeleteMerchantObject(merchantId, parentCompanyId, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates idempotent deletion.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteMerchantObject_MultipleCalls_ExecutesEachTime()
   {
     // Arrange
@@ -403,7 +404,7 @@ public sealed class MerchantStorageFoundationServiceExtendedTests
   /// <summary>
   /// Validates concurrent create operations complete successfully.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateMerchantObject_ConcurrentOperations_AllComplete()
   {
     // Arrange
@@ -426,7 +427,7 @@ public sealed class MerchantStorageFoundationServiceExtendedTests
   /// <summary>
   /// Validates concurrent read operations complete successfully.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchantObject_ConcurrentOperations_AllComplete()
   {
     // Arrange
@@ -441,7 +442,10 @@ public sealed class MerchantStorageFoundationServiceExtendedTests
     var results = await Task.WhenAll(tasks);
 
     // Assert
-    Assert.All(results, result => Assert.NotNull(result));
+    foreach (var result in results)
+    {
+      Assert.IsNotNull(result);
+    }
   }
 
   #endregion
@@ -451,7 +455,7 @@ public sealed class MerchantStorageFoundationServiceExtendedTests
   /// <summary>
   /// Validates handling of OperationCanceledException.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateMerchantObject_OperationCanceledException_ThrowsFoundationDependencyException()
   {
     // Arrange
@@ -462,14 +466,14 @@ public sealed class MerchantStorageFoundationServiceExtendedTests
         .ThrowsAsync(new OperationCanceledException("Operation cancelled"));
 
     // Act & Assert — cancellation must not be reclassified into a domain exception (bug fix)
-    await Assert.ThrowsAsync<OperationCanceledException>(() =>
+    await Assert.ThrowsExactlyAsync<OperationCanceledException>(() =>
         service.CreateMerchantObject(merchant, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates handling of ArgumentException from broker.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateMerchantObject_ArgumentException_ThrowsFoundationServiceException()
   {
     // Arrange
@@ -480,14 +484,14 @@ public sealed class MerchantStorageFoundationServiceExtendedTests
         .ThrowsAsync(new ArgumentException("Invalid argument"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantFoundationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantFoundationServiceException>(() =>
         service.CreateMerchantObject(merchant, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates handling of NullReferenceException.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchantObject_NullReferenceException_ThrowsFoundationServiceException()
   {
     // Arrange
@@ -498,7 +502,7 @@ public sealed class MerchantStorageFoundationServiceExtendedTests
         .ThrowsAsync(new ArgumentNullException("parameter", "Null reference"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantFoundationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantFoundationServiceException>(() =>
         service.ReadMerchantObject(merchantId, null, CancellationToken.None));
   }
 

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Foundation/MerchantStorageFoundationServiceTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Foundation/MerchantStorageFoundationServiceTests.cs
@@ -15,13 +15,14 @@ using Microsoft.Extensions.Logging;
 
 using Moq;
 
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 /// <summary>
 /// Comprehensive unit tests for <see cref="MerchantStorageFoundationService"/> targeting 95%+ code coverage.
 /// Tests validate CRUD operations, exception handling, validation, and broker coordination.
 /// Method naming follows MethodName_Condition_ExpectedResult pattern per repository standards.
 /// </summary>
+[TestClass]
 public sealed class MerchantStorageFoundationServiceTests
 {
   private readonly Mock<IInvoiceNoSqlBroker> mockBroker;
@@ -52,15 +53,15 @@ public sealed class MerchantStorageFoundationServiceTests
   /// <summary>
   /// Verifies constructor throws ArgumentNullException when broker is null.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Constructor_NullBroker_ThrowsArgumentNullException() =>
-      Assert.Throws<ArgumentNullException>(() =>
+      Assert.ThrowsExactly<ArgumentNullException>(() =>
           new MerchantStorageFoundationService(null!, mockLoggerFactory.Object));
 
   /// <summary>
   /// Validates successful instantiation with all valid dependencies.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Constructor_ValidDependencies_CreatesInstance()
   {
     // Arrange & Act
@@ -69,7 +70,7 @@ public sealed class MerchantStorageFoundationServiceTests
         mockLoggerFactory.Object);
 
     // Assert
-    Assert.NotNull(svc);
+    Assert.IsNotNull(svc);
   }
 
   #endregion
@@ -79,7 +80,7 @@ public sealed class MerchantStorageFoundationServiceTests
   /// <summary>
   /// Validates successful merchant creation through foundation layer.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateMerchantObject_ValidMerchant_CallsBrokerSuccessfully()
   {
     // Arrange
@@ -100,7 +101,7 @@ public sealed class MerchantStorageFoundationServiceTests
   /// <summary>
   /// Ensures creation succeeds without parent company identifier.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateMerchantObject_NoParentCompanyId_CreatesSuccessfully()
   {
     // Arrange
@@ -122,21 +123,21 @@ public sealed class MerchantStorageFoundationServiceTests
   /// Note: The validation exception class lacks the required constructor for Validator.ValidateAndThrow,
   /// causing a MissingMethodException that falls through to the generic exception handler.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateMerchantObject_EmptyMerchantId_ThrowsFoundationServiceException()
   {
     // Arrange
     var merchant = MerchantTestDataBuilder.CreateMerchantWithSpecificProperties(id: Guid.Empty);
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantFoundationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantFoundationServiceException>(() =>
         service.CreateMerchantObject(merchant, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates OperationCanceledException during creation is wrapped into foundation dependency exception.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateMerchantObject_OperationCanceledException_PropagatesOperationCanceledException()
   {
     // Arrange
@@ -147,14 +148,14 @@ public sealed class MerchantStorageFoundationServiceTests
         .ThrowsAsync(new OperationCanceledException("Operation cancelled"));
 
     // Act & Assert — cancellation must not be reclassified into a domain exception (bug fix)
-    await Assert.ThrowsAsync<OperationCanceledException>(() =>
+    await Assert.ThrowsExactlyAsync<OperationCanceledException>(() =>
         service.CreateMerchantObject(merchant, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Ensures generic exceptions during creation are wrapped into foundation service exceptions.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateMerchantObject_GenericException_ThrowsFoundationServiceException()
   {
     // Arrange
@@ -165,15 +166,15 @@ public sealed class MerchantStorageFoundationServiceTests
         .ThrowsAsync(new InvalidOperationException("Unexpected error"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantFoundationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantFoundationServiceException>(() =>
         service.CreateMerchantObject(merchant, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates multiple merchant creations work in sequence.
   /// </summary>
-  [Theory]
-  [MemberData(nameof(GetMerchantTestData))]
+  [TestMethod]
+  [DynamicData(nameof(GetMerchantTestData))]
   public async Task CreateMerchantObject_MultipleMerchants_AllCreateSuccessfully(Merchant merchant)
   {
     // Arrange
@@ -195,7 +196,7 @@ public sealed class MerchantStorageFoundationServiceTests
   /// <summary>
   /// Validates successful retrieval of single merchant by identifier.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchantObject_ValidIdentifier_ReturnsMerchant()
   {
     // Arrange
@@ -211,15 +212,15 @@ public sealed class MerchantStorageFoundationServiceTests
     var result = await service.ReadMerchantObject(merchantId, parentCompanyId, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
-    Assert.Equal(expectedMerchant.id, result.id);
+    Assert.IsNotNull(result);
+    Assert.AreEqual(expectedMerchant.id, result.id);
     mockBroker.Verify(b => b.ReadMerchantAsync(merchantId, parentCompanyId, It.IsAny<CancellationToken>()), Times.Once);
   }
 
   /// <summary>
   /// Ensures read operation succeeds without parent company identifier.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchantObject_NoParentCompanyId_ReturnsMerchant()
   {
     // Arrange
@@ -234,14 +235,14 @@ public sealed class MerchantStorageFoundationServiceTests
     var result = await service.ReadMerchantObject(merchantId, null, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
+    Assert.IsNotNull(result);
     mockBroker.Verify(b => b.ReadMerchantAsync(merchantId, null, It.IsAny<CancellationToken>()), Times.Once);
   }
 
   /// <summary>
   /// Validates OperationCanceledException during read is wrapped into foundation dependency exception.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchantObject_OperationCanceledException_PropagatesOperationCanceledException()
   {
     // Arrange
@@ -252,14 +253,14 @@ public sealed class MerchantStorageFoundationServiceTests
         .ThrowsAsync(new OperationCanceledException("Cancelled"));
 
     // Act & Assert — cancellation must not be reclassified into a domain exception (bug fix)
-    await Assert.ThrowsAsync<OperationCanceledException>(() =>
+    await Assert.ThrowsExactlyAsync<OperationCanceledException>(() =>
         service.ReadMerchantObject(merchantId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Ensures generic exceptions during read are wrapped into foundation service exceptions.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchantObject_GenericException_ThrowsFoundationServiceException()
   {
     // Arrange
@@ -270,7 +271,7 @@ public sealed class MerchantStorageFoundationServiceTests
         .ThrowsAsync(new InvalidOperationException("Unexpected error"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantFoundationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantFoundationServiceException>(() =>
         service.ReadMerchantObject(merchantId, null, CancellationToken.None));
   }
 
@@ -281,7 +282,7 @@ public sealed class MerchantStorageFoundationServiceTests
   /// <summary>
   /// Validates successful retrieval of all merchants for a parent company.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadAllMerchantObjects_WithParentCompanyId_ReturnsMerchantCollection()
   {
     // Arrange
@@ -296,15 +297,15 @@ public sealed class MerchantStorageFoundationServiceTests
     var result = await service.ReadAllMerchantObjects(parentCompanyId, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
-    Assert.Equal(5, ((List<Merchant>)result).Count);
+    Assert.IsNotNull(result);
+    Assert.AreEqual(5, ((List<Merchant>)result).Count);
     mockBroker.Verify(b => b.ReadMerchantsAsync(parentCompanyId, It.IsAny<CancellationToken>()), Times.Once);
   }
 
   /// <summary>
   /// Validates empty collection is returned when no merchants exist.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadAllMerchantObjects_NoMerchants_ReturnsEmptyCollection()
   {
     // Arrange
@@ -319,14 +320,14 @@ public sealed class MerchantStorageFoundationServiceTests
     var result = await service.ReadAllMerchantObjects(parentCompanyId, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
-    Assert.Empty(result);
+    Assert.IsNotNull(result);
+    Assert.IsEmpty(result);
   }
 
   /// <summary>
   /// Validates OperationCanceledException during bulk read is wrapped appropriately.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadAllMerchantObjects_OperationCanceledException_PropagatesOperationCanceledException()
   {
     // Arrange
@@ -337,14 +338,14 @@ public sealed class MerchantStorageFoundationServiceTests
         .ThrowsAsync(new OperationCanceledException("Query timeout"));
 
     // Act & Assert — cancellation must not be reclassified into a domain exception (bug fix)
-    await Assert.ThrowsAsync<OperationCanceledException>(() =>
+    await Assert.ThrowsExactlyAsync<OperationCanceledException>(() =>
         service.ReadAllMerchantObjects(parentCompanyId, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates ArgumentNullException (programming error) during bulk read surfaces as a foundation service exception.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadAllMerchantObjects_ArgumentNullException_ThrowsFoundationServiceException()
   {
     // Arrange
@@ -355,14 +356,14 @@ public sealed class MerchantStorageFoundationServiceTests
         .ThrowsAsync(new ArgumentNullException("parameter"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantFoundationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantFoundationServiceException>(() =>
         service.ReadAllMerchantObjects(parentCompanyId, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates generic exceptions during bulk read propagate as foundation service exceptions.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadAllMerchantObjects_GenericException_ThrowsFoundationServiceException()
   {
     // Arrange
@@ -373,7 +374,7 @@ public sealed class MerchantStorageFoundationServiceTests
         .ThrowsAsync(new InvalidOperationException("Unexpected error"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantFoundationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantFoundationServiceException>(() =>
         service.ReadAllMerchantObjects(parentCompanyId, CancellationToken.None));
   }
 
@@ -384,7 +385,7 @@ public sealed class MerchantStorageFoundationServiceTests
   /// <summary>
   /// Validates successful merchant update through foundation layer.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateMerchantObject_ValidUpdate_ReturnsUpdatedMerchant()
   {
     // Arrange
@@ -405,8 +406,8 @@ public sealed class MerchantStorageFoundationServiceTests
     var result = await service.UpdateMerchantObject(updatedMerchant, merchantId, parentCompanyId, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
-    Assert.Equal(updatedMerchant.id, result.id);
+    Assert.IsNotNull(result);
+    Assert.AreEqual(updatedMerchant.id, result.id);
     mockBroker.Verify(b => b.ReadMerchantAsync(merchantId, parentCompanyId, It.IsAny<CancellationToken>()), Times.Once);
     mockBroker.Verify(b => b.UpdateMerchantAsync(currentMerchant, updatedMerchant, It.IsAny<CancellationToken>()), Times.Once);
   }
@@ -414,7 +415,7 @@ public sealed class MerchantStorageFoundationServiceTests
   /// <summary>
   /// Ensures update succeeds without parent company identifier.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateMerchantObject_NoParentCompanyId_UpdatesSuccessfully()
   {
     // Arrange
@@ -434,14 +435,14 @@ public sealed class MerchantStorageFoundationServiceTests
     var result = await service.UpdateMerchantObject(updatedMerchant, merchantId, null, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
+    Assert.IsNotNull(result);
     mockBroker.Verify(b => b.UpdateMerchantAsync(currentMerchant, updatedMerchant, It.IsAny<CancellationToken>()), Times.Once);
   }
 
   /// <summary>
   /// Validates null current merchant during update throws exception.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateMerchantObject_NullCurrentMerchant_ThrowsFoundationServiceException()
   {
     // Arrange
@@ -453,14 +454,14 @@ public sealed class MerchantStorageFoundationServiceTests
         .ReturnsAsync((Merchant?)null);
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantFoundationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantFoundationServiceException>(() =>
         service.UpdateMerchantObject(updatedMerchant, merchantId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Ensures generic exceptions during update are wrapped into foundation service exceptions.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateMerchantObject_GenericException_ThrowsFoundationServiceException()
   {
     // Arrange
@@ -477,7 +478,7 @@ public sealed class MerchantStorageFoundationServiceTests
         .ThrowsAsync(new InvalidOperationException("Update failed"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantFoundationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantFoundationServiceException>(() =>
         service.UpdateMerchantObject(updatedMerchant, merchantId, null, CancellationToken.None));
   }
 
@@ -488,7 +489,7 @@ public sealed class MerchantStorageFoundationServiceTests
   /// <summary>
   /// Validates successful merchant deletion through foundation layer.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteMerchantObject_ValidIdentifiers_DeletesSuccessfully()
   {
     // Arrange
@@ -511,7 +512,7 @@ public sealed class MerchantStorageFoundationServiceTests
   /// Note: The validation exception class lacks the required constructor for Validator.ValidateAndThrow,
   /// causing a MissingMethodException that falls through to the generic exception handler.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteMerchantObject_EmptyMerchantId_ThrowsFoundationServiceException()
   {
     // Arrange
@@ -519,7 +520,7 @@ public sealed class MerchantStorageFoundationServiceTests
     var parentCompanyId = Guid.NewGuid();
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantFoundationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantFoundationServiceException>(() =>
         service.DeleteMerchantObject(emptyId, parentCompanyId, CancellationToken.None));
   }
 
@@ -528,7 +529,7 @@ public sealed class MerchantStorageFoundationServiceTests
   /// Note: The validation exception class lacks the required constructor for Validator.ValidateAndThrow,
   /// causing a MissingMethodException that falls through to the generic exception handler.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteMerchantObject_EmptyParentCompanyId_ThrowsFoundationServiceException()
   {
     // Arrange
@@ -536,7 +537,7 @@ public sealed class MerchantStorageFoundationServiceTests
     var emptyParentId = Guid.Empty;
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantFoundationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantFoundationServiceException>(() =>
         service.DeleteMerchantObject(merchantId, emptyParentId, CancellationToken.None));
   }
 
@@ -545,21 +546,21 @@ public sealed class MerchantStorageFoundationServiceTests
   /// Note: The validation exception class lacks the required constructor for Validator.ValidateAndThrow,
   /// causing a MissingMethodException that falls through to the generic exception handler.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteMerchantObject_NullParentCompanyId_ThrowsFoundationServiceException()
   {
     // Arrange
     var merchantId = Guid.NewGuid();
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantFoundationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantFoundationServiceException>(() =>
         service.DeleteMerchantObject(merchantId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates OperationCanceledException during delete is wrapped into foundation dependency exception.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteMerchantObject_OperationCanceledException_PropagatesOperationCanceledException()
   {
     // Arrange
@@ -571,14 +572,14 @@ public sealed class MerchantStorageFoundationServiceTests
         .ThrowsAsync(new OperationCanceledException("Cancelled"));
 
     // Act & Assert — cancellation must not be reclassified into a domain exception (bug fix)
-    await Assert.ThrowsAsync<OperationCanceledException>(() =>
+    await Assert.ThrowsExactlyAsync<OperationCanceledException>(() =>
         service.DeleteMerchantObject(merchantId, parentCompanyId, CancellationToken.None));
   }
 
   /// <summary>
   /// Ensures generic exceptions during delete are wrapped into foundation service exceptions.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteMerchantObject_GenericException_ThrowsFoundationServiceException()
   {
     // Arrange
@@ -590,14 +591,14 @@ public sealed class MerchantStorageFoundationServiceTests
         .ThrowsAsync(new InvalidOperationException("Deletion failed"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantFoundationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantFoundationServiceException>(() =>
         service.DeleteMerchantObject(merchantId, parentCompanyId, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates idempotency of delete operation (repeated calls succeed).
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteMerchantObject_IdempotentCalls_SucceedMultipleTimes()
   {
     // Arrange

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Foundation/MerchantStorageFoundationServiceTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Foundation/MerchantStorageFoundationServiceTests.cs
@@ -624,7 +624,7 @@ public sealed class MerchantStorageFoundationServiceTests
   /// <summary>
   /// Provides theory data containing several randomized merchants for parameterized tests.
   /// </summary>
-  public static TheoryData<Merchant> GetMerchantTestData() => MerchantTestDataBuilder.GetMerchantTheoryData();
+  public static IEnumerable<object[]> GetMerchantTestData() => MerchantTestDataBuilder.GetMerchantTheoryData();
 
   #endregion
 }

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Orchestration/InvoiceOrchestrationServiceExceptionsTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Orchestration/InvoiceOrchestrationServiceExceptionsTests.cs
@@ -16,12 +16,13 @@ using Microsoft.Extensions.Logging;
 
 using Moq;
 
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 /// <summary>
 /// Unit tests validating that <see cref="InvoiceOrchestrationService"/> classifies each foundation
 /// outer exception tier to its matching orchestration outer tier (no collapse).
 /// </summary>
+[TestClass]
 public sealed class InvoiceOrchestrationServiceExceptionsTests
 {
   private readonly Mock<IInvoiceAnalysisFoundationService> mockAnalysisService;
@@ -53,7 +54,7 @@ public sealed class InvoiceOrchestrationServiceExceptionsTests
   /// <summary>
   /// Foundation validation failures must surface as orchestration validation (no collapse into dependency-validation).
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateInvoice_WhenFoundationThrowsValidation_ThrowsOrchestrationValidation()
   {
     var invoice = InvoiceBuilder.CreateRandomInvoice();
@@ -62,14 +63,14 @@ public sealed class InvoiceOrchestrationServiceExceptionsTests
       .Setup(s => s.CreateInvoiceObject(It.IsAny<Invoice>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new InvoiceFoundationValidationException(inner));
 
-    await Assert.ThrowsAsync<InvoiceOrchestrationValidationException>(
+    await Assert.ThrowsExactlyAsync<InvoiceOrchestrationValidationException>(
       () => orchestrationService.CreateInvoiceObject(invoice, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Foundation dependency-validation failures must surface distinctly as orchestration dependency-validation.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateInvoice_WhenFoundationThrowsDependencyValidation_ThrowsOrchestrationDependencyValidation()
   {
     var invoice = InvoiceBuilder.CreateRandomInvoice();
@@ -78,14 +79,14 @@ public sealed class InvoiceOrchestrationServiceExceptionsTests
       .Setup(s => s.CreateInvoiceObject(It.IsAny<Invoice>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new InvoiceFoundationDependencyValidationException(inner));
 
-    await Assert.ThrowsAsync<InvoiceOrchestrationDependencyValidationException>(
+    await Assert.ThrowsExactlyAsync<InvoiceOrchestrationDependencyValidationException>(
       () => orchestrationService.CreateInvoiceObject(invoice, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Foundation dependency failures must surface as orchestration dependency.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateInvoice_WhenFoundationThrowsDependency_ThrowsOrchestrationDependency()
   {
     var invoice = InvoiceBuilder.CreateRandomInvoice();
@@ -94,14 +95,14 @@ public sealed class InvoiceOrchestrationServiceExceptionsTests
       .Setup(s => s.CreateInvoiceObject(It.IsAny<Invoice>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new InvoiceFoundationDependencyException(inner));
 
-    await Assert.ThrowsAsync<InvoiceOrchestrationDependencyException>(
+    await Assert.ThrowsExactlyAsync<InvoiceOrchestrationDependencyException>(
       () => orchestrationService.CreateInvoiceObject(invoice, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Foundation service failures must surface as orchestration service failures.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateInvoice_WhenFoundationThrowsService_ThrowsOrchestrationService()
   {
     var invoice = InvoiceBuilder.CreateRandomInvoice();
@@ -110,14 +111,14 @@ public sealed class InvoiceOrchestrationServiceExceptionsTests
       .Setup(s => s.CreateInvoiceObject(It.IsAny<Invoice>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new InvoiceFoundationServiceException(inner));
 
-    await Assert.ThrowsAsync<InvoiceOrchestrationServiceException>(
+    await Assert.ThrowsExactlyAsync<InvoiceOrchestrationServiceException>(
       () => orchestrationService.CreateInvoiceObject(invoice, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Unknown exceptions from the foundation must be treated as orchestration service failures (catch-all).
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateInvoice_WhenFoundationThrowsUnknown_ThrowsOrchestrationService()
   {
     var invoice = InvoiceBuilder.CreateRandomInvoice();
@@ -125,7 +126,7 @@ public sealed class InvoiceOrchestrationServiceExceptionsTests
       .Setup(s => s.CreateInvoiceObject(It.IsAny<Invoice>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new InvalidOperationException("unknown"));
 
-    await Assert.ThrowsAsync<InvoiceOrchestrationServiceException>(
+    await Assert.ThrowsExactlyAsync<InvoiceOrchestrationServiceException>(
       () => orchestrationService.CreateInvoiceObject(invoice, null, CancellationToken.None));
   }
 }

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Orchestration/InvoiceOrchestrationServiceExtendedTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Orchestration/InvoiceOrchestrationServiceExtendedTests.cs
@@ -19,13 +19,14 @@ using Microsoft.Extensions.Logging;
 
 using Moq;
 
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 /// <summary>
 /// Extended unit tests for <see cref="InvoiceOrchestrationService"/> covering additional edge cases,
 /// exception scenarios, and boundary conditions for comprehensive code coverage.
 /// Method naming follows MethodName_Condition_ExpectedResult pattern per repository standards.
 /// </summary>
+[TestClass]
 public sealed class InvoiceOrchestrationServiceExtendedTests
 {
   private readonly Mock<IInvoiceStorageFoundationService> mockStorageService;
@@ -57,7 +58,7 @@ public sealed class InvoiceOrchestrationServiceExtendedTests
   /// <summary>
   /// Validates constructor throws when logger factory is null.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Constructor_NullLoggerFactory_CreatesInstanceWithNullLogger()
   {
     // Note: LoggerFactory null handling depends on implementation
@@ -67,7 +68,7 @@ public sealed class InvoiceOrchestrationServiceExtendedTests
         mockStorageService.Object,
         mockLoggerFactory.Object);
 
-    Assert.NotNull(service);
+    Assert.IsNotNull(service);
   }
 
   #endregion
@@ -77,7 +78,7 @@ public sealed class InvoiceOrchestrationServiceExtendedTests
   /// <summary>
   /// Validates invoice creation with foundation validation exception wrapping.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateInvoiceObject_FoundationValidationException_ThrowsOrchestrationValidationException()
   {
     // Arrange
@@ -90,14 +91,14 @@ public sealed class InvoiceOrchestrationServiceExtendedTests
         .ThrowsAsync(foundationException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceOrchestrationValidationException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceOrchestrationValidationException>(() =>
         orchestrationService.CreateInvoiceObject(invoice, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates invoice creation with foundation dependency exception wrapping.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateInvoiceObject_FoundationDependencyException_ThrowsOrchestrationDependencyException()
   {
     // Arrange
@@ -110,14 +111,14 @@ public sealed class InvoiceOrchestrationServiceExtendedTests
         .ThrowsAsync(foundationException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceOrchestrationDependencyException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceOrchestrationDependencyException>(() =>
         orchestrationService.CreateInvoiceObject(invoice, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates invoice creation with foundation dependency validation exception wrapping.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateInvoiceObject_FoundationDependencyValidationException_ThrowsOrchestrationDependencyValidationException()
   {
     // Arrange
@@ -130,14 +131,14 @@ public sealed class InvoiceOrchestrationServiceExtendedTests
         .ThrowsAsync(foundationException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceOrchestrationDependencyValidationException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceOrchestrationDependencyValidationException>(() =>
         orchestrationService.CreateInvoiceObject(invoice, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates invoice creation with foundation service exception wrapping.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateInvoiceObject_FoundationServiceException_ThrowsOrchestrationServiceException()
   {
     // Arrange
@@ -150,14 +151,14 @@ public sealed class InvoiceOrchestrationServiceExtendedTests
         .ThrowsAsync(foundationException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceOrchestrationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceOrchestrationServiceException>(() =>
         orchestrationService.CreateInvoiceObject(invoice, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates invoice creation with generic exception wrapping.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateInvoiceObject_GenericException_ThrowsOrchestrationServiceException()
   {
     // Arrange
@@ -168,7 +169,7 @@ public sealed class InvoiceOrchestrationServiceExtendedTests
         .ThrowsAsync(new InvalidOperationException("Unexpected error"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceOrchestrationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceOrchestrationServiceException>(() =>
         orchestrationService.CreateInvoiceObject(invoice, null, CancellationToken.None));
   }
 
@@ -179,7 +180,7 @@ public sealed class InvoiceOrchestrationServiceExtendedTests
   /// <summary>
   /// Validates invoice read with null user identifier.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoiceObject_NullUserIdentifier_ReturnsInvoice()
   {
     // Arrange
@@ -194,13 +195,13 @@ public sealed class InvoiceOrchestrationServiceExtendedTests
     var result = await orchestrationService.ReadInvoiceObject(invoiceId, null, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
+    Assert.IsNotNull(result);
   }
 
   /// <summary>
   /// Validates invoice read with foundation validation exception wrapping.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoiceObject_FoundationValidationException_ThrowsOrchestrationValidationException()
   {
     // Arrange
@@ -213,14 +214,14 @@ public sealed class InvoiceOrchestrationServiceExtendedTests
         .ThrowsAsync(foundationException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceOrchestrationValidationException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceOrchestrationValidationException>(() =>
         orchestrationService.ReadInvoiceObject(invoiceId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates invoice read with foundation dependency exception wrapping.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoiceObject_FoundationDependencyException_ThrowsOrchestrationDependencyException()
   {
     // Arrange
@@ -233,14 +234,14 @@ public sealed class InvoiceOrchestrationServiceExtendedTests
         .ThrowsAsync(foundationException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceOrchestrationDependencyException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceOrchestrationDependencyException>(() =>
         orchestrationService.ReadInvoiceObject(invoiceId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates invoice read with generic exception wrapping.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoiceObject_GenericException_ThrowsOrchestrationServiceException()
   {
     // Arrange
@@ -251,7 +252,7 @@ public sealed class InvoiceOrchestrationServiceExtendedTests
         .ThrowsAsync(new InvalidOperationException("Unexpected error"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceOrchestrationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceOrchestrationServiceException>(() =>
         orchestrationService.ReadInvoiceObject(invoiceId, null, CancellationToken.None));
   }
 
@@ -262,7 +263,7 @@ public sealed class InvoiceOrchestrationServiceExtendedTests
   /// <summary>
   /// Validates bulk read returns empty collection.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadAllInvoiceObjects_NoInvoices_ReturnsEmptyCollection()
   {
     // Arrange
@@ -276,14 +277,14 @@ public sealed class InvoiceOrchestrationServiceExtendedTests
     var result = await orchestrationService.ReadAllInvoiceObjects(userId, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
-    Assert.Empty(result);
+    Assert.IsNotNull(result);
+    Assert.IsEmpty(result);
   }
 
   /// <summary>
   /// Validates bulk read returns large collection.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadAllInvoiceObjects_LargeCollection_ReturnsAllInvoices()
   {
     // Arrange
@@ -298,13 +299,13 @@ public sealed class InvoiceOrchestrationServiceExtendedTests
     var result = await orchestrationService.ReadAllInvoiceObjects(userId, CancellationToken.None);
 
     // Assert
-    Assert.Equal(100, result.Count());
+    Assert.AreEqual(100, result.Count());
   }
 
   /// <summary>
   /// Validates bulk read with foundation dependency exception wrapping.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadAllInvoiceObjects_FoundationDependencyException_ThrowsOrchestrationDependencyException()
   {
     // Arrange
@@ -317,14 +318,14 @@ public sealed class InvoiceOrchestrationServiceExtendedTests
         .ThrowsAsync(foundationException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceOrchestrationDependencyException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceOrchestrationDependencyException>(() =>
         orchestrationService.ReadAllInvoiceObjects(userId, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates bulk read with foundation validation exception wrapping.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadAllInvoiceObjects_FoundationValidationException_ThrowsOrchestrationValidationException()
   {
     // Arrange
@@ -337,14 +338,14 @@ public sealed class InvoiceOrchestrationServiceExtendedTests
         .ThrowsAsync(foundationException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceOrchestrationValidationException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceOrchestrationValidationException>(() =>
         orchestrationService.ReadAllInvoiceObjects(userId, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates bulk read with generic exception wrapping.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadAllInvoiceObjects_GenericException_ThrowsOrchestrationServiceException()
   {
     // Arrange
@@ -355,7 +356,7 @@ public sealed class InvoiceOrchestrationServiceExtendedTests
         .ThrowsAsync(new InvalidOperationException("Unexpected error"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceOrchestrationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceOrchestrationServiceException>(() =>
         orchestrationService.ReadAllInvoiceObjects(userId, CancellationToken.None));
   }
 
@@ -366,7 +367,7 @@ public sealed class InvoiceOrchestrationServiceExtendedTests
   /// <summary>
   /// Validates invoice update with null user identifier.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateInvoiceObject_NullUserIdentifier_ReturnsUpdatedInvoice()
   {
     // Arrange
@@ -381,13 +382,13 @@ public sealed class InvoiceOrchestrationServiceExtendedTests
     var result = await orchestrationService.UpdateInvoiceObject(updatedInvoice, invoiceId, null, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
+    Assert.IsNotNull(result);
   }
 
   /// <summary>
   /// Validates invoice update with foundation validation exception wrapping.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateInvoiceObject_FoundationValidationException_ThrowsOrchestrationValidationException()
   {
     // Arrange
@@ -401,14 +402,14 @@ public sealed class InvoiceOrchestrationServiceExtendedTests
         .ThrowsAsync(foundationException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceOrchestrationValidationException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceOrchestrationValidationException>(() =>
         orchestrationService.UpdateInvoiceObject(updatedInvoice, invoiceId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates invoice update with foundation dependency exception wrapping.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateInvoiceObject_FoundationDependencyException_ThrowsOrchestrationDependencyException()
   {
     // Arrange
@@ -422,14 +423,14 @@ public sealed class InvoiceOrchestrationServiceExtendedTests
         .ThrowsAsync(foundationException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceOrchestrationDependencyException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceOrchestrationDependencyException>(() =>
         orchestrationService.UpdateInvoiceObject(updatedInvoice, invoiceId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates invoice update with foundation dependency validation exception wrapping.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateInvoiceObject_FoundationDependencyValidationException_ThrowsOrchestrationDependencyValidationException()
   {
     // Arrange
@@ -443,14 +444,14 @@ public sealed class InvoiceOrchestrationServiceExtendedTests
         .ThrowsAsync(foundationException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceOrchestrationDependencyValidationException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceOrchestrationDependencyValidationException>(() =>
         orchestrationService.UpdateInvoiceObject(updatedInvoice, invoiceId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates invoice update with generic exception wrapping.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateInvoiceObject_GenericException_ThrowsOrchestrationServiceException()
   {
     // Arrange
@@ -462,7 +463,7 @@ public sealed class InvoiceOrchestrationServiceExtendedTests
         .ThrowsAsync(new InvalidOperationException("Unexpected error"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceOrchestrationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceOrchestrationServiceException>(() =>
         orchestrationService.UpdateInvoiceObject(updatedInvoice, invoiceId, null, CancellationToken.None));
   }
 
@@ -473,7 +474,7 @@ public sealed class InvoiceOrchestrationServiceExtendedTests
   /// <summary>
   /// Validates invoice delete with null user identifier.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteInvoiceObject_NullUserIdentifier_DeletesSuccessfully()
   {
     // Arrange
@@ -493,7 +494,7 @@ public sealed class InvoiceOrchestrationServiceExtendedTests
   /// <summary>
   /// Validates invoice delete with foundation validation exception wrapping.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteInvoiceObject_FoundationValidationException_ThrowsOrchestrationValidationException()
   {
     // Arrange
@@ -506,14 +507,14 @@ public sealed class InvoiceOrchestrationServiceExtendedTests
         .ThrowsAsync(foundationException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceOrchestrationValidationException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceOrchestrationValidationException>(() =>
         orchestrationService.DeleteInvoiceObject(invoiceId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates invoice delete with foundation dependency exception wrapping.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteInvoiceObject_FoundationDependencyException_ThrowsOrchestrationDependencyException()
   {
     // Arrange
@@ -526,14 +527,14 @@ public sealed class InvoiceOrchestrationServiceExtendedTests
         .ThrowsAsync(foundationException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceOrchestrationDependencyException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceOrchestrationDependencyException>(() =>
         orchestrationService.DeleteInvoiceObject(invoiceId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates invoice delete with generic exception wrapping.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteInvoiceObject_GenericException_ThrowsOrchestrationServiceException()
   {
     // Arrange
@@ -544,14 +545,14 @@ public sealed class InvoiceOrchestrationServiceExtendedTests
         .ThrowsAsync(new InvalidOperationException("Unexpected error"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceOrchestrationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceOrchestrationServiceException>(() =>
         orchestrationService.DeleteInvoiceObject(invoiceId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates idempotent delete operations.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteInvoiceObject_IdempotentCalls_SucceedMultipleTimes()
   {
     // Arrange
@@ -578,7 +579,7 @@ public sealed class InvoiceOrchestrationServiceExtendedTests
   /// <summary>
   /// Validates analysis with CompleteAnalysis option.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoiceWithOptions_CompleteAnalysis_CallsAllServices()
   {
     // Arrange
@@ -609,7 +610,7 @@ public sealed class InvoiceOrchestrationServiceExtendedTests
   /// <summary>
   /// Validates analysis with InvoiceOnly option.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoiceWithOptions_InvoiceOnlyOption_CallsAnalysisService()
   {
     // Arrange
@@ -639,7 +640,7 @@ public sealed class InvoiceOrchestrationServiceExtendedTests
   /// <summary>
   /// Validates analysis read failure wrapping.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoiceWithOptions_ReadFails_ThrowsOrchestrationServiceException()
   {
     // Arrange
@@ -651,14 +652,14 @@ public sealed class InvoiceOrchestrationServiceExtendedTests
         .ThrowsAsync(new InvalidOperationException("Read failed"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceOrchestrationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceOrchestrationServiceException>(() =>
         orchestrationService.AnalyzeInvoiceWithOptions(options, invoiceId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates analysis service failure wrapping.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoiceWithOptions_AnalysisFails_ThrowsOrchestrationServiceException()
   {
     // Arrange
@@ -675,14 +676,14 @@ public sealed class InvoiceOrchestrationServiceExtendedTests
         .ThrowsAsync(new InvalidOperationException("Analysis failed"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceOrchestrationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceOrchestrationServiceException>(() =>
         orchestrationService.AnalyzeInvoiceWithOptions(options, invoiceId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates analysis update failure wrapping.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoiceWithOptions_UpdateFails_ThrowsOrchestrationServiceException()
   {
     // Arrange
@@ -703,14 +704,14 @@ public sealed class InvoiceOrchestrationServiceExtendedTests
         .ThrowsAsync(new InvalidOperationException("Update failed"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceOrchestrationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceOrchestrationServiceException>(() =>
         orchestrationService.AnalyzeInvoiceWithOptions(options, invoiceId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates analysis with foundation dependency exception.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoiceWithOptions_FoundationDependencyException_ThrowsOrchestrationDependencyException()
   {
     // Arrange
@@ -724,14 +725,14 @@ public sealed class InvoiceOrchestrationServiceExtendedTests
         .ThrowsAsync(foundationException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceOrchestrationDependencyException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceOrchestrationDependencyException>(() =>
         orchestrationService.AnalyzeInvoiceWithOptions(options, invoiceId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates analysis with foundation validation exception.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoiceWithOptions_FoundationValidationException_ThrowsOrchestrationValidationException()
   {
     // Arrange
@@ -745,7 +746,7 @@ public sealed class InvoiceOrchestrationServiceExtendedTests
         .ThrowsAsync(foundationException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceOrchestrationValidationException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceOrchestrationValidationException>(() =>
         orchestrationService.AnalyzeInvoiceWithOptions(options, invoiceId, null, CancellationToken.None));
   }
 

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Orchestration/InvoiceOrchestrationServiceTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Orchestration/InvoiceOrchestrationServiceTests.cs
@@ -19,13 +19,14 @@ using Microsoft.Extensions.Logging;
 
 using Moq;
 
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 /// <summary>
 /// Comprehensive unit tests for <see cref="InvoiceOrchestrationService"/> targeting 99% code coverage.
 /// Tests validate orchestration logic, exception handling, telemetry integration and foundation service coordination.
 /// Method naming follows MethodName_Condition_ExpectedResult pattern per repository standards.
 /// </summary>
+[TestClass]
 public sealed class InvoiceOrchestrationServiceTests
 {
   private readonly Mock<IInvoiceAnalysisFoundationService> mockAnalysisService;
@@ -63,25 +64,25 @@ public sealed class InvoiceOrchestrationServiceTests
   /// <summary>
   /// Verifies constructor throws ArgumentNullException when analysis service is null.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Constructor_NullAnalysisService_ThrowsArgumentNullException() =>
     // Arrange & Act & Assert
-    Assert.Throws<ArgumentNullException>(() =>
+    Assert.ThrowsExactly<ArgumentNullException>(() =>
       new InvoiceOrchestrationService(null!, mockStorageService.Object, mockLoggerFactory.Object));
 
   /// <summary>
   /// Verifies constructor throws ArgumentNullException when storage service is null.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Constructor_NullStorageService_ThrowsArgumentNullException() =>
     // Arrange & Act & Assert
-    Assert.Throws<ArgumentNullException>(() =>
+    Assert.ThrowsExactly<ArgumentNullException>(() =>
       new InvoiceOrchestrationService(mockAnalysisService.Object, null!, mockLoggerFactory.Object));
 
   /// <summary>
   /// Validates successful instantiation with all valid dependencies.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Constructor_ValidDependencies_CreatesInstance()
   {
     // Arrange & Act
@@ -91,7 +92,7 @@ public sealed class InvoiceOrchestrationServiceTests
       mockLoggerFactory.Object);
 
     // Assert
-    Assert.NotNull(service);
+    Assert.IsNotNull(service);
   }
 
   #endregion
@@ -101,7 +102,7 @@ public sealed class InvoiceOrchestrationServiceTests
   /// <summary>
   /// Ensures successful invoice analysis orchestration with complete workflow execution.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoiceWithOptions_ValidInput_ExecutesCompleteWorkflow()
   {
     // Arrange
@@ -135,7 +136,7 @@ public sealed class InvoiceOrchestrationServiceTests
   /// <summary>
   /// Validates analysis workflow execution without user identifier (partition-less operation).
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoiceWithOptions_NoUserIdentifier_ExecutesWorkflow()
   {
     // Arrange
@@ -165,7 +166,7 @@ public sealed class InvoiceOrchestrationServiceTests
   /// <summary>
   /// Confirms that foundation validation exceptions are surfaced as orchestration validation exceptions (no collapse).
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoiceWithOptions_FoundationValidationException_ThrowsOrchestrationValidationException()
   {
     // Arrange
@@ -178,14 +179,14 @@ public sealed class InvoiceOrchestrationServiceTests
    .ThrowsAsync(foundationException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceOrchestrationValidationException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceOrchestrationValidationException>(() =>
       orchestrationService.AnalyzeInvoiceWithOptions(AnalysisOptions.NoAnalysis, invoiceId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates foundation dependency exceptions are wrapped into orchestration dependency exceptions.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoiceWithOptions_FoundationDependencyException_ThrowsOrchestrationDependencyException()
   {
     // Arrange
@@ -198,14 +199,14 @@ public sealed class InvoiceOrchestrationServiceTests
       .ThrowsAsync(foundationException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceOrchestrationDependencyException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceOrchestrationDependencyException>(() =>
       orchestrationService.AnalyzeInvoiceWithOptions(AnalysisOptions.CompleteAnalysis, invoiceId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Ensures foundation dependency validation exceptions propagate as orchestration dependency validation exceptions.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoiceWithOptions_FoundationDependencyValidationException_ThrowsOrchestrationDependencyValidationException()
   {
     // Arrange
@@ -218,14 +219,14 @@ public sealed class InvoiceOrchestrationServiceTests
       .ThrowsAsync(foundationException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceOrchestrationDependencyValidationException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceOrchestrationDependencyValidationException>(() =>
       orchestrationService.AnalyzeInvoiceWithOptions(AnalysisOptions.InvoiceItemsOnly, invoiceId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Verifies foundation service exceptions are wrapped into orchestration service exceptions.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoiceWithOptions_FoundationServiceException_ThrowsOrchestrationServiceException()
   {
     // Arrange
@@ -238,14 +239,14 @@ public sealed class InvoiceOrchestrationServiceTests
  .ThrowsAsync(foundationException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceOrchestrationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceOrchestrationServiceException>(() =>
   orchestrationService.AnalyzeInvoiceWithOptions(AnalysisOptions.InvoiceMerchantOnly, invoiceId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Confirms generic exceptions are wrapped into orchestration service exceptions.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoiceWithOptions_GenericException_ThrowsOrchestrationServiceException()
   {
     // Arrange
@@ -257,7 +258,7 @@ public sealed class InvoiceOrchestrationServiceTests
       .ThrowsAsync(exception);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceOrchestrationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceOrchestrationServiceException>(() =>
         orchestrationService.AnalyzeInvoiceWithOptions(AnalysisOptions.CompleteAnalysis, invoiceId, null, CancellationToken.None));
   }
 
@@ -268,7 +269,7 @@ public sealed class InvoiceOrchestrationServiceTests
   /// <summary>
   /// Validates successful invoice creation through orchestration layer.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateInvoiceObject_ValidInvoice_ReturnsCreatedInvoice()
   {
     // Arrange
@@ -282,15 +283,15 @@ public sealed class InvoiceOrchestrationServiceTests
     var result = await orchestrationService.CreateInvoiceObject(invoice, userId, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
-    Assert.Equal(invoice.id, result.id);
+    Assert.IsNotNull(result);
+    Assert.AreEqual(invoice.id, result.id);
     mockStorageService.Verify(s => s.CreateInvoiceObject(invoice, userId, It.IsAny<CancellationToken>()), Times.Once);
   }
 
   /// <summary>
   /// Ensures creation succeeds without user identifier.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateInvoiceObject_NoUserIdentifier_CreatesSuccessfully()
   {
     // Arrange
@@ -303,14 +304,14 @@ public sealed class InvoiceOrchestrationServiceTests
     var result = await orchestrationService.CreateInvoiceObject(invoice, null, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
+    Assert.IsNotNull(result);
     mockStorageService.Verify(s => s.CreateInvoiceObject(invoice, null, It.IsAny<CancellationToken>()), Times.Once);
   }
 
   /// <summary>
   /// Confirms foundation validation exceptions propagate as orchestration dependency validation exceptions during creation.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateInvoiceObject_FoundationValidationException_ThrowsOrchestrationValidationException()
   {
     // Arrange
@@ -323,14 +324,14 @@ public sealed class InvoiceOrchestrationServiceTests
          .ThrowsAsync(foundationException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceOrchestrationValidationException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceOrchestrationValidationException>(() =>
       orchestrationService.CreateInvoiceObject(invoice, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates foundation dependency exceptions during creation are wrapped appropriately.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateInvoiceObject_FoundationDependencyException_ThrowsOrchestrationDependencyException()
   {
     // Arrange
@@ -343,14 +344,14 @@ public sealed class InvoiceOrchestrationServiceTests
       .ThrowsAsync(foundationException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceOrchestrationDependencyException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceOrchestrationDependencyException>(() =>
       orchestrationService.CreateInvoiceObject(invoice, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Ensures generic exceptions during creation are wrapped into orchestration service exceptions.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateInvoiceObject_GenericException_ThrowsOrchestrationServiceException()
   {
     // Arrange
@@ -362,7 +363,7 @@ public sealed class InvoiceOrchestrationServiceTests
   .ThrowsAsync(exception);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceOrchestrationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceOrchestrationServiceException>(() =>
       orchestrationService.CreateInvoiceObject(invoice, null, CancellationToken.None));
   }
 
@@ -373,7 +374,7 @@ public sealed class InvoiceOrchestrationServiceTests
   /// <summary>
   /// Validates successful retrieval of single invoice by identifier.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoiceObject_ValidIdentifier_ReturnsInvoice()
   {
     // Arrange
@@ -389,15 +390,15 @@ public sealed class InvoiceOrchestrationServiceTests
     var result = await orchestrationService.ReadInvoiceObject(invoiceId, userId, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
-    Assert.Equal(expectedInvoice.id, result.id);
+    Assert.IsNotNull(result);
+    Assert.AreEqual(expectedInvoice.id, result.id);
     mockStorageService.Verify(s => s.ReadInvoiceObject(invoiceId, userId, It.IsAny<CancellationToken>()), Times.Once);
   }
 
   /// <summary>
   /// Ensures read operation succeeds without user identifier.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoiceObject_NoUserIdentifier_ReturnsInvoice()
   {
     // Arrange
@@ -412,14 +413,14 @@ public sealed class InvoiceOrchestrationServiceTests
     var result = await orchestrationService.ReadInvoiceObject(invoiceId, null, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
+    Assert.IsNotNull(result);
     mockStorageService.Verify(s => s.ReadInvoiceObject(invoiceId, null, It.IsAny<CancellationToken>()), Times.Once);
   }
 
   /// <summary>
   /// Confirms foundation validation exceptions during read are wrapped appropriately.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoiceObject_FoundationValidationException_ThrowsOrchestrationValidationException()
   {
     // Arrange
@@ -432,14 +433,14 @@ public sealed class InvoiceOrchestrationServiceTests
       .ThrowsAsync(foundationException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceOrchestrationValidationException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceOrchestrationValidationException>(() =>
       orchestrationService.ReadInvoiceObject(invoiceId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates foundation service exceptions during read propagate correctly.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoiceObject_FoundationServiceException_ThrowsOrchestrationServiceException()
   {
     // Arrange
@@ -452,7 +453,7 @@ public sealed class InvoiceOrchestrationServiceTests
       .ThrowsAsync(foundationException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceOrchestrationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceOrchestrationServiceException>(() =>
       orchestrationService.ReadInvoiceObject(invoiceId, null, CancellationToken.None));
   }
 
@@ -463,7 +464,7 @@ public sealed class InvoiceOrchestrationServiceTests
   /// <summary>
   /// Validates successful retrieval of all invoices for a user.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadAllInvoiceObjects_WithUserIdentifier_ReturnsInvoiceCollection()
   {
     // Arrange
@@ -478,15 +479,15 @@ public sealed class InvoiceOrchestrationServiceTests
     var result = await orchestrationService.ReadAllInvoiceObjects(userId, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
-    Assert.Equal(5, result.Count());
+    Assert.IsNotNull(result);
+    Assert.AreEqual(5, result.Count());
     mockStorageService.Verify(s => s.ReadAllInvoiceObjects(userId, It.IsAny<CancellationToken>()), Times.Once);
   }
 
   /// <summary>
   /// Validates empty collection is returned when no invoices exist.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadAllInvoiceObjects_NoInvoices_ReturnsEmptyCollection()
   {
     // Arrange
@@ -501,14 +502,14 @@ public sealed class InvoiceOrchestrationServiceTests
     var result = await orchestrationService.ReadAllInvoiceObjects(userId, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
-    Assert.Empty(result);
+    Assert.IsNotNull(result);
+    Assert.IsEmpty(result);
   }
 
   /// <summary>
   /// Confirms foundation dependency exceptions during bulk read are wrapped appropriately.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadAllInvoiceObjects_FoundationDependencyException_ThrowsOrchestrationDependencyException()
   {
     // Arrange
@@ -521,14 +522,14 @@ public sealed class InvoiceOrchestrationServiceTests
       .ThrowsAsync(foundationException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceOrchestrationDependencyException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceOrchestrationDependencyException>(() =>
       orchestrationService.ReadAllInvoiceObjects(userId, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates generic exceptions during bulk read propagate as orchestration service exceptions.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadAllInvoiceObjects_GenericException_ThrowsOrchestrationServiceException()
   {
     // Arrange
@@ -540,7 +541,7 @@ public sealed class InvoiceOrchestrationServiceTests
       .ThrowsAsync(exception);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceOrchestrationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceOrchestrationServiceException>(() =>
       orchestrationService.ReadAllInvoiceObjects(userId, CancellationToken.None));
   }
 
@@ -551,7 +552,7 @@ public sealed class InvoiceOrchestrationServiceTests
   /// <summary>
   /// Validates successful invoice update through orchestration layer.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateInvoiceObject_ValidUpdate_ReturnsUpdatedInvoice()
   {
     // Arrange
@@ -567,15 +568,15 @@ public sealed class InvoiceOrchestrationServiceTests
     var result = await orchestrationService.UpdateInvoiceObject(updatedInvoice, invoiceId, userId, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
-    Assert.Equal(updatedInvoice.id, result.id);
+    Assert.IsNotNull(result);
+    Assert.AreEqual(updatedInvoice.id, result.id);
     mockStorageService.Verify(s => s.UpdateInvoiceObject(updatedInvoice, invoiceId, userId, It.IsAny<CancellationToken>()), Times.Once);
   }
 
   /// <summary>
   /// Ensures update succeeds without user identifier.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateInvoiceObject_NoUserIdentifier_UpdatesSuccessfully()
   {
     // Arrange
@@ -590,14 +591,14 @@ public sealed class InvoiceOrchestrationServiceTests
     var result = await orchestrationService.UpdateInvoiceObject(updatedInvoice, invoiceId, null, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
+    Assert.IsNotNull(result);
     mockStorageService.Verify(s => s.UpdateInvoiceObject(updatedInvoice, invoiceId, null, It.IsAny<CancellationToken>()), Times.Once);
   }
 
   /// <summary>
   /// Confirms foundation validation exceptions during update are wrapped appropriately.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateInvoiceObject_FoundationValidationException_ThrowsOrchestrationValidationException()
   {
     // Arrange
@@ -611,14 +612,14 @@ public sealed class InvoiceOrchestrationServiceTests
       .ThrowsAsync(foundationException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceOrchestrationValidationException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceOrchestrationValidationException>(() =>
       orchestrationService.UpdateInvoiceObject(updatedInvoice, invoiceId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates foundation dependency validation exceptions during update propagate correctly.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateInvoiceObject_FoundationDependencyValidationException_ThrowsOrchestrationDependencyValidationException()
   {
     // Arrange
@@ -632,14 +633,14 @@ public sealed class InvoiceOrchestrationServiceTests
       .ThrowsAsync(foundationException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceOrchestrationDependencyValidationException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceOrchestrationDependencyValidationException>(() =>
       orchestrationService.UpdateInvoiceObject(updatedInvoice, invoiceId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Ensures generic exceptions during update are wrapped into orchestration service exceptions.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateInvoiceObject_GenericException_ThrowsOrchestrationServiceException()
   {
     // Arrange
@@ -652,7 +653,7 @@ public sealed class InvoiceOrchestrationServiceTests
       .ThrowsAsync(exception);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceOrchestrationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceOrchestrationServiceException>(() =>
       orchestrationService.UpdateInvoiceObject(updatedInvoice, invoiceId, null, CancellationToken.None));
   }
 
@@ -663,7 +664,7 @@ public sealed class InvoiceOrchestrationServiceTests
   /// <summary>
   /// Validates successful invoice deletion through orchestration layer.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteInvoiceObject_ValidIdentifier_DeletesSuccessfully()
   {
     // Arrange
@@ -684,7 +685,7 @@ public sealed class InvoiceOrchestrationServiceTests
   /// <summary>
   /// Ensures deletion succeeds without user identifier.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteInvoiceObject_NoUserIdentifier_DeletesSuccessfully()
   {
     // Arrange
@@ -704,7 +705,7 @@ public sealed class InvoiceOrchestrationServiceTests
   /// <summary>
   /// Confirms foundation validation exceptions during delete are wrapped appropriately.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteInvoiceObject_FoundationValidationException_ThrowsOrchestrationValidationException()
   {
     // Arrange
@@ -717,14 +718,14 @@ public sealed class InvoiceOrchestrationServiceTests
        .ThrowsAsync(foundationException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceOrchestrationValidationException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceOrchestrationValidationException>(() =>
       orchestrationService.DeleteInvoiceObject(invoiceId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates foundation dependency exceptions during delete propagate correctly.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteInvoiceObject_FoundationDependencyException_ThrowsOrchestrationDependencyException()
   {
     // Arrange
@@ -737,14 +738,14 @@ public sealed class InvoiceOrchestrationServiceTests
       .ThrowsAsync(foundationException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceOrchestrationDependencyException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceOrchestrationDependencyException>(() =>
       orchestrationService.DeleteInvoiceObject(invoiceId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Ensures foundation service exceptions during delete are wrapped appropriately.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteInvoiceObject_FoundationServiceException_ThrowsOrchestrationServiceException()
   {
     // Arrange
@@ -757,14 +758,14 @@ public sealed class InvoiceOrchestrationServiceTests
       .ThrowsAsync(foundationException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceOrchestrationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceOrchestrationServiceException>(() =>
       orchestrationService.DeleteInvoiceObject(invoiceId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates generic exceptions during delete are wrapped into orchestration service exceptions.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteInvoiceObject_GenericException_ThrowsOrchestrationServiceException()
   {
     // Arrange
@@ -776,14 +777,14 @@ public sealed class InvoiceOrchestrationServiceTests
       .ThrowsAsync(exception);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceOrchestrationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceOrchestrationServiceException>(() =>
       orchestrationService.DeleteInvoiceObject(invoiceId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates idempotency of delete operation (repeated calls succeed).
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteInvoiceObject_IdempotentCalls_SucceedMultipleTimes()
   {
     // Arrange

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Orchestration/MerchantOrchestrationServiceExceptionsTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Orchestration/MerchantOrchestrationServiceExceptionsTests.cs
@@ -15,12 +15,13 @@ using Microsoft.Extensions.Logging;
 
 using Moq;
 
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 /// <summary>
 /// Unit tests validating that <see cref="MerchantOrchestrationService"/> classifies each foundation
 /// outer exception tier to its matching orchestration outer tier (no collapse).
 /// </summary>
+[TestClass]
 public sealed class MerchantOrchestrationServiceExceptionsTests
 {
   private readonly Mock<IMerchantStorageFoundationService> mockStorageService;
@@ -49,7 +50,7 @@ public sealed class MerchantOrchestrationServiceExceptionsTests
   /// <summary>
   /// Foundation validation failures must surface as orchestration validation (no collapse into dependency-validation).
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateMerchant_WhenFoundationThrowsValidation_ThrowsOrchestrationValidation()
   {
     var merchant = MerchantTestDataBuilder.CreateRandomMerchant();
@@ -58,14 +59,14 @@ public sealed class MerchantOrchestrationServiceExceptionsTests
       .Setup(s => s.CreateMerchantObject(It.IsAny<Merchant>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new MerchantFoundationServiceValidationException(inner));
 
-    await Assert.ThrowsAsync<MerchantOrchestrationServiceValidationException>(
+    await Assert.ThrowsExactlyAsync<MerchantOrchestrationServiceValidationException>(
       () => orchestrationService.CreateMerchantObject(merchant, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Foundation dependency-validation failures must surface distinctly as orchestration dependency-validation.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateMerchant_WhenFoundationThrowsDependencyValidation_ThrowsOrchestrationDependencyValidation()
   {
     var merchant = MerchantTestDataBuilder.CreateRandomMerchant();
@@ -74,14 +75,14 @@ public sealed class MerchantOrchestrationServiceExceptionsTests
       .Setup(s => s.CreateMerchantObject(It.IsAny<Merchant>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new MerchantFoundationServiceDependencyValidationException(inner));
 
-    await Assert.ThrowsAsync<MerchantOrchestrationServiceDependencyValidationException>(
+    await Assert.ThrowsExactlyAsync<MerchantOrchestrationServiceDependencyValidationException>(
       () => orchestrationService.CreateMerchantObject(merchant, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Foundation dependency failures must surface as orchestration dependency.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateMerchant_WhenFoundationThrowsDependency_ThrowsOrchestrationDependency()
   {
     var merchant = MerchantTestDataBuilder.CreateRandomMerchant();
@@ -90,14 +91,14 @@ public sealed class MerchantOrchestrationServiceExceptionsTests
       .Setup(s => s.CreateMerchantObject(It.IsAny<Merchant>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new MerchantFoundationServiceDependencyException(inner));
 
-    await Assert.ThrowsAsync<MerchantOrchestrationServiceDependencyException>(
+    await Assert.ThrowsExactlyAsync<MerchantOrchestrationServiceDependencyException>(
       () => orchestrationService.CreateMerchantObject(merchant, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Foundation service failures must surface as orchestration service failures.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateMerchant_WhenFoundationThrowsService_ThrowsOrchestrationService()
   {
     var merchant = MerchantTestDataBuilder.CreateRandomMerchant();
@@ -106,14 +107,14 @@ public sealed class MerchantOrchestrationServiceExceptionsTests
       .Setup(s => s.CreateMerchantObject(It.IsAny<Merchant>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new MerchantFoundationServiceException(inner));
 
-    await Assert.ThrowsAsync<MerchantOrchestrationServiceException>(
+    await Assert.ThrowsExactlyAsync<MerchantOrchestrationServiceException>(
       () => orchestrationService.CreateMerchantObject(merchant, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Unknown exceptions from the foundation must be treated as orchestration service failures (catch-all).
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateMerchant_WhenFoundationThrowsUnknown_ThrowsOrchestrationService()
   {
     var merchant = MerchantTestDataBuilder.CreateRandomMerchant();
@@ -121,7 +122,7 @@ public sealed class MerchantOrchestrationServiceExceptionsTests
       .Setup(s => s.CreateMerchantObject(It.IsAny<Merchant>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new InvalidOperationException("unknown"));
 
-    await Assert.ThrowsAsync<MerchantOrchestrationServiceException>(
+    await Assert.ThrowsExactlyAsync<MerchantOrchestrationServiceException>(
       () => orchestrationService.CreateMerchantObject(merchant, null, CancellationToken.None));
   }
 }

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Orchestration/MerchantOrchestrationServiceExtendedTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Orchestration/MerchantOrchestrationServiceExtendedTests.cs
@@ -17,12 +17,13 @@ using Microsoft.Extensions.Logging;
 
 using Moq;
 
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 /// <summary>
 /// Extended unit tests for <see cref="MerchantOrchestrationService"/> covering additional
 /// edge cases, exception scenarios, and boundary conditions for comprehensive code coverage.
 /// </summary>
+[TestClass]
 public sealed class MerchantOrchestrationServiceExtendedTests
 {
   private readonly Mock<IMerchantStorageFoundationService> mockStorageService;
@@ -53,7 +54,7 @@ public sealed class MerchantOrchestrationServiceExtendedTests
   /// <summary>
   /// Validates successful instantiation with valid dependencies.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Constructor_ValidDependencies_CreatesInstance()
   {
     // Act
@@ -62,7 +63,7 @@ public sealed class MerchantOrchestrationServiceExtendedTests
         mockLoggerFactory.Object);
 
     // Assert
-    Assert.NotNull(svc);
+    Assert.IsNotNull(svc);
   }
 
   #endregion
@@ -72,7 +73,7 @@ public sealed class MerchantOrchestrationServiceExtendedTests
   /// <summary>
   /// Validates merchant creation with minimal data.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateMerchantObject_MinimalMerchant_CreatesSuccessfully()
   {
     // Arrange
@@ -93,7 +94,7 @@ public sealed class MerchantOrchestrationServiceExtendedTests
   /// <summary>
   /// Validates merchant creation with empty Guid parent company.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateMerchantObject_EmptyGuidParentCompany_CreatesSuccessfully()
   {
     // Arrange
@@ -113,7 +114,7 @@ public sealed class MerchantOrchestrationServiceExtendedTests
   /// <summary>
   /// Validates merchant creation with null parent company ID.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateMerchantObject_NullParentCompanyId_CreatesSuccessfully()
   {
     // Arrange
@@ -133,7 +134,7 @@ public sealed class MerchantOrchestrationServiceExtendedTests
   /// <summary>
   /// Validates foundation validation exception is wrapped into orchestration validation exception.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateMerchantObject_FoundationValidationException_ThrowsOrchestrationValidationException()
   {
     // Arrange
@@ -144,14 +145,14 @@ public sealed class MerchantOrchestrationServiceExtendedTests
         .ThrowsAsync(new MerchantFoundationServiceValidationException(new InvalidOperationException("Validation error")));
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantOrchestrationServiceValidationException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantOrchestrationServiceValidationException>(() =>
         service.CreateMerchantObject(merchant, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates foundation dependency exception is wrapped into orchestration dependency exception.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateMerchantObject_FoundationDependencyException_ThrowsOrchestrationDependencyException()
   {
     // Arrange
@@ -162,14 +163,14 @@ public sealed class MerchantOrchestrationServiceExtendedTests
         .ThrowsAsync(new MerchantFoundationServiceDependencyException(new InvalidOperationException("Dependency error")));
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantOrchestrationServiceDependencyException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantOrchestrationServiceDependencyException>(() =>
         service.CreateMerchantObject(merchant, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates foundation service exception is wrapped into orchestration service exception.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateMerchantObject_FoundationServiceException_ThrowsOrchestrationServiceException()
   {
     // Arrange
@@ -180,14 +181,14 @@ public sealed class MerchantOrchestrationServiceExtendedTests
         .ThrowsAsync(new MerchantFoundationServiceException(new InvalidOperationException("Service error")));
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantOrchestrationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantOrchestrationServiceException>(() =>
         service.CreateMerchantObject(merchant, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates generic exception is wrapped into orchestration service exception.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateMerchantObject_GenericException_ThrowsOrchestrationServiceException()
   {
     // Arrange
@@ -198,7 +199,7 @@ public sealed class MerchantOrchestrationServiceExtendedTests
         .ThrowsAsync(new InvalidOperationException("Unexpected error"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantOrchestrationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantOrchestrationServiceException>(() =>
         service.CreateMerchantObject(merchant, null, CancellationToken.None));
   }
 
@@ -209,7 +210,7 @@ public sealed class MerchantOrchestrationServiceExtendedTests
   /// <summary>
   /// Validates reading merchant with specific identifiers.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchantObject_ValidIdentifiers_ReturnsMerchant()
   {
     // Arrange
@@ -225,14 +226,14 @@ public sealed class MerchantOrchestrationServiceExtendedTests
     var result = await service.ReadMerchantObject(merchantId, parentCompanyId, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
-    Assert.Same(expectedMerchant, result);
+    Assert.IsNotNull(result);
+    Assert.AreSame(expectedMerchant, result);
   }
 
   /// <summary>
   /// Validates reading merchant with null parent company ID.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchantObject_NullParentCompanyId_ReturnsMerchant()
   {
     // Arrange
@@ -247,13 +248,13 @@ public sealed class MerchantOrchestrationServiceExtendedTests
     var result = await service.ReadMerchantObject(merchantId, null, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
+    Assert.IsNotNull(result);
   }
 
   /// <summary>
   /// Validates reading merchant with empty Guid identifiers.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchantObject_EmptyGuidIdentifiers_ReturnsMerchant()
   {
     // Arrange
@@ -267,13 +268,13 @@ public sealed class MerchantOrchestrationServiceExtendedTests
     var result = await service.ReadMerchantObject(Guid.Empty, Guid.Empty, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
+    Assert.IsNotNull(result);
   }
 
   /// <summary>
   /// Validates foundation dependency exception during read is wrapped.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchantObject_FoundationDependencyException_ThrowsOrchestrationDependencyException()
   {
     // Arrange
@@ -284,14 +285,14 @@ public sealed class MerchantOrchestrationServiceExtendedTests
         .ThrowsAsync(new MerchantFoundationServiceDependencyException(new InvalidOperationException("Dependency error")));
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantOrchestrationServiceDependencyException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantOrchestrationServiceDependencyException>(() =>
         service.ReadMerchantObject(merchantId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates generic exception during read is wrapped.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchantObject_GenericException_ThrowsOrchestrationServiceException()
   {
     // Arrange
@@ -302,7 +303,7 @@ public sealed class MerchantOrchestrationServiceExtendedTests
         .ThrowsAsync(new InvalidOperationException("Unexpected error"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantOrchestrationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantOrchestrationServiceException>(() =>
         service.ReadMerchantObject(merchantId, null, CancellationToken.None));
   }
 
@@ -313,7 +314,7 @@ public sealed class MerchantOrchestrationServiceExtendedTests
   /// <summary>
   /// Validates bulk read returns all merchants.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadAllMerchantObjects_ValidParentCompanyId_ReturnsAllMerchants()
   {
     // Arrange
@@ -330,13 +331,13 @@ public sealed class MerchantOrchestrationServiceExtendedTests
     var result = await service.ReadAllMerchantObjects(parentCompanyId, CancellationToken.None);
 
     // Assert
-    Assert.Equal(10, result.Count());
+    Assert.AreEqual(10, result.Count());
   }
 
   /// <summary>
   /// Validates bulk read returns empty collection when no merchants exist.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadAllMerchantObjects_NoMerchants_ReturnsEmptyCollection()
   {
     // Arrange
@@ -350,13 +351,13 @@ public sealed class MerchantOrchestrationServiceExtendedTests
     var result = await service.ReadAllMerchantObjects(parentCompanyId, CancellationToken.None);
 
     // Assert
-    Assert.Empty(result);
+    Assert.IsEmpty(result);
   }
 
   /// <summary>
   /// Validates bulk read with empty Guid parent company ID.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadAllMerchantObjects_EmptyGuidParentCompanyId_ReturnsAllMerchants()
   {
     // Arrange
@@ -372,13 +373,13 @@ public sealed class MerchantOrchestrationServiceExtendedTests
     var result = await service.ReadAllMerchantObjects(Guid.Empty, CancellationToken.None);
 
     // Assert
-    Assert.Equal(5, result.Count());
+    Assert.AreEqual(5, result.Count());
   }
 
   /// <summary>
   /// Validates foundation dependency exception during bulk read is wrapped.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadAllMerchantObjects_FoundationDependencyException_ThrowsOrchestrationDependencyException()
   {
     // Arrange
@@ -389,14 +390,14 @@ public sealed class MerchantOrchestrationServiceExtendedTests
         .ThrowsAsync(new MerchantFoundationServiceDependencyException(new InvalidOperationException("Dependency error")));
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantOrchestrationServiceDependencyException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantOrchestrationServiceDependencyException>(() =>
         service.ReadAllMerchantObjects(parentCompanyId, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates generic exception during bulk read is wrapped.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadAllMerchantObjects_GenericException_ThrowsOrchestrationServiceException()
   {
     // Arrange
@@ -407,14 +408,14 @@ public sealed class MerchantOrchestrationServiceExtendedTests
         .ThrowsAsync(new InvalidOperationException("Unexpected error"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantOrchestrationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantOrchestrationServiceException>(() =>
         service.ReadAllMerchantObjects(parentCompanyId, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates bulk read with large collection.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadAllMerchantObjects_LargeCollection_ReturnsAllMerchants()
   {
     // Arrange
@@ -431,7 +432,7 @@ public sealed class MerchantOrchestrationServiceExtendedTests
     var result = await service.ReadAllMerchantObjects(parentCompanyId, CancellationToken.None);
 
     // Assert
-    Assert.Equal(1000, result.Count());
+    Assert.AreEqual(1000, result.Count());
   }
 
   #endregion
@@ -441,7 +442,7 @@ public sealed class MerchantOrchestrationServiceExtendedTests
   /// <summary>
   /// Validates merchant update with valid data.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateMerchantObject_ValidData_ReturnsUpdatedMerchant()
   {
     // Arrange
@@ -457,13 +458,13 @@ public sealed class MerchantOrchestrationServiceExtendedTests
     var result = await service.UpdateMerchantObject(merchant, merchantId, parentCompanyId, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
+    Assert.IsNotNull(result);
   }
 
   /// <summary>
   /// Validates merchant update with null parent company ID.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateMerchantObject_NullParentCompanyId_ReturnsUpdatedMerchant()
   {
     // Arrange
@@ -478,13 +479,13 @@ public sealed class MerchantOrchestrationServiceExtendedTests
     var result = await service.UpdateMerchantObject(merchant, merchantId, null, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
+    Assert.IsNotNull(result);
   }
 
   /// <summary>
   /// Validates foundation validation exception during update is wrapped.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateMerchantObject_FoundationValidationException_ThrowsOrchestrationValidationException()
   {
     // Arrange
@@ -496,14 +497,14 @@ public sealed class MerchantOrchestrationServiceExtendedTests
         .ThrowsAsync(new MerchantFoundationServiceValidationException(new InvalidOperationException("Validation error")));
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantOrchestrationServiceValidationException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantOrchestrationServiceValidationException>(() =>
         service.UpdateMerchantObject(merchant, merchantId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates foundation dependency exception during update is wrapped.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateMerchantObject_FoundationDependencyException_ThrowsOrchestrationDependencyException()
   {
     // Arrange
@@ -515,14 +516,14 @@ public sealed class MerchantOrchestrationServiceExtendedTests
         .ThrowsAsync(new MerchantFoundationServiceDependencyException(new InvalidOperationException("Dependency error")));
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantOrchestrationServiceDependencyException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantOrchestrationServiceDependencyException>(() =>
         service.UpdateMerchantObject(merchant, merchantId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates generic exception during update is wrapped.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateMerchantObject_GenericException_ThrowsOrchestrationServiceException()
   {
     // Arrange
@@ -534,7 +535,7 @@ public sealed class MerchantOrchestrationServiceExtendedTests
         .ThrowsAsync(new InvalidOperationException("Unexpected error"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantOrchestrationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantOrchestrationServiceException>(() =>
         service.UpdateMerchantObject(merchant, merchantId, null, CancellationToken.None));
   }
 
@@ -545,7 +546,7 @@ public sealed class MerchantOrchestrationServiceExtendedTests
   /// <summary>
   /// Validates merchant deletion with valid identifiers.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteMerchantObject_ValidIdentifiers_DeletesSuccessfully()
   {
     // Arrange
@@ -566,7 +567,7 @@ public sealed class MerchantOrchestrationServiceExtendedTests
   /// <summary>
   /// Validates merchant deletion with null parent company ID.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteMerchantObject_NullParentCompanyId_DeletesSuccessfully()
   {
     // Arrange
@@ -586,7 +587,7 @@ public sealed class MerchantOrchestrationServiceExtendedTests
   /// <summary>
   /// Validates foundation validation exception during deletion is wrapped.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteMerchantObject_FoundationValidationException_ThrowsOrchestrationValidationException()
   {
     // Arrange
@@ -597,14 +598,14 @@ public sealed class MerchantOrchestrationServiceExtendedTests
         .ThrowsAsync(new MerchantFoundationServiceValidationException(new InvalidOperationException("Validation error")));
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantOrchestrationServiceValidationException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantOrchestrationServiceValidationException>(() =>
         service.DeleteMerchantObject(merchantId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates foundation dependency exception during deletion is wrapped.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteMerchantObject_FoundationDependencyException_ThrowsOrchestrationDependencyException()
   {
     // Arrange
@@ -615,14 +616,14 @@ public sealed class MerchantOrchestrationServiceExtendedTests
         .ThrowsAsync(new MerchantFoundationServiceDependencyException(new InvalidOperationException("Dependency error")));
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantOrchestrationServiceDependencyException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantOrchestrationServiceDependencyException>(() =>
         service.DeleteMerchantObject(merchantId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates generic exception during deletion is wrapped.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteMerchantObject_GenericException_ThrowsOrchestrationServiceException()
   {
     // Arrange
@@ -633,14 +634,14 @@ public sealed class MerchantOrchestrationServiceExtendedTests
         .ThrowsAsync(new InvalidOperationException("Unexpected error"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantOrchestrationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantOrchestrationServiceException>(() =>
         service.DeleteMerchantObject(merchantId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates idempotent deletion.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteMerchantObject_MultipleCalls_AllComplete()
   {
     // Arrange
@@ -667,7 +668,7 @@ public sealed class MerchantOrchestrationServiceExtendedTests
   /// <summary>
   /// Validates concurrent create operations complete successfully.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateMerchantObject_ConcurrentOperations_AllComplete()
   {
     // Arrange
@@ -691,7 +692,7 @@ public sealed class MerchantOrchestrationServiceExtendedTests
   /// <summary>
   /// Validates concurrent read operations complete successfully.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchantObject_ConcurrentOperations_AllComplete()
   {
     // Arrange
@@ -706,7 +707,10 @@ public sealed class MerchantOrchestrationServiceExtendedTests
     var results = await Task.WhenAll(tasks);
 
     // Assert
-    Assert.All(results, r => Assert.NotNull(r));
+    foreach (var r in results)
+    {
+      Assert.IsNotNull(r);
+    }
   }
 
   #endregion
@@ -716,7 +720,7 @@ public sealed class MerchantOrchestrationServiceExtendedTests
   /// <summary>
   /// Validates TimeoutException is wrapped correctly.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateMerchantObject_TimeoutException_ThrowsOrchestrationServiceException()
   {
     // Arrange
@@ -727,14 +731,14 @@ public sealed class MerchantOrchestrationServiceExtendedTests
         .ThrowsAsync(new TimeoutException("Timeout"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantOrchestrationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantOrchestrationServiceException>(() =>
         service.CreateMerchantObject(merchant, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates ArgumentException is wrapped correctly.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchantObject_ArgumentException_ThrowsOrchestrationServiceException()
   {
     // Arrange
@@ -745,14 +749,14 @@ public sealed class MerchantOrchestrationServiceExtendedTests
         .ThrowsAsync(new ArgumentException("Invalid argument"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantOrchestrationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantOrchestrationServiceException>(() =>
         service.ReadMerchantObject(merchantId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates OperationCanceledException is wrapped correctly.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateMerchantObject_OperationCanceledException_PropagatesOperationCanceledException()
   {
     // Arrange
@@ -764,7 +768,7 @@ public sealed class MerchantOrchestrationServiceExtendedTests
         .ThrowsAsync(new OperationCanceledException("Cancelled"));
 
     // Act & Assert — cancellation must not be reclassified into a domain exception (bug fix)
-    await Assert.ThrowsAsync<OperationCanceledException>(() =>
+    await Assert.ThrowsExactlyAsync<OperationCanceledException>(() =>
         service.UpdateMerchantObject(merchant, merchantId, null, CancellationToken.None));
   }
 

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Orchestration/MerchantOrchestrationServiceTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Orchestration/MerchantOrchestrationServiceTests.cs
@@ -746,7 +746,7 @@ public sealed class MerchantOrchestrationServiceTests
   /// <summary>
   /// Provides theory data containing several randomized merchants for parameterized tests.
   /// </summary>
-  public static TheoryData<Merchant> GetMerchantTestData() => MerchantTestDataBuilder.GetMerchantTheoryData();
+  public static IEnumerable<object[]> GetMerchantTestData() => MerchantTestDataBuilder.GetMerchantTheoryData();
 
   #endregion
 }

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Orchestration/MerchantOrchestrationServiceTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Orchestration/MerchantOrchestrationServiceTests.cs
@@ -17,13 +17,14 @@ using Microsoft.Extensions.Logging;
 
 using Moq;
 
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 /// <summary>
 /// Comprehensive unit tests for <see cref="MerchantOrchestrationService"/> targeting 95%+ code coverage.
 /// Tests validate orchestration logic, exception handling, telemetry integration and foundation service coordination.
 /// Method naming follows MethodName_Condition_ExpectedResult pattern per repository standards.
 /// </summary>
+[TestClass]
 public sealed class MerchantOrchestrationServiceTests
 {
   private readonly Mock<IMerchantStorageFoundationService> mockStorageService;
@@ -58,15 +59,15 @@ public sealed class MerchantOrchestrationServiceTests
   /// <summary>
   /// Verifies constructor throws ArgumentNullException when storage service is null.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Constructor_NullStorageService_ThrowsArgumentNullException() =>
-      Assert.Throws<ArgumentNullException>(() =>
+      Assert.ThrowsExactly<ArgumentNullException>(() =>
           new MerchantOrchestrationService(null!, mockLoggerFactory.Object));
 
   /// <summary>
   /// Validates successful instantiation with all valid dependencies.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Constructor_ValidDependencies_CreatesInstance()
   {
     // Arrange & Act
@@ -75,7 +76,7 @@ public sealed class MerchantOrchestrationServiceTests
         mockLoggerFactory.Object);
 
     // Assert
-    Assert.NotNull(service);
+    Assert.IsNotNull(service);
   }
 
   #endregion
@@ -85,7 +86,7 @@ public sealed class MerchantOrchestrationServiceTests
   /// <summary>
   /// Validates successful merchant creation through orchestration layer.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateMerchantObject_ValidMerchant_CallsFoundationService()
   {
     // Arrange
@@ -106,7 +107,7 @@ public sealed class MerchantOrchestrationServiceTests
   /// <summary>
   /// Ensures creation succeeds without parent company identifier.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateMerchantObject_NoParentCompanyId_CreatesSuccessfully()
   {
     // Arrange
@@ -126,7 +127,7 @@ public sealed class MerchantOrchestrationServiceTests
   /// <summary>
   /// Confirms foundation validation exceptions propagate as orchestration validation exceptions during creation.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateMerchantObject_FoundationValidationException_ThrowsOrchestrationValidationException()
   {
     // Arrange
@@ -139,14 +140,14 @@ public sealed class MerchantOrchestrationServiceTests
         .ThrowsAsync(foundationException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantOrchestrationServiceValidationException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantOrchestrationServiceValidationException>(() =>
         orchestrationService.CreateMerchantObject(merchant, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates foundation dependency exceptions during creation are wrapped appropriately.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateMerchantObject_FoundationDependencyException_ThrowsOrchestrationDependencyException()
   {
     // Arrange
@@ -159,14 +160,14 @@ public sealed class MerchantOrchestrationServiceTests
         .ThrowsAsync(foundationException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantOrchestrationServiceDependencyException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantOrchestrationServiceDependencyException>(() =>
         orchestrationService.CreateMerchantObject(merchant, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates foundation dependency validation exceptions during creation are wrapped appropriately.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateMerchantObject_FoundationDependencyValidationException_ThrowsOrchestrationDependencyValidationException()
   {
     // Arrange
@@ -179,14 +180,14 @@ public sealed class MerchantOrchestrationServiceTests
         .ThrowsAsync(foundationException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantOrchestrationServiceDependencyValidationException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantOrchestrationServiceDependencyValidationException>(() =>
         orchestrationService.CreateMerchantObject(merchant, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates foundation service exceptions during creation are wrapped appropriately.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateMerchantObject_FoundationServiceException_ThrowsOrchestrationServiceException()
   {
     // Arrange
@@ -199,14 +200,14 @@ public sealed class MerchantOrchestrationServiceTests
         .ThrowsAsync(foundationException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantOrchestrationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantOrchestrationServiceException>(() =>
         orchestrationService.CreateMerchantObject(merchant, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Ensures generic exceptions during creation are wrapped into orchestration service exceptions.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateMerchantObject_GenericException_ThrowsOrchestrationServiceException()
   {
     // Arrange
@@ -218,7 +219,7 @@ public sealed class MerchantOrchestrationServiceTests
         .ThrowsAsync(exception);
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantOrchestrationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantOrchestrationServiceException>(() =>
         orchestrationService.CreateMerchantObject(merchant, null, CancellationToken.None));
   }
 
@@ -229,7 +230,7 @@ public sealed class MerchantOrchestrationServiceTests
   /// <summary>
   /// Validates successful retrieval of single merchant by identifier.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchantObject_ValidIdentifier_ReturnsMerchant()
   {
     // Arrange
@@ -245,15 +246,15 @@ public sealed class MerchantOrchestrationServiceTests
     var result = await orchestrationService.ReadMerchantObject(merchantId, parentCompanyId, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
-    Assert.Equal(expectedMerchant.id, result.id);
+    Assert.IsNotNull(result);
+    Assert.AreEqual(expectedMerchant.id, result.id);
     mockStorageService.Verify(s => s.ReadMerchantObject(merchantId, parentCompanyId, It.IsAny<CancellationToken>()), Times.Once);
   }
 
   /// <summary>
   /// Ensures read operation succeeds without parent company identifier.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchantObject_NoParentCompanyId_ReturnsMerchant()
   {
     // Arrange
@@ -268,14 +269,14 @@ public sealed class MerchantOrchestrationServiceTests
     var result = await orchestrationService.ReadMerchantObject(merchantId, null, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
+    Assert.IsNotNull(result);
     mockStorageService.Verify(s => s.ReadMerchantObject(merchantId, null, It.IsAny<CancellationToken>()), Times.Once);
   }
 
   /// <summary>
   /// Confirms foundation validation exceptions during read are wrapped appropriately.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchantObject_FoundationValidationException_ThrowsOrchestrationValidationException()
   {
     // Arrange
@@ -288,14 +289,14 @@ public sealed class MerchantOrchestrationServiceTests
         .ThrowsAsync(foundationException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantOrchestrationServiceValidationException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantOrchestrationServiceValidationException>(() =>
         orchestrationService.ReadMerchantObject(merchantId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates foundation dependency exceptions during read propagate correctly.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchantObject_FoundationDependencyException_ThrowsOrchestrationDependencyException()
   {
     // Arrange
@@ -308,14 +309,14 @@ public sealed class MerchantOrchestrationServiceTests
         .ThrowsAsync(foundationException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantOrchestrationServiceDependencyException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantOrchestrationServiceDependencyException>(() =>
         orchestrationService.ReadMerchantObject(merchantId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates foundation service exceptions during read propagate correctly.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchantObject_FoundationServiceException_ThrowsOrchestrationServiceException()
   {
     // Arrange
@@ -328,14 +329,14 @@ public sealed class MerchantOrchestrationServiceTests
         .ThrowsAsync(foundationException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantOrchestrationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantOrchestrationServiceException>(() =>
         orchestrationService.ReadMerchantObject(merchantId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Ensures generic exceptions during read are wrapped into orchestration service exceptions.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchantObject_GenericException_ThrowsOrchestrationServiceException()
   {
     // Arrange
@@ -347,7 +348,7 @@ public sealed class MerchantOrchestrationServiceTests
         .ThrowsAsync(exception);
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantOrchestrationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantOrchestrationServiceException>(() =>
         orchestrationService.ReadMerchantObject(merchantId, null, CancellationToken.None));
   }
 
@@ -358,7 +359,7 @@ public sealed class MerchantOrchestrationServiceTests
   /// <summary>
   /// Validates successful retrieval of all merchants for a parent company.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadAllMerchantObjects_WithParentCompanyId_ReturnsMerchantCollection()
   {
     // Arrange
@@ -373,15 +374,15 @@ public sealed class MerchantOrchestrationServiceTests
     var result = await orchestrationService.ReadAllMerchantObjects(parentCompanyId, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
-    Assert.Equal(5, result.Count());
+    Assert.IsNotNull(result);
+    Assert.AreEqual(5, result.Count());
     mockStorageService.Verify(s => s.ReadAllMerchantObjects(parentCompanyId, It.IsAny<CancellationToken>()), Times.Once);
   }
 
   /// <summary>
   /// Validates empty collection is returned when no merchants exist.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadAllMerchantObjects_NoMerchants_ReturnsEmptyCollection()
   {
     // Arrange
@@ -396,14 +397,14 @@ public sealed class MerchantOrchestrationServiceTests
     var result = await orchestrationService.ReadAllMerchantObjects(parentCompanyId, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
-    Assert.Empty(result);
+    Assert.IsNotNull(result);
+    Assert.IsEmpty(result);
   }
 
   /// <summary>
   /// Confirms foundation dependency exceptions during bulk read are wrapped appropriately.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadAllMerchantObjects_FoundationDependencyException_ThrowsOrchestrationDependencyException()
   {
     // Arrange
@@ -416,14 +417,14 @@ public sealed class MerchantOrchestrationServiceTests
         .ThrowsAsync(foundationException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantOrchestrationServiceDependencyException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantOrchestrationServiceDependencyException>(() =>
         orchestrationService.ReadAllMerchantObjects(parentCompanyId, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates generic exceptions during bulk read propagate as orchestration service exceptions.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadAllMerchantObjects_GenericException_ThrowsOrchestrationServiceException()
   {
     // Arrange
@@ -435,14 +436,14 @@ public sealed class MerchantOrchestrationServiceTests
         .ThrowsAsync(exception);
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantOrchestrationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantOrchestrationServiceException>(() =>
         orchestrationService.ReadAllMerchantObjects(parentCompanyId, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates foundation validation exceptions during bulk read are wrapped appropriately.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadAllMerchantObjects_FoundationValidationException_ThrowsOrchestrationValidationException()
   {
     // Arrange
@@ -455,7 +456,7 @@ public sealed class MerchantOrchestrationServiceTests
         .ThrowsAsync(foundationException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantOrchestrationServiceValidationException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantOrchestrationServiceValidationException>(() =>
         orchestrationService.ReadAllMerchantObjects(parentCompanyId, CancellationToken.None));
   }
 
@@ -466,7 +467,7 @@ public sealed class MerchantOrchestrationServiceTests
   /// <summary>
   /// Validates successful merchant update through orchestration layer.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateMerchantObject_ValidUpdate_ReturnsUpdatedMerchant()
   {
     // Arrange
@@ -482,15 +483,15 @@ public sealed class MerchantOrchestrationServiceTests
     var result = await orchestrationService.UpdateMerchantObject(updatedMerchant, merchantId, parentCompanyId, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
-    Assert.Equal(updatedMerchant.id, result.id);
+    Assert.IsNotNull(result);
+    Assert.AreEqual(updatedMerchant.id, result.id);
     mockStorageService.Verify(s => s.UpdateMerchantObject(updatedMerchant, merchantId, parentCompanyId, It.IsAny<CancellationToken>()), Times.Once);
   }
 
   /// <summary>
   /// Ensures update succeeds without parent company identifier.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateMerchantObject_NoParentCompanyId_UpdatesSuccessfully()
   {
     // Arrange
@@ -505,14 +506,14 @@ public sealed class MerchantOrchestrationServiceTests
     var result = await orchestrationService.UpdateMerchantObject(updatedMerchant, merchantId, null, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
+    Assert.IsNotNull(result);
     mockStorageService.Verify(s => s.UpdateMerchantObject(updatedMerchant, merchantId, null, It.IsAny<CancellationToken>()), Times.Once);
   }
 
   /// <summary>
   /// Confirms foundation validation exceptions during update are wrapped appropriately.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateMerchantObject_FoundationValidationException_ThrowsOrchestrationValidationException()
   {
     // Arrange
@@ -526,14 +527,14 @@ public sealed class MerchantOrchestrationServiceTests
         .ThrowsAsync(foundationException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantOrchestrationServiceValidationException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantOrchestrationServiceValidationException>(() =>
         orchestrationService.UpdateMerchantObject(updatedMerchant, merchantId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates foundation dependency validation exceptions during update propagate correctly.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateMerchantObject_FoundationDependencyValidationException_ThrowsOrchestrationDependencyValidationException()
   {
     // Arrange
@@ -547,14 +548,14 @@ public sealed class MerchantOrchestrationServiceTests
         .ThrowsAsync(foundationException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantOrchestrationServiceDependencyValidationException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantOrchestrationServiceDependencyValidationException>(() =>
         orchestrationService.UpdateMerchantObject(updatedMerchant, merchantId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates foundation dependency exceptions during update propagate correctly.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateMerchantObject_FoundationDependencyException_ThrowsOrchestrationDependencyException()
   {
     // Arrange
@@ -568,14 +569,14 @@ public sealed class MerchantOrchestrationServiceTests
         .ThrowsAsync(foundationException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantOrchestrationServiceDependencyException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantOrchestrationServiceDependencyException>(() =>
         orchestrationService.UpdateMerchantObject(updatedMerchant, merchantId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Ensures generic exceptions during update are wrapped into orchestration service exceptions.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateMerchantObject_GenericException_ThrowsOrchestrationServiceException()
   {
     // Arrange
@@ -588,7 +589,7 @@ public sealed class MerchantOrchestrationServiceTests
         .ThrowsAsync(exception);
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantOrchestrationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantOrchestrationServiceException>(() =>
         orchestrationService.UpdateMerchantObject(updatedMerchant, merchantId, null, CancellationToken.None));
   }
 
@@ -599,7 +600,7 @@ public sealed class MerchantOrchestrationServiceTests
   /// <summary>
   /// Validates successful merchant deletion through orchestration layer.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteMerchantObject_ValidIdentifiers_DeletesSuccessfully()
   {
     // Arrange
@@ -620,7 +621,7 @@ public sealed class MerchantOrchestrationServiceTests
   /// <summary>
   /// Ensures deletion succeeds without parent company identifier.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteMerchantObject_NoParentCompanyId_DeletesSuccessfully()
   {
     // Arrange
@@ -640,7 +641,7 @@ public sealed class MerchantOrchestrationServiceTests
   /// <summary>
   /// Confirms foundation validation exceptions during delete are wrapped appropriately.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteMerchantObject_FoundationValidationException_ThrowsOrchestrationValidationException()
   {
     // Arrange
@@ -653,14 +654,14 @@ public sealed class MerchantOrchestrationServiceTests
         .ThrowsAsync(foundationException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantOrchestrationServiceValidationException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantOrchestrationServiceValidationException>(() =>
         orchestrationService.DeleteMerchantObject(merchantId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates foundation dependency exceptions during delete propagate correctly.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteMerchantObject_FoundationDependencyException_ThrowsOrchestrationDependencyException()
   {
     // Arrange
@@ -673,14 +674,14 @@ public sealed class MerchantOrchestrationServiceTests
         .ThrowsAsync(foundationException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantOrchestrationServiceDependencyException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantOrchestrationServiceDependencyException>(() =>
         orchestrationService.DeleteMerchantObject(merchantId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Ensures foundation service exceptions during delete are wrapped appropriately.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteMerchantObject_FoundationServiceException_ThrowsOrchestrationServiceException()
   {
     // Arrange
@@ -693,14 +694,14 @@ public sealed class MerchantOrchestrationServiceTests
         .ThrowsAsync(foundationException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantOrchestrationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantOrchestrationServiceException>(() =>
         orchestrationService.DeleteMerchantObject(merchantId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates generic exceptions during delete are wrapped into orchestration service exceptions.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteMerchantObject_GenericException_ThrowsOrchestrationServiceException()
   {
     // Arrange
@@ -712,14 +713,14 @@ public sealed class MerchantOrchestrationServiceTests
         .ThrowsAsync(exception);
 
     // Act & Assert
-    await Assert.ThrowsAsync<MerchantOrchestrationServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<MerchantOrchestrationServiceException>(() =>
         orchestrationService.DeleteMerchantObject(merchantId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates idempotency of delete operation (repeated calls succeed).
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteMerchantObject_IdempotentCalls_SucceedMultipleTimes()
   {
     // Arrange

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Processing/InvoiceProcessingServiceEdgeCaseTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Processing/InvoiceProcessingServiceEdgeCaseTests.cs
@@ -22,12 +22,13 @@ using Microsoft.Extensions.Logging;
 
 using Moq;
 
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 /// <summary>
 /// Edge case unit tests for <see cref="InvoiceProcessingService"/> covering
 /// product management, scan management, metadata management, and merchant operations.
 /// </summary>
+[TestClass]
 public sealed class InvoiceProcessingServiceEdgeCaseTests
 {
   private readonly Mock<IInvoiceOrchestrationService> mockInvoiceOrchestrationService;
@@ -61,7 +62,7 @@ public sealed class InvoiceProcessingServiceEdgeCaseTests
   /// <summary>
   /// Validates adding a product to an invoice.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AddProduct_ValidProduct_AddsSuccessfully()
   {
     // Arrange
@@ -87,7 +88,7 @@ public sealed class InvoiceProcessingServiceEdgeCaseTests
   /// <summary>
   /// Validates adding a product with null user identifier.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AddProduct_NullUserIdentifier_AddsSuccessfully()
   {
     // Arrange
@@ -112,7 +113,7 @@ public sealed class InvoiceProcessingServiceEdgeCaseTests
   /// <summary>
   /// Validates getting products from an invoice.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task GetProducts_ValidInvoice_ReturnsProducts()
   {
     // Arrange
@@ -128,13 +129,13 @@ public sealed class InvoiceProcessingServiceEdgeCaseTests
     var result = await service.GetProducts(invoiceId, userId, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
+    Assert.IsNotNull(result);
   }
 
   /// <summary>
   /// Validates getting products returns empty collection when invoice has no products.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task GetProducts_EmptyProducts_ReturnsEmptyCollection()
   {
     // Arrange
@@ -150,13 +151,13 @@ public sealed class InvoiceProcessingServiceEdgeCaseTests
     var result = await service.GetProducts(invoiceId, null, CancellationToken.None);
 
     // Assert
-    Assert.Empty(result);
+    Assert.IsEmpty(result);
   }
 
   /// <summary>
   /// Validates getting a specific product by name.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task GetProduct_ValidProductName_ReturnsProduct()
   {
     // Arrange
@@ -175,14 +176,14 @@ public sealed class InvoiceProcessingServiceEdgeCaseTests
     var result = await service.GetProduct(productName, invoiceId, userId, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
-    Assert.Equal(productName, result.Name);
+    Assert.IsNotNull(result);
+    Assert.AreEqual(productName, result.Name);
   }
 
   /// <summary>
   /// Validates deleting a product by name.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteProduct_ValidProductName_DeletesSuccessfully()
   {
     // Arrange
@@ -210,7 +211,7 @@ public sealed class InvoiceProcessingServiceEdgeCaseTests
   /// <summary>
   /// Validates deleting a product by product object.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteProduct_ByProductObject_DeletesSuccessfully()
   {
     // Arrange
@@ -238,7 +239,7 @@ public sealed class InvoiceProcessingServiceEdgeCaseTests
   /// <summary>
   /// Validates adding product with empty GUID identifier.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AddProduct_EmptyGuidInvoiceId_CallsOrchestration()
   {
     // Arrange
@@ -266,7 +267,7 @@ public sealed class InvoiceProcessingServiceEdgeCaseTests
   /// <summary>
   /// Validates creating an invoice scan.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateInvoiceScan_ValidScan_CreatesSuccessfully()
   {
     // Arrange
@@ -292,7 +293,7 @@ public sealed class InvoiceProcessingServiceEdgeCaseTests
   /// <summary>
   /// Validates reading invoice scans.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoiceScans_ValidInvoice_ReturnsScans()
   {
     // Arrange
@@ -308,13 +309,13 @@ public sealed class InvoiceProcessingServiceEdgeCaseTests
     var result = await service.ReadInvoiceScans(invoiceId, userId, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
+    Assert.IsNotNull(result);
   }
 
   /// <summary>
   /// Validates deleting an invoice scan.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteInvoiceScan_ValidScan_DeletesSuccessfully()
   {
     // Arrange
@@ -340,7 +341,7 @@ public sealed class InvoiceProcessingServiceEdgeCaseTests
   /// <summary>
   /// Validates creating scan with PNG type.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateInvoiceScan_PngType_CreatesSuccessfully()
   {
     // Arrange
@@ -369,7 +370,7 @@ public sealed class InvoiceProcessingServiceEdgeCaseTests
   /// <summary>
   /// Validates adding metadata to an invoice.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AddMetadataToInvoice_ValidMetadata_AddsSuccessfully()
   {
     // Arrange
@@ -395,7 +396,7 @@ public sealed class InvoiceProcessingServiceEdgeCaseTests
   /// <summary>
   /// Validates updating metadata on an invoice.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateMetadataOnInvoice_ValidMetadata_ReturnsUpdatedMetadata()
   {
     // Arrange
@@ -415,13 +416,13 @@ public sealed class InvoiceProcessingServiceEdgeCaseTests
     var result = await service.UpdateMetadataOnInvoice(metadata, invoiceId, userId, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
+    Assert.IsNotNull(result);
   }
 
   /// <summary>
   /// Validates getting metadata from an invoice.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task GetMetadataFromInvoice_ValidInvoice_ReturnsMetadata()
   {
     // Arrange
@@ -437,13 +438,13 @@ public sealed class InvoiceProcessingServiceEdgeCaseTests
     var result = await service.GetMetadataFromInvoice(invoiceId, userId, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
+    Assert.IsNotNull(result);
   }
 
   /// <summary>
   /// Validates deleting metadata from an invoice.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteMetadataFromInvoice_ValidKeys_DeletesSuccessfully()
   {
     // Arrange
@@ -471,7 +472,7 @@ public sealed class InvoiceProcessingServiceEdgeCaseTests
   /// <summary>
   /// Validates adding empty metadata dictionary.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AddMetadataToInvoice_EmptyMetadata_CompletesSuccessfully()
   {
     // Arrange
@@ -500,7 +501,7 @@ public sealed class InvoiceProcessingServiceEdgeCaseTests
   /// <summary>
   /// Validates merchant creation through processing service.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateMerchant_ValidMerchant_CreatesSuccessfully()
   {
     // Arrange
@@ -521,7 +522,7 @@ public sealed class InvoiceProcessingServiceEdgeCaseTests
   /// <summary>
   /// Validates merchant creation with null parent company ID.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateMerchant_NullParentCompanyId_CreatesSuccessfully()
   {
     // Arrange
@@ -541,7 +542,7 @@ public sealed class InvoiceProcessingServiceEdgeCaseTests
   /// <summary>
   /// Validates merchant read through processing service.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchant_ValidIdentifier_ReturnsMerchant()
   {
     // Arrange
@@ -557,14 +558,14 @@ public sealed class InvoiceProcessingServiceEdgeCaseTests
     var result = await service.ReadMerchant(merchantId, parentCompanyId, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
-    Assert.Same(expectedMerchant, result);
+    Assert.IsNotNull(result);
+    Assert.AreSame(expectedMerchant, result);
   }
 
   /// <summary>
   /// Validates merchant read with null parent company ID.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchant_NullParentCompanyId_ReturnsMerchant()
   {
     // Arrange
@@ -579,13 +580,13 @@ public sealed class InvoiceProcessingServiceEdgeCaseTests
     var result = await service.ReadMerchant(merchantId, null, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
+    Assert.IsNotNull(result);
   }
 
   /// <summary>
   /// Validates reading all merchants through processing service.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchants_ValidParentCompanyId_ReturnsAllMerchants()
   {
     // Arrange
@@ -602,13 +603,13 @@ public sealed class InvoiceProcessingServiceEdgeCaseTests
     var result = await service.ReadMerchants(parentCompanyId, CancellationToken.None);
 
     // Assert
-    Assert.Equal(5, result.Count());
+    Assert.AreEqual(5, result.Count());
   }
 
   /// <summary>
   /// Validates merchant update through processing service.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateMerchant_ValidData_ReturnsUpdatedMerchant()
   {
     // Arrange
@@ -624,13 +625,13 @@ public sealed class InvoiceProcessingServiceEdgeCaseTests
     var result = await service.UpdateMerchant(merchant, merchantId, parentCompanyId, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
+    Assert.IsNotNull(result);
   }
 
   /// <summary>
   /// Validates merchant deletion through processing service.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteMerchant_ValidIdentifier_DeletesSuccessfully()
   {
     // Arrange
@@ -651,7 +652,7 @@ public sealed class InvoiceProcessingServiceEdgeCaseTests
   /// <summary>
   /// Validates merchant deletion with null parent company ID.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteMerchant_NullParentCompanyId_DeletesSuccessfully()
   {
     // Arrange
@@ -675,7 +676,7 @@ public sealed class InvoiceProcessingServiceEdgeCaseTests
   /// <summary>
   /// Validates orchestration exception is wrapped during product addition.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AddProduct_OrchestrationException_ThrowsProcessingException()
   {
     // Arrange
@@ -687,14 +688,14 @@ public sealed class InvoiceProcessingServiceEdgeCaseTests
         .ThrowsAsync(new InvoiceOrchestrationServiceException(new InvalidOperationException("Error")));
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceProcessingServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceException>(() =>
         service.AddProduct(product, invoiceId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates orchestration validation exception is wrapped during product deletion.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteProduct_OrchestrationValidationException_ThrowsProcessingValidationException()
   {
     // Arrange
@@ -707,14 +708,14 @@ public sealed class InvoiceProcessingServiceEdgeCaseTests
         .ThrowsAsync(new InvoiceOrchestrationValidationException(new InvalidOperationException("Validation error")));
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceProcessingServiceValidationException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceValidationException>(() =>
         service.DeleteProduct(productName, invoiceId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates merchant orchestration exception is wrapped during creation.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateMerchant_OrchestrationException_ThrowsProcessingException()
   {
     // Arrange
@@ -725,14 +726,14 @@ public sealed class InvoiceProcessingServiceEdgeCaseTests
         .ThrowsAsync(new MerchantOrchestrationServiceException(new InvalidOperationException("Error")));
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceProcessingServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceException>(() =>
         service.CreateMerchant(merchant, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates merchant orchestration validation exception is wrapped during update.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateMerchant_OrchestrationValidationException_ThrowsProcessingDependencyValidationException()
   {
     // Arrange
@@ -744,14 +745,14 @@ public sealed class InvoiceProcessingServiceEdgeCaseTests
         .ThrowsAsync(new MerchantOrchestrationServiceValidationException(new InvalidOperationException("Validation error")));
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceProcessingServiceDependencyValidationException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceDependencyValidationException>(() =>
         service.UpdateMerchant(merchant, merchantId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates generic exception during scan creation is wrapped.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateInvoiceScan_GenericException_ThrowsProcessingException()
   {
     // Arrange
@@ -763,14 +764,14 @@ public sealed class InvoiceProcessingServiceEdgeCaseTests
         .ThrowsAsync(new InvalidOperationException("Unexpected error"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceProcessingServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceException>(() =>
         service.CreateInvoiceScan(scan, invoiceId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates generic exception during metadata update is wrapped.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateMetadataOnInvoice_GenericException_ThrowsProcessingException()
   {
     // Arrange
@@ -782,14 +783,14 @@ public sealed class InvoiceProcessingServiceEdgeCaseTests
         .ThrowsAsync(new InvalidOperationException("Unexpected error"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceProcessingServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceException>(() =>
         service.UpdateMetadataOnInvoice(metadata, invoiceId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates dependency exception is wrapped during product get.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task GetProducts_DependencyException_ThrowsProcessingDependencyException()
   {
     // Arrange
@@ -800,7 +801,7 @@ public sealed class InvoiceProcessingServiceEdgeCaseTests
         .ThrowsAsync(new InvoiceOrchestrationDependencyException(new InvalidOperationException("Dependency error")));
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceProcessingServiceDependencyException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceDependencyException>(() =>
         service.GetProducts(invoiceId, null, CancellationToken.None));
   }
 
@@ -811,7 +812,7 @@ public sealed class InvoiceProcessingServiceEdgeCaseTests
   /// <summary>
   /// Validates concurrent product additions complete successfully.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AddProduct_ConcurrentOperations_AllComplete()
   {
     // Arrange
@@ -840,7 +841,7 @@ public sealed class InvoiceProcessingServiceEdgeCaseTests
   /// <summary>
   /// Validates concurrent merchant reads complete successfully.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchant_ConcurrentOperations_AllComplete()
   {
     // Arrange
@@ -856,13 +857,16 @@ public sealed class InvoiceProcessingServiceEdgeCaseTests
     var results = await Task.WhenAll(tasks);
 
     // Assert
-    Assert.All(results, r => Assert.NotNull(r));
+    foreach (var r in results)
+    {
+      Assert.IsNotNull(r);
+    }
   }
 
   /// <summary>
   /// Validates concurrent metadata operations complete successfully.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task GetMetadataFromInvoice_ConcurrentOperations_AllComplete()
   {
     // Arrange
@@ -878,7 +882,10 @@ public sealed class InvoiceProcessingServiceEdgeCaseTests
     var results = await Task.WhenAll(tasks);
 
     // Assert
-    Assert.All(results, r => Assert.NotNull(r));
+    foreach (var r in results)
+    {
+      Assert.IsNotNull(r);
+    }
   }
 
   #endregion
@@ -888,7 +895,7 @@ public sealed class InvoiceProcessingServiceEdgeCaseTests
   /// <summary>
   /// Validates invoice analysis with valid options.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoice_ValidOptions_AnalyzesSuccessfully()
   {
     // Arrange
@@ -910,7 +917,7 @@ public sealed class InvoiceProcessingServiceEdgeCaseTests
   /// <summary>
   /// Validates invoice analysis with null user identifier.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoice_NullUserIdentifier_AnalyzesSuccessfully()
   {
     // Arrange
@@ -931,7 +938,7 @@ public sealed class InvoiceProcessingServiceEdgeCaseTests
   /// <summary>
   /// Validates orchestration dependency exception during analysis is wrapped.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoice_OrchestrationDependencyException_ThrowsProcessingDependencyException()
   {
     // Arrange
@@ -943,7 +950,7 @@ public sealed class InvoiceProcessingServiceEdgeCaseTests
         .ThrowsAsync(new InvoiceOrchestrationDependencyException(new InvalidOperationException("Dependency error")));
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceProcessingServiceDependencyException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceDependencyException>(() =>
         service.AnalyzeInvoice(options, invoiceId, null, CancellationToken.None));
   }
 
@@ -954,7 +961,7 @@ public sealed class InvoiceProcessingServiceEdgeCaseTests
   /// <summary>
   /// Validates single invoice deletion.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteInvoice_ValidIdentifier_DeletesSuccessfully()
   {
     // Arrange
@@ -975,7 +982,7 @@ public sealed class InvoiceProcessingServiceEdgeCaseTests
   /// <summary>
   /// Validates invoice deletion with null user identifier.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteInvoice_NullUserIdentifier_DeletesSuccessfully()
   {
     // Arrange

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Processing/InvoiceProcessingServiceExceptionsTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Processing/InvoiceProcessingServiceExceptionsTests.cs
@@ -16,13 +16,14 @@ using Microsoft.Extensions.Logging;
 
 using Moq;
 
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 /// <summary>
 /// Unit tests validating that <see cref="InvoiceProcessingService"/> classifies each upstream
 /// orchestration outer exception tier to its matching processing outer tier via the unified
 /// Classify switch. Exercises 4 commonly-hit delegates across all 4 orchestration tiers.
 /// </summary>
+[TestClass]
 public sealed class InvoiceProcessingServiceExceptionsTests
 {
   private readonly Mock<IInvoiceOrchestrationService> mockInvoiceOrchestrationService;
@@ -56,7 +57,7 @@ public sealed class InvoiceProcessingServiceExceptionsTests
   /// <summary>
   /// Orchestration validation failures must surface as processing validation.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateInvoice_WhenOrchestrationThrowsValidation_ThrowsProcessingValidation()
   {
     var invoice = InvoiceBuilder.CreateRandomInvoice();
@@ -65,14 +66,14 @@ public sealed class InvoiceProcessingServiceExceptionsTests
       .Setup(s => s.CreateInvoiceObject(It.IsAny<Invoice>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new InvoiceOrchestrationValidationException(inner));
 
-    await Assert.ThrowsAsync<InvoiceProcessingServiceValidationException>(
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceValidationException>(
       () => processingService.CreateInvoice(invoice, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Orchestration dependency-validation failures must bubble distinctly as processing dependency-validation.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateInvoice_WhenOrchestrationThrowsDependencyValidation_ThrowsProcessingDependencyValidation()
   {
     var invoice = InvoiceBuilder.CreateRandomInvoice();
@@ -81,14 +82,14 @@ public sealed class InvoiceProcessingServiceExceptionsTests
       .Setup(s => s.CreateInvoiceObject(It.IsAny<Invoice>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new InvoiceOrchestrationDependencyValidationException(inner));
 
-    await Assert.ThrowsAsync<InvoiceProcessingServiceDependencyValidationException>(
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceDependencyValidationException>(
       () => processingService.CreateInvoice(invoice, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Orchestration dependency failures must surface as processing dependency.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateInvoice_WhenOrchestrationThrowsDependency_ThrowsProcessingDependency()
   {
     var invoice = InvoiceBuilder.CreateRandomInvoice();
@@ -97,14 +98,14 @@ public sealed class InvoiceProcessingServiceExceptionsTests
       .Setup(s => s.CreateInvoiceObject(It.IsAny<Invoice>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new InvoiceOrchestrationDependencyException(inner));
 
-    await Assert.ThrowsAsync<InvoiceProcessingServiceDependencyException>(
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceDependencyException>(
       () => processingService.CreateInvoice(invoice, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Orchestration service failures must surface as processing service failures.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateInvoice_WhenOrchestrationThrowsService_ThrowsProcessingService()
   {
     var invoice = InvoiceBuilder.CreateRandomInvoice();
@@ -113,7 +114,7 @@ public sealed class InvoiceProcessingServiceExceptionsTests
       .Setup(s => s.CreateInvoiceObject(It.IsAny<Invoice>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new InvoiceOrchestrationServiceException(inner));
 
-    await Assert.ThrowsAsync<InvoiceProcessingServiceException>(
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceException>(
       () => processingService.CreateInvoice(invoice, null, CancellationToken.None));
   }
 
@@ -124,7 +125,7 @@ public sealed class InvoiceProcessingServiceExceptionsTests
   /// <summary>
   /// Orchestration validation failures must surface as processing validation on read path.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoice_WhenOrchestrationThrowsValidation_ThrowsProcessingValidation()
   {
     var inner = new InvalidOperationException("validation-inner");
@@ -132,14 +133,14 @@ public sealed class InvoiceProcessingServiceExceptionsTests
       .Setup(s => s.ReadInvoiceObject(It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new InvoiceOrchestrationValidationException(inner));
 
-    await Assert.ThrowsAsync<InvoiceProcessingServiceValidationException>(
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceValidationException>(
       () => processingService.ReadInvoice(Guid.NewGuid(), null, CancellationToken.None));
   }
 
   /// <summary>
   /// Orchestration dependency-validation failures must bubble distinctly on read path.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoice_WhenOrchestrationThrowsDependencyValidation_ThrowsProcessingDependencyValidation()
   {
     var inner = new InvalidOperationException("depval-inner");
@@ -147,14 +148,14 @@ public sealed class InvoiceProcessingServiceExceptionsTests
       .Setup(s => s.ReadInvoiceObject(It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new InvoiceOrchestrationDependencyValidationException(inner));
 
-    await Assert.ThrowsAsync<InvoiceProcessingServiceDependencyValidationException>(
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceDependencyValidationException>(
       () => processingService.ReadInvoice(Guid.NewGuid(), null, CancellationToken.None));
   }
 
   /// <summary>
   /// Orchestration dependency failures must surface as processing dependency on read path.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoice_WhenOrchestrationThrowsDependency_ThrowsProcessingDependency()
   {
     var inner = new InvalidOperationException("dep-inner");
@@ -162,14 +163,14 @@ public sealed class InvoiceProcessingServiceExceptionsTests
       .Setup(s => s.ReadInvoiceObject(It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new InvoiceOrchestrationDependencyException(inner));
 
-    await Assert.ThrowsAsync<InvoiceProcessingServiceDependencyException>(
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceDependencyException>(
       () => processingService.ReadInvoice(Guid.NewGuid(), null, CancellationToken.None));
   }
 
   /// <summary>
   /// Orchestration service failures must surface as processing service on read path.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoice_WhenOrchestrationThrowsService_ThrowsProcessingService()
   {
     var inner = new InvalidOperationException("svc-inner");
@@ -177,7 +178,7 @@ public sealed class InvoiceProcessingServiceExceptionsTests
       .Setup(s => s.ReadInvoiceObject(It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new InvoiceOrchestrationServiceException(inner));
 
-    await Assert.ThrowsAsync<InvoiceProcessingServiceException>(
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceException>(
       () => processingService.ReadInvoice(Guid.NewGuid(), null, CancellationToken.None));
   }
 
@@ -188,7 +189,7 @@ public sealed class InvoiceProcessingServiceExceptionsTests
   /// <summary>
   /// Orchestration validation failures must surface as processing validation on update path.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateInvoice_WhenOrchestrationThrowsValidation_ThrowsProcessingValidation()
   {
     var invoice = InvoiceBuilder.CreateRandomInvoice();
@@ -197,14 +198,14 @@ public sealed class InvoiceProcessingServiceExceptionsTests
       .Setup(s => s.UpdateInvoiceObject(It.IsAny<Invoice>(), It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new InvoiceOrchestrationValidationException(inner));
 
-    await Assert.ThrowsAsync<InvoiceProcessingServiceValidationException>(
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceValidationException>(
       () => processingService.UpdateInvoice(invoice, invoice.id, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Orchestration dependency-validation failures must bubble distinctly on update path.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateInvoice_WhenOrchestrationThrowsDependencyValidation_ThrowsProcessingDependencyValidation()
   {
     var invoice = InvoiceBuilder.CreateRandomInvoice();
@@ -213,14 +214,14 @@ public sealed class InvoiceProcessingServiceExceptionsTests
       .Setup(s => s.UpdateInvoiceObject(It.IsAny<Invoice>(), It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new InvoiceOrchestrationDependencyValidationException(inner));
 
-    await Assert.ThrowsAsync<InvoiceProcessingServiceDependencyValidationException>(
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceDependencyValidationException>(
       () => processingService.UpdateInvoice(invoice, invoice.id, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Orchestration dependency failures must surface as processing dependency on update path.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateInvoice_WhenOrchestrationThrowsDependency_ThrowsProcessingDependency()
   {
     var invoice = InvoiceBuilder.CreateRandomInvoice();
@@ -229,14 +230,14 @@ public sealed class InvoiceProcessingServiceExceptionsTests
       .Setup(s => s.UpdateInvoiceObject(It.IsAny<Invoice>(), It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new InvoiceOrchestrationDependencyException(inner));
 
-    await Assert.ThrowsAsync<InvoiceProcessingServiceDependencyException>(
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceDependencyException>(
       () => processingService.UpdateInvoice(invoice, invoice.id, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Orchestration service failures must surface as processing service on update path.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateInvoice_WhenOrchestrationThrowsService_ThrowsProcessingService()
   {
     var invoice = InvoiceBuilder.CreateRandomInvoice();
@@ -245,7 +246,7 @@ public sealed class InvoiceProcessingServiceExceptionsTests
       .Setup(s => s.UpdateInvoiceObject(It.IsAny<Invoice>(), It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new InvoiceOrchestrationServiceException(inner));
 
-    await Assert.ThrowsAsync<InvoiceProcessingServiceException>(
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceException>(
       () => processingService.UpdateInvoice(invoice, invoice.id, null, CancellationToken.None));
   }
 
@@ -256,7 +257,7 @@ public sealed class InvoiceProcessingServiceExceptionsTests
   /// <summary>
   /// Orchestration validation failures must surface as processing validation on delete path.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteInvoice_WhenOrchestrationThrowsValidation_ThrowsProcessingValidation()
   {
     var inner = new InvalidOperationException("validation-inner");
@@ -264,14 +265,14 @@ public sealed class InvoiceProcessingServiceExceptionsTests
       .Setup(s => s.DeleteInvoiceObject(It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new InvoiceOrchestrationValidationException(inner));
 
-    await Assert.ThrowsAsync<InvoiceProcessingServiceValidationException>(
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceValidationException>(
       () => processingService.DeleteInvoice(Guid.NewGuid(), null, CancellationToken.None));
   }
 
   /// <summary>
   /// Orchestration dependency-validation failures must bubble distinctly on delete path.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteInvoice_WhenOrchestrationThrowsDependencyValidation_ThrowsProcessingDependencyValidation()
   {
     var inner = new InvalidOperationException("depval-inner");
@@ -279,14 +280,14 @@ public sealed class InvoiceProcessingServiceExceptionsTests
       .Setup(s => s.DeleteInvoiceObject(It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new InvoiceOrchestrationDependencyValidationException(inner));
 
-    await Assert.ThrowsAsync<InvoiceProcessingServiceDependencyValidationException>(
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceDependencyValidationException>(
       () => processingService.DeleteInvoice(Guid.NewGuid(), null, CancellationToken.None));
   }
 
   /// <summary>
   /// Orchestration dependency failures must surface as processing dependency on delete path.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteInvoice_WhenOrchestrationThrowsDependency_ThrowsProcessingDependency()
   {
     var inner = new InvalidOperationException("dep-inner");
@@ -294,14 +295,14 @@ public sealed class InvoiceProcessingServiceExceptionsTests
       .Setup(s => s.DeleteInvoiceObject(It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new InvoiceOrchestrationDependencyException(inner));
 
-    await Assert.ThrowsAsync<InvoiceProcessingServiceDependencyException>(
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceDependencyException>(
       () => processingService.DeleteInvoice(Guid.NewGuid(), null, CancellationToken.None));
   }
 
   /// <summary>
   /// Orchestration service failures must surface as processing service on delete path.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteInvoice_WhenOrchestrationThrowsService_ThrowsProcessingService()
   {
     var inner = new InvalidOperationException("svc-inner");
@@ -309,7 +310,7 @@ public sealed class InvoiceProcessingServiceExceptionsTests
       .Setup(s => s.DeleteInvoiceObject(It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new InvoiceOrchestrationServiceException(inner));
 
-    await Assert.ThrowsAsync<InvoiceProcessingServiceException>(
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceException>(
       () => processingService.DeleteInvoice(Guid.NewGuid(), null, CancellationToken.None));
   }
 
@@ -320,7 +321,7 @@ public sealed class InvoiceProcessingServiceExceptionsTests
   /// <summary>
   /// Unknown exceptions from orchestration must fall through to processing service (catch-all).
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateInvoice_WhenOrchestrationThrowsUnknown_ThrowsProcessingService()
   {
     var invoice = InvoiceBuilder.CreateRandomInvoice();
@@ -328,7 +329,7 @@ public sealed class InvoiceProcessingServiceExceptionsTests
       .Setup(s => s.CreateInvoiceObject(It.IsAny<Invoice>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new InvalidOperationException("unknown"));
 
-    await Assert.ThrowsAsync<InvoiceProcessingServiceException>(
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceException>(
       () => processingService.CreateInvoice(invoice, null, CancellationToken.None));
   }
 

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Processing/InvoiceProcessingServiceExtendedTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Processing/InvoiceProcessingServiceExtendedTests.cs
@@ -22,13 +22,14 @@ using Microsoft.Extensions.Logging;
 
 using Moq;
 
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 /// <summary>
 /// Extended unit tests for <see cref="InvoiceProcessingService"/> covering additional edge cases,
 /// exception scenarios, and boundary conditions for comprehensive code coverage.
 /// Method naming follows MethodName_Condition_ExpectedResult pattern per repository standards.
 /// </summary>
+[TestClass]
 public sealed class InvoiceProcessingServiceExtendedTests
 {
   private readonly Mock<IInvoiceOrchestrationService> mockInvoiceOrchestrationService;
@@ -60,7 +61,7 @@ public sealed class InvoiceProcessingServiceExtendedTests
   /// <summary>
   /// Validates analysis with InvoiceOnly option.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoice_InvoiceOnlyOption_CallsOrchestrationService()
   {
     // Arrange
@@ -82,7 +83,7 @@ public sealed class InvoiceProcessingServiceExtendedTests
   /// <summary>
   /// Validates analysis with NoAnalysis option.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoice_NoAnalysisOption_CallsOrchestrationService()
   {
     // Arrange
@@ -103,7 +104,7 @@ public sealed class InvoiceProcessingServiceExtendedTests
   /// <summary>
   /// Validates analysis with InvoiceItemsOnly option.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoice_InvoiceItemsOnlyOption_CallsOrchestrationService()
   {
     // Arrange
@@ -124,7 +125,7 @@ public sealed class InvoiceProcessingServiceExtendedTests
   /// <summary>
   /// Validates analysis with InvoiceMerchantOnly option.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoice_InvoiceMerchantOnlyOption_CallsOrchestrationService()
   {
     // Arrange
@@ -145,7 +146,7 @@ public sealed class InvoiceProcessingServiceExtendedTests
   /// <summary>
   /// Validates orchestration validation exception wrapping during analysis.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoice_OrchestrationValidationException_ThrowsProcessingValidationException()
   {
     // Arrange
@@ -159,14 +160,14 @@ public sealed class InvoiceProcessingServiceExtendedTests
         .ThrowsAsync(orchException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceProcessingServiceValidationException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceValidationException>(() =>
         processingService.AnalyzeInvoice(options, invoiceId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates orchestration dependency validation exception wrapping during analysis.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoice_OrchestrationDependencyValidationException_ThrowsProcessingDependencyValidationException()
   {
     // Arrange
@@ -180,14 +181,14 @@ public sealed class InvoiceProcessingServiceExtendedTests
         .ThrowsAsync(orchException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceProcessingServiceDependencyValidationException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceDependencyValidationException>(() =>
         processingService.AnalyzeInvoice(options, invoiceId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates orchestration service exception wrapping during analysis.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoice_OrchestrationServiceException_ThrowsProcessingServiceException()
   {
     // Arrange
@@ -201,7 +202,7 @@ public sealed class InvoiceProcessingServiceExtendedTests
         .ThrowsAsync(orchException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceProcessingServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceException>(() =>
         processingService.AnalyzeInvoice(options, invoiceId, null, CancellationToken.None));
   }
 
@@ -212,7 +213,7 @@ public sealed class InvoiceProcessingServiceExtendedTests
   /// <summary>
   /// Validates invoice creation with null user identifier.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateInvoice_NullUserIdentifier_CallsOrchestrationService()
   {
     // Arrange
@@ -232,7 +233,7 @@ public sealed class InvoiceProcessingServiceExtendedTests
   /// <summary>
   /// Validates orchestration validation exception wrapping during creation.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateInvoice_OrchestrationValidationException_ThrowsProcessingValidationException()
   {
     // Arrange
@@ -245,14 +246,14 @@ public sealed class InvoiceProcessingServiceExtendedTests
         .ThrowsAsync(orchException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceProcessingServiceValidationException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceValidationException>(() =>
         processingService.CreateInvoice(invoice, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates orchestration dependency exception wrapping during creation.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateInvoice_OrchestrationDependencyException_ThrowsProcessingDependencyException()
   {
     // Arrange
@@ -265,7 +266,7 @@ public sealed class InvoiceProcessingServiceExtendedTests
         .ThrowsAsync(orchException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceProcessingServiceDependencyException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceDependencyException>(() =>
         processingService.CreateInvoice(invoice, null, CancellationToken.None));
   }
 
@@ -276,7 +277,7 @@ public sealed class InvoiceProcessingServiceExtendedTests
   /// <summary>
   /// Validates invoice retrieval with null user identifier.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoice_NullUserIdentifier_ReturnsInvoice()
   {
     // Arrange
@@ -291,13 +292,13 @@ public sealed class InvoiceProcessingServiceExtendedTests
     var result = await processingService.ReadInvoice(invoiceId, null, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
+    Assert.IsNotNull(result);
   }
 
   /// <summary>
   /// Validates orchestration dependency exception wrapping during read.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoice_OrchestrationDependencyException_ThrowsProcessingDependencyException()
   {
     // Arrange
@@ -310,14 +311,14 @@ public sealed class InvoiceProcessingServiceExtendedTests
         .ThrowsAsync(orchException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceProcessingServiceDependencyException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceDependencyException>(() =>
         processingService.ReadInvoice(invoiceId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates orchestration service exception wrapping during read.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoice_OrchestrationServiceException_ThrowsProcessingServiceException()
   {
     // Arrange
@@ -330,14 +331,14 @@ public sealed class InvoiceProcessingServiceExtendedTests
         .ThrowsAsync(orchException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceProcessingServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceException>(() =>
         processingService.ReadInvoice(invoiceId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates generic exception wrapping during read.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoice_GenericException_ThrowsProcessingServiceException()
   {
     // Arrange
@@ -348,7 +349,7 @@ public sealed class InvoiceProcessingServiceExtendedTests
         .ThrowsAsync(new InvalidOperationException("Unexpected error"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceProcessingServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceException>(() =>
         processingService.ReadInvoice(invoiceId, null, CancellationToken.None));
   }
 
@@ -359,7 +360,7 @@ public sealed class InvoiceProcessingServiceExtendedTests
   /// <summary>
   /// Validates orchestration dependency exception wrapping during bulk read.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoices_OrchestrationDependencyException_ThrowsProcessingDependencyException()
   {
     // Arrange
@@ -372,14 +373,14 @@ public sealed class InvoiceProcessingServiceExtendedTests
         .ThrowsAsync(orchException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceProcessingServiceDependencyException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceDependencyException>(() =>
         processingService.ReadInvoices(userId, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates orchestration service exception wrapping during bulk read.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoices_OrchestrationServiceException_ThrowsProcessingServiceException()
   {
     // Arrange
@@ -392,14 +393,14 @@ public sealed class InvoiceProcessingServiceExtendedTests
         .ThrowsAsync(orchException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceProcessingServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceException>(() =>
         processingService.ReadInvoices(userId, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates large collection handling during bulk read.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoices_LargeCollection_ReturnsAllInvoices()
   {
     // Arrange
@@ -414,7 +415,7 @@ public sealed class InvoiceProcessingServiceExtendedTests
     var result = await processingService.ReadInvoices(userId, CancellationToken.None);
 
     // Assert
-    Assert.Equal(100, result.Count());
+    Assert.AreEqual(100, result.Count());
   }
 
   #endregion
@@ -424,7 +425,7 @@ public sealed class InvoiceProcessingServiceExtendedTests
   /// <summary>
   /// Validates update with null user identifier.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateInvoice_NullUserIdentifier_ReturnsUpdatedInvoice()
   {
     // Arrange
@@ -439,13 +440,13 @@ public sealed class InvoiceProcessingServiceExtendedTests
     var result = await processingService.UpdateInvoice(updatedInvoice, invoiceId, null, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
+    Assert.IsNotNull(result);
   }
 
   /// <summary>
   /// Validates orchestration validation exception wrapping during update.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateInvoice_OrchestrationValidationException_ThrowsProcessingValidationException()
   {
     // Arrange
@@ -459,14 +460,14 @@ public sealed class InvoiceProcessingServiceExtendedTests
         .ThrowsAsync(orchException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceProcessingServiceValidationException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceValidationException>(() =>
         processingService.UpdateInvoice(updatedInvoice, invoiceId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates orchestration dependency exception wrapping during update.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateInvoice_OrchestrationDependencyException_ThrowsProcessingDependencyException()
   {
     // Arrange
@@ -480,14 +481,14 @@ public sealed class InvoiceProcessingServiceExtendedTests
         .ThrowsAsync(orchException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceProcessingServiceDependencyException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceDependencyException>(() =>
         processingService.UpdateInvoice(updatedInvoice, invoiceId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates generic exception wrapping during update.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateInvoice_GenericException_ThrowsProcessingServiceException()
   {
     // Arrange
@@ -499,7 +500,7 @@ public sealed class InvoiceProcessingServiceExtendedTests
         .ThrowsAsync(new InvalidOperationException("Unexpected error"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceProcessingServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceException>(() =>
         processingService.UpdateInvoice(updatedInvoice, invoiceId, null, CancellationToken.None));
   }
 
@@ -510,7 +511,7 @@ public sealed class InvoiceProcessingServiceExtendedTests
   /// <summary>
   /// Validates delete with null user identifier.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteInvoice_NullUserIdentifier_DeletesSuccessfully()
   {
     // Arrange
@@ -530,7 +531,7 @@ public sealed class InvoiceProcessingServiceExtendedTests
   /// <summary>
   /// Validates orchestration validation exception wrapping during delete.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteInvoice_OrchestrationValidationException_ThrowsProcessingValidationException()
   {
     // Arrange
@@ -543,14 +544,14 @@ public sealed class InvoiceProcessingServiceExtendedTests
         .ThrowsAsync(orchException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceProcessingServiceValidationException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceValidationException>(() =>
         processingService.DeleteInvoice(invoiceId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates orchestration dependency exception wrapping during delete.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteInvoice_OrchestrationDependencyException_ThrowsProcessingDependencyException()
   {
     // Arrange
@@ -563,14 +564,14 @@ public sealed class InvoiceProcessingServiceExtendedTests
         .ThrowsAsync(orchException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceProcessingServiceDependencyException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceDependencyException>(() =>
         processingService.DeleteInvoice(invoiceId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates generic exception wrapping during delete.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteInvoice_GenericException_ThrowsProcessingServiceException()
   {
     // Arrange
@@ -581,7 +582,7 @@ public sealed class InvoiceProcessingServiceExtendedTests
         .ThrowsAsync(new InvalidOperationException("Unexpected error"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceProcessingServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceException>(() =>
         processingService.DeleteInvoice(invoiceId, null, CancellationToken.None));
   }
 
@@ -592,7 +593,7 @@ public sealed class InvoiceProcessingServiceExtendedTests
   /// <summary>
   /// Validates orchestration exception during bulk delete read phase.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteInvoices_ReadThrows_ThrowsProcessingServiceException()
   {
     // Arrange
@@ -603,14 +604,14 @@ public sealed class InvoiceProcessingServiceExtendedTests
         .ThrowsAsync(new InvalidOperationException("Read failed"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceProcessingServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceException>(() =>
         processingService.DeleteInvoices(userId, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates orchestration exception during bulk delete loop.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteInvoices_DeleteThrows_ThrowsProcessingServiceException()
   {
     // Arrange
@@ -626,14 +627,14 @@ public sealed class InvoiceProcessingServiceExtendedTests
         .ThrowsAsync(new InvalidOperationException("Delete failed"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceProcessingServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceException>(() =>
         processingService.DeleteInvoices(userId, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates bulk delete with large collection.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteInvoices_LargeCollection_DeletesAll()
   {
     // Arrange
@@ -662,7 +663,7 @@ public sealed class InvoiceProcessingServiceExtendedTests
   /// <summary>
   /// Validates product addition with null user identifier.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AddProduct_NullUserIdentifier_AddsProduct()
   {
     // Arrange
@@ -688,7 +689,7 @@ public sealed class InvoiceProcessingServiceExtendedTests
   /// <summary>
   /// Validates exception during product addition read phase.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AddProduct_ReadThrows_ThrowsProcessingServiceException()
   {
     // Arrange
@@ -700,14 +701,14 @@ public sealed class InvoiceProcessingServiceExtendedTests
         .ThrowsAsync(new InvalidOperationException("Read failed"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceProcessingServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceException>(() =>
         processingService.AddProduct(product, invoiceId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates exception during product addition update phase.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AddProduct_UpdateThrows_ThrowsProcessingServiceException()
   {
     // Arrange
@@ -725,7 +726,7 @@ public sealed class InvoiceProcessingServiceExtendedTests
         .ThrowsAsync(new InvalidOperationException("Update failed"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceProcessingServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceException>(() =>
         processingService.AddProduct(product, invoiceId, userId, CancellationToken.None));
   }
 
@@ -736,7 +737,7 @@ public sealed class InvoiceProcessingServiceExtendedTests
   /// <summary>
   /// Validates products retrieval with null user identifier.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task GetProducts_NullUserIdentifier_ReturnsProducts()
   {
     // Arrange
@@ -751,13 +752,13 @@ public sealed class InvoiceProcessingServiceExtendedTests
     var result = await processingService.GetProducts(invoiceId, null, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
+    Assert.IsNotNull(result);
   }
 
   /// <summary>
   /// Validates exception during products retrieval.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task GetProducts_OrchestrationThrows_ThrowsProcessingServiceException()
   {
     // Arrange
@@ -768,14 +769,14 @@ public sealed class InvoiceProcessingServiceExtendedTests
         .ThrowsAsync(new InvalidOperationException("Read failed"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceProcessingServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceException>(() =>
         processingService.GetProducts(invoiceId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates empty products collection.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task GetProducts_EmptyCollection_ReturnsEmptyEnumerable()
   {
     // Arrange
@@ -791,7 +792,7 @@ public sealed class InvoiceProcessingServiceExtendedTests
     var result = await processingService.GetProducts(invoiceId, null, CancellationToken.None);
 
     // Assert
-    Assert.Empty(result);
+    Assert.IsEmpty(result);
   }
 
   #endregion
@@ -801,7 +802,7 @@ public sealed class InvoiceProcessingServiceExtendedTests
   /// <summary>
   /// Validates product search by partial name match.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task GetProduct_PartialNameMatch_ReturnsProduct()
   {
     // Arrange
@@ -817,13 +818,13 @@ public sealed class InvoiceProcessingServiceExtendedTests
     var result = await processingService.GetProduct(productPartialName, invoiceId, null, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
+    Assert.IsNotNull(result);
   }
 
   /// <summary>
   /// Validates product search by name.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task GetProduct_NameMatch_ReturnsProduct()
   {
     // Arrange
@@ -840,13 +841,13 @@ public sealed class InvoiceProcessingServiceExtendedTests
     var result = await processingService.GetProduct("TestProductName", invoiceId, null, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
+    Assert.IsNotNull(result);
   }
 
   /// <summary>
   /// Validates exception during product retrieval.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task GetProduct_OrchestrationThrows_ThrowsProcessingServiceException()
   {
     // Arrange
@@ -857,7 +858,7 @@ public sealed class InvoiceProcessingServiceExtendedTests
         .ThrowsAsync(new InvalidOperationException("Read failed"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceProcessingServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceException>(() =>
         processingService.GetProduct("test", invoiceId, null, CancellationToken.None));
   }
 
@@ -870,7 +871,7 @@ public sealed class InvoiceProcessingServiceExtendedTests
   /// Merchant validation failures are treated as dependency-validation failures from the
   /// invoice processing tier's perspective (merchant orchestration is a downstream dependency).
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateMerchant_OrchestrationValidationException_ThrowsProcessingDependencyValidationException()
   {
     // Arrange
@@ -883,7 +884,7 @@ public sealed class InvoiceProcessingServiceExtendedTests
         .ThrowsAsync(orchException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceProcessingServiceDependencyValidationException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceDependencyValidationException>(() =>
         processingService.CreateMerchant(merchant, null, CancellationToken.None));
   }
 
@@ -891,7 +892,7 @@ public sealed class InvoiceProcessingServiceExtendedTests
   /// Validates merchant orchestration dependency exception wrapping.
   /// Merchant dependency failures surface as processing-tier dependency exceptions.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateMerchant_OrchestrationDependencyException_ThrowsProcessingDependencyException()
   {
     // Arrange
@@ -904,14 +905,14 @@ public sealed class InvoiceProcessingServiceExtendedTests
         .ThrowsAsync(orchException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceProcessingServiceDependencyException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceDependencyException>(() =>
         processingService.CreateMerchant(merchant, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates merchant read with valid parent company ID.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchant_WithParentCompanyId_ReturnsMerchant()
   {
     // Arrange
@@ -927,13 +928,13 @@ public sealed class InvoiceProcessingServiceExtendedTests
     var result = await processingService.ReadMerchant(merchantId, parentCompanyId, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
+    Assert.IsNotNull(result);
   }
 
   /// <summary>
   /// Validates merchant read without parent company ID.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchant_NullParentCompanyId_ReturnsMerchant()
   {
     // Arrange
@@ -948,13 +949,13 @@ public sealed class InvoiceProcessingServiceExtendedTests
     var result = await processingService.ReadMerchant(merchantId, null, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
+    Assert.IsNotNull(result);
   }
 
   /// <summary>
   /// Validates merchant read orchestration service exception wrapping.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchant_OrchestrationServiceException_ThrowsProcessingServiceException()
   {
     // Arrange
@@ -967,14 +968,14 @@ public sealed class InvoiceProcessingServiceExtendedTests
         .ThrowsAsync(orchException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceProcessingServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceException>(() =>
         processingService.ReadMerchant(merchantId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates merchant update without parent company ID.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateMerchant_NullParentCompanyId_ReturnsUpdatedMerchant()
   {
     // Arrange
@@ -989,13 +990,13 @@ public sealed class InvoiceProcessingServiceExtendedTests
     var result = await processingService.UpdateMerchant(updatedMerchant, merchantId, null, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
+    Assert.IsNotNull(result);
   }
 
   /// <summary>
   /// Validates merchant update orchestration service exception wrapping.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateMerchant_OrchestrationServiceException_ThrowsProcessingServiceException()
   {
     // Arrange
@@ -1009,14 +1010,14 @@ public sealed class InvoiceProcessingServiceExtendedTests
         .ThrowsAsync(orchException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceProcessingServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceException>(() =>
         processingService.UpdateMerchant(updatedMerchant, merchantId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates merchant delete with parent company ID.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteMerchant_WithParentCompanyId_DeletesSuccessfully()
   {
     // Arrange
@@ -1037,7 +1038,7 @@ public sealed class InvoiceProcessingServiceExtendedTests
   /// <summary>
   /// Validates merchant delete without parent company ID.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteMerchant_NullParentCompanyId_DeletesSuccessfully()
   {
     // Arrange

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Processing/InvoiceProcessingServiceTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Processing/InvoiceProcessingServiceTests.cs
@@ -1034,12 +1034,12 @@ public sealed class InvoiceProcessingServiceTests
   /// <summary>
   /// Provides theory data containing several randomized invoices for parameterized tests.
   /// </summary>
-  public static TheoryData<Invoice> GetInvoiceTestData() => InvoiceBuilder.GetInvoiceTheoryData();
+  public static IEnumerable<object[]> GetInvoiceTestData() => InvoiceBuilder.GetInvoiceTheoryData();
 
   /// <summary>
   /// Provides theory data containing several randomized merchants for parameterized tests.
   /// </summary>
-  public static TheoryData<Merchant> GetMerchantTestData() => MerchantTestDataBuilder.GetMerchantTheoryData();
+  public static IEnumerable<object[]> GetMerchantTestData() => MerchantTestDataBuilder.GetMerchantTheoryData();
 
   #endregion
 }

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Processing/InvoiceProcessingServiceTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/Invoices/Services/Processing/InvoiceProcessingServiceTests.cs
@@ -22,13 +22,14 @@ using Microsoft.Extensions.Logging;
 
 using Moq;
 
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 /// <summary>
 /// Comprehensive unit tests for <see cref="InvoiceProcessingService"/> targeting 95%+ code coverage.
 /// Tests validate processing logic, exception handling, orchestration service coordination.
 /// Method naming follows MethodName_Condition_ExpectedResult pattern per repository standards.
 /// </summary>
+[TestClass]
 public sealed class InvoiceProcessingServiceTests
 {
   private readonly Mock<IInvoiceOrchestrationService> mockInvoiceOrchestrationService;
@@ -62,23 +63,23 @@ public sealed class InvoiceProcessingServiceTests
   /// <summary>
   /// Verifies constructor throws ArgumentNullException when invoice orchestration service is null.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Constructor_NullInvoiceOrchestrationService_ThrowsArgumentNullException() =>
-      Assert.Throws<ArgumentNullException>(() =>
+      Assert.ThrowsExactly<ArgumentNullException>(() =>
           new InvoiceProcessingService(null!, mockMerchantOrchestrationService.Object, mockLoggerFactory.Object));
 
   /// <summary>
   /// Verifies constructor throws ArgumentNullException when merchant orchestration service is null.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Constructor_NullMerchantOrchestrationService_ThrowsArgumentNullException() =>
-      Assert.Throws<ArgumentNullException>(() =>
+      Assert.ThrowsExactly<ArgumentNullException>(() =>
           new InvoiceProcessingService(mockInvoiceOrchestrationService.Object, null!, mockLoggerFactory.Object));
 
   /// <summary>
   /// Validates successful instantiation with all valid dependencies.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public void Constructor_ValidDependencies_CreatesInstance()
   {
     // Arrange & Act
@@ -88,7 +89,7 @@ public sealed class InvoiceProcessingServiceTests
         mockLoggerFactory.Object);
 
     // Assert
-    Assert.NotNull(service);
+    Assert.IsNotNull(service);
   }
 
   #endregion
@@ -98,7 +99,7 @@ public sealed class InvoiceProcessingServiceTests
   /// <summary>
   /// Validates successful invoice analysis execution.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoice_ValidInput_CallsOrchestrationService()
   {
     // Arrange
@@ -120,7 +121,7 @@ public sealed class InvoiceProcessingServiceTests
   /// <summary>
   /// Validates orchestration dependency exception is wrapped into processing dependency exception.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoice_OrchestrationDependencyException_ThrowsProcessingDependencyException()
   {
     // Arrange
@@ -134,14 +135,14 @@ public sealed class InvoiceProcessingServiceTests
         .ThrowsAsync(orchException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceProcessingServiceDependencyException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceDependencyException>(() =>
         processingService.AnalyzeInvoice(options, invoiceId, null, CancellationToken.None));
   }
 
   /// <summary>
   /// Validates generic exception is wrapped into processing service exception.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AnalyzeInvoice_GenericException_ThrowsProcessingServiceException()
   {
     // Arrange
@@ -153,7 +154,7 @@ public sealed class InvoiceProcessingServiceTests
         .ThrowsAsync(new InvalidOperationException("Unexpected error"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceProcessingServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceException>(() =>
         processingService.AnalyzeInvoice(options, invoiceId, null, CancellationToken.None));
   }
 
@@ -164,7 +165,7 @@ public sealed class InvoiceProcessingServiceTests
   /// <summary>
   /// Validates successful invoice creation.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateInvoice_ValidInvoice_CallsOrchestrationService()
   {
     // Arrange
@@ -185,7 +186,7 @@ public sealed class InvoiceProcessingServiceTests
   /// <summary>
   /// Validates orchestration service exception is wrapped appropriately.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateInvoice_OrchestrationServiceException_ThrowsProcessingServiceException()
   {
     // Arrange
@@ -198,7 +199,7 @@ public sealed class InvoiceProcessingServiceTests
         .ThrowsAsync(orchException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceProcessingServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceException>(() =>
         processingService.CreateInvoice(invoice, null, CancellationToken.None));
   }
 
@@ -209,7 +210,7 @@ public sealed class InvoiceProcessingServiceTests
   /// <summary>
   /// Validates successful invoice retrieval.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoice_ValidIdentifier_ReturnsInvoice()
   {
     // Arrange
@@ -225,14 +226,14 @@ public sealed class InvoiceProcessingServiceTests
     var result = await processingService.ReadInvoice(invoiceId, userId, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
-    Assert.Equal(expectedInvoice.id, result.id);
+    Assert.IsNotNull(result);
+    Assert.AreEqual(expectedInvoice.id, result.id);
   }
 
   /// <summary>
   /// Validates orchestration validation exception is wrapped appropriately.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoice_OrchestrationValidationException_ThrowsProcessingValidationException()
   {
     // Arrange
@@ -245,7 +246,7 @@ public sealed class InvoiceProcessingServiceTests
         .ThrowsAsync(orchException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceProcessingServiceValidationException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceValidationException>(() =>
         processingService.ReadInvoice(invoiceId, null, CancellationToken.None));
   }
 
@@ -256,7 +257,7 @@ public sealed class InvoiceProcessingServiceTests
   /// <summary>
   /// Validates successful bulk invoice retrieval.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoices_ValidUserId_ReturnsInvoiceCollection()
   {
     // Arrange
@@ -271,14 +272,14 @@ public sealed class InvoiceProcessingServiceTests
     var result = await processingService.ReadInvoices(userId, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
-    Assert.Equal(5, result.Count());
+    Assert.IsNotNull(result);
+    Assert.AreEqual(5, result.Count());
   }
 
   /// <summary>
   /// Validates empty collection returned when no invoices exist.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoices_NoInvoices_ReturnsEmptyCollection()
   {
     // Arrange
@@ -292,8 +293,8 @@ public sealed class InvoiceProcessingServiceTests
     var result = await processingService.ReadInvoices(userId, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
-    Assert.Empty(result);
+    Assert.IsNotNull(result);
+    Assert.IsEmpty(result);
   }
 
   #endregion
@@ -303,7 +304,7 @@ public sealed class InvoiceProcessingServiceTests
   /// <summary>
   /// Validates successful invoice update.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateInvoice_ValidUpdate_ReturnsUpdatedInvoice()
   {
     // Arrange
@@ -319,14 +320,14 @@ public sealed class InvoiceProcessingServiceTests
     var result = await processingService.UpdateInvoice(updatedInvoice, invoiceId, userId, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
-    Assert.Equal(updatedInvoice.id, result.id);
+    Assert.IsNotNull(result);
+    Assert.AreEqual(updatedInvoice.id, result.id);
   }
 
   /// <summary>
   /// Validates orchestration dependency validation exception is wrapped appropriately.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateInvoice_OrchestrationDependencyValidationException_ThrowsProcessingDependencyValidationException()
   {
     // Arrange
@@ -340,7 +341,7 @@ public sealed class InvoiceProcessingServiceTests
         .ThrowsAsync(orchException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceProcessingServiceDependencyValidationException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceDependencyValidationException>(() =>
         processingService.UpdateInvoice(updatedInvoice, invoiceId, null, CancellationToken.None));
   }
 
@@ -351,7 +352,7 @@ public sealed class InvoiceProcessingServiceTests
   /// <summary>
   /// Validates successful invoice deletion.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteInvoice_ValidIdentifier_DeletesSuccessfully()
   {
     // Arrange
@@ -376,7 +377,7 @@ public sealed class InvoiceProcessingServiceTests
   /// <summary>
   /// Validates successful bulk invoice deletion.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteInvoices_ValidUserId_DeletesAllInvoices()
   {
     // Arrange
@@ -402,7 +403,7 @@ public sealed class InvoiceProcessingServiceTests
   /// <summary>
   /// Validates no deletions when no invoices exist.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteInvoices_NoInvoices_PerformsNoDeletions()
   {
     // Arrange
@@ -426,7 +427,7 @@ public sealed class InvoiceProcessingServiceTests
   /// <summary>
   /// Validates successful product addition to invoice.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AddProduct_ValidProduct_AddsToInvoice()
   {
     // Arrange
@@ -459,7 +460,7 @@ public sealed class InvoiceProcessingServiceTests
   /// <summary>
   /// Validates successful products retrieval from invoice.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task GetProducts_ValidInvoiceId_ReturnsProductCollection()
   {
     // Arrange
@@ -475,8 +476,8 @@ public sealed class InvoiceProcessingServiceTests
     var result = await processingService.GetProducts(invoiceId, userId, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
-    Assert.Equal(invoice.Items.Count, result.Count());
+    Assert.IsNotNull(result);
+    Assert.AreEqual(invoice.Items.Count, result.Count());
   }
 
   #endregion
@@ -486,7 +487,7 @@ public sealed class InvoiceProcessingServiceTests
   /// <summary>
   /// Validates successful product retrieval by name.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task GetProduct_ExistingProduct_ReturnsProduct()
   {
     // Arrange
@@ -503,13 +504,13 @@ public sealed class InvoiceProcessingServiceTests
     var result = await processingService.GetProduct(productName, invoiceId, userId, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
+    Assert.IsNotNull(result);
   }
 
   /// <summary>
   /// Validates default product returned when product not found.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task GetProduct_NonExistingProduct_ReturnsDefaultProduct()
   {
     // Arrange
@@ -525,7 +526,7 @@ public sealed class InvoiceProcessingServiceTests
     var result = await processingService.GetProduct("NonExistingProduct12345", invoiceId, userId, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
+    Assert.IsNotNull(result);
   }
 
   #endregion
@@ -535,7 +536,7 @@ public sealed class InvoiceProcessingServiceTests
   /// <summary>
   /// Validates successful product deletion by name.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteProductByName_ExistingProduct_RemovesFromInvoice()
   {
     // Arrange
@@ -562,7 +563,7 @@ public sealed class InvoiceProcessingServiceTests
   /// <summary>
   /// Validates successful product deletion by product object.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteProductByObject_ExistingProduct_RemovesFromInvoice()
   {
     // Arrange
@@ -593,7 +594,7 @@ public sealed class InvoiceProcessingServiceTests
   /// <summary>
   /// Validates successful scan creation.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateInvoiceScan_ValidScan_AddsToInvoice()
   {
     // Arrange
@@ -624,7 +625,7 @@ public sealed class InvoiceProcessingServiceTests
   /// <summary>
   /// Validates successful scan retrieval.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadInvoiceScans_ValidInvoiceId_ReturnsScanCollection()
   {
     // Arrange
@@ -640,7 +641,7 @@ public sealed class InvoiceProcessingServiceTests
     var result = await processingService.ReadInvoiceScans(invoiceId, userId, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
+    Assert.IsNotNull(result);
   }
 
   #endregion
@@ -650,7 +651,7 @@ public sealed class InvoiceProcessingServiceTests
   /// <summary>
   /// Validates successful scan deletion.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteInvoiceScan_ValidScan_RemovesFromInvoice()
   {
     // Arrange
@@ -682,7 +683,7 @@ public sealed class InvoiceProcessingServiceTests
   /// <summary>
   /// Validates successful metadata addition to invoice.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task AddMetadataToInvoice_ValidMetadata_AddsToInvoice()
   {
     // Arrange
@@ -713,7 +714,7 @@ public sealed class InvoiceProcessingServiceTests
   /// <summary>
   /// Validates successful metadata update on invoice.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateMetadataOnInvoice_ValidMetadata_ReturnsUpdatedMetadata()
   {
     // Arrange
@@ -734,7 +735,7 @@ public sealed class InvoiceProcessingServiceTests
     var result = await processingService.UpdateMetadataOnInvoice(metadata, invoiceId, userId, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
+    Assert.IsNotNull(result);
   }
 
   #endregion
@@ -744,7 +745,7 @@ public sealed class InvoiceProcessingServiceTests
   /// <summary>
   /// Validates successful metadata retrieval from invoice.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task GetMetadataFromInvoice_ValidInvoiceId_ReturnsMetadata()
   {
     // Arrange
@@ -761,8 +762,8 @@ public sealed class InvoiceProcessingServiceTests
     var result = await processingService.GetMetadataFromInvoice(invoiceId, userId, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
-    Assert.True(result.ContainsKey("testKey"));
+    Assert.IsNotNull(result);
+    Assert.IsTrue(result.ContainsKey("testKey"));
   }
 
   #endregion
@@ -772,7 +773,7 @@ public sealed class InvoiceProcessingServiceTests
   /// <summary>
   /// Validates successful metadata deletion from invoice.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteMetadataFromInvoice_ValidKeys_RemovesMetadata()
   {
     // Arrange
@@ -805,7 +806,7 @@ public sealed class InvoiceProcessingServiceTests
   /// <summary>
   /// Validates successful merchant creation.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateMerchant_ValidMerchant_CallsOrchestrationService()
   {
     // Arrange
@@ -826,7 +827,7 @@ public sealed class InvoiceProcessingServiceTests
   /// <summary>
   /// Validates merchant orchestration service exception is wrapped appropriately.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task CreateMerchant_OrchestrationServiceException_ThrowsProcessingServiceException()
   {
     // Arrange
@@ -839,7 +840,7 @@ public sealed class InvoiceProcessingServiceTests
         .ThrowsAsync(orchException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceProcessingServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceException>(() =>
         processingService.CreateMerchant(merchant, null, CancellationToken.None));
   }
 
@@ -850,7 +851,7 @@ public sealed class InvoiceProcessingServiceTests
   /// <summary>
   /// Validates successful merchant retrieval.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchant_ValidIdentifier_ReturnsMerchant()
   {
     // Arrange
@@ -866,14 +867,14 @@ public sealed class InvoiceProcessingServiceTests
     var result = await processingService.ReadMerchant(merchantId, parentCompanyId, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
-    Assert.Equal(expectedMerchant.id, result.id);
+    Assert.IsNotNull(result);
+    Assert.AreEqual(expectedMerchant.id, result.id);
   }
 
   /// <summary>
   /// Validates merchant orchestration validation exception is wrapped appropriately.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchant_OrchestrationValidationException_ThrowsProcessingDependencyValidationException()
   {
     // Arrange
@@ -886,7 +887,7 @@ public sealed class InvoiceProcessingServiceTests
         .ThrowsAsync(orchException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceProcessingServiceDependencyValidationException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceDependencyValidationException>(() =>
         processingService.ReadMerchant(merchantId, null, CancellationToken.None));
   }
 
@@ -897,7 +898,7 @@ public sealed class InvoiceProcessingServiceTests
   /// <summary>
   /// Validates successful bulk merchant retrieval.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchants_ValidParentCompanyId_ReturnsMerchantCollection()
   {
     // Arrange
@@ -912,14 +913,14 @@ public sealed class InvoiceProcessingServiceTests
     var result = await processingService.ReadMerchants(parentCompanyId, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
-    Assert.Equal(5, result.Count());
+    Assert.IsNotNull(result);
+    Assert.AreEqual(5, result.Count());
   }
 
   /// <summary>
   /// Validates merchant orchestration dependency exception is wrapped appropriately.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task ReadMerchants_OrchestrationDependencyException_ThrowsProcessingDependencyException()
   {
     // Arrange
@@ -932,7 +933,7 @@ public sealed class InvoiceProcessingServiceTests
         .ThrowsAsync(orchException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceProcessingServiceDependencyException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceDependencyException>(() =>
         processingService.ReadMerchants(parentCompanyId, CancellationToken.None));
   }
 
@@ -943,7 +944,7 @@ public sealed class InvoiceProcessingServiceTests
   /// <summary>
   /// Validates successful merchant update.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateMerchant_ValidUpdate_ReturnsUpdatedMerchant()
   {
     // Arrange
@@ -959,14 +960,14 @@ public sealed class InvoiceProcessingServiceTests
     var result = await processingService.UpdateMerchant(updatedMerchant, merchantId, parentCompanyId, CancellationToken.None);
 
     // Assert
-    Assert.NotNull(result);
-    Assert.Equal(updatedMerchant.id, result.id);
+    Assert.IsNotNull(result);
+    Assert.AreEqual(updatedMerchant.id, result.id);
   }
 
   /// <summary>
   /// Validates merchant orchestration dependency validation exception is wrapped appropriately.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task UpdateMerchant_OrchestrationDependencyValidationException_ThrowsProcessingDependencyValidationException()
   {
     // Arrange
@@ -980,7 +981,7 @@ public sealed class InvoiceProcessingServiceTests
         .ThrowsAsync(orchException);
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceProcessingServiceDependencyValidationException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceDependencyValidationException>(() =>
         processingService.UpdateMerchant(updatedMerchant, merchantId, null, CancellationToken.None));
   }
 
@@ -991,7 +992,7 @@ public sealed class InvoiceProcessingServiceTests
   /// <summary>
   /// Validates successful merchant deletion.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteMerchant_ValidIdentifier_DeletesSuccessfully()
   {
     // Arrange
@@ -1012,7 +1013,7 @@ public sealed class InvoiceProcessingServiceTests
   /// <summary>
   /// Validates generic exception during merchant deletion is wrapped appropriately.
   /// </summary>
-  [Fact]
+  [TestMethod]
   public async Task DeleteMerchant_GenericException_ThrowsProcessingServiceException()
   {
     // Arrange
@@ -1023,7 +1024,7 @@ public sealed class InvoiceProcessingServiceTests
         .ThrowsAsync(new InvalidOperationException("Unexpected error"));
 
     // Act & Assert
-    await Assert.ThrowsAsync<InvoiceProcessingServiceException>(() =>
+    await Assert.ThrowsExactlyAsync<InvoiceProcessingServiceException>(() =>
         processingService.DeleteMerchant(merchantId, null, CancellationToken.None));
   }
 

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/arolariu.Backend.Domain.Tests.csproj
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/arolariu.Backend.Domain.Tests.csproj
@@ -8,6 +8,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" />
     <PackageReference Include="Moq" />
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/arolariu.Backend.Domain.Tests.csproj
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/arolariu.Backend.Domain.Tests.csproj
@@ -10,11 +10,7 @@
     <PackageReference Include="Moq" />
     <PackageReference Include="MSTest.TestAdapter" />
     <PackageReference Include="MSTest.TestFramework" />
-    <PackageReference Include="xunit" />
-    <PackageReference Include="xunit.runner.visualstudio">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+
     <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/packages.lock.json
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/packages.lock.json
@@ -33,6 +33,26 @@
           "Castle.Core": "5.1.1"
         }
       },
+      "MSTest.TestAdapter": {
+        "type": "Direct",
+        "requested": "[4.3.3, )",
+        "resolved": "4.3.3",
+        "contentHash": "YxXA1YGqwcZ1UjZXHgeu65AWDR25PQ2lN5N5CYOhxftqOQh/FcgQk0Vz0nfHqLhqOGFI6g9uIfOWqAdobSNKSg==",
+        "dependencies": {
+          "MSTest.TestFramework": "4.3.3",
+          "Microsoft.Testing.Extensions.VSTestBridge": "2.3.3",
+          "Microsoft.Testing.Platform.MSBuild": "2.3.3"
+        }
+      },
+      "MSTest.TestFramework": {
+        "type": "Direct",
+        "requested": "[4.3.3, )",
+        "resolved": "4.3.3",
+        "contentHash": "Y4OSRh7VKV3nW+/vIqvfJ3sdLWfVJ9G11KpzynFAq3Bh/fpMaXt73v8GfL4mTz6pJ/ix3hcep4iy6qQNXt408w==",
+        "dependencies": {
+          "MSTest.Analyzers": "4.3.3"
+        }
+      },
       "xunit": {
         "type": "Direct",
         "requested": "[2.9.3, )",
@@ -188,6 +208,47 @@
         "resolved": "1.0.0",
         "contentHash": "N4KeF3cpcm1PUHym1RmakkzfkEv3GRMyofVv40uXsQhCQeglr2OHNcUk2WOG51AKpGO8ynGpo9M/kFXSzghwug=="
       },
+      "Microsoft.Testing.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "2.3.3",
+        "contentHash": "nY8ceQyPWB9TRE1WE5Oe/sks2e10SxgPv61vBHsFYpgCeDtNwhpMZwmL29GklO3/etTdOsLdrCmNr4zJWaR2fg==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "Microsoft.Testing.Platform": "2.3.3"
+        }
+      },
+      "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
+        "type": "Transitive",
+        "resolved": "2.3.3",
+        "contentHash": "dceVNxnfTEjKnrIreLcMfkgrzzBY8kgCCJX5NAv7Lq/6vPlTP4VB5zxKeuYy0yfCoBtWuPkLjUG6qtOBMfpypA==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "2.3.3"
+        }
+      },
+      "Microsoft.Testing.Extensions.VSTestBridge": {
+        "type": "Transitive",
+        "resolved": "2.3.3",
+        "contentHash": "JLovZjH6K10YiHO/BcidsaSHo/M2DfOe9FDjxjFdV6aoHO6VYTTYlLBNcyLJSo20q5gDTmNvmxYVH39A942aJA==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "18.4.0",
+          "Microsoft.Testing.Extensions.Telemetry": "2.3.3",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.3.3",
+          "Microsoft.Testing.Platform": "2.3.3"
+        }
+      },
+      "Microsoft.Testing.Platform": {
+        "type": "Transitive",
+        "resolved": "2.3.3",
+        "contentHash": "ENbH4BQh9riXtOKc25KKITfiGGWhWMBJA7pZuNaF9zxzzSaVkp5AMeZxGQ6sXYaR6xb724NLz985Is6XIYqLSg=="
+      },
+      "Microsoft.Testing.Platform.MSBuild": {
+        "type": "Transitive",
+        "resolved": "2.3.3",
+        "contentHash": "iVAvNbZ5JPDZSrTcIrCDoCsAkzjDxwDEt2mDuMd8ng1P6e2P2NCd0g0BsoBVG+nJLSmK//V+yeEvjCa3E2fxHw==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "2.3.3"
+        }
+      },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
         "resolved": "18.8.1",
@@ -200,6 +261,11 @@
         "dependencies": {
           "Microsoft.TestPlatform.ObjectModel": "18.8.1"
         }
+      },
+      "MSTest.Analyzers": {
+        "type": "Transitive",
+        "resolved": "4.3.3",
+        "contentHash": "cTcdSPIZ8WvchbC5DFmfHxrvVNZCtops+2W94le+Q+mx110Y9L9mqNVVc9flF35lFeL5GsY+rxGBylsjDk4+zg=="
       },
       "Newtonsoft.Json": {
         "type": "Transitive",

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/packages.lock.json
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Domain.Tests/packages.lock.json
@@ -53,23 +53,6 @@
           "MSTest.Analyzers": "4.3.3"
         }
       },
-      "xunit": {
-        "type": "Direct",
-        "requested": "[2.9.3, )",
-        "resolved": "2.9.3",
-        "contentHash": "TlXQBinK35LpOPKHAqbLY4xlEen9TBafjs0V5KnA4wZsoQLQJiirCR4CbIXvOH8NzkW4YeJKP5P/Bnrodm0h9Q==",
-        "dependencies": {
-          "xunit.analyzers": "1.18.0",
-          "xunit.assert": "2.9.3",
-          "xunit.core": "[2.9.3]"
-        }
-      },
-      "xunit.runner.visualstudio": {
-        "type": "Direct",
-        "requested": "[3.1.5, )",
-        "resolved": "3.1.5",
-        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
-      },
       "Azure.Storage.Common": {
         "type": "Transitive",
         "resolved": "12.28.0",
@@ -358,46 +341,6 @@
         "type": "Transitive",
         "resolved": "9.0.4",
         "contentHash": "o94k2RKuAce3GeDMlUvIXlhVa1kWpJw95E6C9LwW0KlG0nj5+SgCiIxJ2Eroqb9sLtG1mEMbFttZIBZ13EJPvQ=="
-      },
-      "xunit.abstractions": {
-        "type": "Transitive",
-        "resolved": "2.0.3",
-        "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
-      },
-      "xunit.analyzers": {
-        "type": "Transitive",
-        "resolved": "1.18.0",
-        "contentHash": "OtFMHN8yqIcYP9wcVIgJrq01AfTxijjAqVDy/WeQVSyrDC1RzBWeQPztL49DN2syXRah8TYnfvk035s7L95EZQ=="
-      },
-      "xunit.assert": {
-        "type": "Transitive",
-        "resolved": "2.9.3",
-        "contentHash": "/Kq28fCE7MjOV42YLVRAJzRF0WmEqsmflm0cfpMjGtzQ2lR5mYVj1/i0Y8uDAOLczkL3/jArrwehfMD0YogMAA=="
-      },
-      "xunit.core": {
-        "type": "Transitive",
-        "resolved": "2.9.3",
-        "contentHash": "BiAEvqGvyme19wE0wTKdADH+NloYqikiU0mcnmiNyXaF9HyHmE6sr/3DC5vnBkgsWaE6yPyWszKSPSApWdRVeQ==",
-        "dependencies": {
-          "xunit.extensibility.core": "[2.9.3]",
-          "xunit.extensibility.execution": "[2.9.3]"
-        }
-      },
-      "xunit.extensibility.core": {
-        "type": "Transitive",
-        "resolved": "2.9.3",
-        "contentHash": "kf3si0YTn2a8J8eZNb+zFpwfoyvIrQ7ivNk5ZYA5yuYk1bEtMe4DxJ2CF/qsRgmEnDr7MnW1mxylBaHTZ4qErA==",
-        "dependencies": {
-          "xunit.abstractions": "2.0.3"
-        }
-      },
-      "xunit.extensibility.execution": {
-        "type": "Transitive",
-        "resolved": "2.9.3",
-        "contentHash": "yMb6vMESlSrE3Wfj7V6cjQ3S4TXdXpRqYeNEI3zsX31uTsGMJjEw6oD5F5u1cHnMptjhEECnmZSsPxB6ChZHDQ==",
-        "dependencies": {
-          "xunit.extensibility.core": "[2.9.3]"
-        }
       },
       "arolariu.backend.common": {
         "type": "Project",

--- a/sites/arolariu.ro/src/app/api/health/route.test.ts
+++ b/sites/arolariu.ro/src/app/api/health/route.test.ts
@@ -214,7 +214,7 @@ describe("/api/health", () => {
       expect(instrumentationMocks.counterAdd).not.toHaveBeenCalled();
     });
 
-    it("records nothing for a Degraded dependency, which answered but unhappily", async () => {
+    it("records a failure for a Degraded dependency, which answered but unhappily", async () => {
       mockFetch.mockResolvedValue({ok: false, status: 503});
 
       const {GET} = await import("./route");
@@ -222,7 +222,12 @@ describe("/api/health", () => {
       const body = await response.json();
 
       expect(body.dependencies[0]?.status).toBe("Degraded");
-      expect(instrumentationMocks.counterAdd).not.toHaveBeenCalled();
+      // Degraded drives this endpoint to 503, so it must reach the counter — it is the
+      // only signal left once routine health telemetry is suppressed. Both dependencies
+      // are Degraded here because the mock answers every fetch.
+      expect(instrumentationMocks.counterAdd).toHaveBeenCalledTimes(2);
+      expect(instrumentationMocks.counterAdd).toHaveBeenCalledWith(1, {check: "exp"});
+      expect(instrumentationMocks.counterAdd).toHaveBeenCalledWith(1, {check: "api"});
     });
   });
 

--- a/sites/arolariu.ro/src/app/api/health/route.test.ts
+++ b/sites/arolariu.ro/src/app/api/health/route.test.ts
@@ -10,6 +10,9 @@ const instrumentationMocks = vi.hoisted(() => ({
     enrichedHeaders.set("X-Request-Id", "feedfacefeedfacefeedfacefeedface");
     return enrichedHeaders;
   }),
+  // Stable across re-imports so tests can assert on the failure counter, which the route
+  // creates at module scope and `vi.resetModules()` re-creates for every test.
+  counterAdd: vi.fn(),
 }));
 
 // Mock server-only and OTel before any imports
@@ -19,7 +22,7 @@ vi.mock("@/instrumentation.server", () => ({
   setSpanAttributes: vi.fn(),
   logWithTrace: vi.fn(),
   createHistogram: vi.fn(() => ({record: vi.fn()})),
-  createCounter: vi.fn(() => ({add: vi.fn()})),
+  createCounter: vi.fn(() => ({add: instrumentationMocks.counterAdd})),
   createHttpServerAttributes: vi.fn(() => ({})),
   getTraceparentHeader: vi.fn(() => ""),
   injectTraceContextHeaders: instrumentationMocks.injectTraceContextHeaders,
@@ -35,6 +38,7 @@ describe("/api/health", () => {
   beforeEach(() => {
     vi.resetModules();
     mockFetch.mockReset();
+    instrumentationMocks.counterAdd.mockReset();
     vi.stubEnv("SITE_ENV", "DEVELOPMENT");
     vi.stubEnv("COMMIT_SHA", "abc123def456");
     vi.stubEnv("SITE_NAME", "dev.arolariu.ro");
@@ -177,6 +181,49 @@ describe("/api/health", () => {
 
     expect(body.dependencies[1]?.status).toBe("Unhealthy");
     expect(body.dependencies[1]?.error).toBe("string error");
+  });
+
+  describe("arolariu.health.check.failures counter", () => {
+    it("records one measurement per Unhealthy dependency, with low-cardinality check values", async () => {
+      mockFetch.mockRejectedValue(new Error("down"));
+
+      const {GET} = await import("./route");
+      await GET();
+
+      expect(instrumentationMocks.counterAdd).toHaveBeenCalledTimes(2);
+      expect(instrumentationMocks.counterAdd).toHaveBeenCalledWith(1, {check: "exp"});
+      expect(instrumentationMocks.counterAdd).toHaveBeenCalledWith(1, {check: "api"});
+    });
+
+    it("records only the failing dependency when one is reachable", async () => {
+      mockFetch.mockResolvedValueOnce({ok: true, status: 200}).mockRejectedValueOnce(new Error("down"));
+
+      const {GET} = await import("./route");
+      await GET();
+
+      expect(instrumentationMocks.counterAdd).toHaveBeenCalledTimes(1);
+      expect(instrumentationMocks.counterAdd).toHaveBeenCalledWith(1, {check: "api"});
+    });
+
+    it("records nothing when all dependencies are healthy", async () => {
+      mockFetch.mockResolvedValue({ok: true, status: 200});
+
+      const {GET} = await import("./route");
+      await GET();
+
+      expect(instrumentationMocks.counterAdd).not.toHaveBeenCalled();
+    });
+
+    it("records nothing for a Degraded dependency, which answered but unhappily", async () => {
+      mockFetch.mockResolvedValue({ok: false, status: 503});
+
+      const {GET} = await import("./route");
+      const response = await GET();
+      const body = await response.json();
+
+      expect(body.dependencies[0]?.status).toBe("Degraded");
+      expect(instrumentationMocks.counterAdd).not.toHaveBeenCalled();
+    });
   });
 
   it("uses fallback values when env vars are missing", async () => {

--- a/sites/arolariu.ro/src/app/api/health/route.ts
+++ b/sites/arolariu.ro/src/app/api/health/route.ts
@@ -119,10 +119,14 @@ export async function GET(): Promise<NextResponse<HealthResponse>> {
   const checkDurationMs = Math.round(performance.now() - checkStart);
 
   // The single always-on signal that survives suppression. Dimension values match the
-  // .NET and Python services so one query spans the estate. Names are of the form
-  // "exp (config proxy)" / "api (backend)"; the leading token keeps cardinality bounded.
+  // .NET and Python services so one query spans the estate: the backend counts every
+  // check whose status is not Healthy, and exp counts every health 5xx. Degraded is
+  // therefore counted here too — a dependency that answered 503 still drives this
+  // endpoint to 503, and with routine health telemetry suppressed this counter is the
+  // only remaining signal. Names are of the form "exp (config proxy)" / "api (backend)";
+  // the leading token keeps cardinality bounded.
   for (const dependency of dependencies) {
-    if (dependency.status === "Unhealthy") {
+    if (dependency.status !== "Healthy") {
       healthFailureCounter.add(1, {check: dependency.name.split(" ")[0]!});
     }
   }

--- a/sites/arolariu.ro/src/app/api/health/route.ts
+++ b/sites/arolariu.ro/src/app/api/health/route.ts
@@ -119,10 +119,11 @@ export async function GET(): Promise<NextResponse<HealthResponse>> {
   const checkDurationMs = Math.round(performance.now() - checkStart);
 
   // The single always-on signal that survives suppression. Dimension values match the
-  // .NET and Python services so one query spans the estate.
+  // .NET and Python services so one query spans the estate. Names are of the form
+  // "exp (config proxy)" / "api (backend)"; the leading token keeps cardinality bounded.
   for (const dependency of dependencies) {
     if (dependency.status === "Unhealthy") {
-      healthFailureCounter.add(1, {check: dependency.name.split(" ")[0] ?? dependency.name});
+      healthFailureCounter.add(1, {check: dependency.name.split(" ")[0]!});
     }
   }
 

--- a/sites/arolariu.ro/src/app/api/health/route.ts
+++ b/sites/arolariu.ro/src/app/api/health/route.ts
@@ -5,26 +5,21 @@
  * @remarks
  * Reports website health status including latency to upstream dependencies
  * (exp.arolariu.ro config proxy and api.arolariu.ro backend API).
- * Instrumented with OpenTelemetry spans and metrics.
+ * Telemetry is handled automatically by the OTel ignore hooks; the only
+ * hand-authored instrument is the always-on failure counter.
  */
 
-import {
-  addSpanEvent,
-  createCounter,
-  createHistogram,
-  createHttpServerAttributes,
-  injectTraceContextHeaders,
-  logWithTrace,
-  setSpanAttributes,
-  withSpan,
-} from "@/instrumentation.server";
+import {createCounter, injectTraceContextHeaders} from "@/instrumentation.server";
 import {version as nextVersion} from "next/package.json";
 import {NextResponse} from "next/server";
 
 export const dynamic = "force-dynamic";
 
-const healthCheckDuration = createHistogram("website.health.duration", "Health check total duration", "ms");
-const healthCheckCounter = createCounter("website.health.requests", "Total health check requests", "1");
+const healthFailureCounter = createCounter(
+  "arolariu.health.check.failures",
+  "Health check failures, dimensioned by the failing check name.",
+  "{failure}",
+);
 
 /** Whether we're running with Azure identity (determines exp URL). */
 const HAS_AZURE_CLIENT_ID = Boolean(process.env["AZURE_CLIENT_ID"]);
@@ -89,12 +84,6 @@ async function checkDependency(name: string, url: string): Promise<DependencySta
       signal: AbortSignal.timeout(10_000),
     });
     const latencyMs = Math.round(performance.now() - start);
-    addSpanEvent("health.dependency.checked", {
-      "dependency.name": name,
-      "dependency.status_code": response.status,
-      "dependency.url": url,
-      "dependency.latency_ms": latencyMs,
-    });
 
     if (response.ok) {
       return {name, status: "Healthy", url, latencyMs, statusCode: response.status};
@@ -103,7 +92,6 @@ async function checkDependency(name: string, url: string): Promise<DependencySta
   } catch (error) {
     const latencyMs = Math.round(performance.now() - start);
     const message = error instanceof Error ? error.message : String(error);
-    logWithTrace("warn", `Health check failed for ${name}`, {url, error: message}, "api");
     return {name, status: "Unhealthy", url, latencyMs, error: message};
   }
 }
@@ -120,66 +108,52 @@ function deriveOverallStatus(dependencies: readonly DependencyStatus[]): HealthS
  * @returns JSON health report with dependency latencies, process info, and build metadata.
  */
 export async function GET(): Promise<NextResponse<HealthResponse>> {
-  return withSpan("api.health.check", async () => {
-    const checkStart = performance.now();
-    healthCheckCounter.add(1);
+  const checkStart = performance.now();
 
-    addSpanEvent("health.check.start");
-    setSpanAttributes({
-      "health.exp_url": EXP_URL,
-      "health.api_url": API_URL,
-    });
+  const dependencies = await Promise.all([
+    checkDependency("exp (config proxy)", `${EXP_URL}/api/health`),
+    checkDependency("api (backend)", `${API_URL}/health`),
+  ]);
 
-    // Check dependencies in parallel
-    const dependencies = await Promise.all([
-      checkDependency("exp (config proxy)", `${EXP_URL}/api/health`),
-      checkDependency("api (backend)", `${API_URL}/health`),
-    ]);
+  const overallStatus = deriveOverallStatus(dependencies);
+  const checkDurationMs = Math.round(performance.now() - checkStart);
 
-    const overallStatus = deriveOverallStatus(dependencies);
-    const checkDurationMs = Math.round(performance.now() - checkStart);
+  // The single always-on signal that survives suppression. Dimension values match the
+  // .NET and Python services so one query spans the estate.
+  for (const dependency of dependencies) {
+    if (dependency.status === "Unhealthy") {
+      healthFailureCounter.add(1, {check: dependency.name.split(" ")[0] ?? dependency.name});
+    }
+  }
 
-    addSpanEvent("health.check.complete", {
-      "overall.status": overallStatus,
-      "check.duration_ms": checkDurationMs,
-      "dependencies.count": dependencies.length,
-    });
-
-    healthCheckDuration.record(checkDurationMs, {
-      ...createHttpServerAttributes("GET", overallStatus === "Healthy" ? 200 : 503, {route: "/api/health"}),
-    });
-
-    const mem = process.memoryUsage();
-    const response: HealthResponse = {
-      status: overallStatus,
-      timestamp: new Date().toISOString(),
-      checkDurationMs,
-      process: {
-        uptimeSeconds: Math.round((Date.now() - startedAt) / 1000),
-        startedAt: startedAtISO,
-        nodeVersion: process.version,
-        nextVersion: nextVersion ?? "unknown",
-        platform: process.platform,
-        arch: process.arch,
-        memoryUsageMB: {
-          rss: Math.round(mem.rss / 1024 / 1024),
-          heapUsed: Math.round(mem.heapUsed / 1024 / 1024),
-          heapTotal: Math.round(mem.heapTotal / 1024 / 1024),
-        },
+  const mem = process.memoryUsage();
+  const response: HealthResponse = {
+    status: overallStatus,
+    timestamp: new Date().toISOString(),
+    checkDurationMs,
+    process: {
+      uptimeSeconds: Math.round((Date.now() - startedAt) / 1000),
+      startedAt: startedAtISO,
+      nodeVersion: process.version,
+      nextVersion: nextVersion ?? "unknown",
+      platform: process.platform,
+      arch: process.arch,
+      memoryUsageMB: {
+        rss: Math.round(mem.rss / 1024 / 1024),
+        heapUsed: Math.round(mem.heapUsed / 1024 / 1024),
+        heapTotal: Math.round(mem.heapTotal / 1024 / 1024),
       },
-      build: {
-        commitSha: process.env["COMMIT_SHA"] ?? "unknown",
-        environment: process.env["SITE_ENV"] ?? "unknown",
-        siteName: process.env["SITE_NAME"] ?? "unknown",
-        siteUrl: process.env["SITE_URL"] ?? "unknown",
-        infraMode: process.env["INFRA"] ?? "unknown",
-      },
-      dependencies,
-    };
+    },
+    build: {
+      commitSha: process.env["COMMIT_SHA"] ?? "unknown",
+      environment: process.env["SITE_ENV"] ?? "unknown",
+      siteName: process.env["SITE_NAME"] ?? "unknown",
+      siteUrl: process.env["SITE_URL"] ?? "unknown",
+      infraMode: process.env["INFRA"] ?? "unknown",
+    },
+    dependencies,
+  };
 
-    logWithTrace("info", "Health check completed", {status: overallStatus, checkDurationMs}, "api");
-
-    const httpStatus = overallStatus === "Healthy" ? 200 : 503;
-    return NextResponse.json(response, {status: httpStatus});
-  });
+  const httpStatus = overallStatus === "Healthy" ? 200 : 503;
+  return NextResponse.json(response, {status: httpStatus});
 }

--- a/sites/arolariu.ro/src/instrumentation.server.ts
+++ b/sites/arolariu.ro/src/instrumentation.server.ts
@@ -132,7 +132,8 @@ export type MetricName =
   | `page.${string}`
   | `component.${string}`
   | `business.${string}`
-  | `website.${string}`;
+  | `website.${string}`
+  | `arolariu.${string}`;
 
 /**
  * Standard semantic attribute keys for HTTP operations.

--- a/sites/arolariu.ro/src/instrumentation.server.ts
+++ b/sites/arolariu.ro/src/instrumentation.server.ts
@@ -51,6 +51,7 @@ import {NodeSDK} from "@opentelemetry/sdk-node";
 // eslint-disable-next-line n/no-extraneous-import -- sdk-logs ships with the pinned OpenTelemetry SDK family used by the website runtime
 import {BatchLogRecordProcessor, LoggerProvider} from "@opentelemetry/sdk-logs";
 import {BatchSpanProcessor} from "@opentelemetry/sdk-trace-node";
+import {parseSuppressionFlag, shouldSuppressTelemetry, SUPPRESSION_ENV_VAR} from "@/lib/telemetry/healthPolicy";
 
 // #endregion
 
@@ -564,6 +565,15 @@ const sdk = new NodeSDK({
       "@opentelemetry/instrumentation-fs": {
         enabled: false,
       },
+      // Inbound: drop spans for the website's own health probe.
+      "@opentelemetry/instrumentation-http": {
+        ignoreIncomingRequestHook: (request) => shouldSuppressTelemetry(request.url),
+      },
+      // Outbound: fetch() in route handlers goes through undici, not http. Without this
+      // hook the /api/health fan-out to api and exp still emits dependency spans.
+      "@opentelemetry/instrumentation-undici": {
+        ignoreRequestHook: (request) => shouldSuppressTelemetry(request.path),
+      },
     }),
   ],
 });
@@ -598,6 +608,9 @@ export function startTelemetry(): void {
   try {
     sdk.start();
     console.log("📊 OpenTelemetry SDK started successfully");
+    console.log(
+      `>>> 🔇 Health telemetry suppression enabled: ${parseSuppressionFlag(process.env[SUPPRESSION_ENV_VAR])}. Override with ${SUPPRESSION_ENV_VAR}.`,
+    );
   } catch (error) {
     console.error("❌ Failed to start OpenTelemetry SDK:", error);
   }

--- a/sites/arolariu.ro/src/lib/telemetry/healthPolicy.test.ts
+++ b/sites/arolariu.ro/src/lib/telemetry/healthPolicy.test.ts
@@ -1,5 +1,5 @@
-import {describe, expect, it} from "vitest";
-import {isSuppressedPath, parseSuppressionFlag, shouldSuppressTelemetry} from "./healthPolicy";
+import {afterEach, describe, expect, it, vi} from "vitest";
+import {SUPPRESSION_ENV_VAR, isSuppressedPath, parseSuppressionFlag, shouldSuppressTelemetry} from "./healthPolicy";
 
 describe("healthPolicy", () => {
   describe("isSuppressedPath", () => {
@@ -33,12 +33,26 @@ describe("healthPolicy", () => {
   });
 
   describe("shouldSuppressTelemetry", () => {
-    it("suppresses a health path when the flag is enabled", () => {
+    afterEach(() => vi.unstubAllEnvs());
+
+    it("suppresses a health path when the env var is unset", () => {
+      vi.stubEnv(SUPPRESSION_ENV_VAR, undefined as unknown as string);
       expect(shouldSuppressTelemetry("/api/health")).toBe(true);
     });
 
-    it("never suppresses a real route", () => {
+    it("never suppresses a real route even when the env var is unset", () => {
+      vi.stubEnv(SUPPRESSION_ENV_VAR, undefined as unknown as string);
       expect(shouldSuppressTelemetry("/api/user")).toBe(false);
+    });
+
+    it("does not suppress a health path when the env var is 'false'", () => {
+      vi.stubEnv(SUPPRESSION_ENV_VAR, "false");
+      expect(shouldSuppressTelemetry("/api/health")).toBe(false);
+    });
+
+    it("suppresses a health path when the env var is an unparseable value (fail-safe)", () => {
+      vi.stubEnv(SUPPRESSION_ENV_VAR, "garbage");
+      expect(shouldSuppressTelemetry("/api/health")).toBe(true);
     });
   });
 });

--- a/sites/arolariu.ro/src/lib/telemetry/healthPolicy.test.ts
+++ b/sites/arolariu.ro/src/lib/telemetry/healthPolicy.test.ts
@@ -25,6 +25,7 @@ describe("healthPolicy", () => {
       ["true", true],
       ["TRUE", true],
       ["not-a-bool", true],
+      ["undefined", true],
       ["false", false],
       ["False", false],
     ])("parses %s as %s", (raw, expected) => {
@@ -36,12 +37,14 @@ describe("healthPolicy", () => {
     afterEach(() => vi.unstubAllEnvs());
 
     it("suppresses a health path when the env var is unset", () => {
-      vi.stubEnv(SUPPRESSION_ENV_VAR, undefined as unknown as string);
+      delete process.env[SUPPRESSION_ENV_VAR];
+      expect(process.env[SUPPRESSION_ENV_VAR]).toBeUndefined();
       expect(shouldSuppressTelemetry("/api/health")).toBe(true);
     });
 
     it("never suppresses a real route even when the env var is unset", () => {
-      vi.stubEnv(SUPPRESSION_ENV_VAR, undefined as unknown as string);
+      delete process.env[SUPPRESSION_ENV_VAR];
+      expect(process.env[SUPPRESSION_ENV_VAR]).toBeUndefined();
       expect(shouldSuppressTelemetry("/api/user")).toBe(false);
     });
 

--- a/sites/arolariu.ro/src/lib/telemetry/healthPolicy.test.ts
+++ b/sites/arolariu.ro/src/lib/telemetry/healthPolicy.test.ts
@@ -1,0 +1,44 @@
+import {describe, expect, it} from "vitest";
+import {isSuppressedPath, parseSuppressionFlag, shouldSuppressTelemetry} from "./healthPolicy";
+
+describe("healthPolicy", () => {
+  describe("isSuppressedPath", () => {
+    it.each(["/health", "/api/health", "/api/ready", "/HEALTH", "/Api/Health", "/health/", "/api/health?x=1"])(
+      "suppresses %s",
+      (path) => {
+        expect(isSuppressedPath(path)).toBe(true);
+      },
+    );
+
+    it.each(["/", "/api/user", "/api/healthy", "/healthcheck-admin", "/health/details", "", undefined])(
+      "does not suppress %s",
+      (path) => {
+        expect(isSuppressedPath(path)).toBe(false);
+      },
+    );
+  });
+
+  describe("parseSuppressionFlag", () => {
+    it.each([
+      [undefined, true],
+      ["", true],
+      ["true", true],
+      ["TRUE", true],
+      ["not-a-bool", true],
+      ["false", false],
+      ["False", false],
+    ])("parses %s as %s", (raw, expected) => {
+      expect(parseSuppressionFlag(raw)).toBe(expected);
+    });
+  });
+
+  describe("shouldSuppressTelemetry", () => {
+    it("suppresses a health path when the flag is enabled", () => {
+      expect(shouldSuppressTelemetry("/api/health")).toBe(true);
+    });
+
+    it("never suppresses a real route", () => {
+      expect(shouldSuppressTelemetry("/api/user")).toBe(false);
+    });
+  });
+});

--- a/sites/arolariu.ro/src/lib/telemetry/healthPolicy.ts
+++ b/sites/arolariu.ro/src/lib/telemetry/healthPolicy.ts
@@ -26,8 +26,14 @@ export function parseSuppressionFlag(rawValue: string | undefined): boolean {
 
 function normalize(path: string): string {
   const queryIndex = path.indexOf("?");
-  const withoutQuery = queryIndex >= 0 ? path.slice(0, queryIndex) : path;
-  return withoutQuery.length > 1 ? withoutQuery.replace(/\/+$/u, "") : withoutQuery;
+  const withoutQuery = queryIndex === -1 ? path : path.slice(0, queryIndex);
+  if (withoutQuery.length <= 1) return withoutQuery;
+
+  // Trailing slashes are trimmed by scanning rather than with /\/+$/u: the quantifier in
+  // that pattern backtracks super-linearly on adversarial input (sonarjs/super-linear-regex).
+  let end = withoutQuery.length;
+  while (end > 0 && withoutQuery[end - 1] === "/") end--;
+  return withoutQuery.slice(0, end);
 }
 
 /**

--- a/sites/arolariu.ro/src/lib/telemetry/healthPolicy.ts
+++ b/sites/arolariu.ro/src/lib/telemetry/healthPolicy.ts
@@ -45,7 +45,10 @@ export function isSuppressedPath(path: string | undefined): boolean {
  * Determines whether telemetry should be suppressed for a path.
  * @param path The request path, with or without a query string.
  * @returns True when telemetry must be suppressed.
- * @remarks Fails open toward emitting: a malformed env var leaves suppression at its default.
+ * @remarks
+ * Fails safe toward suppression: an unset or malformed env var leaves suppression
+ * enabled, so cost control holds even when the environment is misconfigured. Only the
+ * literal `false` re-enables health telemetry.
  */
 export function shouldSuppressTelemetry(path: string | undefined): boolean {
   return parseSuppressionFlag(process.env[SUPPRESSION_ENV_VAR]) && isSuppressedPath(path);

--- a/sites/arolariu.ro/src/lib/telemetry/healthPolicy.ts
+++ b/sites/arolariu.ro/src/lib/telemetry/healthPolicy.ts
@@ -1,0 +1,52 @@
+/**
+ * @fileoverview Health and connectivity telemetry suppression policy.
+ * @module sites/arolariu.ro/src/lib/telemetry/healthPolicy
+ *
+ * @remarks
+ * Sole owner of the suppressed path list for the website. Consumed by the OpenTelemetry
+ * ignore hooks in `instrumentation.server.ts`. Deliberately free of `server-only` so it
+ * remains directly unit-testable.
+ */
+
+/** Paths whose telemetry is suppressed. Matched exactly, never by prefix. */
+export const SUPPRESSED_HEALTH_PATHS: readonly string[] = ["/health", "/api/health", "/api/ready"];
+
+/** Environment variable controlling suppression. Only the literal `false` disables it. */
+export const SUPPRESSION_ENV_VAR = "OTEL_SUPPRESS_HEALTH_TELEMETRY";
+
+/**
+ * Parses the raw suppression environment variable value.
+ * @param rawValue The raw environment variable value, possibly undefined or malformed.
+ * @returns `false` only when the value is exactly `false`, case-insensitively.
+ */
+export function parseSuppressionFlag(rawValue: string | undefined): boolean {
+  if (rawValue === undefined || rawValue.trim() === "") return true;
+  return rawValue.trim().toLowerCase() !== "false";
+}
+
+function normalize(path: string): string {
+  const queryIndex = path.indexOf("?");
+  const withoutQuery = queryIndex >= 0 ? path.slice(0, queryIndex) : path;
+  return withoutQuery.length > 1 ? withoutQuery.replace(/\/+$/u, "") : withoutQuery;
+}
+
+/**
+ * Determines whether a path is one of the suppressed health endpoints.
+ * @param path The request path, with or without a query string.
+ * @returns True when the normalized path matches a suppressed endpoint exactly.
+ */
+export function isSuppressedPath(path: string | undefined): boolean {
+  if (path === undefined || path === "") return false;
+  const normalized = normalize(path).toLowerCase();
+  return SUPPRESSED_HEALTH_PATHS.includes(normalized);
+}
+
+/**
+ * Determines whether telemetry should be suppressed for a path.
+ * @param path The request path, with or without a query string.
+ * @returns True when telemetry must be suppressed.
+ * @remarks Fails open toward emitting: a malformed env var leaves suppression at its default.
+ */
+export function shouldSuppressTelemetry(path: string | undefined): boolean {
+  return parseSuppressionFlag(process.env[SUPPRESSION_ENV_VAR]) && isSuppressedPath(path);
+}

--- a/sites/exp.arolariu.ro/main.py
+++ b/sites/exp.arolariu.ro/main.py
@@ -26,6 +26,7 @@ from telemetry.bootstrap import (
     shutdown_telemetry,
     start_span,
 )
+from telemetry.health_policy import should_suppress_telemetry
 
 logger = logging.getLogger(__name__)
 
@@ -126,17 +127,18 @@ async def attach_request_context(
     )
     trace_context = get_current_trace_context()
 
-    logger.info(
-        "request_id=%s request_id_source=%s trace_id=%s span_id=%s method=%s path=%s status=%s durationMs=%.2f",
-        request_id,
-        request_id_source,
-        trace_context.trace_id if trace_context else "0",
-        trace_context.span_id if trace_context else "0",
-        request.method,
-        request.url.path,
-        response.status_code,
-        elapsed_ms,
-    )
+    if not should_suppress_telemetry(request.url.path):
+        logger.info(
+            "request_id=%s request_id_source=%s trace_id=%s span_id=%s method=%s path=%s status=%s durationMs=%.2f",
+            request_id,
+            request_id_source,
+            trace_context.trace_id if trace_context else "0",
+            trace_context.span_id if trace_context else "0",
+            request.method,
+            request.url.path,
+            response.status_code,
+            elapsed_ms,
+        )
     return response
 
 

--- a/sites/exp.arolariu.ro/main.py
+++ b/sites/exp.arolariu.ro/main.py
@@ -22,11 +22,12 @@ from telemetry.bootstrap import (
     get_current_trace_context,
     initialize_telemetry,
     record_current_span_exception,
+    record_health_failure_metric,
     set_current_span_attributes,
     shutdown_telemetry,
     start_span,
 )
-from telemetry.health_policy import should_suppress_telemetry
+from telemetry.health_policy import is_suppressed_path, should_suppress_telemetry
 
 logger = logging.getLogger(__name__)
 
@@ -126,6 +127,9 @@ async def attach_request_context(
         }
     )
     trace_context = get_current_trace_context()
+
+    if is_suppressed_path(request.url.path) and response.status_code >= 500:
+        record_health_failure_metric(check="config")
 
     if not should_suppress_telemetry(request.url.path):
         logger.info(

--- a/sites/exp.arolariu.ro/main.test.py
+++ b/sites/exp.arolariu.ro/main.test.py
@@ -133,3 +133,46 @@ class TestRequestCorrelation:
 
         assert response.status_code == 200
         assert response.headers.get("X-Request-Id") == upstream_request_id
+
+
+class TestHealthFailureCounterMiddleware:
+    """The failure counter must fire on a real readiness failure, and only then."""
+
+    def test_records_counter_on_readiness_failure(self, client: TestClient) -> None:
+        """A 503 from /api/ready must record exactly one check=config measurement."""
+
+        with patch("main.record_health_failure_metric") as recorder, patch(
+            "api.health.get_config", side_effect=RuntimeError("config unavailable")
+        ):
+            response = client.get("/api/ready")
+
+        assert response.status_code == 503
+        recorder.assert_called_once_with(check="config")
+
+    def test_records_nothing_when_readiness_succeeds(self, client: TestClient) -> None:
+        """A healthy readiness probe must not touch the counter."""
+
+        with patch("main.record_health_failure_metric") as recorder:
+            response = client.get("/api/ready")
+
+        assert response.status_code == 200
+        recorder.assert_not_called()
+
+    def test_records_nothing_for_liveness(self, client: TestClient) -> None:
+        """/api/health is pure liveness and always 200, so it has no failure state."""
+
+        with patch("main.record_health_failure_metric") as recorder:
+            response = client.get("/api/health")
+
+        assert response.status_code == 200
+        recorder.assert_not_called()
+
+    def test_records_nothing_for_non_health_route(self, client: TestClient) -> None:
+        """A 5xx on a normal route must not be attributed to the health counter."""
+
+        with patch("main.record_health_failure_metric") as recorder, patch(
+            "api.config.get_config", side_effect=RuntimeError("boom")
+        ):
+            client.get("/api/v1/config")
+
+        recorder.assert_not_called()

--- a/sites/exp.arolariu.ro/telemetry/bootstrap.py
+++ b/sites/exp.arolariu.ro/telemetry/bootstrap.py
@@ -12,6 +12,11 @@ from typing import Any
 
 from fastapi import FastAPI
 
+from telemetry.health_policy import (
+    SUPPRESSED_HEALTH_PATHS,
+    SUPPRESSION_ENV_VAR,
+    parse_suppression_flag,
+)
 from telemetry.settings import TelemetrySettings, get_telemetry_settings
 
 logger = logging.getLogger(__name__)
@@ -83,6 +88,7 @@ _config_load_duration_histogram: Any = None
 _auth_decision_counter: Any = None
 _config_delivery_counter: Any = None
 _config_values_counter: Any = None
+_health_failure_counter: Any = None
 
 
 class SafeOtelFormatter(logging.Formatter):
@@ -380,6 +386,7 @@ def _configure_custom_metrics(runtime: TelemetryRuntime) -> None:
     global _auth_decision_counter
     global _config_delivery_counter
     global _config_values_counter
+    global _health_failure_counter
 
     if runtime.meter_provider is None or runtime.dependencies is None:
         return
@@ -409,6 +416,11 @@ def _configure_custom_metrics(runtime: TelemetryRuntime) -> None:
         "exp.config.values_served",
         unit="value",
         description="Number of config values returned by successful config responses.",
+    )
+    _health_failure_counter = meter.create_counter(
+        "arolariu.health.check.failures",
+        unit="{failure}",
+        description="Health check failures, dimensioned by the failing check name.",
     )
 
     meter.create_observable_gauge(
@@ -631,6 +643,12 @@ def initialize_telemetry(app: FastAPI) -> TelemetryRuntime:
             settings.console_log_export_enabled,
             settings.azure_export_enabled,
         )
+        logging.getLogger(__name__).info(
+            "health telemetry suppression enabled=%s paths=%s override=%s",
+            parse_suppression_flag(os.environ.get(SUPPRESSION_ENV_VAR)),
+            ",".join(SUPPRESSED_HEALTH_PATHS),
+            SUPPRESSION_ENV_VAR,
+        )
 
         _telemetry_runtime = runtime
         return runtime
@@ -660,6 +678,7 @@ def shutdown_telemetry() -> None:
     global _auth_decision_counter
     global _config_delivery_counter
     global _config_values_counter
+    global _health_failure_counter
 
     with _runtime_lock:
         runtime = _telemetry_runtime
@@ -669,6 +688,7 @@ def shutdown_telemetry() -> None:
         _auth_decision_counter = None
         _config_delivery_counter = None
         _config_values_counter = None
+        _health_failure_counter = None
 
     if runtime is None or not runtime.initialized:
         return
@@ -699,6 +719,7 @@ def reset_telemetry_state() -> None:
     global _auth_decision_counter
     global _config_delivery_counter
     global _config_values_counter
+    global _health_failure_counter
 
     with _runtime_lock:
         _telemetry_runtime = None
@@ -707,6 +728,7 @@ def reset_telemetry_state() -> None:
         _auth_decision_counter = None
         _config_delivery_counter = None
         _config_values_counter = None
+        _health_failure_counter = None
 
 
 def _set_span_attributes(span: Any, attributes: AttributeMap | None) -> None:
@@ -871,3 +893,18 @@ def record_config_delivery_metric(
 
     if _config_values_counter is not None:
         _config_values_counter.add(value_count, attributes)
+
+
+def record_health_failure_metric(*, check: str) -> None:
+    """Record one health or readiness check failure.
+
+    This is the single always-on signal that survives health telemetry suppression; its
+    volume is effectively zero until a dependency actually fails.
+    """
+
+    runtime = _telemetry_runtime
+    if runtime is None:
+        return
+
+    if _health_failure_counter is not None:
+        _health_failure_counter.add(1, _get_metric_attributes({"check": check}))

--- a/sites/exp.arolariu.ro/telemetry/bootstrap.py
+++ b/sites/exp.arolariu.ro/telemetry/bootstrap.py
@@ -573,11 +573,17 @@ def _instrument_fastapi_app(runtime: TelemetryRuntime, app: FastAPI) -> None:
     if getattr(app.state, "exp_otel_instrumented", False):
         return
 
+    # Exclusions are dropped entirely when the operator disables suppression, so
+    # OTEL_SUPPRESS_HEALTH_TELEMETRY=false restores traces and HTTP metrics for probe
+    # endpoints as documented -- not just the request logs guarded in main.
+    suppression_enabled = parse_suppression_flag(os.environ.get(SUPPRESSION_ENV_VAR))
+    excluded_urls = runtime.settings.excluded_urls if suppression_enabled else ""
+
     runtime.dependencies.FastAPIInstrumentor.instrument_app(
         app,
         tracer_provider=runtime.tracer_provider,
         meter_provider=runtime.meter_provider,
-        excluded_urls=runtime.settings.excluded_urls,
+        excluded_urls=excluded_urls,
         server_request_hook=_server_request_hook,
         client_response_hook=_client_response_hook,
         exclude_spans=["receive", "send"],

--- a/sites/exp.arolariu.ro/telemetry/bootstrap.py
+++ b/sites/exp.arolariu.ro/telemetry/bootstrap.py
@@ -15,6 +15,7 @@ from fastapi import FastAPI
 from telemetry.health_policy import (
     SUPPRESSED_HEALTH_PATHS,
     SUPPRESSION_ENV_VAR,
+    build_excluded_urls,
     parse_suppression_flag,
 )
 from telemetry.settings import TelemetrySettings, get_telemetry_settings
@@ -573,11 +574,16 @@ def _instrument_fastapi_app(runtime: TelemetryRuntime, app: FastAPI) -> None:
     if getattr(app.state, "exp_otel_instrumented", False):
         return
 
-    # Exclusions are dropped entirely when the operator disables suppression, so
+    # Only the health-derived defaults answer to the suppression flag, so
     # OTEL_SUPPRESS_HEALTH_TELEMETRY=false restores traces and HTTP metrics for probe
     # endpoints as documented -- not just the request logs guarded in main.
-    suppression_enabled = parse_suppression_flag(os.environ.get(SUPPRESSION_ENV_VAR))
-    excluded_urls = runtime.settings.excluded_urls if suppression_enabled else ""
+    #
+    # An operator who set EXP_OTEL_EXCLUDED_URLS explicitly gets that list honoured verbatim:
+    # it is a general-purpose exclusion knob, and a flag about *health* telemetry has no
+    # business silently discarding unrelated exclusions.
+    excluded_urls = runtime.settings.excluded_urls
+    if not parse_suppression_flag(os.environ.get(SUPPRESSION_ENV_VAR)) and excluded_urls == build_excluded_urls():
+        excluded_urls = ""
 
     runtime.dependencies.FastAPIInstrumentor.instrument_app(
         app,

--- a/sites/exp.arolariu.ro/telemetry/bootstrap.test.py
+++ b/sites/exp.arolariu.ro/telemetry/bootstrap.test.py
@@ -312,9 +312,46 @@ class TestTelemetryBootstrap:
         finally:
             shutdown_telemetry()
 
+    def test_override_drops_health_exclusions(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """OTEL_SUPPRESS_HEALTH_TELEMETRY=false must restore probe traces, not just logs.
+
+        Guards the wiring, not just the predicate: the flag has to actually reach
+        FastAPIInstrumentor, otherwise disabling suppression silently leaves traces off.
+        """
+
+        dependencies = _build_fake_dependencies()
+        monkeypatch.setenv("EXP_OTEL_ENABLED", "true")
+        monkeypatch.setenv("INFRA", "local")
+        monkeypatch.setenv("OTEL_SUPPRESS_HEALTH_TELEMETRY", "false")
+        monkeypatch.delenv("EXP_OTEL_EXCLUDED_URLS", raising=False)
+        monkeypatch.setattr("telemetry.bootstrap._import_telemetry_dependencies", lambda: dependencies)
+
+        app = FastAPI()
+        initialize_telemetry(app)
+        try:
+            assert dependencies.FastAPIInstrumentor.instrument_calls[0]["excluded_urls"] == ""
+        finally:
+            shutdown_telemetry()
+
+    def test_override_preserves_operator_supplied_exclusions(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A health flag must not silently discard an unrelated, explicitly-set exclusion list."""
+
+        dependencies = _build_fake_dependencies()
+        monkeypatch.setenv("EXP_OTEL_ENABLED", "true")
+        monkeypatch.setenv("INFRA", "local")
+        monkeypatch.setenv("OTEL_SUPPRESS_HEALTH_TELEMETRY", "false")
+        monkeypatch.setenv("EXP_OTEL_EXCLUDED_URLS", "/internal/debug")
+        monkeypatch.setattr("telemetry.bootstrap._import_telemetry_dependencies", lambda: dependencies)
+
+        app = FastAPI()
+        initialize_telemetry(app)
+        try:
+            assert dependencies.FastAPIInstrumentor.instrument_calls[0]["excluded_urls"] == "/internal/debug"
+        finally:
+            shutdown_telemetry()
+
     def test_initializes_azure_monitor_exporters(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
+        self,        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         dependencies = _build_fake_dependencies()
         monkeypatch.setenv("EXP_OTEL_ENABLED", "true")

--- a/sites/exp.arolariu.ro/telemetry/bootstrap.test.py
+++ b/sites/exp.arolariu.ro/telemetry/bootstrap.test.py
@@ -10,6 +10,7 @@ import pytest
 from fastapi import FastAPI
 
 from telemetry.bootstrap import TelemetryDependencies, initialize_telemetry, shutdown_telemetry
+from telemetry.health_policy import build_excluded_urls
 
 
 def _build_fake_dependencies() -> TelemetryDependencies:
@@ -306,7 +307,7 @@ class TestTelemetryBootstrap:
             assert len(runtime.meter_provider.metric_readers) == 1
             assert isinstance(runtime.meter_provider.metric_readers[0].exporter, dependencies.ConsoleMetricExporter)
             assert len(dependencies.FastAPIInstrumentor.instrument_calls) == 1
-            expected_excluded = "/api/health,/api/ready"
+            expected_excluded = build_excluded_urls()
             assert dependencies.FastAPIInstrumentor.instrument_calls[0]["excluded_urls"] == expected_excluded
         finally:
             shutdown_telemetry()

--- a/sites/exp.arolariu.ro/telemetry/bootstrap.test.py
+++ b/sites/exp.arolariu.ro/telemetry/bootstrap.test.py
@@ -306,7 +306,7 @@ class TestTelemetryBootstrap:
             assert len(runtime.meter_provider.metric_readers) == 1
             assert isinstance(runtime.meter_provider.metric_readers[0].exporter, dependencies.ConsoleMetricExporter)
             assert len(dependencies.FastAPIInstrumentor.instrument_calls) == 1
-            expected_excluded = "/api/health,/api/ready,/admin"
+            expected_excluded = "/api/health,/api/ready"
             assert dependencies.FastAPIInstrumentor.instrument_calls[0]["excluded_urls"] == expected_excluded
         finally:
             shutdown_telemetry()

--- a/sites/exp.arolariu.ro/telemetry/bootstrap.test.py
+++ b/sites/exp.arolariu.ro/telemetry/bootstrap.test.py
@@ -351,7 +351,8 @@ class TestTelemetryBootstrap:
             shutdown_telemetry()
 
     def test_initializes_azure_monitor_exporters(
-        self,        monkeypatch: pytest.MonkeyPatch,
+        self,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         dependencies = _build_fake_dependencies()
         monkeypatch.setenv("EXP_OTEL_ENABLED", "true")

--- a/sites/exp.arolariu.ro/telemetry/bootstrap.test.py
+++ b/sites/exp.arolariu.ro/telemetry/bootstrap.test.py
@@ -347,3 +347,14 @@ class TestTelemetryBootstrap:
             assert log_exporter.kwargs["disable_offline_storage"] is True
         finally:
             shutdown_telemetry()
+
+
+class TestHealthFailureMetric:
+    """Behaviour of the health failure counter."""
+
+    def test_record_health_failure_metric_is_safe_without_runtime(self) -> None:
+        from telemetry.bootstrap import record_health_failure_metric, reset_telemetry_state
+
+        reset_telemetry_state()
+
+        record_health_failure_metric(check="config")

--- a/sites/exp.arolariu.ro/telemetry/health_policy.py
+++ b/sites/exp.arolariu.ro/telemetry/health_policy.py
@@ -65,9 +65,18 @@ def build_excluded_urls() -> str:
     would also swallow ``/api/healthy`` and ``/api/health/extra``. That contradicts the
     exact-match policy implemented by :func:`is_suppressed_path`.
 
-    Each path is therefore emitted as an anchored, case-insensitive expression tolerating an
-    optional trailing slash and an optional query string, so trace and HTTP-metric exclusion
-    matches :func:`is_suppressed_path` exactly.
+    The ASGI instrumentation matches against the **full request URL** — it calls
+    ``url_disabled`` with the output of ``get_host_port_url_tuple``, e.g.
+    ``http://exp/api/health`` — so a pattern anchored directly to the path would never
+    match in production. Each entry therefore allows an optional ``scheme://host`` prefix
+    before the path.
+
+    Each path is emitted as an anchored, case-insensitive expression tolerating that
+    optional origin, an optional trailing slash, and an optional query string, so trace and
+    HTTP-metric exclusion matches :func:`is_suppressed_path` exactly.
     """
 
-    return ",".join(f"(?i:^{re.escape(path)}/?(\\?.*)?$)" for path in SUPPRESSED_HEALTH_PATHS)
+    return ",".join(
+        f"(?i:^(?:[a-z][a-z0-9+.\\-]*://[^/]*)?{re.escape(path)}/?(\\?.*)?$)"
+        for path in SUPPRESSED_HEALTH_PATHS
+    )

--- a/sites/exp.arolariu.ro/telemetry/health_policy.py
+++ b/sites/exp.arolariu.ro/telemetry/health_policy.py
@@ -1,0 +1,54 @@
+"""Health and connectivity telemetry suppression policy for the exp service.
+
+Sole owner of the suppressed path list. Consumed by the request middleware in ``main``
+to keep probe traffic out of exported logs. Traces are excluded separately via
+``TelemetrySettings.excluded_urls``.
+"""
+
+import os
+
+SUPPRESSED_HEALTH_PATHS: tuple[str, ...] = ("/health", "/api/health", "/api/ready")
+
+SUPPRESSION_ENV_VAR: str = "OTEL_SUPPRESS_HEALTH_TELEMETRY"
+
+
+def _normalize(path: str) -> str:
+    """Strip the query string and any trailing slash from a request path."""
+
+    without_query = path.split("?", 1)[0]
+    return without_query.rstrip("/") if len(without_query) > 1 else without_query
+
+
+def parse_suppression_flag(raw_value: str | None) -> bool:
+    """Return whether suppression is enabled for the supplied raw environment value.
+
+    Unset and unparseable values resolve to the safe default of enabled suppression;
+    only the literal string ``false`` disables it.
+    """
+
+    if raw_value is None or not raw_value.strip():
+        return True
+
+    return raw_value.strip().lower() != "false"
+
+
+def is_suppressed_path(path: str | None) -> bool:
+    """Return whether ``path`` is one of the suppressed health endpoints.
+
+    Matching is exact on the normalized path and case-insensitive. Prefix matching is
+    deliberately avoided so that paths such as ``/healthcheck-admin`` are not swallowed.
+    """
+
+    if not path:
+        return False
+
+    return _normalize(path).lower() in SUPPRESSED_HEALTH_PATHS
+
+
+def should_suppress_telemetry(path: str | None) -> bool:
+    """Return whether telemetry must be suppressed for ``path``.
+
+    Fails open toward emitting: a malformed override leaves suppression at its default.
+    """
+
+    return parse_suppression_flag(os.environ.get(SUPPRESSION_ENV_VAR)) and is_suppressed_path(path)

--- a/sites/exp.arolariu.ro/telemetry/health_policy.py
+++ b/sites/exp.arolariu.ro/telemetry/health_policy.py
@@ -1,11 +1,12 @@
 """Health and connectivity telemetry suppression policy for the exp service.
 
 Sole owner of the suppressed path list. Consumed by the request middleware in ``main``
-to keep probe traffic out of exported logs. Traces are excluded separately via
-``TelemetrySettings.excluded_urls``.
+to keep probe traffic out of exported logs, and by ``TelemetrySettings`` to build the
+trace/HTTP-metric exclusion patterns handed to ``FastAPIInstrumentor``.
 """
 
 import os
+import re
 
 SUPPRESSED_HEALTH_PATHS: tuple[str, ...] = ("/health", "/api/health", "/api/ready")
 
@@ -52,3 +53,19 @@ def should_suppress_telemetry(path: str | None) -> bool:
     """
 
     return parse_suppression_flag(os.environ.get(SUPPRESSION_ENV_VAR)) and is_suppressed_path(path)
+
+
+def build_excluded_urls() -> str:
+    """Return the comma-separated exclusion patterns for ``FastAPIInstrumentor``.
+
+    OpenTelemetry's ``ExcludeList`` joins the supplied entries with ``|`` and applies
+    ``re.search``, so a bare path such as ``/api/health`` is an **unanchored** regex that
+    would also swallow ``/api/healthy`` and ``/api/health/extra``. That contradicts the
+    exact-match policy implemented by :func:`is_suppressed_path`.
+
+    Each path is therefore emitted as an anchored, case-insensitive expression tolerating an
+    optional trailing slash and an optional query string, so trace and HTTP-metric exclusion
+    matches :func:`is_suppressed_path` exactly.
+    """
+
+    return ",".join(f"(?i:^{re.escape(path)}/?(\\?.*)?$)" for path in SUPPRESSED_HEALTH_PATHS)

--- a/sites/exp.arolariu.ro/telemetry/health_policy.py
+++ b/sites/exp.arolariu.ro/telemetry/health_policy.py
@@ -49,7 +49,9 @@ def is_suppressed_path(path: str | None) -> bool:
 def should_suppress_telemetry(path: str | None) -> bool:
     """Return whether telemetry must be suppressed for ``path``.
 
-    Fails open toward emitting: a malformed override leaves suppression at its default.
+    Fails safe toward suppression: an unset or malformed override leaves suppression
+    enabled, so cost control holds even when the environment is misconfigured. Only the
+    literal string ``false`` re-enables health telemetry.
     """
 
     return parse_suppression_flag(os.environ.get(SUPPRESSION_ENV_VAR)) and is_suppressed_path(path)

--- a/sites/exp.arolariu.ro/telemetry/health_policy.test.py
+++ b/sites/exp.arolariu.ro/telemetry/health_policy.test.py
@@ -107,3 +107,44 @@ class TestBuildExcludedUrls:
             "/",
         ]:
             assert exclude_list.url_disabled(path) is is_suppressed_path(path), path
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://exp/health",
+            "http://exp/api/health",
+            "http://exp:8080/api/health",
+            "https://exp.arolariu.ro/api/health",
+            "http://exp/api/health?probe=1",
+            "http://exp/api/health/",
+            "https://exp.arolariu.ro/api/ready",
+        ],
+    )
+    def test_excludes_full_request_urls(self, url: str) -> None:
+        """Regression: the ASGI instrumentation matches the full URL, not the bare path.
+
+        ``OpenTelemetryMiddleware`` calls ``url_disabled`` with the output of
+        ``get_host_port_url_tuple``, e.g. ``http://exp/api/health``. Patterns anchored
+        directly to the path silently never matched in production, so probe traces and
+        HTTP metrics were still exported despite the exclusion list being configured.
+        """
+
+        from opentelemetry.util.http import parse_excluded_urls
+
+        assert parse_excluded_urls(build_excluded_urls()).url_disabled(url) is True
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://exp/api/healthy",
+            "http://exp/api/health/extra",
+            "http://exp/healthcheck-admin",
+            "https://exp.arolariu.ro/api/v1/config",
+        ],
+    )
+    def test_does_not_exclude_full_url_near_misses(self, url: str) -> None:
+        """Tolerating an origin prefix must not loosen the exact-match policy."""
+
+        from opentelemetry.util.http import parse_excluded_urls
+
+        assert parse_excluded_urls(build_excluded_urls()).url_disabled(url) is False

--- a/sites/exp.arolariu.ro/telemetry/health_policy.test.py
+++ b/sites/exp.arolariu.ro/telemetry/health_policy.test.py
@@ -1,0 +1,66 @@
+"""Tests for the health telemetry suppression policy."""
+
+import pytest
+
+from telemetry.health_policy import (
+    is_suppressed_path,
+    parse_suppression_flag,
+    should_suppress_telemetry,
+)
+
+
+class TestIsSuppressedPath:
+    """Behaviour of the suppressed-path predicate."""
+
+    @pytest.mark.parametrize(
+        "path",
+        ["/health", "/api/health", "/api/ready", "/HEALTH", "/Api/Health", "/health/", "/api/ready?x=1"],
+    )
+    def test_returns_true_for_health_paths(self, path: str) -> None:
+        assert is_suppressed_path(path) is True
+
+    @pytest.mark.parametrize(
+        "path",
+        ["/", "/admin", "/api/v1/config", "/api/healthy", "/healthcheck-admin", "", None],
+    )
+    def test_returns_false_for_other_paths(self, path: str | None) -> None:
+        assert is_suppressed_path(path) is False
+
+
+class TestParseSuppressionFlag:
+    """Behaviour of the environment variable parser."""
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            (None, True),
+            ("", True),
+            ("   ", True),
+            ("true", True),
+            ("TRUE", True),
+            ("not-a-bool", True),
+            ("false", False),
+            ("False", False),
+        ],
+    )
+    def test_parses_value(self, raw: str | None, expected: bool) -> None:
+        assert parse_suppression_flag(raw) is expected
+
+
+class TestShouldSuppressTelemetry:
+    """Combined path and environment gate."""
+
+    def test_suppresses_health_path_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("OTEL_SUPPRESS_HEALTH_TELEMETRY", raising=False)
+
+        assert should_suppress_telemetry("/api/health") is True
+
+    def test_never_suppresses_real_route(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("OTEL_SUPPRESS_HEALTH_TELEMETRY", raising=False)
+
+        assert should_suppress_telemetry("/api/v1/config") is False
+
+    def test_override_restores_health_telemetry(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OTEL_SUPPRESS_HEALTH_TELEMETRY", "false")
+
+        assert should_suppress_telemetry("/api/health") is False

--- a/sites/exp.arolariu.ro/telemetry/health_policy.test.py
+++ b/sites/exp.arolariu.ro/telemetry/health_policy.test.py
@@ -3,6 +3,7 @@
 import pytest
 
 from telemetry.health_policy import (
+    build_excluded_urls,
     is_suppressed_path,
     parse_suppression_flag,
     should_suppress_telemetry,
@@ -64,3 +65,45 @@ class TestShouldSuppressTelemetry:
         monkeypatch.setenv("OTEL_SUPPRESS_HEALTH_TELEMETRY", "false")
 
         assert should_suppress_telemetry("/api/health") is False
+
+class TestBuildExcludedUrls:
+    """Exclusion patterns handed to FastAPIInstrumentor must match is_suppressed_path exactly."""
+
+    @pytest.mark.parametrize(
+        "path",
+        ["/health", "/health/", "/HEALTH", "/api/health", "/api/health?x=1", "/api/health/?x=1", "/api/ready"],
+    )
+    def test_excludes_every_suppressed_path(self, path: str) -> None:
+        from opentelemetry.util.http import parse_excluded_urls
+
+        assert parse_excluded_urls(build_excluded_urls()).url_disabled(path) is True
+
+    @pytest.mark.parametrize(
+        "path",
+        ["/api/healthy", "/api/health/extra", "/healthcheck-admin", "/api/v1/config", "/admin", "/"],
+    )
+    def test_does_not_exclude_near_misses(self, path: str) -> None:
+        """Regression: bare paths are unanchored regexes and would swallow these."""
+
+        from opentelemetry.util.http import parse_excluded_urls
+
+        assert parse_excluded_urls(build_excluded_urls()).url_disabled(path) is False
+
+    def test_agrees_with_is_suppressed_path(self) -> None:
+        """The regex and the predicate are two encodings of one policy; they must not drift."""
+
+        from opentelemetry.util.http import parse_excluded_urls
+
+        exclude_list = parse_excluded_urls(build_excluded_urls())
+        for path in [
+            "/health",
+            "/api/health",
+            "/api/ready",
+            "/api/healthy",
+            "/api/health/extra",
+            "/healthcheck-admin",
+            "/admin",
+            "/api/v1/config",
+            "/",
+        ]:
+            assert exclude_list.url_disabled(path) is is_suppressed_path(path), path

--- a/sites/exp.arolariu.ro/telemetry/settings.py
+++ b/sites/exp.arolariu.ro/telemetry/settings.py
@@ -23,7 +23,7 @@ DEFAULT_TRACE_SAMPLE_RATIO = 1.0
 DEFAULT_LOG_LEVEL = "INFO"
 DEFAULT_SERVICE_NAME = "exp.arolariu.ro"
 DEFAULT_SERVICE_NAMESPACE = "arolariu.ro"
-DEFAULT_EXCLUDED_URLS = "/api/health,/api/ready,/admin"
+DEFAULT_EXCLUDED_URLS = "/api/health,/api/ready"
 
 
 @dataclass(frozen=True, slots=True)

--- a/sites/exp.arolariu.ro/telemetry/settings.py
+++ b/sites/exp.arolariu.ro/telemetry/settings.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from config.settings import get_runtime_infra_mode
+from telemetry.health_policy import build_excluded_urls
 
 DEFAULT_TELEMETRY_ENABLED = True
 DEFAULT_CONSOLE_LOG_EXPORT_ENABLED = False
@@ -23,7 +24,7 @@ DEFAULT_TRACE_SAMPLE_RATIO = 1.0
 DEFAULT_LOG_LEVEL = "INFO"
 DEFAULT_SERVICE_NAME = "exp.arolariu.ro"
 DEFAULT_SERVICE_NAMESPACE = "arolariu.ro"
-DEFAULT_EXCLUDED_URLS = "/api/health,/api/ready"
+DEFAULT_EXCLUDED_URLS = build_excluded_urls()
 
 
 @dataclass(frozen=True, slots=True)

--- a/sites/exp.arolariu.ro/telemetry/settings.test.py
+++ b/sites/exp.arolariu.ro/telemetry/settings.test.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import pytest
+from opentelemetry.util.http import parse_excluded_urls
 
+from telemetry.health_policy import build_excluded_urls
 from telemetry.settings import get_telemetry_settings
 
 
@@ -22,7 +24,7 @@ class TestTelemetrySettings:
         assert settings.console_metric_export_enabled is True
         assert settings.console_log_export_enabled is False
         assert settings.azure_export_enabled is False
-        assert settings.excluded_urls == "/api/health,/api/ready"
+        assert settings.excluded_urls == build_excluded_urls()
         assert settings.service_version == "3.0.0"
 
     def test_resolves_azure_export_when_connection_string_is_present(
@@ -55,12 +57,19 @@ class TestTelemetrySettings:
         assert settings.log_level_name == "DEBUG"
 
     def test_excluded_urls_cover_health_paths_only(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Assert on matching behaviour rather than the literal pattern string.
+
+        The value is a set of anchored regexes, not bare paths, because OpenTelemetry applies
+        ``re.search`` to these entries. See ``build_excluded_urls``.
+        """
+
         monkeypatch.delenv("EXP_OTEL_EXCLUDED_URLS", raising=False)
 
         settings = get_telemetry_settings()
+        exclude_list = parse_excluded_urls(settings.excluded_urls)
 
-        excluded = [entry.strip() for entry in settings.excluded_urls.split(",")]
-
-        assert "/api/health" in excluded
-        assert "/api/ready" in excluded
-        assert "/admin" not in excluded
+        assert exclude_list.url_disabled("/api/health") is True
+        assert exclude_list.url_disabled("/api/ready") is True
+        assert exclude_list.url_disabled("/health") is True
+        assert exclude_list.url_disabled("/admin") is False
+        assert exclude_list.url_disabled("/api/healthy") is False

--- a/sites/exp.arolariu.ro/telemetry/settings.test.py
+++ b/sites/exp.arolariu.ro/telemetry/settings.test.py
@@ -22,7 +22,7 @@ class TestTelemetrySettings:
         assert settings.console_metric_export_enabled is True
         assert settings.console_log_export_enabled is False
         assert settings.azure_export_enabled is False
-        assert settings.excluded_urls == "/api/health,/api/ready,/admin"
+        assert settings.excluded_urls == "/api/health,/api/ready"
         assert settings.service_version == "3.0.0"
 
     def test_resolves_azure_export_when_connection_string_is_present(
@@ -53,3 +53,14 @@ class TestTelemetrySettings:
         assert settings.metric_export_interval_millis == 15_000
         assert settings.trace_sample_ratio == 0.25
         assert settings.log_level_name == "DEBUG"
+
+    def test_excluded_urls_cover_health_paths_only(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("EXP_OTEL_EXCLUDED_URLS", raising=False)
+
+        settings = get_telemetry_settings()
+
+        excluded = [entry.strip() for entry in settings.excluded_urls.split(",")]
+
+        assert "/api/health" in excluded
+        assert "/api/ready" in excluded
+        assert "/admin" not in excluded

--- a/tooling/AppHost.Tests/AppHost.Tests.csproj
+++ b/tooling/AppHost.Tests/AppHost.Tests.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.3.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.3.3" />
     <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tooling/AppHost.Tests/ExpConfigGeneratorTests.cs
+++ b/tooling/AppHost.Tests/ExpConfigGeneratorTests.cs
@@ -2,14 +2,15 @@ namespace AppHost.Tests;
 
 using System.Text.Json;
 using AppHost.Aspire;
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 /// <summary>
 /// Unit tests for <see cref="ExpConfigGenerator.GenerateAspireConfig"/>.
 /// </summary>
+[TestClass]
 public sealed class ExpConfigGeneratorTests
 {
-  [Fact]
+  [TestMethod]
   public void GenerateAspireConfig_KeyPresentInOverrides_UpdatesKeyAndPreservesUnrelatedTopLevelKeys()
   {
     var sourcePath = Path.GetTempFileName();
@@ -29,10 +30,10 @@ public sealed class ExpConfigGeneratorTests
       using var doc = JsonDocument.Parse(File.ReadAllText(targetPath));
       var root = doc.RootElement;
 
-      Assert.Equal("localhost:1433", root.GetProperty("DbConnection").GetString());
-      Assert.True(root.GetProperty("FeatureFlag").GetBoolean());
-      Assert.Equal(3, root.GetProperty("RetryCount").GetInt32());
-      Assert.False(root.TryGetProperty("UnknownKey", out _));
+      Assert.AreEqual("localhost:1433", root.GetProperty("DbConnection").GetString());
+      Assert.IsTrue(root.GetProperty("FeatureFlag").GetBoolean());
+      Assert.AreEqual(3, root.GetProperty("RetryCount").GetInt32());
+      Assert.IsFalse(root.TryGetProperty("UnknownKey", out _));
     }
     finally
     {
@@ -41,7 +42,7 @@ public sealed class ExpConfigGeneratorTests
     }
   }
 
-  [Fact]
+  [TestMethod]
   public void GenerateAspireConfig_CalledTwiceWithSameInputs_ProducesIdenticalFileContent()
   {
     var sourcePath = Path.GetTempFileName();
@@ -57,7 +58,7 @@ public sealed class ExpConfigGeneratorTests
       ExpConfigGenerator.GenerateAspireConfig(sourcePath, targetPath, overrides);
       var second = File.ReadAllText(targetPath);
 
-      Assert.Equal(first, second);
+      Assert.AreEqual(first, second);
     }
     finally
     {
@@ -66,7 +67,7 @@ public sealed class ExpConfigGeneratorTests
     }
   }
 
-  [Fact]
+  [TestMethod]
   public void GenerateAspireConfig_SourceMissing_Throws()
   {
     var missing = Path.Combine(Path.GetTempPath(), $"does-not-exist-{Guid.NewGuid():N}.json");
@@ -74,7 +75,7 @@ public sealed class ExpConfigGeneratorTests
 
     try
     {
-      var ex = Assert.Throws<InvalidOperationException>(() =>
+      var ex = Assert.ThrowsExactly<InvalidOperationException>(() =>
           ExpConfigGenerator.GenerateAspireConfig(
               missing, targetPath, new Dictionary<string, string>()));
       Assert.Contains("config.docker.json", ex.Message, StringComparison.Ordinal);
@@ -85,7 +86,7 @@ public sealed class ExpConfigGeneratorTests
     }
   }
 
-  [Fact]
+  [TestMethod]
   public void GenerateAspireConfig_SourceNotJsonObject_Throws()
   {
     var sourcePath = Path.GetTempFileName();
@@ -94,7 +95,7 @@ public sealed class ExpConfigGeneratorTests
 
     try
     {
-      Assert.Throws<InvalidOperationException>(() =>
+      Assert.ThrowsExactly<InvalidOperationException>(() =>
           ExpConfigGenerator.GenerateAspireConfig(
               sourcePath, targetPath, new Dictionary<string, string>()));
     }


### PR DESCRIPTION
## Summary

Release PR from `preview` into `main`. It carries **two independent bodies of work** plus the fixes made in response to review on this PR.

---

## 1. Health and connectivity telemetry suppression

**Motivation: cost.** Health and readiness probes dominate request volume while carrying almost no diagnostic value. This change stops exporting telemetry for them across all three services.

**Behaviour**

- Suppressed paths — `/health`, `/api/health`, `/api/ready` — are matched **exactly** on the normalized path (query string and trailing slash stripped, case-insensitive). Prefix matching is deliberately avoided so `/healthcheck-admin` and `/api/healthy` are *not* swallowed.
- Each service owns the path list in exactly one place: `HealthTelemetryPolicy.cs` (.NET), `healthPolicy.ts` (website), `health_policy.py` (exp).
- On the Python side the paths are additionally emitted as anchored regexes for `FastAPIInstrumentor`, because OpenTelemetry's `ExcludeList` applies `re.search` — a bare `/api/health` would otherwise be an unanchored pattern that also matched `/api/healthy`.

**Operational contract — read this before changing the environment**

`OTEL_SUPPRESS_HEALTH_TELEMETRY` controls suppression, and it **fails safe toward suppression**: unset, blank, and unparseable values all leave suppression *enabled*. Only the literal string `false` re-enables health telemetry. Cost control therefore holds even when the environment is misconfigured, which is the opposite of a fail-open default — the docs in all three services previously claimed the reverse and have been corrected in this PR.

**What survives suppression**

One always-on instrument: the `arolariu.health.check.failures` counter, dimensioned by check name. With routine health telemetry off, this is the only remaining outage signal, so all three services now count consistently:

| Service | Counts |
|---|---|
| .NET | every check whose status is not `Healthy` |
| exp (Python) | every health response with status ≥ 500 |
| website | every dependency whose status is not `Healthy` — **fixed in this PR**, it previously counted only `Unhealthy` and stayed silent on `Degraded` |

**Operational implication:** the website's `/api/health` returns 503 for a `Degraded` dependency (an upstream that answered, but with an error status). Before this fix that 503 produced no metric at all, so an upstream degradation was invisible to alerting. Anyone with dashboards or alerts on `arolariu.health.check.failures` should expect the website to become *more* talkative for partial outages.

---

## 2. xUnit → MSTest consolidation

Removes xUnit from the repository and consolidates all .NET testing on **MSTest 4.3.3**, which `arolariu.Backend.Core.Tests` already used. No new dependency: MSTest was already pinned in `Directory.Packages.props`; the net change is the *removal* of `xunit` 2.9.3 and `xunit.runner.visualstudio` 3.1.5.

The delicate part is that the two frameworks **invert** the naming of exception and type assertions:

| xUnit | Semantics | Correct MSTest |
|---|---|---|
| `Assert.Throws<T>` / `ThrowsAsync<T>` | **exact** type | `Assert.ThrowsExactly<T>` / `ThrowsExactlyAsync<T>` |
| `Assert.ThrowsAny<T>` / `ThrowsAnyAsync<T>` | assignable | `Assert.Throws<T>` / `ThrowsAsync<T>` |
| `Assert.IsType<T>` | **exact** type | `Assert.IsExactInstanceOfType<T>` |
| `Assert.IsAssignableFrom<T>` | assignable | `Assert.IsInstanceOfType<T>` |

Mapping `Assert.Throws` → `Assert.Throws` compiles, keeps every test green, and silently weakens the suite. Also handled by hand: `Assert.All` → `foreach` (no MSTest equivalent), the reversed argument order of `Assert.Contains`'s predicate overload, and `Assert.Equal` on collections → `Assert.AreSequenceEqual` (MSTest's `AreEqual` is reference equality for `List<T>`).

Agent scaffolding under `.github/` was updated too — otherwise the next scaffolded service would reintroduce xUnit by process.

**Evidence.** A `.trx` inventory captured before the migration and diffed after by normalised `class.method → case count`: **1016 methods / 1220 cases on both sides, CLEAN**. Coverage `line-rate` delta 0.0000 on all three projects. Release build: 0 warnings, 0 errors, with no `NoWarn` or `#pragma` added.

---

## Review fixes applied on this PR

| # | Fix | Commit |
|---|---|---|
| 1 | Website counts `Degraded` in the failure counter | `e987faa6d` |
| 2 | Python test parameter layout | `66173ff1e` |
| 3 | This PR description now covers the telemetry scope | — |
| 4–6 | Suppression fail-safe direction corrected in all three services' docs | `9185a99fe`, `480ccf86c`, `9601a3fea` |
| 7–11 | Agent governance contract added to five `.github` assets | `80ea71af9`, `7401f2177`, `b2d42867e`, `4bd1fb841`, `6dcdb621a` |

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring, build process, CI, etc.)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] Ran unit tests
- [x] Ran integration tests

```
Passed! - Failed: 0, Passed:  126, Skipped: 0, Total:  126 - arolariu.Backend.Core.Tests.dll
Passed! - Failed: 0, Passed: 1090, Skipped: 0, Total: 1090 - arolariu.Backend.Domain.Tests.dll
Passed! - Failed: 0, Passed:    4, Skipped: 0, Total:    4 - AppHost.Tests.dll

exp:     128 passed (pytest) · ruff: all checks passed
website: vitest health + telemetry suites passed
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
