### PR TITLE
feat: add zero-touch Aspire local development

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,9 @@ Two coexisting dev modes:
 **`aspire` mode (default)** — `npm run dev -- --engine rancher` or `npm run dev -- --engine podman` (or F5 in VS Code/VS 2026 with the same environment)
 - Apps run **native** (.NET via dotnet, Next.js/Svelte/Docusaurus/status via npm dev scripts, exp via uvicorn) and are reachable at `http://localhost:<port>` (api: 5000, website: 3000, exp: 5002, cv: 4173, docs: 3100, status: 3002). Hot reload preserved.
 - Infrastructure (SQL Server, Cosmos vNext emulator, Azurite, Redis) runs as containers spawned by Aspire 13.x's AppHost (`tooling/AppHost/Program.cs`) through the selected Rancher Desktop or Podman Desktop engine — native Aspire integrations, not Docker Compose.
+- Before the API starts, `local-bootstrap` clears Cosmos invoice/merchant documents, resets Azurite invoice blobs and the `invoice-analysis` queue, then restores the tracked deterministic scenario. SQL, Redis, emulator schemas, indexes, and named volumes stay warm.
+- Seed personas are Alice (rich account: 8 invoices/5 merchants), Bob (empty account), and Charlie (light account: 3 invoices/2 merchants). Dates are relative to UTC launch day; identifiers and relationships are stable.
+- The local `local-identities` resource supplies signed Alice/Bob/Charlie JWTs. Development Swagger displays persona controls that preauthorize its existing Bearer scheme. No token or signing secret is committed.
 - Aspire dashboard at `https://localhost:17080` (auto-opens on AppHost start) with live OTel traces / metrics / logs and clickable URLs / health badges per resource.
 
 **`selfhost` mode (advanced)** — `npm run dev:selfhost -- --engine rancher` or `npm run dev:selfhost -- --engine podman`

--- a/docs/rfc/2002-opentelemetry-backend-observability.md
+++ b/docs/rfc/2002-opentelemetry-backend-observability.md
@@ -248,6 +248,22 @@ public static void AddGeneralDomainConfiguration(this WebApplicationBuilder buil
 - **Development**: Uses `DefaultAzureCredential()` (Visual Studio, Azure CLI, etc.)
 - **Production**: Uses Managed Identity via `AZURE_CLIENT_ID` environment variable
 
+**Local Swagger personas**:
+
+- Aspire runs a loopback-only `local-identities` tooling resource for Alice,
+  Bob, and Charlie.
+- Tokens use the same issuer, audience, signature, lifetime validation, and
+  `userIdentifier` claim contract as normal API Bearer tokens.
+- Development Swagger injects persona controls only when the environment is
+  Development, `INFRA=local`, no Azure managed identity is present, and AppHost
+  supplies the loopback identity endpoint.
+- The API content security policy adds that exact loopback origin to
+  `connect-src`; production retains the same-origin-only policy.
+- Tokens, signing secrets, connection strings, raw fixture documents, and scan
+  contents are never logged or exported.
+- The identity helper and seed bootstrap are excluded from deployment manifests;
+  production authentication and observability remain unchanged.
+
 **Connection String Resolution**:
 
 ```csharp

--- a/docs/rfc/2003-the-standard-implementation.md
+++ b/docs/rfc/2003-the-standard-implementation.md
@@ -166,7 +166,8 @@ Both regions use the raw Cosmos SDK paths in
 `IQueueBroker`, implemented by `AzureStorageQueueBroker`, owns transport through
 the backend queue named `invoice-analysis`. It:
 
-- assumes the deployment-provisioned queue already exists;
+- assumes the queue provisioned by Azure Bicep, Aspire bootstrap, or selfhost
+  bootstrap already exists;
 - serializes and enqueues a `QueueAnalysisMessage`;
 - returns Azure Queue's `MessageId`;
 - receives at most one visible message with a caller-supplied visibility timeout;
@@ -177,6 +178,9 @@ the backend queue named `invoice-analysis`. It:
 The Broker maps received provider data into `AnalysisQueueReceipt`, which carries
 the application message, provider `MessageId`, current pop receipt, dequeue
 count, and next-visible time.
+
+Queue creation remains an infrastructure responsibility. The Broker, Foundation,
+Processing service, and worker never call provider create APIs.
 
 ### Analysis capability brokers
 
@@ -322,6 +326,19 @@ poll and resolves only
 `IInvoiceManagementService`. It processes at most one received message per
 iteration through `ProcessAnalysisAsync` and waits five seconds when no message
 is visible.
+
+### Local development bootstrap
+
+Aspire starts a tooling-only one-shot bootstrap before the API. It clears local
+Cosmos invoice/merchant documents, resets Azurite invoice blobs and analysis
+messages, and writes a deterministic Alice/Bob/Charlie scenario. The tooling
+project references domain models for invariant-safe fixture construction but is
+not part of the Management → Processing → Orchestration → Foundation → Broker
+runtime graph. It is excluded from deployment manifests and refuses non-emulator
+targets.
+
+SQL, Redis, emulator schemas, indexes, and named volumes are retained between
+launches. No production seed path exists.
 
 ---
 

--- a/infra/Azure/Bicep/storage/README.md
+++ b/infra/Azure/Bicep/storage/README.md
@@ -134,7 +134,10 @@ module storage 'storage/storageAccount.bicep' = {
 
 **Queue/Table Service:**
 
-- Enabled
+- Queue and table services are enabled.
+- The `invoice-analysis` queue is provisioned declaratively for durable
+  invoice and merchant analysis work. Application Brokers consume this queue
+  but never create infrastructure at runtime.
 
 **Lifecycle Management:**
 

--- a/infra/Azure/Bicep/storage/storageAccount.bicep
+++ b/infra/Azure/Bicep/storage/storageAccount.bicep
@@ -195,6 +195,16 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2025-06-01' = {
   resource queueServices 'queueServices@2025-06-01' = {
     name: 'default'
     properties: {}
+
+    resource analysisQueue 'queues@2025-06-01' = {
+      name: 'invoice-analysis'
+      properties: {
+        metadata: {
+          owner: 'api.arolariu.ro'
+          purpose: 'durable-invoice-analysis'
+        }
+      }
+    }
   }
 
   // Table service configuration

--- a/scripts/container-runtime/selfhost.test.ts
+++ b/scripts/container-runtime/selfhost.test.ts
@@ -5,7 +5,12 @@
 
 import {afterEach, describe, expect, it} from "vitest";
 import {getContainerAdapter} from "./adapters.ts";
-import {buildSelfhostPlan, getRequiredSqlPassword, shouldGenerateTaxonomyArtifacts} from "./selfhost.ts";
+import {
+  buildLocalStorageBootstrapCommand,
+  buildSelfhostPlan,
+  getRequiredSqlPassword,
+  shouldGenerateTaxonomyArtifacts,
+} from "./selfhost.ts";
 
 const originalSqlPassword = process.env["MSSQL_SA_PASSWORD"];
 
@@ -67,6 +72,21 @@ describe("getRequiredSqlPassword", () => {
     process.env["MSSQL_SA_PASSWORD"] = "local-strong-password";
 
     expect(getRequiredSqlPassword()).toBe("local-strong-password");
+  });
+
+  describe("buildLocalStorageBootstrapCommand", () => {
+    it("uses the shared .NET local storage provisioner", () => {
+      expect(buildLocalStorageBootstrapCommand()).toEqual({
+        command: "dotnet",
+        args: [
+          "run",
+          "--project",
+          "../../tooling/LocalDevelopment.Bootstrap",
+          "--",
+          "--ensure-storage-only",
+        ],
+      });
+    });
   });
 
   describe("shouldGenerateTaxonomyArtifacts", () => {

--- a/scripts/container-runtime/selfhost.ts
+++ b/scripts/container-runtime/selfhost.ts
@@ -10,7 +10,7 @@ import {setTimeout as delay} from "node:timers/promises";
 import {fileURLToPath} from "node:url";
 import {getContainerAdapter, type ContainerRuntimeAdapter, type RuntimeCommand} from "./adapters.ts";
 import {runArtifactGeneration, runSharedPreflight} from "./preflight.ts";
-import {defaultRunner, formatCommand, type CommandRunner} from "./process.ts";
+import {defaultRunner, formatCommand, type CommandRunner, type CommandRunnerOptions} from "./process.ts";
 import {resolveContainerEngine} from "./selection.ts";
 import {removeSelfhostTraefikConfig, writeSelfhostTraefikConfig} from "./traefik.ts";
 import {ContainerRuntimeError, exitWithError} from "./types.ts";
@@ -89,12 +89,38 @@ export function buildSelfhostPlan(inputs: SelfhostPlanInputs): readonly RuntimeC
   ];
 }
 
-async function runCommandOrThrow(runner: CommandRunner, command: RuntimeCommand): Promise<void> {
+async function runCommandOrThrow(
+  runner: CommandRunner,
+  command: RuntimeCommand,
+  options: CommandRunnerOptions = {},
+): Promise<void> {
   console.log(`$ ${formatCommand(command)}`);
-  const result = await runner.run(command, {cwd: "infra/Local", stdio: "tee"});
+  const result = await runner.run(command, {
+    cwd: options.cwd ?? "infra/Local",
+    env: options.env,
+    stdio: options.stdio ?? "tee",
+  });
   if (result.code !== 0) {
     throw new ContainerRuntimeError(`Command failed: ${formatCommand(command)}\n${result.output}`);
   }
+}
+
+/**
+ * Builds the shared storage-only local bootstrap command.
+ *
+ * @returns The command that idempotently provisions Azurite resources.
+ */
+export function buildLocalStorageBootstrapCommand(): RuntimeCommand {
+  return {
+    command: "dotnet",
+    args: [
+      "run",
+      "--project",
+      "../../tooling/LocalDevelopment.Bootstrap",
+      "--",
+      "--ensure-storage-only",
+    ],
+  };
 }
 
 async function pathExists(path: string): Promise<boolean> {
@@ -206,6 +232,17 @@ async function bootstrapSelfhost(adapter: ContainerRuntimeAdapter, runner: Comma
   );
   await bootstrapCosmos();
   await bootstrapAzurite();
+  await runCommandOrThrow(
+    runner,
+    buildLocalStorageBootstrapCommand(),
+    {
+      env: {
+        DOTNET_ENVIRONMENT: "Development",
+        INFRA: "local",
+        ConnectionStrings__storage: azuriteDevelopmentConnectionString,
+      },
+    },
+  );
 }
 
 /**

--- a/scripts/container-runtime/selfhost.ts
+++ b/scripts/container-runtime/selfhost.ts
@@ -239,7 +239,8 @@ async function bootstrapSelfhost(adapter: ContainerRuntimeAdapter, runner: Comma
       env: {
         DOTNET_ENVIRONMENT: "Development",
         INFRA: "local",
-        ConnectionStrings__storage: azuriteDevelopmentConnectionString,
+        ConnectionStrings__blobs: azuriteDevelopmentConnectionString,
+        ConnectionStrings__queues: azuriteDevelopmentConnectionString,
       },
     },
   );

--- a/sites/api.arolariu.ro/src/Common/DDD/Contracts/BaseEntity.cs
+++ b/sites/api.arolariu.ro/src/Common/DDD/Contracts/BaseEntity.cs
@@ -117,6 +117,7 @@ public abstract class BaseEntity<T> : IAuditable
   /// This timestamp should be updated by the business logic layer before persistence.
   /// Used for optimistic concurrency control and change tracking.
   /// </remarks>
+  [Newtonsoft.Json.JsonProperty]
   [JsonPropertyOrder(byte.MaxValue - 08)]
   public DateTimeOffset LastUpdatedAt { get; protected set; } = DateTimeOffset.UtcNow;
 
@@ -125,6 +126,7 @@ public abstract class BaseEntity<T> : IAuditable
   /// Should be updated to reflect the identifier of the user or system making changes.
   /// Protected setter ensures updates are controlled through business logic methods.
   /// </remarks>
+  [Newtonsoft.Json.JsonProperty]
   [JsonPropertyOrder(byte.MaxValue - 07)]
   public Guid LastUpdatedBy { get; protected set; }
 
@@ -154,6 +156,7 @@ public abstract class BaseEntity<T> : IAuditable
   /// Protected setter ensures soft deletion is controlled through the SoftDelete method.
   /// Soft-deleted entities should be filtered out of normal business operations.
   /// </remarks>
+  [Newtonsoft.Json.JsonProperty]
   [JsonPropertyOrder(byte.MaxValue - 04)]
   public bool IsSoftDeleted { get; protected set; } = false;
 

--- a/sites/api.arolariu.ro/src/Core/Domain/General/Extensions/WebApplicationExtensions.cs
+++ b/sites/api.arolariu.ro/src/Core/Domain/General/Extensions/WebApplicationExtensions.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
@@ -136,7 +137,23 @@ internal static class WebApplicationExtensions
     app.UseStaticFiles();
     app.UseRequestLocalization();
     app.UseSwagger(SwaggerConfigurationService.GetSwaggerOptions());
-    app.UseSwaggerUI(SwaggerConfigurationService.GetSwaggerUIOptions());
+    LocalDevelopmentSwaggerOptions localSwagger =
+      LocalDevelopmentSwagger.Resolve(app.Environment, app.Configuration);
+
+    if (localSwagger is { Enabled: true, IdentityEndpoint: not null })
+    {
+      string personaScript = LocalDevelopmentSwagger.CreateScript(
+        localSwagger.IdentityEndpoint);
+      app.MapGet(
+          "/swagger/local-development-personas.js",
+          () => Results.Text(
+            personaScript,
+            contentType: "application/javascript"))
+        .ExcludeFromDescription();
+    }
+
+    app.UseSwaggerUI(
+      SwaggerConfigurationService.GetSwaggerUIOptions(localSwagger));
     app.MapOpenApi();
     var healthChecks = app.MapHealthChecks("/health", new HealthCheckOptions
     {

--- a/sites/api.arolariu.ro/src/Core/Domain/General/Middlewares/SecurityHeadersMiddleware.cs
+++ b/sites/api.arolariu.ro/src/Core/Domain/General/Middlewares/SecurityHeadersMiddleware.cs
@@ -4,7 +4,11 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 
+using arolariu.Backend.Core.Domain.General.Services.Swagger;
+
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
 
 /// <summary>
 /// Middleware that adds security headers to all HTTP responses to enhance application security posture.
@@ -38,12 +42,12 @@ using Microsoft.AspNetCore.Http;
 /// </para>
 /// <para>
 /// <strong>Strict-Transport-Security (HSTS):</strong> Enforces HTTPS connections for one year,
-/// including all subdomains. Only applied in production environments. Includes preload directive
-/// for browser HSTS preload lists.
+/// including all subdomains. Includes the preload directive for browser HSTS preload lists.
 /// </para>
 /// <para>
 /// <strong>Content-Security-Policy (CSP):</strong> Defines allowed sources for various resource types
-/// to prevent XSS and data injection attacks. Only applied in production to avoid development friction.
+/// to prevent XSS and data injection attacks. Local Development adds only the strictly gated
+/// loopback identity origin to <c>connect-src</c>.
 /// </para>
 /// </remarks>
 /// <example>
@@ -56,12 +60,21 @@ using Microsoft.AspNetCore.Http;
 /// Initializes a new instance of the <see cref="SecurityHeadersMiddleware"/> class.
 /// </remarks>
 /// <param name="next">The next middleware delegate in the request pipeline.</param>
+/// <param name="environment">The current web host environment.</param>
+/// <param name="configuration">The application configuration.</param>
 [ExcludeFromCodeCoverage] // Infrastructure middleware - integration tested, not unit tested
 #pragma warning disable CA1812
-internal sealed class SecurityHeadersMiddleware(RequestDelegate next)
+internal sealed class SecurityHeadersMiddleware(
+  RequestDelegate next,
+  IWebHostEnvironment environment,
+  IConfiguration configuration)
 #pragma warning restore CA1812
 {
   private readonly RequestDelegate _next = next ?? throw new ArgumentNullException(nameof(next));
+  private readonly string contentSecurityPolicy =
+    LocalDevelopmentSwagger.CreateContentSecurityPolicy(
+      LocalDevelopmentSwagger.Resolve(environment, configuration)
+        .IdentityEndpoint);
 
   /// <summary>
   /// Processes an HTTP request by adding security headers to the response.
@@ -80,7 +93,7 @@ internal sealed class SecurityHeadersMiddleware(RequestDelegate next)
     // Add security headers that apply to all environments
     AddCommonSecurityHeaders(context);
 
-    AddProductionSecurityHeaders(context);
+    AddTransportAndContentSecurityHeaders(context, contentSecurityPolicy);
 
     // Continue processing the request
     await _next(context).ConfigureAwait(false);
@@ -120,14 +133,19 @@ internal sealed class SecurityHeadersMiddleware(RequestDelegate next)
   }
 
   /// <summary>
-  /// Adds security headers that should only be applied in production environments.
+  /// Adds transport and content security headers.
   /// </summary>
   /// <param name="context">The HTTP context containing the response headers.</param>
+  /// <param name="contentSecurityPolicy">
+  /// The resolved policy for the current runtime.
+  /// </param>
   /// <remarks>
-  /// These headers are excluded from development to avoid interference with local debugging
-  /// and to allow HTTP connections during development.
+  /// The content security policy remains restrictive in every environment. The resolved
+  /// local policy permits only the gated loopback identity origin in addition to self.
   /// </remarks>
-  private static void AddProductionSecurityHeaders(HttpContext context)
+  private static void AddTransportAndContentSecurityHeaders(
+    HttpContext context,
+    string contentSecurityPolicy)
   {
     var headers = context.Response.Headers;
 
@@ -147,15 +165,6 @@ internal sealed class SecurityHeadersMiddleware(RequestDelegate next)
     // frame-ancestors 'none': Prevent embedding in frames (redundant with X-Frame-Options)
     // base-uri 'self': Restrict <base> tag URLs to same origin
     // form-action 'self': Only allow form submissions to same origin
-    headers.ContentSecurityPolicy =
-      "default-src 'self'; " +
-      "script-src 'self'; " +
-      "style-src 'self' 'unsafe-inline'; " +
-      "img-src 'self' data: https:; " +
-      "font-src 'self'; " +
-      "connect-src 'self'; " +
-      "frame-ancestors 'none'; " +
-      "base-uri 'self'; " +
-      "form-action 'self'";
+    headers.ContentSecurityPolicy = contentSecurityPolicy;
   }
 }

--- a/sites/api.arolariu.ro/src/Core/Domain/General/Services/Swagger/LocalDevelopmentSwagger.cs
+++ b/sites/api.arolariu.ro/src/Core/Domain/General/Services/Swagger/LocalDevelopmentSwagger.cs
@@ -1,0 +1,158 @@
+namespace arolariu.Backend.Core.Domain.General.Services.Swagger;
+
+using System;
+using System.Text.Json;
+
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+
+/// <summary>
+/// Describes whether the local Swagger persona bridge is enabled.
+/// </summary>
+/// <param name="Enabled">Whether the persona selector may be served.</param>
+/// <param name="IdentityEndpoint">The loopback identity endpoint when enabled.</param>
+internal sealed record LocalDevelopmentSwaggerOptions(
+  bool Enabled,
+  Uri? IdentityEndpoint)
+{
+  internal static LocalDevelopmentSwaggerOptions Disabled { get; } =
+    new(false, IdentityEndpoint: null);
+}
+
+/// <summary>
+/// Resolves and renders the development-only Swagger persona bridge.
+/// </summary>
+internal static class LocalDevelopmentSwagger
+{
+  /// <summary>
+  /// Resolves local persona controls only when every production-safety gate passes.
+  /// </summary>
+  /// <param name="environment">The current hosting environment.</param>
+  /// <param name="configuration">The application configuration.</param>
+  /// <returns>The resolved local Swagger options.</returns>
+  internal static LocalDevelopmentSwaggerOptions Resolve(
+    IWebHostEnvironment environment,
+    IConfiguration configuration)
+  {
+    ArgumentNullException.ThrowIfNull(environment);
+    ArgumentNullException.ThrowIfNull(configuration);
+
+    if (!environment.IsDevelopment()
+        || !string.Equals(
+          configuration["INFRA"],
+          "local",
+          StringComparison.Ordinal)
+        || !string.IsNullOrWhiteSpace(configuration["AZURE_CLIENT_ID"])
+        || !Uri.TryCreate(
+          configuration["LOCAL_DEVELOPMENT_IDENTITY_URL"],
+          UriKind.Absolute,
+          out Uri? identityEndpoint)
+        || identityEndpoint is null
+        || !identityEndpoint.IsLoopback)
+    {
+      return LocalDevelopmentSwaggerOptions.Disabled;
+    }
+
+    return new(true, identityEndpoint);
+  }
+
+  /// <summary>
+  /// Creates the browser script that selects a local persona and preauthorizes
+  /// Swagger's existing Bearer security scheme.
+  /// </summary>
+  /// <param name="identityEndpoint">The loopback identity service endpoint.</param>
+  /// <returns>The JavaScript source served only in local Development.</returns>
+  internal static string CreateScript(Uri identityEndpoint)
+  {
+    ArgumentNullException.ThrowIfNull(identityEndpoint);
+
+    if (!identityEndpoint.IsLoopback)
+    {
+      throw new ArgumentException(
+        "Local Swagger identity endpoint must be loopback.",
+        nameof(identityEndpoint));
+    }
+
+    string baseUrl = JsonSerializer.Serialize(
+      identityEndpoint.ToString().TrimEnd('/'));
+
+    return $$"""
+      (() => {
+        "use strict";
+        const identityBaseUrl = {{baseUrl}};
+
+        const waitForSwagger = async () => {
+          for (let attempt = 0; attempt < 100; attempt += 1) {
+            const authWrapper = document.querySelector(".auth-wrapper");
+            if (window.ui && authWrapper) {
+              return authWrapper;
+            }
+            await new Promise((resolve) => setTimeout(resolve, 100));
+          }
+          return null;
+        };
+
+        const setStatus = (container, text, isError = false) => {
+          const status = container.querySelector("[data-local-persona-status]");
+          if (!status) return;
+          status.textContent = text;
+          status.style.color = isError ? "#b42318" : "#344054";
+        };
+
+        const initialize = async () => {
+          const authWrapper = await waitForSwagger();
+          if (!authWrapper || document.querySelector("[data-local-personas]")) return;
+
+          const container = document.createElement("div");
+          container.dataset.localPersonas = "true";
+          container.style.display = "inline-flex";
+          container.style.alignItems = "center";
+          container.style.gap = "8px";
+          container.style.marginRight = "12px";
+
+          const status = document.createElement("span");
+          status.dataset.localPersonaStatus = "true";
+          status.textContent = "Development persona";
+          container.appendChild(status);
+
+          try {
+            const personasResponse = await fetch(`${identityBaseUrl}/personas`, {
+              cache: "no-store"
+            });
+            if (!personasResponse.ok) throw new Error("persona-list");
+            const personas = await personasResponse.json();
+
+            for (const persona of personas) {
+              const button = document.createElement("button");
+              button.type = "button";
+              button.textContent = persona.displayName;
+              button.className = "btn authorize unlocked";
+              button.addEventListener("click", async () => {
+                try {
+                  setStatus(container, `Authorizing ${persona.displayName}...`);
+                  const tokenResponse = await fetch(
+                    `${identityBaseUrl}/personas/${encodeURIComponent(persona.key)}/token`,
+                    { cache: "no-store" });
+                  if (!tokenResponse.ok) throw new Error("persona-token");
+                  const payload = await tokenResponse.json();
+                  window.ui.preauthorizeApiKey("Bearer", payload.token);
+                  setStatus(container, `Active: ${persona.displayName}`);
+                } catch {
+                  setStatus(container, "Persona authorization failed", true);
+                }
+              });
+              container.appendChild(button);
+            }
+          } catch {
+            setStatus(container, "Development personas unavailable", true);
+          }
+
+          authWrapper.prepend(container);
+        };
+
+        void initialize();
+      })();
+      """;
+  }
+}

--- a/sites/api.arolariu.ro/src/Core/Domain/General/Services/Swagger/LocalDevelopmentSwagger.cs
+++ b/sites/api.arolariu.ro/src/Core/Domain/General/Services/Swagger/LocalDevelopmentSwagger.cs
@@ -150,6 +150,9 @@ internal static class LocalDevelopmentSwagger
 
           const status = document.createElement("span");
           status.dataset.localPersonaStatus = "true";
+          status.setAttribute("role", "status");
+          status.setAttribute("aria-live", "polite");
+          status.setAttribute("aria-atomic", "true");
           status.textContent = "Development persona";
           container.appendChild(status);
 

--- a/sites/api.arolariu.ro/src/Core/Domain/General/Services/Swagger/LocalDevelopmentSwagger.cs
+++ b/sites/api.arolariu.ro/src/Core/Domain/General/Services/Swagger/LocalDevelopmentSwagger.cs
@@ -58,6 +58,43 @@ internal static class LocalDevelopmentSwagger
   }
 
   /// <summary>
+  /// Creates the API content security policy, allowing the local identity origin
+  /// only when the development-only bridge is enabled.
+  /// </summary>
+  /// <param name="identityEndpoint">
+  /// The gated loopback identity endpoint, or <see langword="null"/>.
+  /// </param>
+  /// <returns>The complete content security policy.</returns>
+  internal static string CreateContentSecurityPolicy(Uri? identityEndpoint)
+  {
+    string connectSources = "'self'";
+
+    if (identityEndpoint is not null)
+    {
+      if (!identityEndpoint.IsLoopback)
+      {
+        throw new ArgumentException(
+          "Local Swagger identity endpoint must be loopback.",
+          nameof(identityEndpoint));
+      }
+
+      connectSources +=
+        $" {identityEndpoint.GetLeftPart(UriPartial.Authority)}";
+    }
+
+    return
+      "default-src 'self'; " +
+      "script-src 'self'; " +
+      "style-src 'self' 'unsafe-inline'; " +
+      "img-src 'self' data: https:; " +
+      "font-src 'self'; " +
+      $"connect-src {connectSources}; " +
+      "frame-ancestors 'none'; " +
+      "base-uri 'self'; " +
+      "form-action 'self'";
+  }
+
+  /// <summary>
   /// Creates the browser script that selects a local persona and preauthorizes
   /// Swagger's existing Bearer security scheme.
   /// </summary>

--- a/sites/api.arolariu.ro/src/Core/Domain/General/Services/Swagger/SwaggerConfigurationService.cs
+++ b/sites/api.arolariu.ro/src/Core/Domain/General/Services/Swagger/SwaggerConfigurationService.cs
@@ -76,7 +76,8 @@ internal static class SwaggerConfigurationService
   /// - Shows OpenAPI extensions and common extensions
   /// </para>
   /// </remarks>
-  internal static SwaggerUIOptions GetSwaggerUIOptions()
+  internal static SwaggerUIOptions GetSwaggerUIOptions(
+    LocalDevelopmentSwaggerOptions? localDevelopment = null)
   {
     var options = new SwaggerUIOptions()
     {
@@ -106,6 +107,11 @@ internal static class SwaggerConfigurationService
     // OpenAPI spec endpoints:
     options.SwaggerEndpoint("/swagger/v1/swagger.json", "Public API (Swagger OpenAPI 3.0)");
     options.SwaggerEndpoint("/openapi/v1.json", "Public API (MS OpenAPI 3.0)");
+
+    if (localDevelopment is { Enabled: true })
+    {
+      options.InjectJavascript("/swagger/local-development-personas.js");
+    }
 
     return options;
   }

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/DDD/BaseEntityTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Common/DDD/BaseEntityTests.cs
@@ -6,6 +6,8 @@ using arolariu.Backend.Core.Tests.Shared.TestDoubles;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+using Newtonsoft.Json;
+
 /// <summary>
 /// Tests for the base entity abstraction verifying audit field initialization, soft delete behavior,
 /// update simulation and importance flag toggling. Method names follow the mandated
@@ -68,5 +70,27 @@ public sealed class BaseEntityTests
     Assert.IsFalse(entity.IsImportant);
     entity.IsImportant = true;
     Assert.IsTrue(entity.IsImportant);
+  }
+
+  /// <summary>
+  /// Verifies the Cosmos SDK serializer preserves protected persistence state.
+  /// </summary>
+  [TestMethod]
+  public void NewtonsoftRoundTrip_ProtectedState_PreservesValues()
+  {
+    var entity = new TestEntity { CreatedBy = Guid.NewGuid() };
+    Guid updater = Guid.NewGuid();
+    entity.SimulateUpdate(updater);
+    entity.SoftDelete();
+    DateTimeOffset expectedLastUpdatedAt = entity.LastUpdatedAt;
+
+    string json = JsonConvert.SerializeObject(entity);
+    TestEntity roundTripped = JsonConvert.DeserializeObject<TestEntity>(json)
+      ?? throw new AssertFailedException(
+        "Deserializing TestEntity produced null.");
+
+    Assert.IsTrue(roundTripped.IsSoftDeleted);
+    Assert.AreEqual(updater, roundTripped.LastUpdatedBy);
+    Assert.AreEqual(expectedLastUpdatedAt, roundTripped.LastUpdatedAt);
   }
 }

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Core/Swagger/LocalDevelopmentSwaggerTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Core/Swagger/LocalDevelopmentSwaggerTests.cs
@@ -91,6 +91,21 @@ public sealed class LocalDevelopmentSwaggerTests
     Assert.IsFalse(script.Contains("console.", StringComparison.Ordinal));
   }
 
+  /// <summary>
+  /// Verifies the local identity origin is added to Swagger's connection policy.
+  /// </summary>
+  [TestMethod]
+  public void CreateContentSecurityPolicy_LocalIdentityEndpoint_AllowsOrigin()
+  {
+    string policy = LocalDevelopmentSwagger.CreateContentSecurityPolicy(
+      new Uri("http://127.0.0.1:5123/personas"));
+
+    StringAssert.Contains(
+      policy,
+      "connect-src 'self' http://127.0.0.1:5123;",
+      StringComparison.Ordinal);
+  }
+
   private static IConfiguration CreateConfiguration(
     string infra,
     string? azureClientId,

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Core/Swagger/LocalDevelopmentSwaggerTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Core/Swagger/LocalDevelopmentSwaggerTests.cs
@@ -1,0 +1,129 @@
+namespace arolariu.Backend.Core.Tests.Core.Swagger;
+
+using System;
+using System.Collections.Generic;
+
+using arolariu.Backend.Core.Domain.General.Services.Swagger;
+
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+/// <summary>
+/// Verifies the local-only Swagger persona bridge.
+/// </summary>
+[TestClass]
+public sealed class LocalDevelopmentSwaggerTests
+{
+  /// <summary>
+  /// Verifies all local safety gates enable the selector.
+  /// </summary>
+  [TestMethod]
+  public void Resolve_AllLocalGatesPresent_EnablesPersonaControls()
+  {
+    LocalDevelopmentSwaggerOptions options = LocalDevelopmentSwagger.Resolve(
+      CreateEnvironment(Environments.Development),
+      CreateConfiguration(
+        infra: "local",
+        azureClientId: null,
+        identityUrl: "http://127.0.0.1:5123"));
+
+    Assert.IsTrue(options.Enabled);
+    Assert.AreEqual(
+      new Uri("http://127.0.0.1:5123"),
+      options.IdentityEndpoint);
+  }
+
+  /// <summary>
+  /// Verifies unsafe runtime combinations disable persona controls.
+  /// </summary>
+  [TestMethod]
+  [DataRow("Production", "local", null)]
+  [DataRow("Development", "azure", null)]
+  [DataRow("Development", "local", "managed-identity")]
+  public void Resolve_UnsafeGate_DisablesPersonaControls(
+    string environment,
+    string infra,
+    string? azureClientId)
+  {
+    LocalDevelopmentSwaggerOptions options = LocalDevelopmentSwagger.Resolve(
+      CreateEnvironment(environment),
+      CreateConfiguration(
+        infra,
+        azureClientId,
+        "http://127.0.0.1:5123"));
+
+    Assert.IsFalse(options.Enabled);
+    Assert.IsNull(options.IdentityEndpoint);
+  }
+
+  /// <summary>
+  /// Verifies a non-loopback identity helper is rejected.
+  /// </summary>
+  [TestMethod]
+  public void Resolve_RemoteIdentityUrl_DisablesPersonaControls()
+  {
+    LocalDevelopmentSwaggerOptions options = LocalDevelopmentSwagger.Resolve(
+      CreateEnvironment(Environments.Development),
+      CreateConfiguration(
+        "local",
+        azureClientId: null,
+        "https://identity.example.test"));
+
+    Assert.IsFalse(options.Enabled);
+  }
+
+  /// <summary>
+  /// Verifies the generated selector uses Swagger's Bearer preauthorization.
+  /// </summary>
+  [TestMethod]
+  public void CreateScript_ValidIdentityEndpoint_RendersPersonaSelectorAndBearerPreauthorization()
+  {
+    string script = LocalDevelopmentSwagger.CreateScript(
+      new Uri("http://127.0.0.1:5123"));
+
+    StringAssert.Contains(script, "/personas", StringComparison.Ordinal);
+    StringAssert.Contains(script, "/token", StringComparison.Ordinal);
+    StringAssert.Contains(script, "preauthorizeApiKey", StringComparison.Ordinal);
+    StringAssert.Contains(script, "\"Bearer\"", StringComparison.Ordinal);
+    Assert.IsFalse(script.Contains("console.", StringComparison.Ordinal));
+  }
+
+  private static IConfiguration CreateConfiguration(
+    string infra,
+    string? azureClientId,
+    string identityUrl) =>
+    new ConfigurationBuilder()
+      .AddInMemoryCollection(new Dictionary<string, string?>
+      {
+        ["INFRA"] = infra,
+        ["AZURE_CLIENT_ID"] = azureClientId,
+        ["LOCAL_DEVELOPMENT_IDENTITY_URL"] = identityUrl,
+      })
+      .Build();
+
+  private static TestWebHostEnvironment CreateEnvironment(string name) =>
+    new TestWebHostEnvironment
+    {
+      EnvironmentName = name,
+    };
+
+  private sealed class TestWebHostEnvironment : IWebHostEnvironment
+  {
+    public string ApplicationName { get; set; } = "Tests";
+
+    public IFileProvider WebRootFileProvider { get; set; } =
+      new NullFileProvider();
+
+    public string WebRootPath { get; set; } = string.Empty;
+
+    public string EnvironmentName { get; set; } = Environments.Development;
+
+    public string ContentRootPath { get; set; } = string.Empty;
+
+    public IFileProvider ContentRootFileProvider { get; set; } =
+      new NullFileProvider();
+  }
+}

--- a/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Core/Swagger/LocalDevelopmentSwaggerTests.cs
+++ b/sites/api.arolariu.ro/tests/arolariu.Backend.Core.Tests/Core/Swagger/LocalDevelopmentSwaggerTests.cs
@@ -88,6 +88,8 @@ public sealed class LocalDevelopmentSwaggerTests
     StringAssert.Contains(script, "/token", StringComparison.Ordinal);
     StringAssert.Contains(script, "preauthorizeApiKey", StringComparison.Ordinal);
     StringAssert.Contains(script, "\"Bearer\"", StringComparison.Ordinal);
+    StringAssert.Contains(script, "\"aria-live\"", StringComparison.Ordinal);
+    StringAssert.Contains(script, "\"polite\"", StringComparison.Ordinal);
     Assert.IsFalse(script.Contains("console.", StringComparison.Ordinal));
   }
 

--- a/tooling/AppHost.Tests/AppHost.Tests.csproj
+++ b/tooling/AppHost.Tests/AppHost.Tests.csproj
@@ -17,5 +17,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AppHost\AppHost.csproj" />
+    <ProjectReference Include="..\LocalDevelopment.Bootstrap\LocalDevelopment.Bootstrap.csproj" />
   </ItemGroup>
 </Project>

--- a/tooling/AppHost.Tests/AppHost.Tests.csproj
+++ b/tooling/AppHost.Tests/AppHost.Tests.csproj
@@ -18,5 +18,6 @@
   <ItemGroup>
     <ProjectReference Include="..\AppHost\AppHost.csproj" />
     <ProjectReference Include="..\LocalDevelopment.Bootstrap\LocalDevelopment.Bootstrap.csproj" />
+    <ProjectReference Include="..\LocalDevelopment.Identity\LocalDevelopment.Identity.csproj" />
   </ItemGroup>
 </Project>

--- a/tooling/AppHost.Tests/AzuriteBootstrapTests.cs
+++ b/tooling/AppHost.Tests/AzuriteBootstrapTests.cs
@@ -1,0 +1,44 @@
+namespace AppHost.Tests;
+
+using AppHost.Aspire;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+/// <summary>
+/// Verifies the local Azurite bootstrap connection contract.
+/// </summary>
+[TestClass]
+public sealed class AzuriteBootstrapTests
+{
+  /// <summary>
+  /// Verifies the bootstrap connection string targets both Azurite services.
+  /// </summary>
+  [TestMethod]
+  public void CreateConnectionString_ValidPorts_ContainsBlobAndQueueEndpoints()
+  {
+    string connectionString = AzuriteBootstrap.CreateConnectionString(
+      blobPort: 10000,
+      queuePort: 10001);
+
+    StringAssert.Contains(
+      connectionString,
+      "BlobEndpoint=http://localhost:10000/devstoreaccount1");
+    StringAssert.Contains(
+      connectionString,
+      "QueueEndpoint=http://localhost:10001/devstoreaccount1");
+  }
+
+  /// <summary>
+  /// Verifies non-positive service ports are rejected.
+  /// </summary>
+  [TestMethod]
+  [DataRow(0, 10001)]
+  [DataRow(10000, 0)]
+  public void CreateConnectionString_NonPositivePort_ThrowsArgumentOutOfRangeException(
+    int blobPort,
+    int queuePort)
+  {
+    Assert.ThrowsExactly<ArgumentOutOfRangeException>(
+      () => AzuriteBootstrap.CreateConnectionString(blobPort, queuePort));
+  }
+}

--- a/tooling/AppHost.Tests/DevelopmentPersonaCatalogTests.cs
+++ b/tooling/AppHost.Tests/DevelopmentPersonaCatalogTests.cs
@@ -1,0 +1,30 @@
+namespace AppHost.Tests;
+
+using LocalDevelopment.Identity;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+/// <summary>
+/// Verifies development personas align with deterministic seed ownership.
+/// </summary>
+[TestClass]
+public sealed class DevelopmentPersonaCatalogTests
+{
+  /// <summary>
+  /// Verifies all approved persona identifiers remain stable.
+  /// </summary>
+  [TestMethod]
+  public void All_Always_ContainsApprovedPersonaIdentifiers()
+  {
+    Assert.AreEqual(
+      Guid.Parse("7574070c-3ee9-5031-9b1b-0dc08c61ee86"),
+      DevelopmentPersonaCatalog.Alice.UserIdentifier);
+    Assert.AreEqual(
+      Guid.Parse("6a40503e-c1af-51b0-8b60-3c6648b3724e"),
+      DevelopmentPersonaCatalog.Bob.UserIdentifier);
+    Assert.AreEqual(
+      Guid.Parse("fc687d5c-39d5-5541-868c-f76a3fdbd4e4"),
+      DevelopmentPersonaCatalog.Charlie.UserIdentifier);
+    Assert.HasCount(3, DevelopmentPersonaCatalog.All);
+  }
+}

--- a/tooling/AppHost.Tests/DevelopmentTokenFactoryTests.cs
+++ b/tooling/AppHost.Tests/DevelopmentTokenFactoryTests.cs
@@ -31,12 +31,13 @@ public sealed class DevelopmentTokenFactoryTests
   [TestMethod]
   public void Create_Alice_ReturnsValidSignedTokenWithExpectedClaims()
   {
+    var timeProvider = new FixedTimeProvider(Anchor);
     var factory = new DevelopmentTokenFactory(
       Options,
-      new FixedTimeProvider(Anchor));
+      timeProvider);
 
     string token = factory.Create(DevelopmentPersonaCatalog.Alice);
-    ClaimsPrincipal principal = ValidateToken(token);
+    ClaimsPrincipal principal = ValidateToken(token, timeProvider);
 
     Assert.AreEqual(
       DevelopmentPersonaCatalog.Alice.UserIdentifier.ToString(),
@@ -96,7 +97,9 @@ public sealed class DevelopmentTokenFactoryTests
     Assert.IsNotNull(factory);
   }
 
-  private static ClaimsPrincipal ValidateToken(string token)
+  private static ClaimsPrincipal ValidateToken(
+    string token,
+    TimeProvider timeProvider)
   {
     var handler = new JwtSecurityTokenHandler
     {
@@ -112,6 +115,14 @@ public sealed class DevelopmentTokenFactoryTests
         ValidAudience = Options.Audience,
         ValidateLifetime = true,
         ClockSkew = TimeSpan.Zero,
+        LifetimeValidator = (notBefore, expires, _, _) =>
+        {
+          DateTime now = timeProvider.GetUtcNow().UtcDateTime;
+          return notBefore.HasValue
+            && expires.HasValue
+            && notBefore.Value <= now
+            && expires.Value >= now;
+        },
         ValidateIssuerSigningKey = true,
         IssuerSigningKey = new SymmetricSecurityKey(
           Encoding.UTF8.GetBytes(Options.Secret)),
@@ -133,6 +144,16 @@ public sealed class DevelopmentTokenFactoryTests
 public sealed class LocalIdentityBindingTests
 {
   /// <summary>
+  /// Verifies explicit loopback bindings are accepted.
+  /// </summary>
+  [TestMethod]
+  public void RequireLoopbackBinding_LoopbackUrls_ReturnsNormally()
+  {
+    LocalDevelopment.Identity.Program.RequireLoopbackBinding(
+      "http://localhost:5011;https://127.0.0.1:5012");
+  }
+
+  /// <summary>
   /// Verifies the token service cannot start without an explicit binding.
   /// </summary>
   [TestMethod]
@@ -140,5 +161,18 @@ public sealed class LocalIdentityBindingTests
   {
     Assert.ThrowsExactly<InvalidOperationException>(
       () => LocalDevelopment.Identity.Program.RequireLoopbackBinding(null));
+  }
+
+  /// <summary>
+  /// Verifies any remote binding prevents token service startup.
+  /// </summary>
+  [TestMethod]
+  [DataRow("http://0.0.0.0:5011")]
+  [DataRow("http://localhost:5011;http://192.0.2.1:5011")]
+  public void RequireLoopbackBinding_RemoteUrl_ThrowsInvalidOperationException(
+    string urls)
+  {
+    Assert.ThrowsExactly<InvalidOperationException>(
+      () => LocalDevelopment.Identity.Program.RequireLoopbackBinding(urls));
   }
 }

--- a/tooling/AppHost.Tests/DevelopmentTokenFactoryTests.cs
+++ b/tooling/AppHost.Tests/DevelopmentTokenFactoryTests.cs
@@ -1,0 +1,103 @@
+namespace AppHost.Tests;
+
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+
+using LocalDevelopment.Identity;
+
+using Microsoft.IdentityModel.Tokens;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+/// <summary>
+/// Verifies local persona JWTs preserve the production validation contract.
+/// </summary>
+[TestClass]
+public sealed class DevelopmentTokenFactoryTests
+{
+  private static readonly DateTimeOffset Anchor =
+    new(2026, 8, 21, 12, 0, 0, TimeSpan.Zero);
+
+  private static readonly LocalIdentityOptions Options = new(
+    Issuer: "https://auth.arolariu.ro",
+    Audience: "https://api.arolariu.ro",
+    Secret: "local-test-secret-at-least-thirty-two-bytes",
+    SwaggerOrigin: "http://localhost:5000");
+
+  /// <summary>
+  /// Verifies Alice's token validates and carries the exact API claims.
+  /// </summary>
+  [TestMethod]
+  public void Create_Alice_ReturnsValidSignedTokenWithExpectedClaims()
+  {
+    var factory = new DevelopmentTokenFactory(
+      Options,
+      new FixedTimeProvider(Anchor));
+
+    string token = factory.Create(DevelopmentPersonaCatalog.Alice);
+    ClaimsPrincipal principal = ValidateToken(token);
+
+    Assert.AreEqual(
+      DevelopmentPersonaCatalog.Alice.UserIdentifier.ToString(),
+      principal.FindFirst("userIdentifier")?.Value);
+    Assert.AreEqual("user", principal.FindFirst("role")?.Value);
+  }
+
+  /// <summary>
+  /// Verifies local tokens expire eight hours after issuance.
+  /// </summary>
+  [TestMethod]
+  public void Create_Alice_ExpiresAfterEightHours()
+  {
+    var factory = new DevelopmentTokenFactory(
+      Options,
+      new FixedTimeProvider(Anchor));
+
+    string token = factory.Create(DevelopmentPersonaCatalog.Alice);
+    JwtSecurityToken parsed = new JwtSecurityTokenHandler()
+      .ReadJwtToken(token);
+
+    Assert.AreEqual(Anchor.AddHours(8).UtcDateTime, parsed.ValidTo);
+  }
+
+  /// <summary>
+  /// Verifies weak signing secrets are rejected.
+  /// </summary>
+  [TestMethod]
+  public void Constructor_ShortSecret_ThrowsArgumentException()
+  {
+    Assert.ThrowsExactly<ArgumentException>(() =>
+      new DevelopmentTokenFactory(
+        Options with { Secret = "short" },
+        TimeProvider.System));
+  }
+
+  private static ClaimsPrincipal ValidateToken(string token)
+  {
+    var handler = new JwtSecurityTokenHandler
+    {
+      MapInboundClaims = false,
+    };
+    return handler.ValidateToken(
+      token,
+      new TokenValidationParameters
+      {
+        ValidateIssuer = true,
+        ValidIssuer = Options.Issuer,
+        ValidateAudience = true,
+        ValidAudience = Options.Audience,
+        ValidateLifetime = true,
+        ClockSkew = TimeSpan.Zero,
+        ValidateIssuerSigningKey = true,
+        IssuerSigningKey = new SymmetricSecurityKey(
+          Encoding.UTF8.GetBytes(Options.Secret)),
+      },
+      out _);
+  }
+
+  private sealed class FixedTimeProvider(
+    DateTimeOffset instant) : TimeProvider
+  {
+    public override DateTimeOffset GetUtcNow() => instant;
+  }
+}

--- a/tooling/AppHost.Tests/DevelopmentTokenFactoryTests.cs
+++ b/tooling/AppHost.Tests/DevelopmentTokenFactoryTests.cs
@@ -6,6 +6,7 @@ using System.Text;
 
 using LocalDevelopment.Identity;
 
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -72,6 +73,29 @@ public sealed class DevelopmentTokenFactoryTests
         TimeProvider.System));
   }
 
+  /// <summary>
+  /// Verifies the factory can be constructed through its runtime DI registration.
+  /// </summary>
+  [TestMethod]
+  public void DependencyInjection_ResolveFactory_ConstructsFactory()
+  {
+    var services = new ServiceCollection();
+    services.AddSingleton(Options);
+    services.AddSingleton(TimeProvider.System);
+    services.AddSingleton<DevelopmentTokenFactory>();
+
+    using ServiceProvider provider = services.BuildServiceProvider(
+      new ServiceProviderOptions
+      {
+        ValidateOnBuild = true,
+      });
+
+    DevelopmentTokenFactory factory =
+      provider.GetRequiredService<DevelopmentTokenFactory>();
+
+    Assert.IsNotNull(factory);
+  }
+
   private static ClaimsPrincipal ValidateToken(string token)
   {
     var handler = new JwtSecurityTokenHandler
@@ -99,5 +123,22 @@ public sealed class DevelopmentTokenFactoryTests
     DateTimeOffset instant) : TimeProvider
   {
     public override DateTimeOffset GetUtcNow() => instant;
+  }
+}
+
+/// <summary>
+/// Verifies the local identity service rejects unsafe binding configuration.
+/// </summary>
+[TestClass]
+public sealed class LocalIdentityBindingTests
+{
+  /// <summary>
+  /// Verifies the token service cannot start without an explicit binding.
+  /// </summary>
+  [TestMethod]
+  public void RequireLoopbackBinding_MissingUrls_ThrowsInvalidOperationException()
+  {
+    Assert.ThrowsExactly<InvalidOperationException>(
+      () => LocalDevelopment.Identity.Program.RequireLoopbackBinding(null));
   }
 }

--- a/tooling/AppHost.Tests/LocalDevelopmentResourceConfigurationTests.cs
+++ b/tooling/AppHost.Tests/LocalDevelopmentResourceConfigurationTests.cs
@@ -1,0 +1,49 @@
+namespace AppHost.Tests;
+
+using AppHost.Aspire;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+/// <summary>
+/// Verifies environment values injected into local-only Aspire resources.
+/// </summary>
+[TestClass]
+public sealed class LocalDevelopmentResourceConfigurationTests
+{
+  /// <summary>
+  /// Verifies the bootstrap resource receives every destructive-operation gate.
+  /// </summary>
+  [TestMethod]
+  public void CreateBootstrapEnvironment_Always_ContainsLocalSafetyGates()
+  {
+    IReadOnlyDictionary<string, string> environment =
+      LocalDevelopmentResourceConfiguration.CreateBootstrapEnvironment(
+        manifestPath: "SeedData/scenario.v1.json");
+
+    Assert.AreEqual("Development", environment["DOTNET_ENVIRONMENT"]);
+    Assert.AreEqual("local", environment["INFRA"]);
+    Assert.AreEqual(
+      "SeedData/scenario.v1.json",
+      environment["SEED_MANIFEST_PATH"]);
+    Assert.IsFalse(environment.ContainsKey("AZURE_CLIENT_ID"));
+  }
+
+  /// <summary>
+  /// Verifies the identity resource receives only local config and Swagger origins.
+  /// </summary>
+  [TestMethod]
+  public void CreateIdentityEnvironment_ValidInputs_ReturnsExpectedPaths()
+  {
+    IReadOnlyDictionary<string, string> environment =
+      LocalDevelopmentResourceConfiguration.CreateIdentityEnvironment(
+        configPath: @"C:\repo\config.aspire.json",
+        swaggerOrigin: "http://localhost:5000");
+
+    Assert.AreEqual(
+      @"C:\repo\config.aspire.json",
+      environment["LOCAL_CONFIG_PATH"]);
+    Assert.AreEqual(
+      "http://localhost:5000",
+      environment["LOCAL_SWAGGER_ORIGIN"]);
+  }
+}

--- a/tooling/AppHost.Tests/LocalEnvironmentGuardTests.cs
+++ b/tooling/AppHost.Tests/LocalEnvironmentGuardTests.cs
@@ -65,4 +65,51 @@ public sealed class LocalEnvironmentGuardTests
         "UseDevelopmentStorage=true",
         "UseDevelopmentStorage=true"));
   }
+
+  /// <summary>
+  /// Verifies full bootstrap rejects remote blob and queue endpoints.
+  /// </summary>
+  [TestMethod]
+  [DataRow(
+    "BlobEndpoint=https://storage.example.test/account;",
+    "UseDevelopmentStorage=true")]
+  [DataRow(
+    "UseDevelopmentStorage=true",
+    "QueueEndpoint=https://storage.example.test/account;")]
+  public void Validate_RemoteStorageEndpoint_ThrowsInvalidOperationException(
+    string blobStorageConnectionString,
+    string queueStorageConnectionString)
+  {
+    Assert.ThrowsExactly<InvalidOperationException>(() =>
+      LocalEnvironmentGuard.Validate(
+        "Development",
+        "local",
+        azureClientId: null,
+        EmulatorCosmosConnection,
+        blobStorageConnectionString,
+        queueStorageConnectionString));
+  }
+
+  /// <summary>
+  /// Verifies storage-only bootstrap rejects remote blob and queue endpoints.
+  /// </summary>
+  [TestMethod]
+  [DataRow(
+    "BlobEndpoint=https://storage.example.test/account;",
+    "UseDevelopmentStorage=true")]
+  [DataRow(
+    "UseDevelopmentStorage=true",
+    "QueueEndpoint=https://storage.example.test/account;")]
+  public void ValidateStorage_RemoteStorageEndpoint_ThrowsInvalidOperationException(
+    string blobStorageConnectionString,
+    string queueStorageConnectionString)
+  {
+    Assert.ThrowsExactly<InvalidOperationException>(() =>
+      LocalEnvironmentGuard.ValidateStorage(
+        "Development",
+        "local",
+        azureClientId: null,
+        blobStorageConnectionString,
+        queueStorageConnectionString));
+  }
 }

--- a/tooling/AppHost.Tests/LocalEnvironmentGuardTests.cs
+++ b/tooling/AppHost.Tests/LocalEnvironmentGuardTests.cs
@@ -1,0 +1,65 @@
+namespace AppHost.Tests;
+
+using LocalDevelopment.Bootstrap;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+/// <summary>
+/// Verifies local bootstrap targets cannot escape emulator boundaries.
+/// </summary>
+[TestClass]
+public sealed class LocalEnvironmentGuardTests
+{
+  private const string EmulatorCosmosConnection =
+    "AccountEndpoint=https://localhost:8081/;AccountKey=emulator;";
+
+  /// <summary>
+  /// Verifies the approved local emulator combination is accepted.
+  /// </summary>
+  [TestMethod]
+  public void Validate_LocalEmulators_ReturnsNormally()
+  {
+    LocalEnvironmentGuard.Validate(
+      environmentName: "Development",
+      infra: "local",
+      azureClientId: null,
+      cosmosConnectionString: EmulatorCosmosConnection,
+      storageConnectionString: "UseDevelopmentStorage=true");
+  }
+
+  /// <summary>
+  /// Verifies non-local runtime gates are rejected.
+  /// </summary>
+  [TestMethod]
+  [DataRow("Production", "local", null)]
+  [DataRow("Development", "azure", null)]
+  [DataRow("Development", "local", "managed-identity")]
+  public void Validate_NonLocalGate_ThrowsInvalidOperationException(
+    string environmentName,
+    string infra,
+    string? azureClientId)
+  {
+    Assert.ThrowsExactly<InvalidOperationException>(() =>
+      LocalEnvironmentGuard.Validate(
+        environmentName,
+        infra,
+        azureClientId,
+        EmulatorCosmosConnection,
+        "UseDevelopmentStorage=true"));
+  }
+
+  /// <summary>
+  /// Verifies a remote Cosmos endpoint is rejected even with an account key.
+  /// </summary>
+  [TestMethod]
+  public void Validate_RemoteCosmosEndpoint_ThrowsInvalidOperationException()
+  {
+    Assert.ThrowsExactly<InvalidOperationException>(() =>
+      LocalEnvironmentGuard.Validate(
+        "Development",
+        "local",
+        azureClientId: null,
+        "AccountEndpoint=https://example.documents.azure.com/;AccountKey=value;",
+        "UseDevelopmentStorage=true"));
+  }
+}

--- a/tooling/AppHost.Tests/LocalEnvironmentGuardTests.cs
+++ b/tooling/AppHost.Tests/LocalEnvironmentGuardTests.cs
@@ -24,7 +24,8 @@ public sealed class LocalEnvironmentGuardTests
       infra: "local",
       azureClientId: null,
       cosmosConnectionString: EmulatorCosmosConnection,
-      storageConnectionString: "UseDevelopmentStorage=true");
+      blobStorageConnectionString: "UseDevelopmentStorage=true",
+      queueStorageConnectionString: "UseDevelopmentStorage=true");
   }
 
   /// <summary>
@@ -45,6 +46,7 @@ public sealed class LocalEnvironmentGuardTests
         infra,
         azureClientId,
         EmulatorCosmosConnection,
+        "UseDevelopmentStorage=true",
         "UseDevelopmentStorage=true"));
   }
 
@@ -60,6 +62,7 @@ public sealed class LocalEnvironmentGuardTests
         "local",
         azureClientId: null,
         "AccountEndpoint=https://example.documents.azure.com/;AccountKey=value;",
+        "UseDevelopmentStorage=true",
         "UseDevelopmentStorage=true"));
   }
 }

--- a/tooling/AppHost.Tests/LocalScenarioBootstrapTests.cs
+++ b/tooling/AppHost.Tests/LocalScenarioBootstrapTests.cs
@@ -1,0 +1,108 @@
+namespace AppHost.Tests;
+
+using LocalDevelopment.Bootstrap;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+/// <summary>
+/// Verifies reset and seed orchestration order.
+/// </summary>
+[TestClass]
+public sealed class LocalScenarioBootstrapTests
+{
+  private static readonly string ScenarioPath = Path.GetFullPath(
+    Path.Combine(
+      AppContext.BaseDirectory,
+      "..",
+      "..",
+      "..",
+      "..",
+      "LocalDevelopment.Bootstrap",
+      "SeedData",
+      "scenario.v1.json"));
+
+  /// <summary>
+  /// Verifies every previous document and blob is cleared before seed writes.
+  /// </summary>
+  [TestMethod]
+  public async Task RunAsync_ValidScenario_ResetsThenWritesStorageAndCosmos()
+  {
+    var operations = new List<string>();
+    var cosmos = new RecordingCosmosResetter(operations);
+    var storage = new RecordingAzuriteResetter(operations);
+    var bootstrap = new LocalScenarioBootstrap(
+      cosmos,
+      storage,
+      new FixedTimeProvider(
+        new DateTimeOffset(2026, 8, 21, 12, 0, 0, TimeSpan.Zero)));
+
+    await bootstrap.RunAsync(ScenarioPath, CancellationToken.None);
+
+    List<string> expected =
+      ["cosmos-clear", "storage-reset", "cosmos-write"];
+    CollectionAssert.AreEqual(expected, operations);
+  }
+
+  /// <summary>
+  /// Verifies a reset failure prevents every subsequent write.
+  /// </summary>
+  [TestMethod]
+  public async Task RunAsync_CosmosResetFails_DoesNotResetStorageOrWrite()
+  {
+    var operations = new List<string>();
+    var cosmos = new RecordingCosmosResetter(
+      operations,
+      clearException: new InvalidOperationException("reset failed"));
+    var storage = new RecordingAzuriteResetter(operations);
+    var bootstrap = new LocalScenarioBootstrap(
+      cosmos,
+      storage,
+      TimeProvider.System);
+
+    await Assert.ThrowsExactlyAsync<InvalidOperationException>(
+      () => bootstrap.RunAsync(ScenarioPath, CancellationToken.None));
+
+    CollectionAssert.AreEqual(
+      new List<string> { "cosmos-clear" },
+      operations);
+  }
+
+  private sealed class RecordingCosmosResetter(
+    List<string> operations,
+    Exception? clearException = null) : ILocalCosmosResetter
+  {
+    public Task ClearAsync(CancellationToken cancellationToken)
+    {
+      operations.Add("cosmos-clear");
+      return clearException is null
+        ? Task.CompletedTask
+        : Task.FromException(clearException);
+    }
+
+    public Task WriteAsync(
+      MaterializedSeedScenario scenario,
+      CancellationToken cancellationToken)
+    {
+      operations.Add("cosmos-write");
+      return Task.CompletedTask;
+    }
+  }
+
+  private sealed class RecordingAzuriteResetter(
+    List<string> operations) : ILocalAzuriteResetter
+  {
+    public Task ResetAsync(
+      MaterializedSeedScenario scenario,
+      CancellationToken cancellationToken)
+    {
+      operations.Add("storage-reset");
+      return Task.CompletedTask;
+    }
+  }
+
+  private sealed class FixedTimeProvider(
+    DateTimeOffset instant) : TimeProvider
+  {
+    public override DateTimeOffset GetUtcNow() => instant;
+  }
+}

--- a/tooling/AppHost.Tests/SeedDataTests.cs
+++ b/tooling/AppHost.Tests/SeedDataTests.cs
@@ -48,6 +48,21 @@ public sealed class SeedDataTests
       scenario.Invoices.Count(invoice =>
         invoice.UserIdentifier == PersonaIds.Charlie));
     Assert.AreEqual(
+      7,
+      scenario.Invoices.Count(invoice =>
+        invoice.UserIdentifier == PersonaIds.Alice
+        && !invoice.IsSoftDeleted));
+    Assert.AreEqual(
+      0,
+      scenario.Invoices.Count(invoice =>
+        invoice.UserIdentifier == PersonaIds.Bob
+        && !invoice.IsSoftDeleted));
+    Assert.AreEqual(
+      3,
+      scenario.Invoices.Count(invoice =>
+        invoice.UserIdentifier == PersonaIds.Charlie
+        && !invoice.IsSoftDeleted));
+    Assert.AreEqual(
       5,
       scenario.Merchants.Count(merchant =>
         merchant.CreatedBy == PersonaIds.Alice));
@@ -109,6 +124,25 @@ public sealed class SeedDataTests
     SeedInvoiceDefinition invalidInvoice = manifest.Invoices[0] with
     {
       MerchantKey = "merchant/unknown",
+    };
+
+    Assert.ThrowsExactly<InvalidDataException>(
+      () => SeedManifestValidator.Validate(manifest with
+      {
+        Invoices = [invalidInvoice, .. manifest.Invoices.Skip(1)],
+      }));
+  }
+
+  /// <summary>
+  /// Verifies an invoice cannot reference a blob outside the manifest.
+  /// </summary>
+  [TestMethod]
+  public void Validate_UnknownBlobReference_ThrowsInvalidDataException()
+  {
+    SeedScenarioManifest manifest = SeedData.LoadManifest(ScenarioPath);
+    SeedInvoiceDefinition invalidInvoice = manifest.Invoices[0] with
+    {
+      BlobKey = "blob/unknown",
     };
 
     Assert.ThrowsExactly<InvalidDataException>(

--- a/tooling/AppHost.Tests/SeedDataTests.cs
+++ b/tooling/AppHost.Tests/SeedDataTests.cs
@@ -1,0 +1,171 @@
+namespace AppHost.Tests;
+
+using System.Text.Json;
+
+using LocalDevelopment.Bootstrap;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+/// <summary>
+/// Verifies the deterministic local development scenario.
+/// </summary>
+[TestClass]
+public sealed class SeedDataTests
+{
+  private static readonly string ScenarioPath = Path.GetFullPath(
+    Path.Combine(
+      AppContext.BaseDirectory,
+      "..",
+      "..",
+      "..",
+      "..",
+      "LocalDevelopment.Bootstrap",
+      "SeedData",
+      "scenario.v1.json"));
+
+  /// <summary>
+  /// Verifies the approved fixture gives Alice rich data, Bob a clean slate,
+  /// and Charlie a light account.
+  /// </summary>
+  [TestMethod]
+  public void LoadAndMaterialize_ApprovedScenario_HasExpectedPersonaCounts()
+  {
+    SeedScenarioManifest manifest = SeedData.LoadManifest(ScenarioPath);
+    MaterializedSeedScenario scenario = SeedData.Materialize(
+      manifest,
+      new DateOnly(2026, 8, 21));
+
+    Assert.AreEqual(
+      8,
+      scenario.Invoices.Count(invoice =>
+        invoice.UserIdentifier == PersonaIds.Alice));
+    Assert.AreEqual(
+      0,
+      scenario.Invoices.Count(invoice =>
+        invoice.UserIdentifier == PersonaIds.Bob));
+    Assert.AreEqual(
+      3,
+      scenario.Invoices.Count(invoice =>
+        invoice.UserIdentifier == PersonaIds.Charlie));
+    Assert.AreEqual(
+      5,
+      scenario.Merchants.Count(merchant =>
+        merchant.CreatedBy == PersonaIds.Alice));
+    Assert.AreEqual(
+      2,
+      scenario.Merchants.Count(merchant =>
+        merchant.CreatedBy == PersonaIds.Charlie));
+  }
+
+  /// <summary>
+  /// Verifies the same UTC anchor produces the same fixture-controlled values.
+  /// </summary>
+  [TestMethod]
+  public void Materialize_SameAnchor_ProducesEquivalentBusinessProjection()
+  {
+    SeedScenarioManifest manifest = SeedData.LoadManifest(ScenarioPath);
+    DateOnly anchor = new(2026, 8, 21);
+
+    MaterializedSeedScenario first = SeedData.Materialize(manifest, anchor);
+    MaterializedSeedScenario second = SeedData.Materialize(manifest, anchor);
+
+    Assert.AreEqual(Project(first), Project(second));
+  }
+
+  /// <summary>
+  /// Verifies merchant groups and shared invoice visibility are represented.
+  /// </summary>
+  [TestMethod]
+  public void Materialize_ApprovedScenario_PreservesRelationships()
+  {
+    SeedScenarioManifest manifest = SeedData.LoadManifest(ScenarioPath);
+    MaterializedSeedScenario scenario = SeedData.Materialize(
+      manifest,
+      new DateOnly(2026, 8, 21));
+
+    Assert.IsTrue(
+      scenario.Merchants
+        .Where(merchant => merchant.CreatedBy == PersonaIds.Alice)
+        .GroupBy(merchant => merchant.ParentCompanyId)
+        .Count(group => group.Key != Guid.Empty && group.Count() >= 2) >= 2);
+    Assert.IsTrue(
+      scenario.Invoices.Any(invoice =>
+        invoice.UserIdentifier == PersonaIds.Alice
+        && invoice.SharedWith.Contains(PersonaIds.Charlie)));
+    Assert.IsTrue(
+      scenario.Invoices.All(invoice =>
+        invoice.MerchantReference == Guid.Empty
+        || scenario.Merchants.Any(merchant =>
+          merchant.id == invoice.MerchantReference)));
+  }
+
+  /// <summary>
+  /// Verifies an invoice cannot reference a merchant outside the manifest.
+  /// </summary>
+  [TestMethod]
+  public void Validate_UnknownMerchantReference_ThrowsInvalidDataException()
+  {
+    SeedScenarioManifest manifest = SeedData.LoadManifest(ScenarioPath);
+    SeedInvoiceDefinition invalidInvoice = manifest.Invoices[0] with
+    {
+      MerchantKey = "merchant/unknown",
+    };
+
+    Assert.ThrowsExactly<InvalidDataException>(
+      () => SeedManifestValidator.Validate(manifest with
+      {
+        Invoices = [invalidInvoice, .. manifest.Invoices.Skip(1)],
+      }));
+  }
+
+  /// <summary>
+  /// Verifies the clean-slate persona cannot accidentally gain owned records.
+  /// </summary>
+  [TestMethod]
+  public void Validate_BobOwnsInvoice_ThrowsInvalidDataException()
+  {
+    SeedScenarioManifest manifest = SeedData.LoadManifest(ScenarioPath);
+    SeedInvoiceDefinition bobInvoice = manifest.Invoices[0] with
+    {
+      OwnerKey = "bob",
+    };
+
+    Assert.ThrowsExactly<InvalidDataException>(
+      () => SeedManifestValidator.Validate(manifest with
+      {
+        Invoices = [bobInvoice, .. manifest.Invoices.Skip(1)],
+      }));
+  }
+
+  private static string Project(MaterializedSeedScenario scenario) =>
+    JsonSerializer.Serialize(new
+    {
+      Merchants = scenario.Merchants.Select(merchant => new
+      {
+        merchant.id,
+        merchant.Name,
+        merchant.Description,
+        merchant.ParentCompanyId,
+        merchant.CreatedBy,
+        merchant.ReferencedInvoices,
+      }),
+      Invoices = scenario.Invoices.Select(invoice => new
+      {
+        invoice.id,
+        invoice.UserIdentifier,
+        invoice.Name,
+        invoice.Description,
+        invoice.CreatedAt,
+        invoice.MerchantReference,
+        invoice.SharedWith,
+        invoice.Classification,
+        invoice.Items,
+        invoice.PossibleRecipes,
+        invoice.PaymentInformation,
+        invoice.IsImportant,
+        invoice.IsSoftDeleted,
+        invoice.AdditionalMetadata,
+      }),
+      Blobs = scenario.Blobs,
+    });
+}

--- a/tooling/AppHost/AppHost.csproj
+++ b/tooling/AppHost/AppHost.csproj
@@ -21,6 +21,8 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\sites\api.arolariu.ro\src\Core\arolariu.Backend.Core.csproj" IsAspireProjectResource="true" />
+    <ProjectReference Include="..\LocalDevelopment.Bootstrap\LocalDevelopment.Bootstrap.csproj" IsAspireProjectResource="true" />
+    <ProjectReference Include="..\LocalDevelopment.Identity\LocalDevelopment.Identity.csproj" IsAspireProjectResource="true" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="AppHost.Tests" />

--- a/tooling/AppHost/AppHost.csproj
+++ b/tooling/AppHost/AppHost.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Aspire.Hosting.Python" Version="13.4.6" />
     <PackageReference Include="Aspire.Hosting.Redis" Version="13.4.6" />
     <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.4.6" />
+    <PackageReference Include="Azure.Storage.Queues" Version="12.27.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\sites\api.arolariu.ro\src\Core\arolariu.Backend.Core.csproj" IsAspireProjectResource="true" />

--- a/tooling/AppHost/Aspire/AzuriteBootstrap.cs
+++ b/tooling/AppHost/Aspire/AzuriteBootstrap.cs
@@ -7,6 +7,7 @@ using global::Aspire.Hosting;
 using global::Aspire.Hosting.ApplicationModel;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
+using Azure.Storage.Queues;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
@@ -15,10 +16,11 @@ using Microsoft.Extensions.Logging;
 /// Configures CORS service-properties on the Aspire-managed Azurite storage emulator
 /// so browser-side blob uploads succeed across the origin boundary between
 /// <c>https://localhost:3000</c> (website) and <c>http://localhost:10000</c> (blob endpoint),
-/// and ensures any required blob containers exist (idempotent <c>CreateIfNotExists</c>).
+/// and ensures required blob containers and queues exist through idempotent
+/// <c>CreateIfNotExists</c> operations.
 ///
 /// <para>
-/// Azurite ships with no default CORS rules and no containers; without this hook every
+/// Azurite ships with no default CORS rules, containers, or queues; without this hook every
 /// preflight OPTIONS fails with "No 'Access-Control-Allow-Origin' header is present on the
 /// requested resource", and the first upload to a missing container 404s with
 /// <c>ContainerNotFound</c>. With the named data volume in place (see <c>Program.cs</c>'s
@@ -32,7 +34,7 @@ using Microsoft.Extensions.Logging;
 /// </para>
 ///
 /// <para>
-/// In production these containers are provisioned by Bicep (see <c>infra/Azure/Bicep</c>).
+/// In production these storage resources are provisioned by Bicep (see <c>infra/Azure/Bicep</c>).
 /// This helper brings the local emulator to the same starting state.
 /// </para>
 /// </summary>
@@ -62,8 +64,9 @@ internal static class AzuriteBootstrap
   /// <summary>
   /// Subscribes a bootstrap handler to <paramref name="storage"/>'s
   /// <see cref="ResourceReadyEvent"/>. The handler applies allow-all CORS rules and
-  /// idempotently creates each container in <paramref name="containerNames"/>. CORS and
-  /// container creation are retried independently up to 6 times each with linear backoff.
+  /// idempotently creates each blob container in <paramref name="blobContainerNames"/> and
+  /// queue in <paramref name="queueNames"/>. CORS and resource creation are retried
+  /// independently up to 6 times each with linear backoff.
   /// Bootstrap success/failure is surfaced via a custom health check
   /// (<c>azurite-bootstrap</c>) attached to <paramref name="storage"/>, so the dashboard
   /// turns the storage resource red on persistent failure instead of leaving the user to
@@ -73,23 +76,27 @@ internal static class AzuriteBootstrap
   /// <param name="storage">The Azurite storage resource to configure.</param>
   /// <param name="blobPort">The host port Azurite's blob service is reachable at
   /// (typically <c>10000</c> via <c>WithBlobPort</c>).</param>
-  /// <param name="containerNames">Container names to ensure exist
+  /// <param name="queuePort">The host port Azurite's queue service is reachable at
+  /// (typically <c>10001</c> via <c>WithQueuePort</c>).</param>
+  /// <param name="blobContainerNames">Blob container names to ensure exist
   /// (<c>CreateIfNotExistsAsync</c>). Pass an empty array if no containers are needed.</param>
+  /// <param name="queueNames">Queue names to ensure exist
+  /// (<c>CreateIfNotExistsAsync</c>). Pass an empty array if no queues are needed.</param>
   public static IDistributedApplicationBuilder AddAzuriteBootstrap<TResource>(
       this IDistributedApplicationBuilder builder,
       IResourceBuilder<TResource> storage,
       int blobPort,
-      params string[] containerNames)
+      int queuePort,
+      IReadOnlyList<string> blobContainerNames,
+      IReadOnlyList<string> queueNames)
       where TResource : IResource
   {
     ArgumentNullException.ThrowIfNull(builder);
     ArgumentNullException.ThrowIfNull(storage);
-    ArgumentNullException.ThrowIfNull(containerNames);
+    ArgumentNullException.ThrowIfNull(blobContainerNames);
+    ArgumentNullException.ThrowIfNull(queueNames);
 
-    var connStr =
-        $"DefaultEndpointsProtocol=http;AccountName={AzuriteAccountName};"
-      + $"AccountKey={AzuriteAccountKey};"
-      + $"BlobEndpoint=http://localhost:{blobPort}/{AzuriteAccountName};";
+    string connectionString = CreateConnectionString(blobPort, queuePort);
 
     builder.Services.AddHealthChecks().AddCheck(HealthCheckName, () =>
         _bootstrapError is null
@@ -112,14 +119,25 @@ internal static class AzuriteBootstrap
       var logger = evt.Services.GetService<ILoggerFactory>()
               ?.CreateLogger("AzuriteBootstrap");
 
-      var client = new BlobServiceClient(connStr);
+      var blobServiceClient = new BlobServiceClient(connectionString);
+      var queueServiceClient = new QueueServiceClient(connectionString);
 
       try
       {
-        await ApplyCorsWithRetryAsync(client, logger, ct).ConfigureAwait(false);
-        await EnsureContainersWithRetryAsync(client, containerNames, logger, ct).ConfigureAwait(false);
+        await ApplyCorsWithRetryAsync(blobServiceClient, logger, ct).ConfigureAwait(false);
+        await EnsureContainersWithRetryAsync(
+          blobServiceClient,
+          blobContainerNames,
+          logger,
+          ct).ConfigureAwait(false);
+        await EnsureQueuesWithRetryAsync(
+          queueServiceClient,
+          queueNames,
+          logger,
+          ct).ConfigureAwait(false);
         _bootstrapError = null;
-        logger?.LogInformation("Azurite bootstrap completed (CORS + container creation).");
+        logger?.LogInformation(
+          "Azurite bootstrap completed (CORS + blob container + queue creation).");
       }
       catch (OperationCanceledException)
       {
@@ -137,6 +155,24 @@ internal static class AzuriteBootstrap
     });
 
     return builder;
+  }
+
+  /// <summary>
+  /// Creates the local Azurite connection string for blob and queue services.
+  /// </summary>
+  /// <param name="blobPort">The positive host blob-service port.</param>
+  /// <param name="queuePort">The positive host queue-service port.</param>
+  /// <returns>The connection string targeting both loopback service endpoints.</returns>
+  internal static string CreateConnectionString(int blobPort, int queuePort)
+  {
+    ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(blobPort, 0);
+    ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(queuePort, 0);
+
+    return
+        $"DefaultEndpointsProtocol=http;AccountName={AzuriteAccountName};"
+      + $"AccountKey={AzuriteAccountKey};"
+      + $"BlobEndpoint=http://localhost:{blobPort}/{AzuriteAccountName};"
+      + $"QueueEndpoint=http://localhost:{queuePort}/{AzuriteAccountName};";
   }
 
   // Match the storage resource itself or any descendant (e.g. the Azurite container
@@ -190,11 +226,11 @@ internal static class AzuriteBootstrap
 
   private static async Task EnsureContainersWithRetryAsync(
       BlobServiceClient client,
-      string[] containerNames,
+      IReadOnlyList<string> containerNames,
       ILogger? logger,
       CancellationToken ct)
   {
-    if (containerNames.Length == 0) return;
+    if (containerNames.Count == 0) return;
 
     for (int attempt = 1; attempt <= MaxAttempts; attempt++)
     {
@@ -238,5 +274,50 @@ internal static class AzuriteBootstrap
     }
     throw new InvalidOperationException(
         $"Azurite container bootstrap failed after {MaxAttempts} attempts.");
+  }
+
+  private static async Task EnsureQueuesWithRetryAsync(
+      QueueServiceClient client,
+      IReadOnlyList<string> queueNames,
+      ILogger? logger,
+      CancellationToken cancellationToken)
+  {
+    if (queueNames.Count == 0)
+    {
+      return;
+    }
+
+    for (int attempt = 1; attempt <= MaxAttempts; attempt++)
+    {
+      try
+      {
+        foreach (string queueName in queueNames)
+        {
+          await client
+            .GetQueueClient(queueName)
+            .CreateIfNotExistsAsync(cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+          logger?.LogInformation(
+            "Azurite queue '{Name}' is ready.",
+            queueName);
+        }
+
+        return;
+      }
+      catch (Exception exception) when (attempt < MaxAttempts)
+      {
+        logger?.LogDebug(
+          "Azurite queue creation attempt {Attempt} failed: {Message}; retrying in {DelaySec}s.",
+          attempt,
+          exception.Message,
+          attempt);
+        await Task
+          .Delay(TimeSpan.FromSeconds(attempt), cancellationToken)
+          .ConfigureAwait(false);
+      }
+    }
+
+    throw new InvalidOperationException(
+      $"Azurite queue bootstrap failed after {MaxAttempts} attempts.");
   }
 }

--- a/tooling/AppHost/Aspire/LocalDevelopmentResourceConfiguration.cs
+++ b/tooling/AppHost/Aspire/LocalDevelopmentResourceConfiguration.cs
@@ -1,0 +1,36 @@
+namespace AppHost.Aspire;
+
+/// <summary>
+/// Produces the environment contract for local-only bootstrap resources.
+/// </summary>
+internal static class LocalDevelopmentResourceConfiguration
+{
+  internal static IReadOnlyDictionary<string, string> CreateBootstrapEnvironment(
+    string manifestPath)
+  {
+    ArgumentException.ThrowIfNullOrWhiteSpace(manifestPath);
+
+    return new Dictionary<string, string>(StringComparer.Ordinal)
+    {
+      ["DOTNET_ENVIRONMENT"] = "Development",
+      ["INFRA"] = "local",
+      ["SEED_MANIFEST_PATH"] = manifestPath,
+    };
+  }
+
+  internal static IReadOnlyDictionary<string, string> CreateIdentityEnvironment(
+    string configPath,
+    string swaggerOrigin)
+  {
+    ArgumentException.ThrowIfNullOrWhiteSpace(configPath);
+    ArgumentException.ThrowIfNullOrWhiteSpace(swaggerOrigin);
+
+    return new Dictionary<string, string>(StringComparer.Ordinal)
+    {
+      ["DOTNET_ENVIRONMENT"] = "Development",
+      ["INFRA"] = "local",
+      ["LOCAL_CONFIG_PATH"] = configPath,
+      ["LOCAL_SWAGGER_ORIGIN"] = swaggerOrigin,
+    };
+  }
+}

--- a/tooling/AppHost/Constants.cs
+++ b/tooling/AppHost/Constants.cs
@@ -34,6 +34,7 @@ internal static class Constants
 
   // ── Fixed dev ports — match infra/Local/Storage/docker-compose.yml ──
   public const int ApiPort = 5000;
+  public const int LocalIdentityPort = 5011;
   public const int ExpPort = 5002;
   public const int WebsitePort = 3000;
   public const int CvPort = 4173;

--- a/tooling/AppHost/Constants.cs
+++ b/tooling/AppHost/Constants.cs
@@ -24,6 +24,7 @@ internal static class Constants
   public const string CosmosInvoicesPartitionKey = "/UserIdentifier";
   public const string CosmosMerchantsContainer = "merchants";
   public const string CosmosMerchantsPartitionKey = "/ParentCompanyId";
+  public const string AnalysisQueueName = "invoice-analysis";
 
   // ── Volume names (data persistence across container restarts) ──
   public const string SqlDataVolume = "arolariu-mssql-data";

--- a/tooling/AppHost/Program.cs
+++ b/tooling/AppHost/Program.cs
@@ -147,6 +147,8 @@ var storage = builder
     .WithEndpoint("blob", e => e.IsProxied = false)
     .WithEndpoint("queue", e => e.IsProxied = false)
     .WithIconName("Storage");
+var storageBlobs = storage.AddBlobs("blobs");
+var storageQueues = storage.AddQueues("queues");
 
 // Azurite ships with no CORS rules, containers, or queues — apply allow-all on every
 // startup so browser uploads from https://localhost:3000 → http://localhost:10000
@@ -161,6 +163,24 @@ builder.AddAzuriteBootstrap(
     queuePort: Constants.AzuriteQueuePort,
     blobContainerNames: ["invoices"],
     queueNames: [Constants.AnalysisQueueName]);
+
+IReadOnlyDictionary<string, string> bootstrapEnvironment =
+    LocalDevelopmentResourceConfiguration.CreateBootstrapEnvironment(
+        manifestPath: "SeedData/scenario.v1.json");
+var localBootstrap = builder
+    .AddProject<Projects.LocalDevelopment_Bootstrap>("local-bootstrap")
+    .WithReference(cosmosPrimaryDb)
+    .WithReference(storageBlobs)
+    .WithReference(storageQueues)
+    .WithEnvironment("DOTNET_ENVIRONMENT", bootstrapEnvironment["DOTNET_ENVIRONMENT"])
+    .WithEnvironment("INFRA", bootstrapEnvironment["INFRA"])
+    .WithEnvironment("SEED_MANIFEST_PATH", bootstrapEnvironment["SEED_MANIFEST_PATH"])
+    .WaitFor(cosmosInvoices)
+    .WaitFor(cosmosMerchants)
+    .WaitFor(storageBlobs)
+    .WaitFor(storageQueues)
+    .ExcludeFromManifest()
+    .WithIconName("DatabaseLightning");
 
 var redisPassword = builder.AddParameter("redis-password", secret: true);
 var redis = builder
@@ -206,6 +226,27 @@ var exp = builder
     .WithIconName("KeyMultiple")
     .WithHttpHealthCheck("/api/ready");
 
+string aspireConfigPath = Path.GetFullPath(
+    "../../sites/exp.arolariu.ro/config.aspire.json");
+IReadOnlyDictionary<string, string> identityEnvironment =
+    LocalDevelopmentResourceConfiguration.CreateIdentityEnvironment(
+        aspireConfigPath,
+        $"http://localhost:{Constants.ApiPort}");
+var localIdentities = builder
+    .AddProject<Projects.LocalDevelopment_Identity>("local-identities")
+    .WithHttpEndpoint(
+        port: Constants.LocalIdentityPort,
+        name: "http",
+        isProxied: false)
+    .WithEnvironment("DOTNET_ENVIRONMENT", identityEnvironment["DOTNET_ENVIRONMENT"])
+    .WithEnvironment("INFRA", identityEnvironment["INFRA"])
+    .WithEnvironment("LOCAL_CONFIG_PATH", identityEnvironment["LOCAL_CONFIG_PATH"])
+    .WithEnvironment("LOCAL_SWAGGER_ORIGIN", identityEnvironment["LOCAL_SWAGGER_ORIGIN"])
+    .WaitFor(exp)
+    .ExcludeFromManifest()
+    .WithIconName("PersonKey")
+    .WithHttpHealthCheck("/health");
+
 // ─────────────────────────────────────────────────────────────────────
 // .NET API. API reads connection strings from exp at startup; Aspire
 // injects EXP_PROXY_URL pointing at the native exp endpoint.
@@ -215,7 +256,12 @@ var api = builder
     .AddProject<Projects.arolariu_Backend_Core>("api")
     .WithHttpEndpoint(port: Constants.ApiPort, name: "http")
     .WithEnvironment("EXP_PROXY_URL", exp.GetEndpoint("http"))
+    .WithEnvironment(
+        "LOCAL_DEVELOPMENT_IDENTITY_URL",
+        localIdentities.GetEndpoint("http"))
     .WithReference(exp)
+    .WaitForCompletion(localBootstrap)
+    .WaitFor(localIdentities)
     .WaitFor(exp)
     .WithIconName("CodeBlock")
     .WithHttpHealthCheck("/health");

--- a/tooling/AppHost/Program.cs
+++ b/tooling/AppHost/Program.cs
@@ -148,13 +148,19 @@ var storage = builder
     .WithEndpoint("queue", e => e.IsProxied = false)
     .WithIconName("Storage");
 
-// Azurite ships with no CORS rules and no containers — apply allow-all on every
+// Azurite ships with no CORS rules, containers, or queues — apply allow-all on every
 // startup so browser uploads from https://localhost:3000 → http://localhost:10000
 // succeed, and idempotently create the 'invoices' container so the first upload
-// from uploadScan.ts doesn't 404 with ContainerNotFound. In production these are
+// from uploadScan.ts doesn't 404 with ContainerNotFound. The analysis queue is
+// created before the hosted worker starts polling. In production these are
 // provisioned by Bicep; this brings the local emulator to the same starting state.
 // See Aspire/AzuriteBootstrap.cs for the retry / event-subscription details.
-builder.AddAzuriteBootstrap(storage, Constants.AzuriteBlobPort, "invoices");
+builder.AddAzuriteBootstrap(
+    storage,
+    blobPort: Constants.AzuriteBlobPort,
+    queuePort: Constants.AzuriteQueuePort,
+    blobContainerNames: ["invoices"],
+    queueNames: [Constants.AnalysisQueueName]);
 
 var redisPassword = builder.AddParameter("redis-password", secret: true);
 var redis = builder

--- a/tooling/LocalDevelopment.Bootstrap/BootstrapOptions.cs
+++ b/tooling/LocalDevelopment.Bootstrap/BootstrapOptions.cs
@@ -1,0 +1,27 @@
+namespace LocalDevelopment.Bootstrap;
+
+/// <summary>
+/// Resolves local bootstrap inputs from Aspire-provided environment variables.
+/// </summary>
+internal sealed record BootstrapOptions(
+  string EnvironmentName,
+  string Infra,
+  string? AzureClientId,
+  string? CosmosConnectionString,
+  string StorageConnectionString,
+  string ManifestPath)
+{
+  internal static BootstrapOptions FromEnvironment() =>
+    new(
+      Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT")
+        ?? Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT")
+        ?? string.Empty,
+      Environment.GetEnvironmentVariable("INFRA") ?? string.Empty,
+      Environment.GetEnvironmentVariable("AZURE_CLIENT_ID"),
+      Environment.GetEnvironmentVariable("ConnectionStrings__primary"),
+      Environment.GetEnvironmentVariable("ConnectionStrings__storage")
+        ?? throw new InvalidOperationException(
+          "ConnectionStrings__storage is required."),
+      Environment.GetEnvironmentVariable("SEED_MANIFEST_PATH")
+        ?? Path.Combine(AppContext.BaseDirectory, "SeedData", "scenario.v1.json"));
+}

--- a/tooling/LocalDevelopment.Bootstrap/BootstrapOptions.cs
+++ b/tooling/LocalDevelopment.Bootstrap/BootstrapOptions.cs
@@ -8,7 +8,8 @@ internal sealed record BootstrapOptions(
   string Infra,
   string? AzureClientId,
   string? CosmosConnectionString,
-  string StorageConnectionString,
+  string BlobStorageConnectionString,
+  string QueueStorageConnectionString,
   string ManifestPath)
 {
   internal static BootstrapOptions FromEnvironment() =>
@@ -19,9 +20,12 @@ internal sealed record BootstrapOptions(
       Environment.GetEnvironmentVariable("INFRA") ?? string.Empty,
       Environment.GetEnvironmentVariable("AZURE_CLIENT_ID"),
       Environment.GetEnvironmentVariable("ConnectionStrings__primary"),
-      Environment.GetEnvironmentVariable("ConnectionStrings__storage")
+      Environment.GetEnvironmentVariable("ConnectionStrings__blobs")
         ?? throw new InvalidOperationException(
-          "ConnectionStrings__storage is required."),
+          "ConnectionStrings__blobs is required."),
+      Environment.GetEnvironmentVariable("ConnectionStrings__queues")
+        ?? throw new InvalidOperationException(
+          "ConnectionStrings__queues is required."),
       Environment.GetEnvironmentVariable("SEED_MANIFEST_PATH")
         ?? Path.Combine(AppContext.BaseDirectory, "SeedData", "scenario.v1.json"));
 }

--- a/tooling/LocalDevelopment.Bootstrap/LocalAzuriteResetter.cs
+++ b/tooling/LocalDevelopment.Bootstrap/LocalAzuriteResetter.cs
@@ -1,0 +1,81 @@
+namespace LocalDevelopment.Bootstrap;
+
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using Azure.Storage.Queues;
+
+internal interface ILocalAzuriteResetter
+{
+  Task ResetAsync(
+    MaterializedSeedScenario scenario,
+    CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Resets local invoice blobs and analysis messages before uploading seed scans.
+/// </summary>
+internal sealed class LocalAzuriteResetter(
+  BlobServiceClient blobServiceClient,
+  QueueServiceClient queueServiceClient) : ILocalAzuriteResetter
+{
+  private const string BlobContainerName = "invoices";
+  private const string AnalysisQueueName = "invoice-analysis";
+
+  public async Task ResetAsync(
+    MaterializedSeedScenario scenario,
+    CancellationToken cancellationToken)
+  {
+    ArgumentNullException.ThrowIfNull(scenario);
+
+    BlobContainerClient container =
+      blobServiceClient.GetBlobContainerClient(BlobContainerName);
+    await container
+      .DeleteIfExistsAsync(cancellationToken: cancellationToken)
+      .ConfigureAwait(false);
+    await container
+      .CreateIfNotExistsAsync(
+        PublicAccessType.Blob,
+        cancellationToken: cancellationToken)
+      .ConfigureAwait(false);
+
+    foreach (MaterializedSeedBlob blob in scenario.Blobs)
+    {
+      using var stream = new MemoryStream(blob.Content, writable: false);
+      await container
+        .GetBlobClient($"seed/{blob.Key}.png")
+        .UploadAsync(
+          stream,
+          new BlobUploadOptions
+          {
+            HttpHeaders = new BlobHttpHeaders
+            {
+              ContentType = blob.ContentType,
+            },
+          },
+          cancellationToken)
+        .ConfigureAwait(false);
+    }
+
+    QueueClient queue = queueServiceClient.GetQueueClient(AnalysisQueueName);
+    await queue
+      .CreateIfNotExistsAsync(cancellationToken: cancellationToken)
+      .ConfigureAwait(false);
+    await queue
+      .ClearMessagesAsync(cancellationToken)
+      .ConfigureAwait(false);
+  }
+
+  internal async Task EnsureStorageAsync(CancellationToken cancellationToken)
+  {
+    await blobServiceClient
+      .GetBlobContainerClient(BlobContainerName)
+      .CreateIfNotExistsAsync(
+        PublicAccessType.Blob,
+        cancellationToken: cancellationToken)
+      .ConfigureAwait(false);
+    await queueServiceClient
+      .GetQueueClient(AnalysisQueueName)
+      .CreateIfNotExistsAsync(cancellationToken: cancellationToken)
+      .ConfigureAwait(false);
+  }
+}

--- a/tooling/LocalDevelopment.Bootstrap/LocalCosmosResetter.cs
+++ b/tooling/LocalDevelopment.Bootstrap/LocalCosmosResetter.cs
@@ -1,0 +1,95 @@
+namespace LocalDevelopment.Bootstrap;
+
+using arolariu.Backend.Domain.Invoices.DDD.AggregatorRoots.Invoices;
+using arolariu.Backend.Domain.Invoices.DDD.Entities.Merchants;
+
+using Microsoft.Azure.Cosmos;
+
+internal interface ILocalCosmosResetter
+{
+  Task ClearAsync(CancellationToken cancellationToken);
+
+  Task WriteAsync(
+    MaterializedSeedScenario scenario,
+    CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Clears and repopulates the local invoice-domain Cosmos containers.
+/// </summary>
+internal sealed class LocalCosmosResetter(
+  CosmosClient cosmosClient) : ILocalCosmosResetter
+{
+  private const string DatabaseName = "primary";
+  private const string InvoicesContainerName = "invoices";
+  private const string MerchantsContainerName = "merchants";
+
+  public async Task ClearAsync(CancellationToken cancellationToken)
+  {
+    Database database = cosmosClient.GetDatabase(DatabaseName);
+    await ClearContainerAsync(
+      database.GetContainer(InvoicesContainerName),
+      "UserIdentifier",
+      cancellationToken).ConfigureAwait(false);
+    await ClearContainerAsync(
+      database.GetContainer(MerchantsContainerName),
+      "ParentCompanyId",
+      cancellationToken).ConfigureAwait(false);
+  }
+
+  public async Task WriteAsync(
+    MaterializedSeedScenario scenario,
+    CancellationToken cancellationToken)
+  {
+    ArgumentNullException.ThrowIfNull(scenario);
+
+    Database database = cosmosClient.GetDatabase(DatabaseName);
+    Container merchants = database.GetContainer(MerchantsContainerName);
+    Container invoices = database.GetContainer(InvoicesContainerName);
+
+    foreach (Merchant merchant in scenario.Merchants)
+    {
+      await merchants.CreateItemAsync(
+        merchant,
+        new PartitionKey(merchant.ParentCompanyId.ToString()),
+        cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    foreach (Invoice invoice in scenario.Invoices)
+    {
+      await invoices.CreateItemAsync(
+        invoice,
+        new PartitionKey(invoice.UserIdentifier.ToString()),
+        cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+  }
+
+  private static async Task ClearContainerAsync(
+    Container container,
+    string partitionProperty,
+    CancellationToken cancellationToken)
+  {
+    QueryDefinition query = new(
+      $"SELECT c.id, c.{partitionProperty} AS partitionKey FROM c");
+    using FeedIterator<StoredDocumentReference> iterator =
+      container.GetItemQueryIterator<StoredDocumentReference>(query);
+
+    while (iterator.HasMoreResults)
+    {
+      FeedResponse<StoredDocumentReference> response =
+        await iterator.ReadNextAsync(cancellationToken).ConfigureAwait(false);
+
+      foreach (StoredDocumentReference document in response)
+      {
+        await container.DeleteItemAsync<object>(
+          document.Id,
+          new PartitionKey(document.PartitionKey),
+          cancellationToken: cancellationToken).ConfigureAwait(false);
+      }
+    }
+  }
+
+  private sealed record StoredDocumentReference(
+    string Id,
+    string PartitionKey);
+}

--- a/tooling/LocalDevelopment.Bootstrap/LocalDevelopment.Bootstrap.csproj
+++ b/tooling/LocalDevelopment.Bootstrap/LocalDevelopment.Bootstrap.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/tooling/LocalDevelopment.Bootstrap/LocalDevelopment.Bootstrap.csproj
+++ b/tooling/LocalDevelopment.Bootstrap/LocalDevelopment.Bootstrap.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.29.1" />
+    <PackageReference Include="Azure.Storage.Queues" Version="12.27.1" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.62.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\sites\api.arolariu.ro\src\Invoices\arolariu.Backend.Domain.Invoices.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="SeedData\scenario.v1.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="AppHost.Tests" />
+  </ItemGroup>
+</Project>

--- a/tooling/LocalDevelopment.Bootstrap/LocalEnvironmentGuard.cs
+++ b/tooling/LocalDevelopment.Bootstrap/LocalEnvironmentGuard.cs
@@ -10,7 +10,8 @@ internal static class LocalEnvironmentGuard
     string infra,
     string? azureClientId,
     string cosmosConnectionString,
-    string storageConnectionString)
+    string blobStorageConnectionString,
+    string queueStorageConnectionString)
   {
     ValidateRuntime(environmentName, infra, azureClientId);
 
@@ -28,17 +29,28 @@ internal static class LocalEnvironmentGuard
         "Local development bootstrap refused a non-emulator Cosmos target.");
     }
 
-    ValidateStorageConnection(storageConnectionString);
+    ValidateStorageConnection(
+      blobStorageConnectionString,
+      "blob");
+    ValidateStorageConnection(
+      queueStorageConnectionString,
+      "queue");
   }
 
   internal static void ValidateStorage(
     string environmentName,
     string infra,
     string? azureClientId,
-    string storageConnectionString)
+    string blobStorageConnectionString,
+    string queueStorageConnectionString)
   {
     ValidateRuntime(environmentName, infra, azureClientId);
-    ValidateStorageConnection(storageConnectionString);
+    ValidateStorageConnection(
+      blobStorageConnectionString,
+      "blob");
+    ValidateStorageConnection(
+      queueStorageConnectionString,
+      "queue");
   }
 
   private static void ValidateRuntime(
@@ -58,7 +70,9 @@ internal static class LocalEnvironmentGuard
     }
   }
 
-  private static void ValidateStorageConnection(string connectionString)
+  private static void ValidateStorageConnection(
+    string connectionString,
+    string serviceName)
   {
     if (string.Equals(
       connectionString,
@@ -68,21 +82,20 @@ internal static class LocalEnvironmentGuard
       return;
     }
 
-    bool hasBlob = TryReadEndpoint(
+    string endpointKey = string.Equals(
+      serviceName,
+      "blob",
+      StringComparison.Ordinal)
+        ? "BlobEndpoint"
+        : "QueueEndpoint";
+    bool hasEndpoint = TryReadEndpoint(
       connectionString,
-      "BlobEndpoint",
-      out Uri? blobEndpoint);
-    bool hasQueue = TryReadEndpoint(
-      connectionString,
-      "QueueEndpoint",
-      out Uri? queueEndpoint);
+      endpointKey,
+      out Uri? endpoint);
 
-    if (!hasBlob
-        || !hasQueue
-        || blobEndpoint is null
-        || queueEndpoint is null
-        || !blobEndpoint.IsLoopback
-        || !queueEndpoint.IsLoopback)
+    if (!hasEndpoint
+        || endpoint is null
+        || !endpoint.IsLoopback)
     {
       throw new InvalidOperationException(
         "Local development bootstrap refused a non-Azurite storage target.");

--- a/tooling/LocalDevelopment.Bootstrap/LocalEnvironmentGuard.cs
+++ b/tooling/LocalDevelopment.Bootstrap/LocalEnvironmentGuard.cs
@@ -1,0 +1,107 @@
+namespace LocalDevelopment.Bootstrap;
+
+/// <summary>
+/// Prevents destructive reset behavior outside local emulators.
+/// </summary>
+internal static class LocalEnvironmentGuard
+{
+  internal static void Validate(
+    string environmentName,
+    string infra,
+    string? azureClientId,
+    string cosmosConnectionString,
+    string storageConnectionString)
+  {
+    ValidateRuntime(environmentName, infra, azureClientId);
+
+    if (!cosmosConnectionString.Contains(
+          "AccountKey=",
+          StringComparison.Ordinal)
+        || !TryReadEndpoint(
+          cosmosConnectionString,
+          "AccountEndpoint",
+          out Uri? cosmosEndpoint)
+        || cosmosEndpoint is null
+        || !cosmosEndpoint.IsLoopback)
+    {
+      throw new InvalidOperationException(
+        "Local development bootstrap refused a non-emulator Cosmos target.");
+    }
+
+    ValidateStorageConnection(storageConnectionString);
+  }
+
+  internal static void ValidateStorage(
+    string environmentName,
+    string infra,
+    string? azureClientId,
+    string storageConnectionString)
+  {
+    ValidateRuntime(environmentName, infra, azureClientId);
+    ValidateStorageConnection(storageConnectionString);
+  }
+
+  private static void ValidateRuntime(
+    string environmentName,
+    string infra,
+    string? azureClientId)
+  {
+    if (!string.Equals(
+          environmentName,
+          "Development",
+          StringComparison.Ordinal)
+        || !string.Equals(infra, "local", StringComparison.Ordinal)
+        || !string.IsNullOrWhiteSpace(azureClientId))
+    {
+      throw new InvalidOperationException(
+        "Local development bootstrap refused a non-local runtime.");
+    }
+  }
+
+  private static void ValidateStorageConnection(string connectionString)
+  {
+    if (string.Equals(
+      connectionString,
+      "UseDevelopmentStorage=true",
+      StringComparison.OrdinalIgnoreCase))
+    {
+      return;
+    }
+
+    bool hasBlob = TryReadEndpoint(
+      connectionString,
+      "BlobEndpoint",
+      out Uri? blobEndpoint);
+    bool hasQueue = TryReadEndpoint(
+      connectionString,
+      "QueueEndpoint",
+      out Uri? queueEndpoint);
+
+    if (!hasBlob
+        || !hasQueue
+        || blobEndpoint is null
+        || queueEndpoint is null
+        || !blobEndpoint.IsLoopback
+        || !queueEndpoint.IsLoopback)
+    {
+      throw new InvalidOperationException(
+        "Local development bootstrap refused a non-Azurite storage target.");
+    }
+  }
+
+  private static bool TryReadEndpoint(
+    string connectionString,
+    string key,
+    out Uri? endpoint)
+  {
+    endpoint = null;
+    string prefix = $"{key}=";
+    string? segment = connectionString
+      .Split(';', StringSplitOptions.RemoveEmptyEntries)
+      .FirstOrDefault(value =>
+        value.StartsWith(prefix, StringComparison.OrdinalIgnoreCase));
+
+    return segment is not null
+      && Uri.TryCreate(segment[prefix.Length..], UriKind.Absolute, out endpoint);
+  }
+}

--- a/tooling/LocalDevelopment.Bootstrap/LocalScenarioBootstrap.cs
+++ b/tooling/LocalDevelopment.Bootstrap/LocalScenarioBootstrap.cs
@@ -1,0 +1,25 @@
+namespace LocalDevelopment.Bootstrap;
+
+/// <summary>
+/// Coordinates deterministic local reset and seed operations.
+/// </summary>
+internal sealed class LocalScenarioBootstrap(
+  ILocalCosmosResetter cosmos,
+  ILocalAzuriteResetter storage,
+  TimeProvider timeProvider)
+{
+  internal async Task RunAsync(
+    string manifestPath,
+    CancellationToken cancellationToken)
+  {
+    SeedScenarioManifest manifest = SeedData.LoadManifest(manifestPath);
+    DateOnly anchor = DateOnly.FromDateTime(
+      timeProvider.GetUtcNow().UtcDateTime);
+    MaterializedSeedScenario scenario =
+      SeedData.Materialize(manifest, anchor);
+
+    await cosmos.ClearAsync(cancellationToken).ConfigureAwait(false);
+    await storage.ResetAsync(scenario, cancellationToken).ConfigureAwait(false);
+    await cosmos.WriteAsync(scenario, cancellationToken).ConfigureAwait(false);
+  }
+}

--- a/tooling/LocalDevelopment.Bootstrap/Program.cs
+++ b/tooling/LocalDevelopment.Bootstrap/Program.cs
@@ -1,0 +1,74 @@
+namespace LocalDevelopment.Bootstrap;
+
+using Azure.Storage.Blobs;
+using Azure.Storage.Queues;
+
+using Microsoft.Azure.Cosmos;
+
+internal static class Program
+{
+  public static async Task<int> Main(
+    string[] args)
+  {
+    try
+    {
+      BootstrapOptions options = BootstrapOptions.FromEnvironment();
+      bool ensureStorageOnly = args.Contains(
+        "--ensure-storage-only",
+        StringComparer.Ordinal);
+
+      if (ensureStorageOnly)
+      {
+        LocalEnvironmentGuard.ValidateStorage(
+          options.EnvironmentName,
+          options.Infra,
+          options.AzureClientId,
+          options.StorageConnectionString);
+      }
+      else
+      {
+        LocalEnvironmentGuard.Validate(
+          options.EnvironmentName,
+          options.Infra,
+          options.AzureClientId,
+          options.CosmosConnectionString
+            ?? throw new InvalidOperationException(
+              "ConnectionStrings__primary is required."),
+          options.StorageConnectionString);
+      }
+
+      var blobServiceClient =
+        new BlobServiceClient(options.StorageConnectionString);
+      var queueServiceClient =
+        new QueueServiceClient(options.StorageConnectionString);
+      var storage = new LocalAzuriteResetter(
+        blobServiceClient,
+        queueServiceClient);
+
+      if (ensureStorageOnly)
+      {
+        await storage
+          .EnsureStorageAsync(CancellationToken.None)
+          .ConfigureAwait(false);
+        return 0;
+      }
+
+      using var cosmosClient =
+        new CosmosClient(options.CosmosConnectionString);
+      var bootstrap = new LocalScenarioBootstrap(
+        new LocalCosmosResetter(cosmosClient),
+        storage,
+        TimeProvider.System);
+      await bootstrap
+        .RunAsync(options.ManifestPath, CancellationToken.None)
+        .ConfigureAwait(false);
+      return 0;
+    }
+    catch (Exception exception)
+    {
+      Console.Error.WriteLine(
+        $"Local development bootstrap failed: {exception.GetType().Name}: {exception.Message}");
+      return 1;
+    }
+  }
+}

--- a/tooling/LocalDevelopment.Bootstrap/Program.cs
+++ b/tooling/LocalDevelopment.Bootstrap/Program.cs
@@ -56,7 +56,13 @@ internal static class Program
       }
 
       using var cosmosClient =
-        new CosmosClient(options.CosmosConnectionString);
+        new CosmosClient(
+          options.CosmosConnectionString,
+          new CosmosClientOptions
+          {
+            ConnectionMode = ConnectionMode.Gateway,
+            LimitToEndpoint = true,
+          });
       var bootstrap = new LocalScenarioBootstrap(
         new LocalCosmosResetter(cosmosClient),
         storage,

--- a/tooling/LocalDevelopment.Bootstrap/Program.cs
+++ b/tooling/LocalDevelopment.Bootstrap/Program.cs
@@ -23,7 +23,8 @@ internal static class Program
           options.EnvironmentName,
           options.Infra,
           options.AzureClientId,
-          options.StorageConnectionString);
+          options.BlobStorageConnectionString,
+          options.QueueStorageConnectionString);
       }
       else
       {
@@ -34,13 +35,14 @@ internal static class Program
           options.CosmosConnectionString
             ?? throw new InvalidOperationException(
               "ConnectionStrings__primary is required."),
-          options.StorageConnectionString);
+          options.BlobStorageConnectionString,
+          options.QueueStorageConnectionString);
       }
 
       var blobServiceClient =
-        new BlobServiceClient(options.StorageConnectionString);
+        new BlobServiceClient(options.BlobStorageConnectionString);
       var queueServiceClient =
-        new QueueServiceClient(options.StorageConnectionString);
+        new QueueServiceClient(options.QueueStorageConnectionString);
       var storage = new LocalAzuriteResetter(
         blobServiceClient,
         queueServiceClient);

--- a/tooling/LocalDevelopment.Bootstrap/SeedData.cs
+++ b/tooling/LocalDevelopment.Bootstrap/SeedData.cs
@@ -1,0 +1,365 @@
+namespace LocalDevelopment.Bootstrap;
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using arolariu.Backend.Common.DDD.ValueObjects;
+using arolariu.Backend.Domain.Invoices.DDD.AggregatorRoots.Invoices;
+using arolariu.Backend.Domain.Invoices.DDD.Entities.Merchants;
+using arolariu.Backend.Domain.Invoices.DDD.ValueObjects;
+using arolariu.Backend.Domain.Invoices.DDD.ValueObjects.Allergens;
+using arolariu.Backend.Domain.Invoices.DDD.ValueObjects.Classifications;
+using arolariu.Backend.Domain.Invoices.DDD.ValueObjects.Products;
+using arolariu.Backend.Domain.Invoices.DDD.ValueObjects.Recipes;
+
+/// <summary>
+/// Loads and materializes the deterministic local development scenario.
+/// </summary>
+internal static class SeedData
+{
+  private const string SeedOrigin = "arolariu-local-seed";
+
+  private static readonly JsonSerializerOptions SerializerOptions = new()
+  {
+    PropertyNameCaseInsensitive = true,
+    Converters = { new JsonStringEnumConverter() },
+  };
+
+  internal static SeedScenarioManifest LoadManifest(string path)
+  {
+    ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+    if (!File.Exists(path))
+    {
+      throw new InvalidDataException($"Seed manifest was not found at '{path}'.");
+    }
+
+    SeedScenarioManifest manifest =
+      JsonSerializer.Deserialize<SeedScenarioManifest>(
+        File.ReadAllText(path),
+        SerializerOptions)
+      ?? throw new InvalidDataException("Seed manifest could not be deserialized.");
+
+    SeedManifestValidator.Validate(manifest);
+    return manifest;
+  }
+
+  internal static MaterializedSeedScenario Materialize(
+    SeedScenarioManifest manifest,
+    DateOnly utcAnchorDate)
+  {
+    SeedManifestValidator.Validate(manifest);
+
+    Dictionary<string, SeedPersonaDefinition> personas =
+      manifest.Personas.ToDictionary(persona => persona.Key, StringComparer.Ordinal);
+    Dictionary<string, SeedMerchantDefinition> merchantDefinitions =
+      manifest.Merchants.ToDictionary(merchant => merchant.Key, StringComparer.Ordinal);
+
+    List<Merchant> merchants = manifest.Merchants
+      .Select(definition => CreateMerchant(
+        definition,
+        personas[definition.OwnerKey],
+        manifest.Version,
+        utcAnchorDate))
+      .ToList();
+    Dictionary<Guid, Merchant> merchantsById =
+      merchants.ToDictionary(merchant => merchant.id);
+
+    var invoices = new List<Invoice>(manifest.Invoices.Count);
+
+    foreach (SeedInvoiceDefinition definition in manifest.Invoices)
+    {
+      SeedPersonaDefinition owner = personas[definition.OwnerKey];
+      SeedMerchantDefinition merchantDefinition =
+        merchantDefinitions[definition.MerchantKey];
+      Invoice invoice = CreateInvoice(
+        definition,
+        owner,
+        merchantDefinition.Id,
+        personas,
+        manifest.Version,
+        utcAnchorDate);
+      invoices.Add(invoice);
+      merchantsById[merchantDefinition.Id].ReferencedInvoices.Add(invoice.id);
+    }
+
+    List<MaterializedSeedBlob> blobs = manifest.Blobs
+      .Select(blob => new MaterializedSeedBlob(
+        blob.Key,
+        blob.ContentType,
+        Convert.FromBase64String(blob.ContentBase64)))
+      .ToList();
+
+    return new MaterializedSeedScenario(merchants, invoices, blobs);
+  }
+
+  private static Merchant CreateMerchant(
+    SeedMerchantDefinition definition,
+    SeedPersonaDefinition owner,
+    string version,
+    DateOnly utcAnchorDate) =>
+    new()
+    {
+      id = definition.Id,
+      Name = definition.Name,
+      Description = definition.Description,
+      ParentCompanyId = definition.ParentCompanyId,
+      Classification = CreateClassification(
+        ClassificationSystem.Nace21,
+        "2.1",
+        definition.ClassificationCode,
+        definition.ClassificationLabel,
+        ClassificationOrigin.Analysis),
+      Address = new ContactInformation
+      {
+        FullName = definition.Name,
+        Address = "Bucharest, Romania",
+        EmailAddress = $"{definition.Key.Replace('/', '.')}@example.test",
+      },
+      CreatedAt = ResolveDate(utcAnchorDate, 120),
+      CreatedBy = owner.UserIdentifier,
+      AdditionalMetadata =
+      {
+        ["seed.origin"] = SeedOrigin,
+        ["seed.version"] = version,
+        ["seed.key"] = definition.Key,
+      },
+    };
+
+  private static Invoice CreateInvoice(
+    SeedInvoiceDefinition definition,
+    SeedPersonaDefinition owner,
+    Guid merchantIdentifier,
+    IReadOnlyDictionary<string, SeedPersonaDefinition> personas,
+    string version,
+    DateOnly utcAnchorDate)
+  {
+    DateTimeOffset transactionDate = ResolveDate(utcAnchorDate, definition.DaysAgo);
+    Guid sourceRunId = definition.Id;
+    Currency currency = CreateCurrency(definition.CurrencyCode);
+    var invoice = new Invoice
+    {
+      id = definition.Id,
+      UserIdentifier = owner.UserIdentifier,
+      Name = definition.Name,
+      Description = definition.Description,
+      CreatedAt = transactionDate,
+      CreatedBy = owner.UserIdentifier,
+      IsImportant = definition.IsImportant,
+      MerchantReference = merchantIdentifier,
+      Classification = definition.ClassificationCode is null
+        ? null
+        : CreateClassification(
+          ClassificationSystem.EcoicopV2,
+          "2",
+          definition.ClassificationCode,
+          definition.ClassificationLabel
+            ?? definition.ClassificationCode,
+          ClassificationOrigin.Analysis),
+      PaymentInformation = new PaymentInformation
+      {
+        TransactionDate = transactionDate,
+        PaymentType = ParsePaymentType(definition.PaymentType),
+        Currency = currency,
+        TotalCostAmount = definition.TotalAmount,
+        TotalTaxAmount = definition.TaxAmount,
+        SubtotalAmount = definition.TotalAmount - definition.TaxAmount,
+      },
+      Items = definition.Products
+        .Select(product => CreateProduct(product, sourceRunId))
+        .ToList(),
+      PossibleRecipes = definition.IncludeRecipe
+        ? [CreateRecipe(definition, sourceRunId)]
+        : [],
+      ReceiptType = "Itemized",
+      CountryRegion = "RO",
+      TaxDetails =
+      [
+        new TaxDetail
+        {
+          Amount = definition.TaxAmount,
+          Rate = 19,
+          NetAmount = definition.TotalAmount - definition.TaxAmount,
+          Description = "VAT",
+        },
+      ],
+      Payments = CreatePayments(definition),
+    };
+
+    foreach (string sharedPersona in definition.SharedWith)
+    {
+      invoice.SharedWith.Add(personas[sharedPersona].UserIdentifier);
+    }
+
+    if (definition.BlobKey is not null)
+    {
+      invoice.Scans.Add(new InvoiceScan(
+        ScanType.PNG,
+        new Uri(
+          $"http://localhost:10000/devstoreaccount1/invoices/seed/{definition.BlobKey}.png"),
+        new Dictionary<string, object>
+        {
+          ["seed.key"] = definition.BlobKey,
+        }));
+    }
+
+    invoice.AdditionalMetadata["seed.origin"] = SeedOrigin;
+    invoice.AdditionalMetadata["seed.version"] = version;
+    invoice.AdditionalMetadata["seed.key"] = definition.Key;
+
+    if (definition.IsSoftDeleted)
+    {
+      invoice.SoftDelete();
+      foreach (Product product in invoice.Items)
+      {
+        ProductMetadata metadata = product.Metadata;
+        metadata.IsSoftDeleted = true;
+        product.Metadata = metadata;
+      }
+    }
+
+    return invoice;
+  }
+
+  private static Product CreateProduct(
+    SeedProductDefinition definition,
+    Guid sourceRunId) =>
+    new()
+    {
+      Name = definition.Name,
+      Quantity = definition.Quantity,
+      QuantityUnit = definition.QuantityUnit,
+      ProductCode = definition.ProductCode,
+      Price = definition.Price,
+      Classification = definition.ClassificationCode is null
+        ? null
+        : CreateClassification(
+          ClassificationSystem.Gs1Gpc,
+          "2026-05",
+          definition.ClassificationCode,
+          definition.ClassificationLabel
+            ?? definition.ClassificationCode,
+          definition.IsEdited
+            ? ClassificationOrigin.Manual
+            : ClassificationOrigin.Analysis),
+      AllergenAssessment = CreateAllergenAssessment(
+        definition.AllergenState,
+        sourceRunId),
+      Metadata = new ProductMetadata
+      {
+        IsEdited = definition.IsEdited,
+        IsComplete = definition.ClassificationCode is not null,
+        Confidence = definition.ClassificationCode is null ? 0 : 0.91,
+      },
+    };
+
+  private static StandardClassification CreateClassification(
+    ClassificationSystem system,
+    string version,
+    string code,
+    string label,
+    ClassificationOrigin origin) =>
+    new(
+      system,
+      version,
+      code,
+      label,
+      [new ClassificationNode("leaf", code, label)],
+      origin,
+      origin == ClassificationOrigin.Analysis ? 0.91 : null,
+      origin == ClassificationOrigin.Analysis
+        ? [new ClassificationEvidence("seed.fixture", label)]
+        : []);
+
+  private static AllergenAssessment? CreateAllergenAssessment(
+    string state,
+    Guid sourceRunId) =>
+    state.ToLowerInvariant() switch
+    {
+      "detected" => AllergenAssessment.Detected(
+        sourceRunId,
+        [
+          new AllergenSignal(
+            AllergenCode.Milk,
+            AllergenEvidenceLevel.Explicit,
+            0.95,
+            [new AllergenEvidence("seed.fixture", "milk")]),
+        ]),
+      "none" => AllergenAssessment.NoSignals(sourceRunId),
+      "insufficient" => AllergenAssessment.Insufficient(sourceRunId),
+      "unassessed" => null,
+      _ => throw new InvalidDataException(
+        $"Unsupported allergen seed state '{state}'."),
+    };
+
+  private static RecipeSuggestion CreateRecipe(
+    SeedInvoiceDefinition invoice,
+    Guid sourceRunId) =>
+    new(
+      $"{invoice.Name} bowl",
+      "A deterministic local development recipe.",
+      servings: 2,
+      preparationMinutes: 5,
+      cookingMinutes: 10,
+      totalMinutes: 15,
+      RecipeDifficulty.Easy,
+      invoice.Products.Count == 0
+        ? []
+        : [new RecipeIngredient(invoice.Products[0].Name, "1 portion", null)],
+      [new RecipeIngredient("Water", "250 ml", null)],
+      [],
+      [new RecipeStep(1, "Combine the ingredients and cook gently.", null)],
+      [],
+      sourceRunId);
+
+  private static Currency CreateCurrency(string code) =>
+    code.ToUpperInvariant() switch
+    {
+      "RON" => new Currency("Romanian Leu", "RON", "lei"),
+      "EUR" => new Currency("Euro", "EUR", "€"),
+      _ => throw new InvalidDataException($"Unsupported seed currency '{code}'."),
+    };
+
+  private static PaymentType ParsePaymentType(string value) =>
+    string.Equals(value, "SPLIT", StringComparison.OrdinalIgnoreCase)
+      ? PaymentType.Other
+      : Enum.TryParse(value, ignoreCase: true, out PaymentType paymentType)
+      && Enum.IsDefined(paymentType)
+        ? paymentType
+        : throw new InvalidDataException(
+          $"Unsupported seed payment type '{value}'.");
+
+  private static List<PaymentDetail> CreatePayments(
+    SeedInvoiceDefinition definition) =>
+    string.Equals(
+      definition.PaymentType,
+      "SPLIT",
+      StringComparison.OrdinalIgnoreCase)
+      ?
+      [
+        new PaymentDetail
+        {
+          Method = "Cash",
+          Amount = decimal.Round(definition.TotalAmount / 2, 2),
+        },
+        new PaymentDetail
+        {
+          Method = "Card",
+          Amount = definition.TotalAmount
+            - decimal.Round(definition.TotalAmount / 2, 2),
+        },
+      ]
+      :
+      [
+        new PaymentDetail
+        {
+          Method = definition.PaymentType,
+          Amount = definition.TotalAmount,
+        },
+      ];
+
+  private static DateTimeOffset ResolveDate(
+    DateOnly anchor,
+    int daysAgo) =>
+    new(anchor.AddDays(-daysAgo), TimeOnly.MinValue, TimeSpan.Zero);
+}

--- a/tooling/LocalDevelopment.Bootstrap/SeedData/scenario.v1.json
+++ b/tooling/LocalDevelopment.Bootstrap/SeedData/scenario.v1.json
@@ -1,0 +1,485 @@
+{
+  "version": "v1",
+  "personas": [
+    {
+      "key": "alice",
+      "subject": "alice@arolariu.ro",
+      "userIdentifier": "7574070c-3ee9-5031-9b1b-0dc08c61ee86"
+    },
+    {
+      "key": "bob",
+      "subject": "bob@arolariu.ro",
+      "userIdentifier": "6a40503e-c1af-51b0-8b60-3c6648b3724e"
+    },
+    {
+      "key": "charlie",
+      "subject": "charlie@arolariu.ro",
+      "userIdentifier": "fc687d5c-39d5-5541-868c-f76a3fdbd4e4"
+    }
+  ],
+  "merchants": [
+    {
+      "key": "merchant/northstar-central",
+      "id": "646b6472-cc7f-5092-9960-d703e827fd55",
+      "ownerKey": "alice",
+      "name": "Northstar Market Central",
+      "description": "Central grocery location.",
+      "parentCompanyId": "4d86a424-5216-5075-a23f-fd5d2d1f92b4",
+      "classificationCode": "47.11",
+      "classificationLabel": "Retail sale in non-specialised stores"
+    },
+    {
+      "key": "merchant/northstar-riverside",
+      "id": "df0939b8-6b96-516e-8c42-27a192de4549",
+      "ownerKey": "alice",
+      "name": "Northstar Market Riverside",
+      "description": "Riverside grocery location.",
+      "parentCompanyId": "4d86a424-5216-5075-a23f-fd5d2d1f92b4",
+      "classificationCode": "47.11",
+      "classificationLabel": "Retail sale in non-specialised stores"
+    },
+    {
+      "key": "merchant/harbor-home-east",
+      "id": "761c4629-d5b5-557e-b16b-53dd13b2f0d7",
+      "ownerKey": "alice",
+      "name": "Harbor Home East",
+      "description": "Home and household supplies.",
+      "parentCompanyId": "a98397c8-7100-5073-ab14-6387f0aef0a8",
+      "classificationCode": "47.52",
+      "classificationLabel": "Retail sale of hardware"
+    },
+    {
+      "key": "merchant/harbor-home-west",
+      "id": "3dc075f3-0b50-5338-b61b-5654f1fd3f9e",
+      "ownerKey": "alice",
+      "name": "Harbor Home West",
+      "description": "Home improvement location.",
+      "parentCompanyId": "a98397c8-7100-5073-ab14-6387f0aef0a8",
+      "classificationCode": "47.52",
+      "classificationLabel": "Retail sale of hardware"
+    },
+    {
+      "key": "merchant/old-town-market",
+      "id": "b0d77996-d538-5a58-aaa5-c7d330c4ec9c",
+      "ownerKey": "alice",
+      "name": "Old Town Market",
+      "description": "Independent local retailer.",
+      "parentCompanyId": "00000000-0000-0000-0000-000000000000",
+      "classificationCode": "47.21",
+      "classificationLabel": "Retail sale of fruit and vegetables"
+    },
+    {
+      "key": "merchant/charlie-corner-shop",
+      "id": "10c9d400-4c11-5466-ab1b-489a0ba1a6f5",
+      "ownerKey": "charlie",
+      "name": "Charlie's Corner Shop",
+      "description": "Independent neighbourhood store.",
+      "parentCompanyId": "00000000-0000-0000-0000-000000000000",
+      "classificationCode": "47.11",
+      "classificationLabel": "Retail sale in non-specialised stores"
+    },
+    {
+      "key": "merchant/charlie-parent-location",
+      "id": "1ee68b3a-0728-59b0-8513-b088daef8a86",
+      "ownerKey": "charlie",
+      "name": "Charlie Office Supply North",
+      "description": "Office supply location.",
+      "parentCompanyId": "384e4810-b83e-5bb6-b057-10a12235b1f6",
+      "classificationCode": "47.62",
+      "classificationLabel": "Retail sale of stationery"
+    }
+  ],
+  "invoices": [
+    {
+      "key": "invoice/alice-weekly-groceries",
+      "id": "8fc167a9-0f91-5216-9653-771876772771",
+      "ownerKey": "alice",
+      "name": "Weekly groceries",
+      "description": "Milk, bread, and breakfast staples.",
+      "daysAgo": 0,
+      "merchantKey": "merchant/northstar-central",
+      "sharedWith": [],
+      "currencyCode": "RON",
+      "paymentType": "CARD",
+      "totalAmount": 126.40,
+      "taxAmount": 20.18,
+      "isImportant": true,
+      "isSoftDeleted": false,
+      "classificationCode": "01.1",
+      "classificationLabel": "Food",
+      "products": [
+        {
+          "name": "Whole milk",
+          "quantity": 2,
+          "quantityUnit": "l",
+          "productCode": "MILK-001",
+          "price": 8.50,
+          "classificationCode": "10000025",
+          "classificationLabel": "Milk",
+          "allergenState": "detected",
+          "isEdited": false
+        },
+        {
+          "name": "Sourdough bread",
+          "quantity": 1,
+          "quantityUnit": "pcs",
+          "productCode": "BREAD-001",
+          "price": 15.00,
+          "classificationCode": "10000163",
+          "classificationLabel": "Bread",
+          "allergenState": "none",
+          "isEdited": true
+        }
+      ],
+      "includeRecipe": true,
+      "blobKey": "grocery-receipt"
+    },
+    {
+      "key": "invoice/alice-riverside-topup",
+      "id": "2b1405e5-5e0b-576e-91f8-8b63ad223b6a",
+      "ownerKey": "alice",
+      "name": "Riverside top-up",
+      "description": "Small mid-week grocery purchase.",
+      "daysAgo": 1,
+      "merchantKey": "merchant/northstar-riverside",
+      "sharedWith": [],
+      "currencyCode": "RON",
+      "paymentType": "CASH",
+      "totalAmount": 42.30,
+      "taxAmount": 6.75,
+      "isImportant": false,
+      "isSoftDeleted": false,
+      "classificationCode": "01.1",
+      "classificationLabel": "Food",
+      "products": [
+        {
+          "name": "Apples",
+          "quantity": 1.5,
+          "quantityUnit": "kg",
+          "productCode": "APPLE-001",
+          "price": 7.20,
+          "classificationCode": "10000001",
+          "classificationLabel": "Fresh fruit",
+          "allergenState": "none",
+          "isEdited": false
+        }
+      ],
+      "includeRecipe": false,
+      "blobKey": null
+    },
+    {
+      "key": "invoice/alice-household-supplies",
+      "id": "cefd8346-c079-5266-b3ae-94c973e2501a",
+      "ownerKey": "alice",
+      "name": "Household supplies",
+      "description": "Cleaning and home supplies.",
+      "daysAgo": 3,
+      "merchantKey": "merchant/harbor-home-east",
+      "sharedWith": [],
+      "currencyCode": "RON",
+      "paymentType": "TRANSFER",
+      "totalAmount": 238.90,
+      "taxAmount": 38.14,
+      "isImportant": false,
+      "isSoftDeleted": false,
+      "classificationCode": "05.6",
+      "classificationLabel": "Goods and services for routine household maintenance",
+      "products": [
+        {
+          "name": "Laundry detergent",
+          "quantity": 1,
+          "quantityUnit": "pcs",
+          "productCode": "HOME-001",
+          "price": 49.90,
+          "classificationCode": "10000405",
+          "classificationLabel": "Laundry detergent",
+          "allergenState": "unassessed",
+          "isEdited": false
+        }
+      ],
+      "includeRecipe": false,
+      "blobKey": "household-receipt"
+    },
+    {
+      "key": "invoice/alice-home-improvement",
+      "id": "c5f1acbe-bd2b-5dcd-9d38-622863d257eb",
+      "ownerKey": "alice",
+      "name": "Home improvement",
+      "description": "Paint and repair materials.",
+      "daysAgo": 7,
+      "merchantKey": "merchant/harbor-home-west",
+      "sharedWith": [],
+      "currencyCode": "EUR",
+      "paymentType": "CARD",
+      "totalAmount": 84.50,
+      "taxAmount": 13.49,
+      "isImportant": true,
+      "isSoftDeleted": false,
+      "classificationCode": "05.5",
+      "classificationLabel": "Tools and equipment for house and garden",
+      "products": [
+        {
+          "name": "Interior paint",
+          "quantity": 5,
+          "quantityUnit": "l",
+          "productCode": "PAINT-001",
+          "price": 12.90,
+          "classificationCode": "10000600",
+          "classificationLabel": "Paint",
+          "allergenState": "unassessed",
+          "isEdited": true
+        }
+      ],
+      "includeRecipe": false,
+      "blobKey": null
+    },
+    {
+      "key": "invoice/alice-restaurant-dinner",
+      "id": "c48cd638-8a51-5347-aa28-80047559be01",
+      "ownerKey": "alice",
+      "name": "Restaurant dinner",
+      "description": "Dinner with split payment.",
+      "daysAgo": 14,
+      "merchantKey": "merchant/old-town-market",
+      "sharedWith": [],
+      "currencyCode": "RON",
+      "paymentType": "SPLIT",
+      "totalAmount": 185.00,
+      "taxAmount": 29.54,
+      "isImportant": false,
+      "isSoftDeleted": false,
+      "classificationCode": "11.1",
+      "classificationLabel": "Food and beverage serving services",
+      "products": [
+        {
+          "name": "Dinner menu",
+          "quantity": 2,
+          "quantityUnit": "servings",
+          "productCode": "MEAL-001",
+          "price": 82.50,
+          "classificationCode": null,
+          "classificationLabel": null,
+          "allergenState": "insufficient",
+          "isEdited": false
+        }
+      ],
+      "includeRecipe": false,
+      "blobKey": "restaurant-receipt"
+    },
+    {
+      "key": "invoice/alice-pharmacy",
+      "id": "0041a485-71b0-5c2a-8be7-49cb242eafdd",
+      "ownerKey": "alice",
+      "name": "Pharmacy purchase",
+      "description": "Health and personal care items.",
+      "daysAgo": 30,
+      "merchantKey": "merchant/old-town-market",
+      "sharedWith": [],
+      "currencyCode": "RON",
+      "paymentType": "MOBILEPAYMENT",
+      "totalAmount": 68.70,
+      "taxAmount": 10.97,
+      "isImportant": false,
+      "isSoftDeleted": false,
+      "classificationCode": "06.1",
+      "classificationLabel": "Medicines and health products",
+      "products": [
+        {
+          "name": "Vitamin supplement",
+          "quantity": 1,
+          "quantityUnit": "box",
+          "productCode": "HEALTH-001",
+          "price": 68.70,
+          "classificationCode": null,
+          "classificationLabel": null,
+          "allergenState": "unassessed",
+          "isEdited": false
+        }
+      ],
+      "includeRecipe": false,
+      "blobKey": null
+    },
+    {
+      "key": "invoice/alice-shared-family-shop",
+      "id": "c4435cb7-4d5a-5a12-b46e-e9e155ffddc1",
+      "ownerKey": "alice",
+      "name": "Shared family shop",
+      "description": "Shared grocery receipt for Alice and Charlie.",
+      "daysAgo": 60,
+      "merchantKey": "merchant/northstar-central",
+      "sharedWith": ["charlie"],
+      "currencyCode": "RON",
+      "paymentType": "CARD",
+      "totalAmount": 312.10,
+      "taxAmount": 49.83,
+      "isImportant": true,
+      "isSoftDeleted": false,
+      "classificationCode": "01.1",
+      "classificationLabel": "Food",
+      "products": [
+        {
+          "name": "Pasta",
+          "quantity": 4,
+          "quantityUnit": "packs",
+          "productCode": "PASTA-001",
+          "price": 8.20,
+          "classificationCode": "10000214",
+          "classificationLabel": "Pasta",
+          "allergenState": "none",
+          "isEdited": false
+        }
+      ],
+      "includeRecipe": true,
+      "blobKey": null
+    },
+    {
+      "key": "invoice/alice-soft-deleted-archive",
+      "id": "d244d807-161b-5bab-b683-7fdc07912320",
+      "ownerKey": "alice",
+      "name": "Archived receipt",
+      "description": "Soft-deleted historical example.",
+      "daysAgo": 90,
+      "merchantKey": "merchant/old-town-market",
+      "sharedWith": [],
+      "currencyCode": "RON",
+      "paymentType": "CASH",
+      "totalAmount": 24.00,
+      "taxAmount": 3.83,
+      "isImportant": false,
+      "isSoftDeleted": true,
+      "classificationCode": null,
+      "classificationLabel": null,
+      "products": [
+        {
+          "name": "Archived item",
+          "quantity": 1,
+          "quantityUnit": "pcs",
+          "productCode": "ARCHIVE-001",
+          "price": 24.00,
+          "classificationCode": null,
+          "classificationLabel": null,
+          "allergenState": "unassessed",
+          "isEdited": false
+        }
+      ],
+      "includeRecipe": false,
+      "blobKey": null
+    },
+    {
+      "key": "invoice/charlie-breakfast",
+      "id": "c7aec965-5495-5d85-89db-bd3db6156ada",
+      "ownerKey": "charlie",
+      "name": "Breakfast essentials",
+      "description": "A small breakfast purchase.",
+      "daysAgo": 2,
+      "merchantKey": "merchant/charlie-corner-shop",
+      "sharedWith": [],
+      "currencyCode": "RON",
+      "paymentType": "CARD",
+      "totalAmount": 36.40,
+      "taxAmount": 5.81,
+      "isImportant": false,
+      "isSoftDeleted": false,
+      "classificationCode": "01.1",
+      "classificationLabel": "Food",
+      "products": [
+        {
+          "name": "Yogurt",
+          "quantity": 4,
+          "quantityUnit": "cups",
+          "productCode": "YOGURT-001",
+          "price": 4.10,
+          "classificationCode": "10000028",
+          "classificationLabel": "Yogurt",
+          "allergenState": "detected",
+          "isEdited": false
+        }
+      ],
+      "includeRecipe": true,
+      "blobKey": null
+    },
+    {
+      "key": "invoice/charlie-office-supplies",
+      "id": "c622f7a1-d7fe-5c64-87b1-86069b460117",
+      "ownerKey": "charlie",
+      "name": "Office supplies",
+      "description": "Notebooks and stationery.",
+      "daysAgo": 10,
+      "merchantKey": "merchant/charlie-parent-location",
+      "sharedWith": [],
+      "currencyCode": "EUR",
+      "paymentType": "TRANSFER",
+      "totalAmount": 52.00,
+      "taxAmount": 8.30,
+      "isImportant": true,
+      "isSoftDeleted": false,
+      "classificationCode": "09.5",
+      "classificationLabel": "Information and communication",
+      "products": [
+        {
+          "name": "Notebook",
+          "quantity": 3,
+          "quantityUnit": "pcs",
+          "productCode": "OFFICE-001",
+          "price": 9.50,
+          "classificationCode": "10001000",
+          "classificationLabel": "Stationery",
+          "allergenState": "unassessed",
+          "isEdited": true
+        }
+      ],
+      "includeRecipe": false,
+      "blobKey": null
+    },
+    {
+      "key": "invoice/charlie-weekend-market",
+      "id": "591b0694-44ab-5e4f-a72e-68439e13dd49",
+      "ownerKey": "charlie",
+      "name": "Weekend market",
+      "description": "Fresh produce from a local store.",
+      "daysAgo": 45,
+      "merchantKey": "merchant/charlie-corner-shop",
+      "sharedWith": [],
+      "currencyCode": "RON",
+      "paymentType": "CASH",
+      "totalAmount": 74.20,
+      "taxAmount": 11.85,
+      "isImportant": false,
+      "isSoftDeleted": false,
+      "classificationCode": null,
+      "classificationLabel": null,
+      "products": [
+        {
+          "name": "Seasonal vegetables",
+          "quantity": 3,
+          "quantityUnit": "kg",
+          "productCode": "VEG-001",
+          "price": 12.00,
+          "classificationCode": null,
+          "classificationLabel": null,
+          "allergenState": "insufficient",
+          "isEdited": false
+        }
+      ],
+      "includeRecipe": false,
+      "blobKey": null
+    }
+  ],
+  "blobs": [
+    {
+      "key": "grocery-receipt",
+      "contentType": "image/png",
+      "contentBase64": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Wl2rJ0AAAAASUVORK5CYII="
+    },
+    {
+      "key": "household-receipt",
+      "contentType": "image/png",
+      "contentBase64": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Wl2rJ0AAAAASUVORK5CYII="
+    },
+    {
+      "key": "restaurant-receipt",
+      "contentType": "image/png",
+      "contentBase64": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Wl2rJ0AAAAASUVORK5CYII="
+    }
+  ]
+}

--- a/tooling/LocalDevelopment.Bootstrap/SeedManifest.cs
+++ b/tooling/LocalDevelopment.Bootstrap/SeedManifest.cs
@@ -1,0 +1,86 @@
+namespace LocalDevelopment.Bootstrap;
+
+using arolariu.Backend.Domain.Invoices.DDD.AggregatorRoots.Invoices;
+using arolariu.Backend.Domain.Invoices.DDD.Entities.Merchants;
+
+/// <summary>
+/// Identifiers shared by the development identity and seed-data contracts.
+/// </summary>
+internal static class PersonaIds
+{
+  internal static readonly Guid Alice = Guid.Parse("7574070c-3ee9-5031-9b1b-0dc08c61ee86");
+  internal static readonly Guid Bob = Guid.Parse("6a40503e-c1af-51b0-8b60-3c6648b3724e");
+  internal static readonly Guid Charlie = Guid.Parse("fc687d5c-39d5-5541-868c-f76a3fdbd4e4");
+}
+
+/// <summary>
+/// Root logical fixture loaded by the local development bootstrap.
+/// </summary>
+internal sealed record SeedScenarioManifest(
+  string Version,
+  IReadOnlyList<SeedPersonaDefinition> Personas,
+  IReadOnlyList<SeedMerchantDefinition> Merchants,
+  IReadOnlyList<SeedInvoiceDefinition> Invoices,
+  IReadOnlyList<SeedBlobDefinition> Blobs);
+
+internal sealed record SeedPersonaDefinition(
+  string Key,
+  string Subject,
+  Guid UserIdentifier);
+
+internal sealed record SeedMerchantDefinition(
+  string Key,
+  Guid Id,
+  string OwnerKey,
+  string Name,
+  string Description,
+  Guid ParentCompanyId,
+  string ClassificationCode,
+  string ClassificationLabel);
+
+internal sealed record SeedInvoiceDefinition(
+  string Key,
+  Guid Id,
+  string OwnerKey,
+  string Name,
+  string Description,
+  int DaysAgo,
+  string MerchantKey,
+  IReadOnlyList<string> SharedWith,
+  string CurrencyCode,
+  string PaymentType,
+  decimal TotalAmount,
+  decimal TaxAmount,
+  bool IsImportant,
+  bool IsSoftDeleted,
+  string? ClassificationCode,
+  string? ClassificationLabel,
+  IReadOnlyList<SeedProductDefinition> Products,
+  bool IncludeRecipe,
+  string? BlobKey);
+
+internal sealed record SeedProductDefinition(
+  string Name,
+  decimal Quantity,
+  string QuantityUnit,
+  string ProductCode,
+  decimal Price,
+  string? ClassificationCode,
+  string? ClassificationLabel,
+  string AllergenState,
+  bool IsEdited);
+
+internal sealed record SeedBlobDefinition(
+  string Key,
+  string ContentType,
+  string ContentBase64);
+
+internal sealed record MaterializedSeedBlob(
+  string Key,
+  string ContentType,
+  byte[] Content);
+
+internal sealed record MaterializedSeedScenario(
+  IReadOnlyList<Merchant> Merchants,
+  IReadOnlyList<Invoice> Invoices,
+  IReadOnlyList<MaterializedSeedBlob> Blobs);

--- a/tooling/LocalDevelopment.Bootstrap/SeedManifestValidator.cs
+++ b/tooling/LocalDevelopment.Bootstrap/SeedManifestValidator.cs
@@ -29,7 +29,7 @@ internal static class SeedManifestValidator
       invoice => invoice.Key,
       invoice => invoice.Id,
       "invoice");
-    _ = IndexUnique(
+    Dictionary<string, SeedBlobDefinition> blobs = IndexUnique(
       manifest.Blobs,
       blob => blob.Key,
       _ => Guid.Empty,
@@ -61,6 +61,13 @@ internal static class SeedManifestValidator
       {
         throw new InvalidDataException(
           $"Invoice '{invoice.Key}' references unknown merchant '{invoice.MerchantKey}'.");
+      }
+
+      if (invoice.BlobKey is not null
+          && !blobs.ContainsKey(invoice.BlobKey))
+      {
+        throw new InvalidDataException(
+          $"Invoice '{invoice.Key}' references unknown blob '{invoice.BlobKey}'.");
       }
 
       foreach (string sharedPersona in invoice.SharedWith)

--- a/tooling/LocalDevelopment.Bootstrap/SeedManifestValidator.cs
+++ b/tooling/LocalDevelopment.Bootstrap/SeedManifestValidator.cs
@@ -1,0 +1,164 @@
+namespace LocalDevelopment.Bootstrap;
+
+/// <summary>
+/// Validates fixture-only relationships before domain materialization.
+/// </summary>
+internal static class SeedManifestValidator
+{
+  internal static void Validate(SeedScenarioManifest manifest)
+  {
+    ArgumentNullException.ThrowIfNull(manifest);
+
+    if (string.IsNullOrWhiteSpace(manifest.Version))
+    {
+      throw new InvalidDataException("Seed scenario version is required.");
+    }
+
+    Dictionary<string, SeedPersonaDefinition> personas = IndexUnique(
+      manifest.Personas,
+      persona => persona.Key,
+      persona => persona.UserIdentifier,
+      "persona");
+    Dictionary<string, SeedMerchantDefinition> merchants = IndexUnique(
+      manifest.Merchants,
+      merchant => merchant.Key,
+      merchant => merchant.Id,
+      "merchant");
+    _ = IndexUnique(
+      manifest.Invoices,
+      invoice => invoice.Key,
+      invoice => invoice.Id,
+      "invoice");
+    _ = IndexUnique(
+      manifest.Blobs,
+      blob => blob.Key,
+      _ => Guid.Empty,
+      "blob",
+      requireUniqueIdentifier: false);
+
+    RequirePersona(personas, "alice", PersonaIds.Alice);
+    RequirePersona(personas, "bob", PersonaIds.Bob);
+    RequirePersona(personas, "charlie", PersonaIds.Charlie);
+
+    foreach (SeedMerchantDefinition merchant in manifest.Merchants)
+    {
+      if (!personas.ContainsKey(merchant.OwnerKey))
+      {
+        throw new InvalidDataException(
+          $"Merchant '{merchant.Key}' references unknown owner '{merchant.OwnerKey}'.");
+      }
+    }
+
+    foreach (SeedInvoiceDefinition invoice in manifest.Invoices)
+    {
+      if (!personas.ContainsKey(invoice.OwnerKey))
+      {
+        throw new InvalidDataException(
+          $"Invoice '{invoice.Key}' references unknown owner '{invoice.OwnerKey}'.");
+      }
+
+      if (!merchants.ContainsKey(invoice.MerchantKey))
+      {
+        throw new InvalidDataException(
+          $"Invoice '{invoice.Key}' references unknown merchant '{invoice.MerchantKey}'.");
+      }
+
+      foreach (string sharedPersona in invoice.SharedWith)
+      {
+        if (!personas.ContainsKey(sharedPersona))
+        {
+          throw new InvalidDataException(
+            $"Invoice '{invoice.Key}' references unknown shared persona '{sharedPersona}'.");
+        }
+      }
+
+      if (invoice.DaysAgo < 0
+          || invoice.TotalAmount < 0
+          || invoice.TaxAmount < 0
+          || invoice.TaxAmount > invoice.TotalAmount)
+      {
+        throw new InvalidDataException(
+          $"Invoice '{invoice.Key}' contains invalid temporal or payment values.");
+      }
+
+      foreach (SeedProductDefinition product in invoice.Products)
+      {
+        if (product.Quantity <= 0 || product.Price < 0)
+        {
+          throw new InvalidDataException(
+            $"Invoice '{invoice.Key}' contains an invalid product.");
+        }
+      }
+    }
+
+    AssertApprovedCounts(manifest, personas);
+  }
+
+  private static Dictionary<string, TDefinition> IndexUnique<TDefinition>(
+    IReadOnlyList<TDefinition> definitions,
+    Func<TDefinition, string> keySelector,
+    Func<TDefinition, Guid> identifierSelector,
+    string label,
+    bool requireUniqueIdentifier = true)
+  {
+    ArgumentNullException.ThrowIfNull(definitions);
+
+    var byKey = new Dictionary<string, TDefinition>(StringComparer.Ordinal);
+    var identifiers = new HashSet<Guid>();
+
+    foreach (TDefinition definition in definitions)
+    {
+      string key = keySelector(definition);
+
+      if (string.IsNullOrWhiteSpace(key) || !byKey.TryAdd(key, definition))
+      {
+        throw new InvalidDataException($"Duplicate or blank {label} key '{key}'.");
+      }
+
+      Guid identifier = identifierSelector(definition);
+      if (requireUniqueIdentifier
+          && (identifier == Guid.Empty || !identifiers.Add(identifier)))
+      {
+        throw new InvalidDataException(
+          $"Duplicate or empty {label} identifier '{identifier}'.");
+      }
+    }
+
+    return byKey;
+  }
+
+  private static void RequirePersona(
+    IReadOnlyDictionary<string, SeedPersonaDefinition> personas,
+    string key,
+    Guid expectedIdentifier)
+  {
+    if (!personas.TryGetValue(key, out SeedPersonaDefinition? persona)
+        || persona.UserIdentifier != expectedIdentifier)
+    {
+      throw new InvalidDataException(
+        $"Seed persona '{key}' must use identifier '{expectedIdentifier}'.");
+    }
+  }
+
+  private static void AssertApprovedCounts(
+    SeedScenarioManifest manifest,
+    IReadOnlyDictionary<string, SeedPersonaDefinition> personas)
+  {
+    int CountInvoices(string persona) =>
+      manifest.Invoices.Count(invoice => invoice.OwnerKey == persona);
+    int CountMerchants(string persona) =>
+      manifest.Merchants.Count(merchant => merchant.OwnerKey == persona);
+
+    if (CountInvoices("alice") != 8
+        || CountMerchants("alice") != 5
+        || CountInvoices("bob") != 0
+        || CountMerchants("bob") != 0
+        || CountInvoices("charlie") != 3
+        || CountMerchants("charlie") != 2
+        || personas.Count != 3)
+    {
+      throw new InvalidDataException(
+        "Seed scenario does not match the approved Alice/Bob/Charlie record counts.");
+    }
+  }
+}

--- a/tooling/LocalDevelopment.Identity/DevelopmentPersona.cs
+++ b/tooling/LocalDevelopment.Identity/DevelopmentPersona.cs
@@ -1,0 +1,11 @@
+namespace LocalDevelopment.Identity;
+
+/// <summary>
+/// Describes one deterministic local development identity.
+/// </summary>
+internal sealed record DevelopmentPersona(
+  string Key,
+  string DisplayName,
+  string Subject,
+  Guid UserIdentifier,
+  string Role);

--- a/tooling/LocalDevelopment.Identity/DevelopmentPersonaCatalog.cs
+++ b/tooling/LocalDevelopment.Identity/DevelopmentPersonaCatalog.cs
@@ -1,0 +1,40 @@
+namespace LocalDevelopment.Identity;
+
+/// <summary>
+/// Provides the fixed persona identities shared with the local seed fixture.
+/// </summary>
+internal static class DevelopmentPersonaCatalog
+{
+  internal static DevelopmentPersona Alice { get; } = new(
+    "alice",
+    "Alice — rich account",
+    "alice@arolariu.ro",
+    Guid.Parse("7574070c-3ee9-5031-9b1b-0dc08c61ee86"),
+    "user");
+
+  internal static DevelopmentPersona Bob { get; } = new(
+    "bob",
+    "Bob — clean slate",
+    "bob@arolariu.ro",
+    Guid.Parse("6a40503e-c1af-51b0-8b60-3c6648b3724e"),
+    "user");
+
+  internal static DevelopmentPersona Charlie { get; } = new(
+    "charlie",
+    "Charlie — light account",
+    "charlie@arolariu.ro",
+    Guid.Parse("fc687d5c-39d5-5541-868c-f76a3fdbd4e4"),
+    "user");
+
+  internal static IReadOnlyList<DevelopmentPersona> All { get; } =
+    [Alice, Bob, Charlie];
+
+  internal static bool TryGet(
+    string key,
+    out DevelopmentPersona? persona)
+  {
+    persona = All.FirstOrDefault(candidate =>
+      string.Equals(candidate.Key, key, StringComparison.Ordinal));
+    return persona is not null;
+  }
+}

--- a/tooling/LocalDevelopment.Identity/DevelopmentTokenFactory.cs
+++ b/tooling/LocalDevelopment.Identity/DevelopmentTokenFactory.cs
@@ -15,7 +15,7 @@ internal sealed class DevelopmentTokenFactory
   private readonly TimeProvider timeProvider;
   private readonly SigningCredentials signingCredentials;
 
-  internal DevelopmentTokenFactory(
+  public DevelopmentTokenFactory(
     LocalIdentityOptions options,
     TimeProvider timeProvider)
   {

--- a/tooling/LocalDevelopment.Identity/DevelopmentTokenFactory.cs
+++ b/tooling/LocalDevelopment.Identity/DevelopmentTokenFactory.cs
@@ -1,0 +1,63 @@
+namespace LocalDevelopment.Identity;
+
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+
+using Microsoft.IdentityModel.Tokens;
+
+/// <summary>
+/// Creates locally signed JWTs that use the API's production claim contract.
+/// </summary>
+internal sealed class DevelopmentTokenFactory
+{
+  private readonly LocalIdentityOptions options;
+  private readonly TimeProvider timeProvider;
+  private readonly SigningCredentials signingCredentials;
+
+  internal DevelopmentTokenFactory(
+    LocalIdentityOptions options,
+    TimeProvider timeProvider)
+  {
+    ArgumentNullException.ThrowIfNull(options);
+    ArgumentNullException.ThrowIfNull(timeProvider);
+
+    if (Encoding.UTF8.GetByteCount(options.Secret) < 32)
+    {
+      throw new ArgumentException(
+        "Local JWT secret must contain at least 32 UTF-8 bytes.",
+        nameof(options));
+    }
+
+    this.options = options;
+    this.timeProvider = timeProvider;
+    signingCredentials = new SigningCredentials(
+      new SymmetricSecurityKey(Encoding.UTF8.GetBytes(options.Secret)),
+      SecurityAlgorithms.HmacSha256);
+  }
+
+  internal string Create(DevelopmentPersona persona)
+  {
+    ArgumentNullException.ThrowIfNull(persona);
+
+    DateTimeOffset now = timeProvider.GetUtcNow();
+    var descriptor = new SecurityTokenDescriptor
+    {
+      Subject = new ClaimsIdentity(
+      [
+        new Claim(JwtRegisteredClaimNames.Sub, persona.Subject),
+        new Claim("userIdentifier", persona.UserIdentifier.ToString()),
+        new Claim("role", persona.Role),
+      ]),
+      Issuer = options.Issuer,
+      Audience = options.Audience,
+      NotBefore = now.UtcDateTime,
+      IssuedAt = now.UtcDateTime,
+      Expires = now.AddHours(8).UtcDateTime,
+      SigningCredentials = signingCredentials,
+    };
+
+    var handler = new JwtSecurityTokenHandler();
+    return handler.WriteToken(handler.CreateToken(descriptor));
+  }
+}

--- a/tooling/LocalDevelopment.Identity/LocalDevelopment.Identity.csproj
+++ b/tooling/LocalDevelopment.Identity/LocalDevelopment.Identity.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.19.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="AppHost.Tests" />
+  </ItemGroup>
+</Project>

--- a/tooling/LocalDevelopment.Identity/LocalIdentityOptions.cs
+++ b/tooling/LocalDevelopment.Identity/LocalIdentityOptions.cs
@@ -1,0 +1,46 @@
+namespace LocalDevelopment.Identity;
+
+using System.Text.Json;
+
+/// <summary>
+/// Configuration required to issue local development persona tokens.
+/// </summary>
+internal sealed record LocalIdentityOptions(
+  string Issuer,
+  string Audience,
+  string Secret,
+  string SwaggerOrigin)
+{
+  internal static LocalIdentityOptions Load(
+    string configPath,
+    string swaggerOrigin)
+  {
+    ArgumentException.ThrowIfNullOrWhiteSpace(configPath);
+    ArgumentException.ThrowIfNullOrWhiteSpace(swaggerOrigin);
+
+    using JsonDocument document = JsonDocument.Parse(
+      File.ReadAllText(configPath));
+    JsonElement root = document.RootElement;
+
+    return new LocalIdentityOptions(
+      ReadRequired(root, "Auth:JWT:Issuer"),
+      ReadRequired(root, "Auth:JWT:Audience"),
+      ReadRequired(root, "Auth:JWT:Secret"),
+      swaggerOrigin);
+  }
+
+  private static string ReadRequired(
+    JsonElement root,
+    string key)
+  {
+    if (!root.TryGetProperty(key, out JsonElement value)
+        || value.ValueKind != JsonValueKind.String
+        || string.IsNullOrWhiteSpace(value.GetString()))
+    {
+      throw new InvalidOperationException(
+        $"Local identity configuration key '{key}' is required.");
+    }
+
+    return value.GetString()!;
+  }
+}

--- a/tooling/LocalDevelopment.Identity/Program.cs
+++ b/tooling/LocalDevelopment.Identity/Program.cs
@@ -1,6 +1,7 @@
 namespace LocalDevelopment.Identity;
 
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -17,7 +18,10 @@ internal static class Program
       configPath,
       swaggerOrigin);
 
-    RequireLoopbackBinding(builder.Configuration["ASPNETCORE_URLS"]);
+    string? configuredUrls =
+      builder.Configuration[WebHostDefaults.ServerUrlsKey]
+      ?? builder.Configuration["ASPNETCORE_URLS"];
+    RequireLoopbackBinding(configuredUrls);
 
     builder.Services.AddCors(cors =>
       cors.AddDefaultPolicy(policy =>
@@ -66,11 +70,12 @@ internal static class Program
     app.Run();
   }
 
-  private static void RequireLoopbackBinding(string? urls)
+  internal static void RequireLoopbackBinding(string? urls)
   {
     if (string.IsNullOrWhiteSpace(urls))
     {
-      return;
+      throw new InvalidOperationException(
+        "Local development identity service requires an explicit loopback binding.");
     }
 
     foreach (string value in urls.Split(';', StringSplitOptions.RemoveEmptyEntries))

--- a/tooling/LocalDevelopment.Identity/Program.cs
+++ b/tooling/LocalDevelopment.Identity/Program.cs
@@ -1,0 +1,87 @@
+namespace LocalDevelopment.Identity;
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+internal static class Program
+{
+  public static void Main(string[] args)
+  {
+    WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
+    string configPath = builder.Configuration["LOCAL_CONFIG_PATH"]
+      ?? throw new InvalidOperationException("LOCAL_CONFIG_PATH is required.");
+    string swaggerOrigin = builder.Configuration["LOCAL_SWAGGER_ORIGIN"]
+      ?? throw new InvalidOperationException("LOCAL_SWAGGER_ORIGIN is required.");
+    LocalIdentityOptions options = LocalIdentityOptions.Load(
+      configPath,
+      swaggerOrigin);
+
+    RequireLoopbackBinding(builder.Configuration["ASPNETCORE_URLS"]);
+
+    builder.Services.AddCors(cors =>
+      cors.AddDefaultPolicy(policy =>
+        policy
+          .WithOrigins(options.SwaggerOrigin)
+          .WithMethods("GET")
+          .AllowAnyHeader()));
+    builder.Services.AddSingleton(options);
+    builder.Services.AddSingleton(TimeProvider.System);
+    builder.Services.AddSingleton<DevelopmentTokenFactory>();
+
+    WebApplication app = builder.Build();
+    app.UseCors();
+    app.MapGet("/health", () => Results.Ok(new { status = "healthy" }));
+    app.MapGet(
+      "/personas",
+      () => DevelopmentPersonaCatalog.All.Select(persona => new
+      {
+        persona.Key,
+        persona.DisplayName,
+        persona.Subject,
+        persona.UserIdentifier,
+        persona.Role,
+      }));
+    app.MapGet(
+      "/personas/{key}/token",
+      (string key, DevelopmentTokenFactory factory, HttpResponse response) =>
+      {
+        response.Headers.CacheControl = "no-store";
+
+        if (!DevelopmentPersonaCatalog.TryGet(
+          key,
+          out DevelopmentPersona? persona)
+          || persona is null)
+        {
+          return Results.NotFound();
+        }
+
+        return Results.Ok(new
+        {
+          persona = persona.Key,
+          token = factory.Create(persona),
+        });
+      });
+
+    app.Run();
+  }
+
+  private static void RequireLoopbackBinding(string? urls)
+  {
+    if (string.IsNullOrWhiteSpace(urls))
+    {
+      return;
+    }
+
+    foreach (string value in urls.Split(';', StringSplitOptions.RemoveEmptyEntries))
+    {
+      if (!Uri.TryCreate(value, UriKind.Absolute, out Uri? uri)
+          || uri is null
+          || !uri.IsLoopback)
+      {
+        throw new InvalidOperationException(
+          "Local development identity service must bind to loopback.");
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- provision the `invoice-analysis` queue through Azure Bicep, Aspire/Azurite, and selfhost startup
- reset and seed local Cosmos invoice/merchant data, invoice blobs, and the analysis queue before the API starts
- add deterministic Alice, Bob, and Charlie development personas with stable IDs, relationships, and UTC-relative dates
- add a loopback-only local JWT helper and gated Swagger persona controls without changing production JWT validation
- preserve protected audit and soft-delete values through the Cosmos SDK's Newtonsoft persistence round-trip

## Local scenario

| Persona | Stored invoices | Active invoices | Merchants |
| --- | ---: | ---: | ---: |
| Alice | 8 | 7 | 5 |
| Bob | 0 | 0 | 0 |
| Charlie | 3 | 3 | 2 |

The fixture includes grouped and independent merchants, shared invoices, RON/EUR purchases, multiple payment modes, classifications, allergens, recipes, scan assets, important records, and a soft-deleted invoice. The analysis queue starts empty.

Each Aspire launch clears only:

- Cosmos `invoices` and `merchants` documents
- Azurite `invoices` blobs
- Azurite `invoice-analysis` messages

SQL, Redis, emulator schemas, indexes, and named volumes remain intact.

## Safety boundaries

- destructive bootstrap requires Development, `INFRA=local`, no managed identity, and loopback emulator endpoints
- local identity startup requires an explicit loopback binding
- Swagger persona controls require Development, `INFRA=local`, no `AZURE_CLIENT_ID`, and a loopback identity endpoint
- CSP permits only the exact gated identity origin in addition to same-origin requests
- tooling resources are excluded from deployment manifests
- tokens and signing secrets are never logged or committed

## Verification

- Core tests: 134 passed
- analysis persistence serialization tests: 5 passed
- AppHost/tooling tests: 27 passed
- selfhost command tests: 9 passed
- Core and AppHost builds: 0 warnings, 0 errors
- Azure Bicep compilation: exit 0; existing unrelated linter warnings remain

## Manual validation

Validated with Aspire using Podman:

- bootstrap completed and provisioned the blob container and queue
- identity helper and API health endpoints returned 200
- live API active invoice counts were Alice 7, Bob 0, Charlie 3
- raw Cosmos ownership matched 8/0/3 invoices and 5/0/2 merchants
- the archived Alice invoice returned HTTP 423
- Swagger displayed all three persona controls and preauthorized Alice's Bearer token
- a patched seed record persisted before restart and returned to its deterministic fixture value after restart

This is an incremental replacement for the local-development portions of #956.
